### PR TITLE
Add CODEOWNERS for ontos-maintain team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes require review from the ontos-maintain team
+* @databrickslabs/ontos-maintain


### PR DESCRIPTION
## Summary
- Adds a CODEOWNERS file requiring `@databrickslabs/ontos-maintain` review on all PRs
- Ensures no PR merges without team review

## Note
Once merged, a repo admin will need to enable **"Require review from Code Owners"** in the branch protection rules for `main` to enforce this.

## Test plan
- [ ] Verify CODEOWNERS syntax is valid after merge
- [ ] Confirm ontos-maintain team is auto-requested on new PRs
- [ ] Enable branch protection rule to require CODEOWNERS review

This pull request was AI-assisted by Isaac.