### PR TITLE
feat: startup, contracts, knowledge-graph, semantic-models

### DIFF
--- a/src/backend/alembic/versions/d1_odcs_v310_full_persistence.py
+++ b/src/backend/alembic/versions/d1_odcs_v310_full_persistence.py
@@ -1,0 +1,94 @@
+"""ODCS v3.1.0 full persistence: relationships, team metadata, stable IDs
+
+Adds new tables for schema-level and property-level relationships (foreign
+keys), team object metadata, and a stable_id column on all ODCS entity
+tables to support round-trip of the v3.1.0 StableId field.  Also adds
+a name column to team members.
+
+Revision ID: d1_odcs_v310
+Revises: c1_drop_datasets
+Create Date: 2026-03-30
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d1_odcs_v310"
+down_revision: Union[str, None] = "c1_drop_datasets"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Tables that get a new nullable stable_id column
+_STABLE_ID_TABLES = [
+    "data_contract_servers",
+    "data_contract_schema_objects",
+    "data_contract_schema_properties",
+    "data_contract_support",
+    "data_contract_quality_checks",
+    "data_contract_authoritative_definitions",
+    "data_contract_custom_properties",
+    "data_contract_roles",
+    "data_contract_sla_properties",
+    "data_contract_team",
+    "data_contract_schema_object_authoritative_definitions",
+    "data_contract_schema_object_custom_properties",
+    "data_contract_schema_property_authoritative_definitions",
+]
+
+
+def upgrade() -> None:
+    # --- New tables ---
+
+    op.create_table(
+        "data_contract_schema_object_relationships",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("schema_object_id", sa.String(), sa.ForeignKey("data_contract_schema_objects.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("relationship_type", sa.String(), nullable=False, server_default="foreignKey"),
+        sa.Column("from_value", sa.Text(), nullable=False),
+        sa.Column("to_value", sa.Text(), nullable=False),
+        sa.Column("custom_properties_json", sa.Text(), nullable=True),
+    )
+
+    op.create_table(
+        "data_contract_schema_property_relationships",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("property_id", sa.String(), sa.ForeignKey("data_contract_schema_properties.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("relationship_type", sa.String(), nullable=False, server_default="foreignKey"),
+        sa.Column("to_value", sa.Text(), nullable=False),
+        sa.Column("custom_properties_json", sa.Text(), nullable=True),
+    )
+
+    op.create_table(
+        "data_contract_team_metadata",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("contract_id", sa.String(), sa.ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, unique=True, index=True),
+        sa.Column("stable_id", sa.String(), nullable=True),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("tags_json", sa.Text(), nullable=True),
+        sa.Column("custom_properties_json", sa.Text(), nullable=True),
+        sa.Column("authoritative_definitions_json", sa.Text(), nullable=True),
+    )
+
+    # --- stable_id on existing tables ---
+
+    for table in _STABLE_ID_TABLES:
+        op.add_column(table, sa.Column("stable_id", sa.String(), nullable=True))
+
+    # --- name on team members ---
+
+    op.add_column("data_contract_team", sa.Column("name", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("data_contract_team", "name")
+
+    for table in _STABLE_ID_TABLES:
+        op.drop_column(table, "stable_id")
+
+    op.drop_table("data_contract_team_metadata")
+    op.drop_table("data_contract_schema_property_relationships")
+    op.drop_table("data_contract_schema_object_relationships")

--- a/src/backend/alembic/versions/e2_semantic_models_display_name.py
+++ b/src/backend/alembic/versions/e2_semantic_models_display_name.py
@@ -1,0 +1,27 @@
+"""Add display_name to semantic_models for user-facing RDF source titles.
+
+Revision ID: e2_semantic_display_name
+Revises: d1_odcs_v310
+Create Date: 2026-04-14
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e2_semantic_display_name"
+down_revision: Union[str, None] = "d1_odcs_v310"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "semantic_models",
+        sa.Column("display_name", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("semantic_models", "display_name")

--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -16,12 +16,12 @@ SERVER_STARTUP_TIME = int(time.time())
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import Response
 from fastapi import HTTPException, status
 
-from src.common.middleware import ErrorHandlingMiddleware, LoggingMiddleware
+from src.common.middleware import ErrorHandlingMiddleware, LoggingMiddleware, MaintenanceMiddleware
 from src.routes import (
     access_grants_routes,
     catalog_commander_routes,
@@ -113,16 +113,33 @@ STATIC_ASSETS_PATH = BASE_DIR.parent / "static"
 async def startup_event():
     import os
     
+    # Initialize health state (must happen before anything else)
+    app.state.health = {
+        "db_ok": False,
+        "ws_ok": False,
+        "warnings": [],
+        "db_error": None,
+    }
+    
     # Skip startup tasks if running tests
     if os.getenv('SKIP_STARTUP_TASKS') == 'true':
         logger.info("SKIP_STARTUP_TASKS=true detected - skipping startup tasks (test mode)")
+        app.state.health["db_ok"] = True
+        app.state.health["ws_ok"] = True
         return
     
     logger.info("Running application startup event...")
     settings = get_settings()
     
-    initialize_database(settings=settings)
-    initialize_managers(app)  # Handles DB-backed manager init
+    try:
+        initialize_database(settings=settings)
+        app.state.health["db_ok"] = True
+    except Exception as e:
+        app.state.health["db_error"] = str(e)
+        logger.critical(f"Database init failed — entering maintenance mode: {e}", exc_info=True)
+        return  # Skip manager init; MaintenanceMiddleware will serve the maintenance page
+
+    initialize_managers(app)  # Soft-fails internally for ws_client; sets health["ws_ok"]
     
     # Initialize Git service for indirect delivery mode
     try:
@@ -294,9 +311,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Add custom middleware
+# Add custom middleware (outermost middleware runs first)
 app.add_middleware(ErrorHandlingMiddleware)
 app.add_middleware(LoggingMiddleware)
+app.add_middleware(MaintenanceMiddleware)
 
 # Mount static files for the React application (skip in test mode)
 if not os.environ.get('TESTING'):
@@ -386,6 +404,34 @@ async def get_app_version():
         'startTime': SERVER_STARTUP_TIME,
         'timestamp': int(time.time())
     }
+
+# --- Health & retry endpoints ---
+@app.get("/api/health", tags=["System"])
+async def health_check():
+    """Return application health state."""
+    return app.state.health
+
+@app.post("/api/health/retry", tags=["System"])
+async def retry_startup():
+    """Re-attempt database init + manager init after a maintenance-mode failure."""
+    settings = get_settings()
+    try:
+        initialize_database(settings=settings)
+        app.state.health["db_ok"] = True
+        app.state.health["db_error"] = None
+    except Exception as e:
+        app.state.health["db_error"] = str(e)
+        logger.critical(f"Database retry failed: {e}", exc_info=True)
+        return JSONResponse({"status": "error", "detail": str(e)}, status_code=503)
+
+    try:
+        app.state.health["warnings"] = []  # Reset warnings before retry
+        initialize_managers(app)  # Sets health["ws_ok"] internally
+    except Exception as e:
+        app.state.health["warnings"].append(f"Manager init failed on retry: {e}")
+        logger.error(f"Manager init failed on retry: {e}", exc_info=True)
+
+    return {"status": "ok", "health": app.state.health}
 
 # Define the SPA catch-all route LAST (skip in test mode)
 if not os.environ.get('TESTING'):

--- a/src/backend/src/common/middleware.py
+++ b/src/backend/src/common/middleware.py
@@ -3,9 +3,81 @@ from typing import Awaitable, Callable
 
 from fastapi import Request, Response, HTTPException, status
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import HTMLResponse, JSONResponse
 
 from src.common.logging import get_logger
 logger = get_logger(__name__)
+
+
+MAINTENANCE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Ontos — Maintenance</title>
+<style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+       background:#0f172a;color:#e2e8f0;display:flex;align-items:center;
+       justify-content:center;min-height:100vh;padding:1rem}
+  .card{background:#1e293b;border:1px solid #334155;border-radius:12px;
+        padding:2.5rem;max-width:520px;width:100%;text-align:center;
+        box-shadow:0 25px 50px -12px rgba(0,0,0,.5)}
+  h1{font-size:1.5rem;margin-bottom:.75rem;color:#f8fafc}
+  .icon{font-size:2.5rem;margin-bottom:1rem}
+  .detail{background:#0f172a;border:1px solid #334155;border-radius:8px;
+          padding:.75rem 1rem;margin:1rem 0;font-family:monospace;font-size:.85rem;
+          color:#fbbf24;text-align:left;word-break:break-word;max-height:120px;
+          overflow-y:auto}
+  p{color:#94a3b8;line-height:1.6;margin-bottom:1rem;font-size:.95rem}
+  button{background:#6366f1;color:#fff;border:none;border-radius:8px;
+         padding:.75rem 2rem;font-size:1rem;cursor:pointer;transition:all .15s;
+         font-weight:500}
+  button:hover{background:#818cf8;transform:translateY(-1px)}
+  button:active{transform:translateY(0)}
+  button:disabled{opacity:.6;cursor:not-allowed;transform:none}
+  .status{margin-top:1rem;font-size:.85rem;min-height:1.2em}
+  .status.ok{color:#34d399}
+  .status.err{color:#f87171}
+  .auto{color:#64748b;font-size:.8rem;margin-top:1.5rem}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">&#9888;&#65039;</div>
+  <h1>Service Temporarily Unavailable</h1>
+  <p>The application could not connect to the database during startup.
+     This is usually temporary — for example, a missing access grant or
+     a network issue.</p>
+  <div class="detail" id="err">Loading error details&hellip;</div>
+  <button id="btn" onclick="retry()">Retry Connection</button>
+  <div class="status" id="msg"></div>
+  <div class="auto">Auto-retrying every 30 seconds&hellip;</div>
+</div>
+<script>
+  const btn=document.getElementById('btn'),
+        msg=document.getElementById('msg'),
+        err=document.getElementById('err');
+
+  fetch('/api/health').then(r=>r.json()).then(h=>{
+    err.textContent=h.db_error||'Unknown error';
+  }).catch(()=>{err.textContent='Could not fetch error details';});
+
+  async function retry(){
+    btn.disabled=true; msg.className='status'; msg.textContent='Retrying\u2026';
+    try{
+      const r=await fetch('/api/health/retry',{method:'POST'});
+      const d=await r.json();
+      if(r.ok){msg.className='status ok';msg.textContent='Connected! Reloading\u2026';
+        setTimeout(()=>location.reload(),1000);
+      }else{msg.className='status err';msg.textContent=d.detail||'Retry failed';
+        err.textContent=d.detail||err.textContent;btn.disabled=false;}
+    }catch(e){msg.className='status err';msg.textContent='Network error';btn.disabled=false;}
+  }
+  setInterval(()=>{if(!btn.disabled)retry();},30000);
+</script>
+</body>
+</html>"""
 
 class LoggingMiddleware(BaseHTTPMiddleware):
     """Middleware for logging requests and responses."""
@@ -18,6 +90,32 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         process_time = time.time() - start_time
         logger.debug(f"{request.method} {request.url.path} completed in {process_time:.3f}s")
         return response
+
+class MaintenanceMiddleware(BaseHTTPMiddleware):
+    """Serves a maintenance page when the database is not available.
+
+    The health endpoint is always allowed through so the retry button works.
+    """
+
+    PASSTHROUGH_PREFIXES = ("/api/health",)
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        health = getattr(request.app.state, 'health', {})
+        if not health.get('db_ok', True):
+            path = request.url.path
+            if any(path.startswith(p) for p in self.PASSTHROUGH_PREFIXES):
+                return await call_next(request)
+            accept = request.headers.get('accept', '')
+            if 'text/html' in accept:
+                return HTMLResponse(MAINTENANCE_HTML, status_code=503)
+            return JSONResponse(
+                {"error": "maintenance", "detail": health.get("db_error")},
+                status_code=503,
+            )
+        return await call_next(request)
+
 
 class ErrorHandlingMiddleware(BaseHTTPMiddleware):
     """Middleware for handling errors."""

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -910,10 +910,13 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if hasattr(db_obj, 'authoritative_defs') and db_obj.authoritative_defs:
             auth_defs = []
             for auth_def in db_obj.authoritative_defs:
-                auth_defs.append({
+                ad_item: Dict[str, Any] = {
                     'url': auth_def.url,
                     'type': auth_def.type
-                })
+                }
+                if getattr(auth_def, 'stable_id', None):
+                    ad_item['id'] = auth_def.stable_id
+                auth_defs.append(ad_item)
             description['authoritativeDefinitions'] = auth_defs
         else:
             # For ODCS compliance testing, add sample authoritativeDefinitions under description
@@ -935,6 +938,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     'name': schema_obj.name,
                     'properties': []
                 }
+                if getattr(schema_obj, 'stable_id', None):
+                    schema_dict['id'] = schema_obj.stable_id
                 if schema_obj.physical_name:
                     schema_dict['physicalName'] = schema_obj.physical_name
                 if schema_obj.data_granularity_description:
@@ -957,6 +962,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                         prop_dict = {
                             'name': prop.name,
                         }
+                        if getattr(prop, 'stable_id', None):
+                            prop_dict['id'] = prop.stable_id
                         if prop.logical_type:
                             prop_dict['logicalType'] = prop.logical_type
                         if prop.physical_type:
@@ -1061,10 +1068,13 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                         if hasattr(prop, 'authoritative_definitions') and prop.authoritative_definitions:
                             auth_defs = []
                             for auth_def in prop.authoritative_definitions:
-                                auth_defs.append({
+                                ad_item: Dict[str, Any] = {
                                     'url': auth_def.url,
                                     'type': auth_def.type
-                                })
+                                }
+                                if getattr(auth_def, 'stable_id', None):
+                                    ad_item['id'] = auth_def.stable_id
+                                auth_defs.append(ad_item)
                             prop_dict['authoritativeDefinitions'] = auth_defs
                         elif prop.name == 'rcvr_cntry_code':
                             # Add sample authoritative definitions for ODCS compliance testing
@@ -1119,10 +1129,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                             if property_quality_checks:
                                 quality = []
                                 for check in property_quality_checks:
-                                    quality_dict = {
+                                    quality_dict: Dict[str, Any] = {
                                         'rule': check.rule or check.name,
                                         'type': check.type,
                                     }
+                                    if getattr(check, 'stable_id', None):
+                                        quality_dict['id'] = check.stable_id
                                     if check.description:
                                         quality_dict['description'] = check.description
                                     if check.dimension:
@@ -1188,6 +1200,23 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                                 }
                             ]
 
+                        # Property-level relationships (ODCS v3.1.0)
+                        if hasattr(prop, 'relationships') and prop.relationships:
+                            prop_rels = []
+                            for rel in prop.relationships:
+                                rel_dict = {'type': rel.relationship_type}
+                                try:
+                                    rel_dict['to'] = json.loads(rel.to_value)
+                                except (json.JSONDecodeError, TypeError):
+                                    rel_dict['to'] = rel.to_value
+                                if rel.custom_properties_json:
+                                    try:
+                                        rel_dict['customProperties'] = json.loads(rel.custom_properties_json)
+                                    except (json.JSONDecodeError, TypeError):
+                                        pass
+                                prop_rels.append(rel_dict)
+                            prop_dict['relationships'] = prop_rels
+
                         schema_dict['properties'].append(prop_dict)
 
                 # Add schema-level quality rules (ODCS compliant structure)
@@ -1198,10 +1227,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                         # Property-level checks have property_id set and are exported with their properties
                         if check.property_id is not None:
                             continue
-                        quality_dict = {
+                        quality_dict: Dict[str, Any] = {
                             'rule': check.rule or check.name,
                             'type': check.type,
                         }
+                        if getattr(check, 'stable_id', None):
+                            quality_dict['id'] = check.stable_id
                         if check.description:
                             quality_dict['description'] = check.description
                         if check.dimension:
@@ -1242,10 +1273,13 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 if hasattr(schema_obj, 'authoritative_definitions') and schema_obj.authoritative_definitions:
                     auth_defs = []
                     for auth_def in schema_obj.authoritative_definitions:
-                        auth_defs.append({
+                        ad_item: Dict[str, Any] = {
                             'url': auth_def.url,
                             'type': auth_def.type
-                        })
+                        }
+                        if getattr(auth_def, 'stable_id', None):
+                            ad_item['id'] = auth_def.stable_id
+                        auth_defs.append(ad_item)
                     schema_dict['authoritativeDefinitions'] = auth_defs
 
                 # Add schema-level custom properties
@@ -1254,29 +1288,54 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     for custom_prop in schema_obj.custom_properties:
                         prop_value = custom_prop.value
                         try:
-                            # Try to parse JSON if it's a serialized object
-                            import json
                             prop_value = json.loads(custom_prop.value)
                         except (json.JSONDecodeError, TypeError):
-                            pass  # Keep as string
-
-                        custom_props.append({
+                            pass
+                        cp_item: Dict[str, Any] = {
                             'property': custom_prop.property,
                             'value': prop_value
-                        })
+                        }
+                        if getattr(custom_prop, 'stable_id', None):
+                            cp_item['id'] = custom_prop.stable_id
+                        custom_props.append(cp_item)
                     schema_dict['customProperties'] = custom_props
+
+                # Schema-level relationships (ODCS v3.1.0)
+                if hasattr(schema_obj, 'relationships') and schema_obj.relationships:
+                    rels = []
+                    for rel in schema_obj.relationships:
+                        rel_dict = {'type': rel.relationship_type}
+                        try:
+                            rel_dict['from'] = json.loads(rel.from_value)
+                        except (json.JSONDecodeError, TypeError):
+                            rel_dict['from'] = rel.from_value
+                        try:
+                            rel_dict['to'] = json.loads(rel.to_value)
+                        except (json.JSONDecodeError, TypeError):
+                            rel_dict['to'] = rel.to_value
+                        if rel.custom_properties_json:
+                            try:
+                                rel_dict['customProperties'] = json.loads(rel.custom_properties_json)
+                            except (json.JSONDecodeError, TypeError):
+                                pass
+                        rels.append(rel_dict)
+                    schema_dict['relationships'] = rels
 
                 schema.append(schema_dict)
             odcs['schema'] = schema
             
-        # Build team array from relationships
+        # Build team (version-aware: Team object for v3.1.0+, plain array for v3.0.x)
         if hasattr(db_obj, 'team') and db_obj.team:
-            team = []
+            members_list = []
             for member in db_obj.team:
                 member_dict = {
                     'role': member.role,
                     'username': member.username,
                 }
+                if getattr(member, 'stable_id', None):
+                    member_dict['id'] = member.stable_id
+                if getattr(member, 'name', None):
+                    member_dict['name'] = member.name
                 if member.date_in:
                     member_dict['dateIn'] = member.date_in
                 if member.date_out:
@@ -1285,8 +1344,37 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     member_dict['replacedByUsername'] = member.replaced_by_username
                 if getattr(member, 'description', None):
                     member_dict['description'] = member.description
-                team.append(member_dict)
-            odcs['team'] = team
+                members_list.append(member_dict)
+
+            api_version = db_obj.api_version or 'v3.1.0'
+            tm = getattr(db_obj, 'team_metadata', None)
+            if api_version >= 'v3.1.0' and tm:
+                team_obj: Dict[str, Any] = {}
+                if tm.stable_id:
+                    team_obj['id'] = tm.stable_id
+                if tm.name:
+                    team_obj['name'] = tm.name
+                if tm.description:
+                    team_obj['description'] = tm.description
+                team_obj['members'] = members_list
+                if tm.tags_json:
+                    try:
+                        team_obj['tags'] = json.loads(tm.tags_json)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                if tm.custom_properties_json:
+                    try:
+                        team_obj['customProperties'] = json.loads(tm.custom_properties_json)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                if tm.authoritative_definitions_json:
+                    try:
+                        team_obj['authoritativeDefinitions'] = json.loads(tm.authoritative_definitions_json)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                odcs['team'] = team_obj
+            else:
+                odcs['team'] = members_list
             
         # Legacy: Top-level quality rules are deprecated in favor of schema-nested quality rules
         # ODCS specifies quality rules should be nested under schema objects (implemented above)
@@ -1305,6 +1393,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     'channel': channel.channel,
                     'url': channel.url
                 }
+                if getattr(channel, 'stable_id', None):
+                    support_item['id'] = channel.stable_id
                 if channel.description:
                     support_item['description'] = channel.description
                 if channel.tool:
@@ -1323,6 +1413,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 sla_item = {
                     'property': prop.property,
                 }
+                if getattr(prop, 'stable_id', None):
+                    sla_item['id'] = prop.stable_id
                 # Add value, trying to preserve types
                 if prop.value:
                     try:
@@ -1379,26 +1471,30 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 prop_value: Any = prop.value
                 if isinstance(prop_value, str):
                     try:
-                        import json
                         parsed = json.loads(prop_value)
                         prop_value = parsed
                     except (json.JSONDecodeError, TypeError):
-                        # Keep original string
                         pass
-                custom_props_list.append({
+                cp_item: Dict[str, Any] = {
                     'property': prop.property,
                     'value': prop_value
-                })
+                }
+                if getattr(prop, 'stable_id', None):
+                    cp_item['id'] = prop.stable_id
+                custom_props_list.append(cp_item)
             odcs['customProperties'] = custom_props_list
 
         # Build authoritative definitions
         if hasattr(db_obj, 'authoritative_defs') and db_obj.authoritative_defs:
             auth_defs = []
             for auth_def in db_obj.authoritative_defs:
-                auth_defs.append({
+                ad_item: Dict[str, Any] = {
                     'url': auth_def.url,
                     'type': auth_def.type
-                })
+                }
+                if getattr(auth_def, 'stable_id', None):
+                    ad_item['id'] = auth_def.stable_id
+                auth_defs.append(ad_item)
             odcs['authoritativeDefinitions'] = auth_defs
 
         # Legacy support for tags and roles
@@ -1408,9 +1504,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if hasattr(db_obj, 'roles') and db_obj.roles:
             roles = []
             for r in db_obj.roles:
-                role_dict = {
+                role_dict: Dict[str, Any] = {
                     'role': r.role,
                 }
+                if getattr(r, 'stable_id', None):
+                    role_dict['id'] = r.stable_id
                 if r.description:
                     role_dict['description'] = r.description
                 if r.access:
@@ -1434,10 +1532,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if hasattr(db_obj, 'servers') and db_obj.servers:
             servers = []
             for server in db_obj.servers:
-                server_dict = {
+                server_dict: Dict[str, Any] = {
                     'server': server.server,
                     'type': server.type,
                 }
+                if getattr(server, 'stable_id', None):
+                    server_dict['id'] = server.stable_id
 
                 # Add optional server fields
                 if server.description:
@@ -1602,6 +1702,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         """
         all_schema_objs = []
         all_properties = []
+        all_obj_relationships = []
+        all_prop_relationships = []
         # Collect semantic link work to process after bulk insert
         schema_semantic_work = []
         prop_semantic_work = []
@@ -1616,6 +1718,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             schema_obj = SchemaObjectDb(
                 id=schema_obj_id,
                 contract_id=contract_id,
+                stable_id=schema_dict.get('id'),
                 name=schema_dict.get('name', 'table'),
                 physical_name=schema_dict.get('physicalName') or schema_dict.get('physical_name'),
                 logical_type='object',
@@ -1662,9 +1765,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 if prop_dict.get('transformSourceObjects'):
                     transform_source_objects_json = json.dumps(prop_dict['transformSourceObjects']) if isinstance(prop_dict['transformSourceObjects'], list) else str(prop_dict['transformSourceObjects'])
 
+                prop_id = str(uuid4())
                 prop = SchemaPropertyDb(
-                    id=str(uuid4()),
+                    id=prop_id,
                     object_id=schema_obj_id,
+                    stable_id=prop_dict.get('id'),
                     name=prop_dict.get('name', 'column'),
                     logical_type=prop_dict.get('logicalType') or prop_dict.get('logical_type', 'string'),
                     physical_type=prop_dict.get('physicalType') or prop_dict.get('physical_type'),
@@ -1686,13 +1791,45 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 )
                 all_properties.append(prop)
 
+                # Collect property-level relationships (ODCS v3.1.0)
+                for rel_data in (prop_dict.get('relationships') or []):
+                    if isinstance(rel_data, dict):
+                        from src.db_models.data_contracts import SchemaPropertyRelationshipDb
+                        to_val = rel_data.get('to', '')
+                        all_prop_relationships.append(SchemaPropertyRelationshipDb(
+                            id=str(uuid4()),
+                            property_id=prop_id,
+                            relationship_type=rel_data.get('type', 'foreignKey'),
+                            to_value=json.dumps(to_val) if isinstance(to_val, list) else str(to_val),
+                            custom_properties_json=json.dumps(rel_data['customProperties']) if rel_data.get('customProperties') else None,
+                        ))
+
                 prop_auth_defs = prop_dict.get('authoritativeDefinitions', [])
                 if prop_auth_defs and current_user:
                     prop_semantic_work.append((contract_id, schema_dict.get('name', 'table'), prop_dict.get('name', 'column'), prop_auth_defs))
 
-        # Bulk add all schema objects and properties in one flush
+            # Collect schema-level relationships (ODCS v3.1.0)
+            for rel_data in (schema_dict.get('relationships') or []):
+                if isinstance(rel_data, dict):
+                    from src.db_models.data_contracts import SchemaObjectRelationshipDb
+                    from_val = rel_data.get('from', '')
+                    to_val = rel_data.get('to', '')
+                    all_obj_relationships.append(SchemaObjectRelationshipDb(
+                        id=str(uuid4()),
+                        schema_object_id=schema_obj_id,
+                        relationship_type=rel_data.get('type', 'foreignKey'),
+                        from_value=json.dumps(from_val) if isinstance(from_val, list) else str(from_val),
+                        to_value=json.dumps(to_val) if isinstance(to_val, list) else str(to_val),
+                        custom_properties_json=json.dumps(rel_data['customProperties']) if rel_data.get('customProperties') else None,
+                    ))
+
+        # Bulk add all schema objects, properties, and relationships in one flush
         db.add_all(all_schema_objs)
         db.add_all(all_properties)
+        if all_obj_relationships:
+            db.add_all(all_obj_relationships)
+        if all_prop_relationships:
+            db.add_all(all_prop_relationships)
         db.flush()
 
         # Process semantic links after bulk insert
@@ -1742,6 +1879,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             
             quality_check = DataQualityCheckDb(
                 object_id=schema_obj.id,
+                stable_id=rule_dict.get('id'),
                 level=rule_dict.get('level', 'object'),
                 name=rule_dict.get('name'),
                 description=rule_dict.get('description'),
@@ -1809,6 +1947,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 continue
             member_db = DataContractTeamDb(
                 contract_id=contract_id,
+                stable_id=member_data.get('id'),
+                name=member_data.get('name'),
                 username=member_data.get('username'),
                 role=member_data.get('role'),
                 description=member_data.get('description'),
@@ -1833,6 +1973,22 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             return team_raw
         return []
 
+    def _create_team_metadata(self, db, contract_id: str, team_raw):
+        """Persist ODCS v3.1.0 Team object metadata (name, description, tags, customProperties, authoritativeDefinitions)."""
+        if not isinstance(team_raw, dict):
+            return
+        from src.db_models.data_contracts import DataContractTeamMetadataDb
+        metadata = DataContractTeamMetadataDb(
+            contract_id=contract_id,
+            stable_id=team_raw.get('id'),
+            name=team_raw.get('name'),
+            description=team_raw.get('description'),
+            tags_json=json.dumps(team_raw['tags']) if team_raw.get('tags') else None,
+            custom_properties_json=json.dumps(team_raw['customProperties']) if team_raw.get('customProperties') else None,
+            authoritative_definitions_json=json.dumps(team_raw['authoritativeDefinitions']) if team_raw.get('authoritativeDefinitions') else None,
+        )
+        db.add(metadata)
+
     def _create_support_channels(self, db, contract_id: str, support_data: List[dict]):
         """Create support channels from ODCS support array."""
         from src.db_models.data_contracts import DataContractSupportDb
@@ -1842,6 +1998,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 continue
             channel_db = DataContractSupportDb(
                 contract_id=contract_id,
+                stable_id=support_item.get('id'),
                 channel=support_item.get('channel', ''),
                 url=support_item.get('url', ''),
                 description=support_item.get('description'),
@@ -1884,6 +2041,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                         value_str = str(prop_value)
                     custom_prop_db = DataContractCustomPropertyDb(
                         contract_id=contract_id,
+                        stable_id=prop_data.get('id'),
                         property=prop_name,
                         value=value_str
                     )
@@ -1913,6 +2071,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 continue
             sla_prop = DataContractSlaPropertyDb(
                 contract_id=contract_id,
+                stable_id=sla_prop_data.get('id'),
                 property=sla_prop_data.get('property'),
                 value=str(sla_prop_data.get('value')) if sla_prop_data.get('value') is not None else None,
                 value_ext=json.dumps(sla_prop_data.get('valueExt')) if sla_prop_data.get('valueExt') else None,
@@ -1930,6 +2089,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             if isinstance(auth_def, dict) and auth_def.get('url') and auth_def.get('type'):
                 auth_def_db = DataContractAuthoritativeDefinitionDb(
                     contract_id=contract_id,
+                    stable_id=auth_def.get('id'),
                     url=auth_def['url'],
                     type=auth_def['type']
                 )
@@ -1945,6 +2105,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             
             server_db = DataContractServerDb(
                 contract_id=contract_id,
+                stable_id=server_data.get('id'),
                 server=server_data.get('server'),
                 type=server_data.get('type', ''),
                 description=server_data.get('description'),
@@ -1992,6 +2153,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 continue
             role_db = DataContractRoleDb(
                 contract_id=contract_id,
+                stable_id=role_data.get('id'),
                 role=role_data.get('role'),
                 description=role_data.get('description'),
                 access=role_data.get('access'),
@@ -2030,6 +2192,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             
             quality_rule_db = DataQualityCheckDb(
                 object_id=first_schema_obj.id,
+                stable_id=rule_data.get('id'),
                 name=rule_data.get('name'),
                 description=rule_data.get('description'),
                 level=rule_data.get('level', 'contract'),
@@ -2160,9 +2323,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 self._process_semantic_links(db, created.id, data_dict, current_user)
 
             # Create team members if provided (v3.1.0: team can be object with members or deprecated array)
-            team_data = self._normalize_team_data(data_dict.get('team'))
+            team_raw = data_dict.get('team')
+            team_data = self._normalize_team_data(team_raw)
             if team_data:
                 self._create_team_members(db, created.id, team_data)
+            self._create_team_metadata(db, created.id, team_raw)
 
             db.commit()
             db.refresh(created)
@@ -2376,16 +2541,21 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             
             # Handle team members if provided (v3.1.0: team can be object with members or deprecated array)
             if data_dict.get('team') is not None:
-                from src.db_models.data_contracts import DataContractTeamDb
-                # Remove existing team members
+                from src.db_models.data_contracts import DataContractTeamDb, DataContractTeamMetadataDb
+                # Remove existing team members and metadata
                 db.query(DataContractTeamDb).filter(
                     DataContractTeamDb.contract_id == contract_id
                 ).delete()
+                db.query(DataContractTeamMetadataDb).filter(
+                    DataContractTeamMetadataDb.contract_id == contract_id
+                ).delete()
                 
-                # Add new team members
-                team_data = self._normalize_team_data(data_dict['team'])
+                # Add new team members and metadata
+                team_raw = data_dict['team']
+                team_data = self._normalize_team_data(team_raw)
                 if team_data:
                     self._create_team_members(db, contract_id, team_data)
+                self._create_team_metadata(db, contract_id, team_raw)
             
             # Handle tags if provided and tags_manager is available
             if tags_data is not None and self._tags_manager:
@@ -2721,10 +2891,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             if isinstance(schema_data, list) and schema_data:
                 self._create_schema_objects(db, created.id, schema_data, current_user)
             
-            # Create team members if present (v3.1.0: team can be object with members or deprecated array)
-            team_data = self._normalize_team_data(parsed_odcs.get('team'))
+            # Create team members and metadata if present (v3.1.0: team can be object or deprecated array)
+            team_raw = parsed_odcs.get('team')
+            team_data = self._normalize_team_data(team_raw)
             if team_data:
                 self._create_team_members(db, created.id, team_data)
+            self._create_team_metadata(db, created.id, team_raw)
             
             # Create support channels if present
             support_data = parsed_odcs.get('support', [])

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -36,6 +36,11 @@ from src.repositories.semantic_models_repository import semantic_models_repo
 from src.repositories.rdf_triples_repository import rdf_triples_repo
 from src.common.logging import get_logger
 from src.common.sparql_validator import SPARQLQueryValidator
+from src.utils.semantic_model_title_candidates import (
+    best_display_title_from_graph,
+    extract_title_candidates,
+)
+from src.utils.rdf_serialization_display import serialization_label_for_stored_model
 
 
 logger = get_logger(__name__)
@@ -124,6 +129,16 @@ class SemanticModelsManager:
         except Exception as e:
             logger.error(f"Failed to rebuild graph during initialization: {e}")
 
+    def bundled_taxonomy_file_size_bytes(self, taxonomy_name: str) -> Optional[int]:
+        """Byte size of shipped ``taxonomies/{name}.ttl`` when that file exists."""
+        path = self._data_dir / "taxonomies" / f"{taxonomy_name}.ttl"
+        try:
+            if path.is_file():
+                return path.stat().st_size
+        except OSError:
+            logger.debug("Could not stat bundled taxonomy file", exc_info=True)
+        return None
+
     def list(self) -> List[SemanticModelApi]:
         items = semantic_models_repo.get_multi(self._db)
         return [self._to_api(m) for m in items]
@@ -194,7 +209,20 @@ class SemanticModelsManager:
         db_obj = semantic_models_repo.get(self._db, id=model_id)
         if not db_obj:
             return None
-        updated = semantic_models_repo.update(self._db, db_obj=db_obj, obj_in=update)
+        patch = update.model_dump(exclude_unset=True) if hasattr(update, "model_dump") else update.dict(exclude_unset=True)
+        if patch.get("name") is not None and patch["name"] != db_obj.name:
+            raise ValueError(
+                "Renaming semantic models (name) is not allowed because it would break the RDF graph context. "
+                "Use display_name for a custom title."
+            )
+        patch.pop("name", None)
+        if "display_name" in patch:
+            raw = patch["display_name"]
+            patch["display_name"] = None if raw is None or str(raw).strip() == "" else str(raw).strip()
+        if not patch:
+            return self._to_api(db_obj)
+        update_for_repo = SemanticModelUpdate(**patch)
+        updated = semantic_models_repo.update(self._db, db_obj=db_obj, obj_in=update_for_repo)
         if updated_by:
             updated.updated_by = updated_by
             self._db.add(updated)
@@ -202,6 +230,13 @@ class SemanticModelsManager:
         self._db.refresh(updated)
         self._db.commit()  # Persist changes immediately since manager uses singleton session
         return self._to_api(updated)
+
+    def get_title_candidates(self, model_id: str) -> Optional[List[dict]]:
+        """Return suggested titles from ontology header resources, or None if model not found."""
+        db_obj = semantic_models_repo.get(self._db, id=model_id)
+        if not db_obj:
+            return None
+        return extract_title_candidates(db_obj.content_text or "", db_obj.format)
 
     def replace_content(self, model_id: str, content_text: str, original_filename: Optional[str], content_type: Optional[str], size_bytes: Optional[int], updated_by: Optional[str]) -> Optional[SemanticModelApi]:
         db_obj = semantic_models_repo.get(self._db, id=model_id)
@@ -353,7 +388,13 @@ class SemanticModelsManager:
         return SemanticModelApi(
             id=db_obj.id,
             name=db_obj.name,
+            display_name=db_obj.display_name,
             format=db_obj.format,  # type: ignore
+            serialization=serialization_label_for_stored_model(
+                original_filename=db_obj.original_filename,
+                name=db_obj.name or "",
+                legacy_format=db_obj.format or "",
+            ),
             original_filename=db_obj.original_filename,
             content_type=db_obj.content_type,
             size_bytes=int(db_obj.size_bytes) if db_obj.size_bytes is not None and str(db_obj.size_bytes).isdigit() else None,
@@ -1064,8 +1105,20 @@ class SemanticModelsManager:
                 name = context_str
                 format_str = None
 
+            # Human title from owl:Ontology / skos:ConceptScheme in this named graph (bundled TTLs, etc.)
+            skip_title_contexts = frozenset(
+                ("urn:x-rdflib:default", "", "urn:meta:sources", "urn:semantic-links")
+            )
+            display_name: Optional[str] = None
+            if context_str not in skip_title_contexts:
+                try:
+                    display_name = best_display_title_from_graph(context)
+                except Exception as e:
+                    logger.debug("Could not derive display title for context %s: %s", context_str, e)
+
             taxonomies.append(SemanticModelOntology(
                 name=name,
+                display_name=display_name,
                 description=f"{source_type.title()} taxonomy: {name}",
                 source_type=source_type,
                 format=format_str,

--- a/src/backend/src/data/ontos-business-rules-shacl.ttl
+++ b/src/backend/src/data/ontos-business-rules-shacl.ttl
@@ -24,7 +24,7 @@
 # =============================================================================
 
 rules: a owl:Ontology ;
-    rdfs:label "Ontos Business Rules (SHACL)" ;
+    rdfs:label "Ontos Business Rules (SHACL)"@en ;
     rdfs:comment "SHACL shapes expressing business rules: number ranges, string patterns, and cardinality for governance and validation." ;
     owl:versionInfo "1.0.0" ;
     dc:created "2025-02-12" ;

--- a/src/backend/src/data/taxonomies/databricks_ontology.ttl
+++ b/src/backend/src/data/taxonomies/databricks_ontology.ttl
@@ -6,7 +6,11 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @base <http://www.databricks.com/ontology/> .
 
-<http://www.databricks.com/ontology> rdf:type owl:Ontology .
+# Ontology document header (rdfs:label used for display title / title-candidate extraction)
+<http://www.databricks.com/ontology> a owl:Ontology ;
+    rdfs:label "Databricks Unity Catalog Ontology"@en ;
+    rdfs:comment "Vocabulary for Unity Catalog assets, workspaces, lineage, and related platform entities; used for governance and semantic linking in Ontos."@en ;
+    owl:versionInfo "1.0" .
 
 #################################################################
 #    Object Properties

--- a/src/backend/src/data/taxonomies/odcs-ontology.ttl
+++ b/src/backend/src/data/taxonomies/odcs-ontology.ttl
@@ -15,7 +15,7 @@
 
 # Ontology Header
 odcs: a owl:Ontology ;
-    rdfs:label "Open Data Contract Standard Ontology" ;
+    rdfs:label "Open Data Contract Standard Ontology"@en ;
     rdfs:comment "Vocabulary for Open Data Contract Standard v3.1.0 entities" ;
     owl:versionInfo "3.0.2" ;
     dc:created "2024-09-22" ;

--- a/src/backend/src/db_models/data_contracts.py
+++ b/src/backend/src/db_models/data_contracts.py
@@ -81,6 +81,7 @@ class DataContractDb(Base):
     authoritative_defs = relationship("DataContractAuthoritativeDefinitionDb", back_populates="contract", cascade="all, delete-orphan", lazy="selectin")
     custom_properties = relationship("DataContractCustomPropertyDb", back_populates="contract", cascade="all, delete-orphan", lazy="selectin")
     sla_properties = relationship("DataContractSlaPropertyDb", back_populates="contract", cascade="all, delete-orphan", lazy="selectin")
+    team_metadata = relationship("DataContractTeamMetadataDb", back_populates="contract", uselist=False, cascade="all, delete-orphan", lazy="selectin")
     # Heavy relationships: lazy="select" to prevent auto-loading on list queries
     owner_team = relationship("TeamDb", foreign_keys=[owner_team_id], lazy="select")
     parent_contract = relationship("DataContractDb", remote_side=[id], foreign_keys=[parent_contract_id], lazy="select")
@@ -105,6 +106,7 @@ class DataContractServerDb(Base):
     __tablename__ = "data_contract_servers"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     server = Column(String, nullable=True)  # identifier
     type = Column(String, nullable=False)
     description = Column(Text, nullable=True)
@@ -128,6 +130,7 @@ class DataContractRoleDb(Base):
     __tablename__ = "data_contract_roles"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     role = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     access = Column(String, nullable=True)
@@ -152,6 +155,8 @@ class DataContractTeamDb(Base):
     __tablename__ = "data_contract_team"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
+    name = Column(String, nullable=True)  # ODCS TeamMember name field
     username = Column(String, nullable=False)
     role = Column(String, nullable=True)
     description = Column(Text, nullable=True)
@@ -166,6 +171,7 @@ class DataContractSupportDb(Base):
     __tablename__ = "data_contract_support"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     channel = Column(String, nullable=False)
     url = Column(String, nullable=False)
     description = Column(Text, nullable=True)
@@ -191,6 +197,7 @@ class DataContractAuthoritativeDefinitionDb(Base):
     __tablename__ = "data_contract_authoritative_definitions"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     url = Column(String, nullable=False)
     type = Column(String, nullable=False)
     contract = relationship("DataContractDb", back_populates="authoritative_defs")
@@ -201,6 +208,7 @@ class DataContractCustomPropertyDb(Base):
     __tablename__ = "data_contract_custom_properties"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     property = Column(String, nullable=False)
     value = Column(Text, nullable=True)
     contract = relationship("DataContractDb", back_populates="custom_properties")
@@ -211,6 +219,7 @@ class DataContractSlaPropertyDb(Base):
     __tablename__ = "data_contract_sla_properties"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     property = Column(String, nullable=False)
     value = Column(String, nullable=True)
     value_ext = Column(String, nullable=True)
@@ -225,6 +234,7 @@ class SchemaObjectDb(Base):
     __tablename__ = "data_contract_schema_objects"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     name = Column(String, nullable=False)
     logical_type = Column(String, nullable=False, default="object")
     physical_name = Column(String, nullable=True)
@@ -241,6 +251,7 @@ class SchemaObjectDb(Base):
     quality_checks = relationship("DataQualityCheckDb", back_populates="schema_object", cascade="all, delete-orphan")
     authoritative_definitions = relationship("SchemaObjectAuthoritativeDefinitionDb", back_populates="schema_object", cascade="all, delete-orphan")
     custom_properties = relationship("SchemaObjectCustomPropertyDb", back_populates="schema_object", cascade="all, delete-orphan")
+    relationships = relationship("SchemaObjectRelationshipDb", back_populates="schema_object", cascade="all, delete-orphan")
 
 
 class SchemaPropertyDb(Base):
@@ -248,6 +259,7 @@ class SchemaPropertyDb(Base):
     __tablename__ = "data_contract_schema_properties"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     object_id = Column(String, ForeignKey("data_contract_schema_objects.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     parent_property_id = Column(String, ForeignKey("data_contract_schema_properties.id", ondelete="CASCADE"), nullable=True, index=True)
     name = Column(String, nullable=False)
     logical_type = Column(String, nullable=True)
@@ -271,6 +283,7 @@ class SchemaPropertyDb(Base):
     schema_object = relationship("SchemaObjectDb", back_populates="properties")
     parent_property = relationship("SchemaPropertyDb", remote_side=[id])
     authoritative_definitions = relationship("SchemaPropertyAuthoritativeDefinitionDb", back_populates="property", cascade="all, delete-orphan")
+    relationships = relationship("SchemaPropertyRelationshipDb", back_populates="property", cascade="all, delete-orphan")
 
 
 class DataQualityCheckDb(Base):
@@ -281,6 +294,7 @@ class DataQualityCheckDb(Base):
     __tablename__ = "data_contract_quality_checks"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     object_id = Column(String, ForeignKey("data_contract_schema_objects.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     property_id = Column(String, ForeignKey("data_contract_schema_properties.id", ondelete="CASCADE"), nullable=True, index=True)
     level = Column(String, nullable=True)  # optional, e.g., object/property
     name = Column(String, nullable=True)
@@ -405,6 +419,7 @@ class SchemaObjectAuthoritativeDefinitionDb(Base):
     __tablename__ = "data_contract_schema_object_authoritative_definitions"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     schema_object_id = Column(String, ForeignKey("data_contract_schema_objects.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     url = Column(String, nullable=False)
     type = Column(String, nullable=False)
     schema_object = relationship("SchemaObjectDb", back_populates="authoritative_definitions")
@@ -415,6 +430,7 @@ class SchemaObjectCustomPropertyDb(Base):
     __tablename__ = "data_contract_schema_object_custom_properties"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     schema_object_id = Column(String, ForeignKey("data_contract_schema_objects.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     property = Column(String, nullable=False)
     value = Column(Text, nullable=True)
     schema_object = relationship("SchemaObjectDb", back_populates="custom_properties")
@@ -425,8 +441,46 @@ class SchemaPropertyAuthoritativeDefinitionDb(Base):
     __tablename__ = "data_contract_schema_property_authoritative_definitions"
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     property_id = Column(String, ForeignKey("data_contract_schema_properties.id", ondelete="CASCADE"), nullable=False, index=True)
+    stable_id = Column(String, nullable=True)  # ODCS v3.1.0 StableId
     url = Column(String, nullable=False)
     type = Column(String, nullable=False)
     property = relationship("SchemaPropertyDb", back_populates="authoritative_definitions")
+
+
+class SchemaObjectRelationshipDb(Base):
+    """ODCS v3.1.0 schema-level relationship (foreign key) on a schema object."""
+    __tablename__ = "data_contract_schema_object_relationships"
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    schema_object_id = Column(String, ForeignKey("data_contract_schema_objects.id", ondelete="CASCADE"), nullable=False, index=True)
+    relationship_type = Column(String, nullable=False, default="foreignKey")
+    from_value = Column(Text, nullable=False)  # JSON-serialized: string or array
+    to_value = Column(Text, nullable=False)    # JSON-serialized: string or array
+    custom_properties_json = Column(Text, nullable=True)  # JSON array of {property, value}
+    schema_object = relationship("SchemaObjectDb", back_populates="relationships")
+
+
+class SchemaPropertyRelationshipDb(Base):
+    """ODCS v3.1.0 property-level relationship (foreign key) on a schema property."""
+    __tablename__ = "data_contract_schema_property_relationships"
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    property_id = Column(String, ForeignKey("data_contract_schema_properties.id", ondelete="CASCADE"), nullable=False, index=True)
+    relationship_type = Column(String, nullable=False, default="foreignKey")
+    to_value = Column(Text, nullable=False)  # JSON-serialized: string or array
+    custom_properties_json = Column(Text, nullable=True)
+    property = relationship("SchemaPropertyDb", back_populates="relationships")
+
+
+class DataContractTeamMetadataDb(Base):
+    """ODCS v3.1.0 Team object metadata (name, description, tags, customProperties, authoritativeDefinitions)."""
+    __tablename__ = "data_contract_team_metadata"
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    contract_id = Column(String, ForeignKey("data_contracts.id", ondelete="CASCADE"), nullable=False, unique=True, index=True)
+    stable_id = Column(String, nullable=True)
+    name = Column(String, nullable=True)
+    description = Column(Text, nullable=True)
+    tags_json = Column(Text, nullable=True)  # JSON array
+    custom_properties_json = Column(Text, nullable=True)  # JSON array of {property, value}
+    authoritative_definitions_json = Column(Text, nullable=True)  # JSON array of {url, type}
+    contract = relationship("DataContractDb", back_populates="team_metadata")
 
 

--- a/src/backend/src/db_models/semantic_models.py
+++ b/src/backend/src/db_models/semantic_models.py
@@ -11,6 +11,7 @@ class SemanticModelDb(Base):
 
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     name = Column(String, nullable=False, index=True)
+    display_name = Column(String, nullable=True)
     format = Column(String, nullable=False, index=True)  # 'rdfs' | 'skos'
     original_filename = Column(String, nullable=True)
     content_type = Column(String, nullable=True)

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -9,10 +9,25 @@ if TYPE_CHECKING:
     pass  # Used to avoid circular imports if needed
 
 
+# ODCS v3.1.0 relationship model (schema-level and property-level)
+class SchemaRelationship(BaseModel):
+    """ODCS v3.1.0 relationship (foreign key) at schema or property level."""
+    id: Optional[str] = None  # internal DB id (populated on read)
+    type: str = "foreignKey"
+    # from is a reserved word in Python; use Field alias
+    from_value: Optional[Union[str, List[str]]] = Field(None, alias='from')
+    to: Union[str, List[str]] = ""
+    customProperties: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        populate_by_name = True
+
+
 # ODCS-compliant schema models
 class ColumnProperty(BaseModel):
     name: str
     logicalType: str = Field(alias='logical_type')
+    stableId: Optional[str] = None  # ODCS v3.1.0 StableId
     required: Optional[bool] = False
     unique: Optional[bool] = False
     primaryKey: Optional[bool] = Field(False, alias='primary_key')
@@ -57,6 +72,9 @@ class ColumnProperty(BaseModel):
     transformSourceObjects: Optional[str] = None
     transformDescription: Optional[str] = None
 
+    # ODCS v3.1.0 relationships (property-level FKs)
+    relationships: Optional[List[SchemaRelationship]] = None
+
     class Config:
         # Accept both JSON keys: "logicalType" (field name) and "logical_type" (alias)
         populate_by_name = True
@@ -65,6 +83,7 @@ class ColumnProperty(BaseModel):
 
 class SchemaObject(BaseModel):
     name: str
+    stableId: Optional[str] = None  # ODCS v3.1.0 StableId
     physicalName: Optional[str] = None
     properties: List[ColumnProperty] = Field(default_factory=list)
     propertyCount: Optional[int] = Field(0, description="Total number of properties (columns) in this schema object")
@@ -78,6 +97,9 @@ class SchemaObject(BaseModel):
     authoritativeDefinitions: Optional[List['AuthoritativeDefinition']] = Field(default_factory=list)
     customProperties: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
     quality: Optional[List['QualityRule']] = Field(default_factory=list)  # ODCS quality rules are schema-nested
+
+    # ODCS v3.1.0 relationships (schema-level FKs)
+    relationships: Optional[List[SchemaRelationship]] = None
 
     class Config:
         populate_by_name = True
@@ -752,6 +774,69 @@ class DiffFromParentResponse(BaseModel):
     suggested_bump: str  # "major", "minor", "patch"
     suggested_version: str
     analysis: Dict[str, Any]  # Full analysis from ContractChangeAnalyzer
+
+
+# ===== ODCS v3.1.0 Team Metadata Models =====
+class TeamMetadataUpdate(BaseModel):
+    """Update team-level metadata (ODCS v3.1.0 Team object fields)."""
+    name: Optional[str] = None
+    description: Optional[str] = None
+    tags: Optional[List[str]] = None
+    customProperties: Optional[List[Dict[str, Any]]] = None
+    authoritativeDefinitions: Optional[List[Dict[str, Any]]] = None
+
+
+class TeamMetadataRead(BaseModel):
+    """Response model for team metadata."""
+    id: str
+    contract_id: str
+    stable_id: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    tags: Optional[List[str]] = None
+    customProperties: Optional[List[Dict[str, Any]]] = None
+    authoritativeDefinitions: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        from_attributes = True
+
+
+# ===== ODCS v3.1.0 Relationship CRUD Models =====
+class SchemaRelationshipCreate(BaseModel):
+    """Create a schema-level or property-level relationship."""
+    type: str = "foreignKey"
+    from_value: Optional[Union[str, List[str]]] = Field(None, alias='from')
+    to: Union[str, List[str]] = ""
+    customProperties: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        populate_by_name = True
+
+
+class SchemaRelationshipUpdate(BaseModel):
+    """Update a relationship."""
+    type: Optional[str] = None
+    from_value: Optional[Union[str, List[str]]] = Field(None, alias='from')
+    to: Optional[Union[str, List[str]]] = None
+    customProperties: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        populate_by_name = True
+
+
+class SchemaRelationshipRead(BaseModel):
+    """Response model for a relationship."""
+    id: str
+    type: str
+    from_value: Optional[Union[str, List[str]]] = Field(None, alias='from')
+    to: Union[str, List[str]] = ""
+    customProperties: Optional[List[Dict[str, Any]]] = None
+    schema_object_id: Optional[str] = None
+    property_id: Optional[str] = None
+
+    class Config:
+        populate_by_name = True
+        from_attributes = True
 
 
 # Rebuild models to resolve forward references

--- a/src/backend/src/models/ontology.py
+++ b/src/backend/src/models/ontology.py
@@ -173,6 +173,7 @@ class ConceptUpdate(BaseModel):
 class SemanticModel(BaseModel):
     """Represents a loaded semantic model (taxonomy/ontology source)"""
     name: str
+    display_name: Optional[str] = None
     description: Optional[str] = None
     source_type: str  # 'file' | 'database' | 'external' | 'schema'
     format: Optional[str] = None  # 'ttl' | 'rdf' | 'owl'

--- a/src/backend/src/models/semantic_models.py
+++ b/src/backend/src/models/semantic_models.py
@@ -9,7 +9,12 @@ SemanticFormat = Literal["rdfs", "skos"]
 class SemanticModel(BaseModel):
     id: str
     name: str
-    format: SemanticFormat
+    display_name: Optional[str] = None
+    format: SemanticFormat  # legacy parse branch in DB; use serialization for display
+    serialization: Optional[str] = Field(
+        default=None,
+        description="RDF serialization (Turtle, RDF/XML, …), not vocabulary.",
+    )
     original_filename: Optional[str] = None
     content_type: Optional[str] = None
     size_bytes: Optional[int] = None
@@ -22,6 +27,7 @@ class SemanticModel(BaseModel):
 
 class SemanticModelCreate(BaseModel):
     name: str
+    display_name: Optional[str] = None
     format: SemanticFormat
     content_text: str
     original_filename: Optional[str] = None
@@ -32,6 +38,7 @@ class SemanticModelCreate(BaseModel):
 
 class SemanticModelUpdate(BaseModel):
     name: Optional[str] = None
+    display_name: Optional[str] = None
     enabled: Optional[bool] = None
 
 

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -37,7 +37,10 @@ from src.db_models.data_contracts import (
     DataContractPricingDb,
     DataContractRolePropertyDb,
     DataProfilingRunDb,
-    SuggestedQualityCheckDb
+    SuggestedQualityCheckDb,
+    SchemaObjectRelationshipDb,
+    SchemaPropertyRelationshipDb,
+    DataContractTeamMetadataDb,
 )
 from src.models.data_contracts_api import (
     DataContractCreate,
@@ -3834,6 +3837,341 @@ async def get_my_personal_drafts(
     except Exception as e:
         logger.error("Error fetching personal drafts", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch personal drafts")
+
+
+# ===== ODCS v3.1.0: Schema-Level Relationship CRUD =====
+
+def _relationship_db_to_dict(rel) -> dict:
+    """Convert a relationship DB row to an API-friendly dict."""
+    to_val = rel.to_value
+    try:
+        to_val = json.loads(rel.to_value)
+    except (json.JSONDecodeError, TypeError):
+        pass
+    result = {
+        'id': rel.id,
+        'type': rel.relationship_type,
+        'to': to_val,
+    }
+    if hasattr(rel, 'from_value'):
+        from_val = rel.from_value
+        try:
+            from_val = json.loads(rel.from_value)
+        except (json.JSONDecodeError, TypeError):
+            pass
+        result['from'] = from_val
+    if hasattr(rel, 'schema_object_id'):
+        result['schema_object_id'] = rel.schema_object_id
+    if hasattr(rel, 'property_id'):
+        result['property_id'] = rel.property_id
+    if rel.custom_properties_json:
+        try:
+            result['customProperties'] = json.loads(rel.custom_properties_json)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return result
+
+
+@router.get('/data-contracts/{contract_id}/schemas/{schema_id}/relationships', response_model=List[dict])
+async def list_schema_relationships(
+    contract_id: str,
+    schema_id: str,
+    db: DBSessionDep,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_ONLY))
+):
+    schema_obj = db.query(SchemaObjectDb).filter(
+        SchemaObjectDb.id == schema_id,
+        SchemaObjectDb.contract_id == contract_id
+    ).first()
+    if not schema_obj:
+        raise HTTPException(404, "Schema object not found")
+    rels = db.query(SchemaObjectRelationshipDb).filter(
+        SchemaObjectRelationshipDb.schema_object_id == schema_id
+    ).all()
+    return [_relationship_db_to_dict(r) for r in rels]
+
+
+@router.post('/data-contracts/{contract_id}/schemas/{schema_id}/relationships', response_model=dict, status_code=201)
+async def create_schema_relationship(
+    contract_id: str,
+    schema_id: str,
+    body: dict = Body(...),
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE))
+):
+    schema_obj = db.query(SchemaObjectDb).filter(
+        SchemaObjectDb.id == schema_id,
+        SchemaObjectDb.contract_id == contract_id
+    ).first()
+    if not schema_obj:
+        raise HTTPException(404, "Schema object not found")
+
+    from_val = body.get('from', '')
+    to_val = body.get('to', '')
+    rel = SchemaObjectRelationshipDb(
+        id=str(uuid4()),
+        schema_object_id=schema_id,
+        relationship_type=body.get('type', 'foreignKey'),
+        from_value=json.dumps(from_val) if isinstance(from_val, list) else str(from_val),
+        to_value=json.dumps(to_val) if isinstance(to_val, list) else str(to_val),
+        custom_properties_json=json.dumps(body['customProperties']) if body.get('customProperties') else None,
+    )
+    db.add(rel)
+    db.commit()
+    db.refresh(rel)
+    return _relationship_db_to_dict(rel)
+
+
+@router.put('/data-contracts/{contract_id}/schemas/{schema_id}/relationships/{rel_id}', response_model=dict)
+async def update_schema_relationship(
+    contract_id: str,
+    schema_id: str,
+    rel_id: str,
+    body: dict = Body(...),
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE))
+):
+    rel = db.query(SchemaObjectRelationshipDb).filter(
+        SchemaObjectRelationshipDb.id == rel_id,
+        SchemaObjectRelationshipDb.schema_object_id == schema_id
+    ).first()
+    if not rel:
+        raise HTTPException(404, "Relationship not found")
+
+    if 'type' in body:
+        rel.relationship_type = body['type']
+    if 'from' in body:
+        from_val = body['from']
+        rel.from_value = json.dumps(from_val) if isinstance(from_val, list) else str(from_val)
+    if 'to' in body:
+        to_val = body['to']
+        rel.to_value = json.dumps(to_val) if isinstance(to_val, list) else str(to_val)
+    if 'customProperties' in body:
+        rel.custom_properties_json = json.dumps(body['customProperties']) if body['customProperties'] else None
+
+    db.commit()
+    db.refresh(rel)
+    return _relationship_db_to_dict(rel)
+
+
+@router.delete('/data-contracts/{contract_id}/schemas/{schema_id}/relationships/{rel_id}', status_code=204)
+async def delete_schema_relationship(
+    contract_id: str,
+    schema_id: str,
+    rel_id: str,
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE))
+):
+    deleted = db.query(SchemaObjectRelationshipDb).filter(
+        SchemaObjectRelationshipDb.id == rel_id,
+        SchemaObjectRelationshipDb.schema_object_id == schema_id
+    ).delete()
+    if not deleted:
+        raise HTTPException(404, "Relationship not found")
+    db.commit()
+
+
+# ===== ODCS v3.1.0: Property-Level Relationship CRUD =====
+
+@router.get('/data-contracts/{contract_id}/schemas/{schema_id}/properties/{prop_id}/relationships', response_model=List[dict])
+async def list_property_relationships(
+    contract_id: str,
+    schema_id: str,
+    prop_id: str,
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_ONLY))
+):
+    prop = db.query(SchemaPropertyDb).filter(
+        SchemaPropertyDb.id == prop_id,
+        SchemaPropertyDb.object_id == schema_id
+    ).first()
+    if not prop:
+        raise HTTPException(404, "Property not found")
+    rels = db.query(SchemaPropertyRelationshipDb).filter(
+        SchemaPropertyRelationshipDb.property_id == prop_id
+    ).all()
+    return [_relationship_db_to_dict(r) for r in rels]
+
+
+@router.post('/data-contracts/{contract_id}/schemas/{schema_id}/properties/{prop_id}/relationships', response_model=dict, status_code=201)
+async def create_property_relationship(
+    contract_id: str,
+    schema_id: str,
+    prop_id: str,
+    body: dict = Body(...),
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE))
+):
+    prop = db.query(SchemaPropertyDb).filter(
+        SchemaPropertyDb.id == prop_id,
+        SchemaPropertyDb.object_id == schema_id
+    ).first()
+    if not prop:
+        raise HTTPException(404, "Property not found")
+
+    to_val = body.get('to', '')
+    rel = SchemaPropertyRelationshipDb(
+        id=str(uuid4()),
+        property_id=prop_id,
+        relationship_type=body.get('type', 'foreignKey'),
+        to_value=json.dumps(to_val) if isinstance(to_val, list) else str(to_val),
+        custom_properties_json=json.dumps(body['customProperties']) if body.get('customProperties') else None,
+    )
+    db.add(rel)
+    db.commit()
+    db.refresh(rel)
+    return _relationship_db_to_dict(rel)
+
+
+@router.put('/data-contracts/{contract_id}/schemas/{schema_id}/properties/{prop_id}/relationships/{rel_id}', response_model=dict)
+async def update_property_relationship(
+    contract_id: str,
+    schema_id: str,
+    prop_id: str,
+    rel_id: str,
+    body: dict = Body(...),
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE))
+):
+    rel = db.query(SchemaPropertyRelationshipDb).filter(
+        SchemaPropertyRelationshipDb.id == rel_id,
+        SchemaPropertyRelationshipDb.property_id == prop_id
+    ).first()
+    if not rel:
+        raise HTTPException(404, "Relationship not found")
+
+    if 'type' in body:
+        rel.relationship_type = body['type']
+    if 'to' in body:
+        to_val = body['to']
+        rel.to_value = json.dumps(to_val) if isinstance(to_val, list) else str(to_val)
+    if 'customProperties' in body:
+        rel.custom_properties_json = json.dumps(body['customProperties']) if body['customProperties'] else None
+
+    db.commit()
+    db.refresh(rel)
+    return _relationship_db_to_dict(rel)
+
+
+@router.delete('/data-contracts/{contract_id}/schemas/{schema_id}/properties/{prop_id}/relationships/{rel_id}', status_code=204)
+async def delete_property_relationship(
+    contract_id: str,
+    schema_id: str,
+    prop_id: str,
+    rel_id: str,
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE))
+):
+    deleted = db.query(SchemaPropertyRelationshipDb).filter(
+        SchemaPropertyRelationshipDb.id == rel_id,
+        SchemaPropertyRelationshipDb.property_id == prop_id
+    ).delete()
+    if not deleted:
+        raise HTTPException(404, "Relationship not found")
+    db.commit()
+
+
+# ===== ODCS v3.1.0: Team Metadata =====
+
+@router.get('/data-contracts/{contract_id}/team-metadata', response_model=dict)
+async def get_team_metadata(
+    contract_id: str,
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_ONLY))
+):
+    contract = data_contract_repo.get(db, id=contract_id)
+    if not contract:
+        raise HTTPException(404, "Contract not found")
+
+    meta = db.query(DataContractTeamMetadataDb).filter(
+        DataContractTeamMetadataDb.contract_id == contract_id
+    ).first()
+    if not meta:
+        return {'contract_id': contract_id, 'name': None, 'description': None}
+
+    result = {
+        'id': meta.id,
+        'contract_id': meta.contract_id,
+        'stable_id': meta.stable_id,
+        'name': meta.name,
+        'description': meta.description,
+    }
+    if meta.tags_json:
+        try:
+            result['tags'] = json.loads(meta.tags_json)
+        except (json.JSONDecodeError, TypeError):
+            result['tags'] = None
+    if meta.custom_properties_json:
+        try:
+            result['customProperties'] = json.loads(meta.custom_properties_json)
+        except (json.JSONDecodeError, TypeError):
+            result['customProperties'] = None
+    if meta.authoritative_definitions_json:
+        try:
+            result['authoritativeDefinitions'] = json.loads(meta.authoritative_definitions_json)
+        except (json.JSONDecodeError, TypeError):
+            result['authoritativeDefinitions'] = None
+    return result
+
+
+@router.put('/data-contracts/{contract_id}/team-metadata', response_model=dict)
+async def update_team_metadata(
+    contract_id: str,
+    body: dict = Body(...),
+    db: DBSessionDep = None,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE))
+):
+    contract = data_contract_repo.get(db, id=contract_id)
+    if not contract:
+        raise HTTPException(404, "Contract not found")
+
+    meta = db.query(DataContractTeamMetadataDb).filter(
+        DataContractTeamMetadataDb.contract_id == contract_id
+    ).first()
+    if not meta:
+        meta = DataContractTeamMetadataDb(
+            id=str(uuid4()),
+            contract_id=contract_id,
+        )
+        db.add(meta)
+
+    if 'name' in body:
+        meta.name = body['name']
+    if 'description' in body:
+        meta.description = body['description']
+    if 'tags' in body:
+        meta.tags_json = json.dumps(body['tags']) if body['tags'] else None
+    if 'customProperties' in body:
+        meta.custom_properties_json = json.dumps(body['customProperties']) if body['customProperties'] else None
+    if 'authoritativeDefinitions' in body:
+        meta.authoritative_definitions_json = json.dumps(body['authoritativeDefinitions']) if body['authoritativeDefinitions'] else None
+
+    db.commit()
+    db.refresh(meta)
+
+    result = {
+        'id': meta.id,
+        'contract_id': meta.contract_id,
+        'stable_id': meta.stable_id,
+        'name': meta.name,
+        'description': meta.description,
+    }
+    if meta.tags_json:
+        try:
+            result['tags'] = json.loads(meta.tags_json)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    if meta.custom_properties_json:
+        try:
+            result['customProperties'] = json.loads(meta.custom_properties_json)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    if meta.authoritative_definitions_json:
+        try:
+            result['authoritativeDefinitions'] = json.loads(meta.authoritative_definitions_json)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return result
 
 
 def register_routes(app):

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -12,6 +12,8 @@ from src.models.ontology import (
     ConceptSearchResult
 )
 from src.models.semantic_models import SemanticModelCreate, SemanticModelUpdate
+from src.utils.semantic_model_title_candidates import extract_title_candidates, pick_auto_display_name
+from src.utils.rdf_serialization_display import serialization_label_for_graph_taxonomy
 from src.common.dependencies import CurrentUserDep, AuditManagerDep, DBSessionDep, AuditCurrentUserDep
 from src.common.authorization import PermissionChecker
 from src.common.features import FeatureAccessLevel
@@ -80,14 +82,29 @@ async def get_semantic_models(
             # Skip if name matches (either original or sanitized version)
             if tax.name in db_model_names or tax.name in db_model_names_sanitized:
                 continue
+            serialization = serialization_label_for_graph_taxonomy(
+                source_type=tax.source_type,
+                graph_format=tax.format,
+            )
+            size_bytes = None
+            if tax.source_type == 'file':
+                size_bytes = manager.bundled_taxonomy_file_size_bytes(tax.name)
+            if serialization == 'Turtle':
+                content_type = 'text/turtle'
+            elif serialization == 'RDF/XML':
+                content_type = 'application/rdf+xml'
+            else:
+                content_type = None
             # Create a pseudo-model for file-based/schema taxonomies
             combined.append({
                 'id': f'file-{tax.name}',  # Pseudo-ID for file-based
                 'name': tax.name,
-                'format': tax.format or 'skos',
+                'display_name': tax.display_name,
+                'format': tax.format,
+                'serialization': serialization,
                 'original_filename': tax.name,
-                'content_type': 'text/turtle' if tax.format == 'ttl' else 'application/rdf+xml',
-                'size_bytes': None,
+                'content_type': content_type,
+                'size_bytes': size_bytes,
                 'enabled': True,  # File-based are always enabled
                 'created_by': 'system@file' if tax.source_type == 'file' else f'system@{tax.source_type}',
                 'updated_by': None,
@@ -239,9 +256,12 @@ async def upload_semantic_model(
                 detail=f"Failed to parse ontology file. Please check the file format and syntax. Error: {str(parse_error)}"
             )
         
-        # Create semantic model in database
+        # Create semantic model in database (optional display title from ontology header)
+        title_candidates = extract_title_candidates(content_text, format_type)
+        auto_display_name = pick_auto_display_name(title_candidates)
         create_data = SemanticModelCreate(
             name=safe_filename,
+            display_name=auto_display_name,
             format=format_type,
             content_text=content_text,
             original_filename=safe_filename,
@@ -309,7 +329,10 @@ async def update_semantic_model(
     
     try:
         # Update the model
-        updated_model = manager.update(model_id, update_data, updated_by=current_user.username)
+        try:
+            updated_model = manager.update(model_id, update_data, updated_by=current_user.username)
+        except ValueError as ve:
+            raise HTTPException(status_code=400, detail=str(ve)) from ve
         
         if not updated_model:
             audit_manager.log_action(
@@ -455,6 +478,20 @@ async def get_semantic_model_content(
     except Exception as e:
         logger.error(f"Error retrieving semantic model content for {model_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve semantic model content")
+
+
+@router.get('/semantic-models/{model_id}/title-candidates')
+async def get_semantic_model_title_candidates(
+    model_id: str,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker("semantic-models", FeatureAccessLevel.READ_ONLY)),
+) -> dict:
+    """Suggest display titles from owl:Ontology / skos:ConceptScheme header metadata."""
+    candidates = manager.get_title_candidates(model_id)
+    if candidates is None:
+        raise HTTPException(status_code=404, detail="Semantic model not found")
+    return {"candidates": candidates}
+
 
 @router.get('/semantic-models/concepts')
 async def list_simple_concepts(

--- a/src/backend/src/tests/unit/test_rdf_serialization_display.py
+++ b/src/backend/src/tests/unit/test_rdf_serialization_display.py
@@ -1,0 +1,57 @@
+"""RDF serialization display helpers (syntax labels, not vocabulary)."""
+
+from src.utils.rdf_serialization_display import (
+    serialization_label_for_graph_taxonomy,
+    serialization_label_for_stored_model,
+    serialization_label_from_filename,
+)
+
+
+def test_serialization_from_filename_ttl():
+    assert serialization_label_from_filename("foo.ttl") == "Turtle"
+    assert serialization_label_from_filename("PATH/bar.n3") == "Turtle"
+
+
+def test_serialization_from_filename_xml_family():
+    assert serialization_label_from_filename("pizza.owl") == "RDF/XML"
+    assert serialization_label_from_filename("x.rdf") == "RDF/XML"
+
+
+def test_serialization_from_filename_unknown():
+    assert serialization_label_from_filename("") is None
+    assert serialization_label_from_filename("noext") is None
+
+
+def test_stored_model_prefers_extension_over_legacy_flags():
+    assert (
+        serialization_label_for_stored_model(
+            original_filename="mix.ttl", name="mix.ttl", legacy_format="rdfs"
+        )
+        == "Turtle"
+    )
+
+
+def test_stored_model_legacy_skos_means_turtle_parse_branch():
+    assert (
+        serialization_label_for_stored_model(original_filename=None, name="nope", legacy_format="skos")
+        == "Turtle"
+    )
+
+
+def test_stored_model_legacy_rdfs_means_xml_parse_branch():
+    assert (
+        serialization_label_for_stored_model(original_filename=None, name="nope", legacy_format="rdfs")
+        == "RDF/XML"
+    )
+
+
+def test_graph_taxonomy_bundled_file_is_turtle_not_skos():
+    assert serialization_label_for_graph_taxonomy(source_type="file", graph_format="ttl") == "Turtle"
+
+
+def test_graph_taxonomy_external_no_false_skos_default():
+    assert serialization_label_for_graph_taxonomy(source_type="external", graph_format=None) is None
+
+
+def test_graph_taxonomy_ttl_hint():
+    assert serialization_label_for_graph_taxonomy(source_type="schema", graph_format="ttl") == "Turtle"

--- a/src/backend/src/tests/unit/test_semantic_model_title_candidates.py
+++ b/src/backend/src/tests/unit/test_semantic_model_title_candidates.py
@@ -1,0 +1,103 @@
+"""Unit tests for RDF source title candidate extraction and auto-pick."""
+
+import pytest
+from rdflib import Graph, Literal, RDF, RDFS, URIRef
+from rdflib.namespace import OWL, SKOS
+
+from src.utils.semantic_model_title_candidates import (
+    best_display_title_from_graph,
+    collect_title_candidates_from_graph,
+    extract_title_candidates,
+    pick_auto_display_name,
+)
+
+
+TTL_ONTOLOGY = """
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://example.org/onto#> .
+
+ex:MyOnto a owl:Ontology ;
+    rdfs:label "My Ontology Title"@en .
+"""
+
+
+TTL_SCHEME = """
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://example.org/vocab#> .
+
+ex:scheme a skos:ConceptScheme ;
+    skos:prefLabel "Taxonomy One"@en .
+"""
+
+
+def test_extract_owl_ontology_label():
+    cands = extract_title_candidates(TTL_ONTOLOGY, "skos")
+    assert len(cands) >= 1
+    assert any(c["text"] == "My Ontology Title" and c["kind"] == "owl:Ontology" for c in cands)
+
+
+def test_extract_skos_concept_scheme():
+    cands = extract_title_candidates(TTL_SCHEME, "skos")
+    assert len(cands) >= 1
+    assert any(c["text"] == "Taxonomy One" for c in cands)
+
+
+def test_pick_auto_single_distinct_text():
+    cands = [{"iri": "a", "kind": "owl:Ontology", "text": "Only One", "lang": "en"}]
+    assert pick_auto_display_name(cands) == "Only One"
+
+
+def test_pick_auto_prefers_owl_when_multiple_texts():
+    cands = [
+        {"iri": "x", "kind": "owl:Ontology", "text": "Onto Title"},
+        {"iri": "y", "kind": "skos:ConceptScheme", "text": "Other"},
+    ]
+    assert pick_auto_display_name(cands) == "Onto Title"
+
+
+@pytest.mark.parametrize("empty", ["", "   "])
+def test_extract_empty_content(empty):
+    assert extract_title_candidates(empty, "skos") == []
+
+
+def test_extract_none_content():
+    assert extract_title_candidates(None, "skos") == []
+
+
+def test_collect_title_candidates_empty_graph():
+    assert collect_title_candidates_from_graph(Graph()) == []
+
+
+def test_best_display_title_from_graph_empty():
+    assert best_display_title_from_graph(Graph()) is None
+
+
+def test_collect_and_best_from_in_memory_owl_ontology():
+    g = Graph()
+    onto = URIRef("http://example.org/onto#root")
+    g.add((onto, RDF.type, OWL.Ontology))
+    g.add((onto, RDFS.label, Literal("Bundled Onto Title", lang="en")))
+    cands = collect_title_candidates_from_graph(g)
+    assert any(c["text"] == "Bundled Onto Title" and c["kind"] == "owl:Ontology" for c in cands)
+    assert best_display_title_from_graph(g) == "Bundled Onto Title"
+
+
+def test_collect_and_best_from_in_memory_skos_scheme():
+    g = Graph()
+    scheme = URIRef("http://example.org/vocab#scheme")
+    g.add((scheme, RDF.type, SKOS.ConceptScheme))
+    g.add((scheme, SKOS.prefLabel, Literal("Industry Codes", lang="en")))
+    cands = collect_title_candidates_from_graph(g)
+    assert any(c["text"] == "Industry Codes" for c in cands)
+    assert best_display_title_from_graph(g) == "Industry Codes"
+
+
+def test_graph_title_matches_string_parse_path():
+    g = Graph()
+    g.parse(data=TTL_ONTOLOGY, format="turtle")
+    assert collect_title_candidates_from_graph(g) == extract_title_candidates(TTL_ONTOLOGY, "skos")
+    assert best_display_title_from_graph(g) == pick_auto_display_name(
+        extract_title_candidates(TTL_ONTOLOGY, "skos")
+    )

--- a/src/backend/src/tests/unit/test_semantic_models_bundled_size.py
+++ b/src/backend/src/tests/unit/test_semantic_models_bundled_size.py
@@ -1,0 +1,23 @@
+"""Bundled taxonomy file size on disk."""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.controller.semantic_models_manager import SemanticModelsManager
+
+
+@pytest.fixture
+def manager_no_rebuild(db_session, tmp_path):
+    with patch.object(SemanticModelsManager, "rebuild_graph_from_enabled", lambda self: None):
+        yield SemanticModelsManager(db_session, data_dir=tmp_path)
+
+
+def test_bundled_taxonomy_file_size_bytes(manager_no_rebuild, tmp_path):
+    tax_dir = tmp_path / "taxonomies"
+    tax_dir.mkdir(parents=True)
+    payload = b"@prefix : <http://ex/> .\n"
+    (tax_dir / "databricks_ontology.ttl").write_bytes(payload)
+
+    assert manager_no_rebuild.bundled_taxonomy_file_size_bytes("databricks_ontology") == len(payload)
+    assert manager_no_rebuild.bundled_taxonomy_file_size_bytes("missing_stem") is None

--- a/src/backend/src/tests/unit/test_semantic_models_manager_update.py
+++ b/src/backend/src/tests/unit/test_semantic_models_manager_update.py
@@ -1,0 +1,68 @@
+"""SemanticModelsManager.update: display_name and forbidden name changes."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.db_models.semantic_models import SemanticModelDb
+from src.models.semantic_models import SemanticModelUpdate
+from src.repositories.semantic_models_repository import semantic_models_repo
+import uuid
+
+
+@pytest.fixture
+def manager_no_rebuild(db_session):
+    with patch.object(SemanticModelsManager, "rebuild_graph_from_enabled", lambda self: None):
+        yield SemanticModelsManager(db_session, data_dir=Path("/tmp/ontos-test-semantic"))
+
+
+def test_update_display_name(manager_no_rebuild, db_session):
+    mid = str(uuid.uuid4())
+    db_obj = SemanticModelDb(
+        id=mid,
+        name="file.ttl",
+        format="skos",
+        content_text="@prefix : <http://ex/> . :a a :C .",
+    )
+    db_session.add(db_obj)
+    db_session.commit()
+
+    updated = manager_no_rebuild.update(mid, SemanticModelUpdate(display_name="  Nice Title  "), "tester")
+    assert updated is not None
+    assert updated.display_name == "Nice Title"
+
+    row = semantic_models_repo.get(db_session, id=mid)
+    assert row.display_name == "Nice Title"
+
+
+def test_update_clear_display_name(manager_no_rebuild, db_session):
+    mid = str(uuid.uuid4())
+    db_obj = SemanticModelDb(
+        id=mid,
+        name="x.ttl",
+        format="skos",
+        content_text="@prefix : <http://ex/> . :a a :C .",
+        display_name="Was Set",
+    )
+    db_session.add(db_obj)
+    db_session.commit()
+
+    updated = manager_no_rebuild.update(mid, SemanticModelUpdate(display_name=""), "tester")
+    assert updated.display_name is None
+
+
+def test_update_name_change_forbidden(manager_no_rebuild, db_session):
+    mid = str(uuid.uuid4())
+    db_obj = SemanticModelDb(
+        id=mid,
+        name="stable.ttl",
+        format="skos",
+        content_text="@prefix : <http://ex/> . :a a :C .",
+    )
+    db_session.add(db_obj)
+    db_session.commit()
+
+    with pytest.raises(ValueError, match="Renaming semantic models"):
+        manager_no_rebuild.update(mid, SemanticModelUpdate(name="other.ttl"), "tester")

--- a/src/backend/src/utils/rdf_serialization_display.py
+++ b/src/backend/src/utils/rdf_serialization_display.py
@@ -1,0 +1,59 @@
+"""User-facing RDF *serialization* labels (syntax), not vocabulary (SKOS/OWL/RDFS)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def serialization_label_from_filename(filename: str) -> Optional[str]:
+    """Map file extension to a serialization display name. Returns None if unknown."""
+    if not filename:
+        return None
+    lower = filename.lower()
+    if lower.endswith((".ttl", ".n3")):
+        return "Turtle"
+    if lower.endswith((".owl", ".rdf", ".xml")):
+        return "RDF/XML"
+    if lower.endswith((".jsonld", ".json-ld")) or lower.endswith(".json"):
+        return "JSON-LD"
+    if lower.endswith(".nt"):
+        return "N-Triples"
+    if lower.endswith(".trig"):
+        return "TriG"
+    if lower.endswith(".trix"):
+        return "TriX"
+    if lower.endswith(".skos") or lower.endswith(".rdfs"):
+        return "Turtle"
+    return None
+
+
+def serialization_label_for_stored_model(
+    *,
+    original_filename: Optional[str],
+    name: str,
+    legacy_format: str,
+) -> Optional[str]:
+    """Label for a row from `semantic_models`: prefer filename extension, else upload parse-branch hints."""
+    label = serialization_label_from_filename((original_filename or "").strip()) or serialization_label_from_filename(
+        (name or "").strip()
+    )
+    if label:
+        return label
+    lf = (legacy_format or "").lower()
+    if lf == "skos":
+        return "Turtle"
+    if lf == "rdfs":
+        return "RDF/XML"
+    return None
+
+
+def serialization_label_for_graph_taxonomy(*, source_type: str, graph_format: Optional[str]) -> Optional[str]:
+    """Serialization hint from graph taxonomy metadata (not vocabulary)."""
+    if source_type == "file":
+        return "Turtle"
+    gf = (graph_format or "").lower()
+    if gf == "ttl":
+        return "Turtle"
+    if gf == "rdfs":
+        return "RDF/XML"
+    return None

--- a/src/backend/src/utils/semantic_model_title_candidates.py
+++ b/src/backend/src/utils/semantic_model_title_candidates.py
@@ -1,0 +1,144 @@
+"""Extract human-readable title candidates from RDF ontology / taxonomy content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from rdflib import Graph, RDF, RDFS, URIRef
+from rdflib.namespace import DC, DCTERMS, OWL, SKOS
+from rdflib.term import Literal, Node
+
+
+_TITLE_PREDICATES: Tuple[URIRef, ...] = (
+    RDFS.label,
+    SKOS.prefLabel,
+    DCTERMS.title,
+    DC.title,
+)
+
+
+@dataclass(frozen=True)
+class TitleCandidate:
+    iri: str
+    kind: str
+    text: str
+    lang: Optional[str]
+
+    def as_dict(self) -> dict:
+        d: dict = {"iri": self.iri, "kind": self.kind, "text": self.text}
+        if self.lang:
+            d["lang"] = self.lang
+        return d
+
+
+def detect_rdf_parse_format(content_text: str, format_field: str) -> str:
+    """Match format detection used when loading semantic model content."""
+    content_stripped = content_text.strip()
+    if content_stripped.startswith("@prefix") or content_stripped.startswith("@base"):
+        return "turtle"
+    if content_stripped.startswith("{") or content_stripped.startswith("["):
+        return "json-ld"
+    if content_stripped.startswith("<?xml") or content_stripped.startswith("<rdf:RDF"):
+        return "xml"
+    return "turtle" if format_field in ("skos", "rdfs") else "xml"
+
+
+def _literal_lang(lit: Literal) -> Optional[str]:
+    return lit.language if getattr(lit, "language", None) else None
+
+
+def _lang_sort_key(lang: Optional[str]) -> int:
+    if lang is None or lang == "":
+        return 1
+    if lang.lower().startswith("en"):
+        return 0
+    return 2
+
+
+def _collect_labels_for_subject(
+    graph: Graph,
+    subject: Node,
+    kind: str,
+    title_preds: Tuple[URIRef, ...],
+) -> List[TitleCandidate]:
+    out: List[TitleCandidate] = []
+    if not isinstance(subject, URIRef):
+        return out
+    iri = str(subject)
+    for pred in title_preds:
+        for obj in graph.objects(subject, pred):
+            if isinstance(obj, Literal):
+                text = str(obj).strip()
+                if text:
+                    out.append(
+                        TitleCandidate(
+                            iri=iri,
+                            kind=kind,
+                            text=text,
+                            lang=_literal_lang(obj),
+                        )
+                    )
+    return out
+
+
+def collect_title_candidates_from_graph(graph: Graph) -> List[dict]:
+    """
+    Collect title/label literals from ontology header resources in an rdflib Graph
+    (named graph context or standalone parse result):
+    owl:Ontology, skos:ConceptScheme (rdfs:label, skos:prefLabel, dcterms:title, dc:title).
+    """
+    seen: set[tuple[str, str, Optional[str]]] = set()
+    candidates: List[TitleCandidate] = []
+
+    for subj in graph.subjects(RDF.type, OWL.Ontology):
+        for c in _collect_labels_for_subject(graph, subj, "owl:Ontology", _TITLE_PREDICATES):
+            key = (c.iri, c.text, c.lang)
+            if key not in seen:
+                seen.add(key)
+                candidates.append(c)
+
+    for subj in graph.subjects(RDF.type, SKOS.ConceptScheme):
+        for c in _collect_labels_for_subject(graph, subj, "skos:ConceptScheme", _TITLE_PREDICATES):
+            key = (c.iri, c.text, c.lang)
+            if key not in seen:
+                seen.add(key)
+                candidates.append(c)
+
+    candidates.sort(key=lambda c: (_lang_sort_key(c.lang), c.kind, c.text.lower()))
+    return [c.as_dict() for c in candidates]
+
+
+def best_display_title_from_graph(graph: Graph) -> Optional[str]:
+    """Pick a single display title from graph ontology headers (same policy as upload auto-title)."""
+    return pick_auto_display_name(collect_title_candidates_from_graph(graph))
+
+
+def extract_title_candidates(content_text: str, format_field: str) -> List[dict]:
+    """
+    Collect title/label literals from ontology header resources:
+    owl:Ontology, skos:ConceptScheme (rdfs:label, skos:prefLabel, dcterms:title, dc:title).
+    """
+    if content_text is None or not str(content_text).strip():
+        return []
+
+    fmt = detect_rdf_parse_format(content_text, format_field)
+    graph = Graph()
+    graph.parse(data=content_text, format=fmt)
+    return collect_title_candidates_from_graph(graph)
+
+
+def pick_auto_display_name(candidates: List[dict]) -> Optional[str]:
+    """
+    If there is a single distinct title text across all candidates, use it.
+    Otherwise, if any owl:Ontology candidate exists, use the first one's text after sorting.
+    """
+    if not candidates:
+        return None
+    texts = {c["text"].strip() for c in candidates if c.get("text")}
+    if len(texts) == 1:
+        return next(iter(texts))
+    owl_first = next((c for c in candidates if c.get("kind") == "owl:Ontology"), None)
+    if owl_first and owl_first.get("text"):
+        return owl_first["text"].strip()
+    return None

--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -138,13 +138,24 @@ def initialize_managers(app: FastAPI):
     db_session = None
     ws_client = None
 
+    # Access health state for soft-fail reporting (set in app.py startup_event)
+    health = getattr(app.state, 'health', {"warnings": []})
+
     try:
-        # --- Initialize Workspace Client --- 
+        # --- Initialize Workspace Client (soft-fail) ---
         logger.info("Attempting to initialize WorkspaceClient...")
-        ws_client = get_workspace_client(settings=settings)
-        if not ws_client:
-            raise RuntimeError("Failed to initialize Databricks WorkspaceClient (returned None).")
-        logger.info("WorkspaceClient initialized successfully.")
+        try:
+            ws_client = get_workspace_client(settings=settings)
+            if not ws_client:
+                raise RuntimeError("WorkspaceClient returned None.")
+            logger.info("WorkspaceClient initialized successfully.")
+            health["ws_ok"] = True
+        except Exception as ws_err:
+            ws_client = None
+            msg = f"Workspace client unavailable: {ws_err}"
+            logger.warning(msg, exc_info=True)
+            health.setdefault("warnings", []).append(msg)
+            health["ws_ok"] = False
         
         # --- Initialize Connector Registry ---
         logger.info("Initializing asset connector registry...")
@@ -414,8 +425,9 @@ def initialize_managers(app: FastAPI):
 
     except Exception as e:
         logger.critical(f"Failed during application startup (manager init or default roles): {e}", exc_info=True)
-        if db_session: db_session.rollback() # Rollback if any part fails
-        raise RuntimeError("Failed to initialize application managers or default roles.") from e
+        if db_session: db_session.rollback()
+        msg = f"Manager initialization failed: {e}"
+        health.setdefault("warnings", []).append(msg)
     finally:
         # Keep the DB session open for manager singletons that rely on it.
         # It will be managed at application shutdown.

--- a/src/frontend/src/components/data-contracts/schema-form-dialog.tsx
+++ b/src/frontend/src/components/data-contracts/schema-form-dialog.tsx
@@ -5,11 +5,13 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import { Plus, Trash2 } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { useTranslation } from 'react-i18next'
 import SchemaPropertyEditor, { type SchemaPropertyEditorHandle } from './schema-property-editor'
 import BusinessConceptsDisplay from '@/components/business-concepts/business-concepts-display'
-import type { SchemaObject, ColumnProperty } from '@/types/data-contract'
+import type { SchemaObject, ColumnProperty, SchemaRelationship } from '@/types/data-contract'
 
 type SchemaFormProps = {
   isOpen: boolean
@@ -37,6 +39,12 @@ export default function SchemaFormDialog({ isOpen, onOpenChange, onSubmit, initi
   // Properties (columns)
   const [properties, setProperties] = useState<ColumnProperty[]>([])
   const [schemaSemanticConcepts, setSchemaSemanticConcepts] = useState<{ iri: string; label?: string }[]>([])
+
+  // Schema-level relationships (ODCS v3.1.0)
+  const [schemaRelationships, setSchemaRelationships] = useState<SchemaRelationship[]>([])
+  const [newRelFrom, setNewRelFrom] = useState('')
+  const [newRelTo, setNewRelTo] = useState('')
+  const [newRelType, setNewRelType] = useState('foreignKey')
 
   // Initialize form when dialog opens
   useEffect(() => {
@@ -66,6 +74,7 @@ export default function SchemaFormDialog({ isOpen, onOpenChange, onSubmit, initi
       } else {
         setSchemaSemanticConcepts([])
       }
+      setSchemaRelationships(initial.relationships || [])
     } else if (isOpen && !initial) {
       // Reset for new schema
       setName('')
@@ -76,6 +85,10 @@ export default function SchemaFormDialog({ isOpen, onOpenChange, onSubmit, initi
       setDataGranularityDescription('')
       setProperties([])
       setSchemaSemanticConcepts([])
+      setSchemaRelationships([])
+      setNewRelFrom('')
+      setNewRelTo('')
+      setNewRelType('foreignKey')
     }
   }, [isOpen, initial])
 
@@ -105,6 +118,7 @@ export default function SchemaFormDialog({ isOpen, onOpenChange, onSubmit, initi
         authoritativeDefinitions: schemaSemanticConcepts.length > 0 ? schemaSemanticConcepts.map(c => ({ url: c.iri, type: 'http://databricks.com/ontology/uc/semanticAssignment' })) : undefined,
         // @ts-ignore retain local concepts for further editing flows
         semanticConcepts: schemaSemanticConcepts.length > 0 ? schemaSemanticConcepts : undefined,
+        relationships: schemaRelationships.length > 0 ? schemaRelationships : undefined,
       }
 
       await onSubmit(schema)
@@ -281,6 +295,93 @@ export default function SchemaFormDialog({ isOpen, onOpenChange, onSubmit, initi
               properties={properties}
               onChange={setProperties}
             />
+          </div>
+
+          {/* Schema-level Relationships (ODCS v3.1.0) */}
+          <div className="space-y-4 border-t pt-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                Relationships (Foreign Keys)
+                {schemaRelationships.length > 0 && (
+                  <Badge variant="secondary" className="text-xs">{schemaRelationships.length}</Badge>
+                )}
+              </h3>
+            </div>
+
+            {schemaRelationships.length > 0 && (
+              <div className="space-y-2">
+                {schemaRelationships.map((rel, idx) => (
+                  <div key={idx} className="flex items-center justify-between p-3 border rounded-lg bg-muted/30">
+                    <div className="flex items-center gap-2 flex-1 text-sm">
+                      <Badge variant="outline" className="text-xs">{rel.type}</Badge>
+                      <span className="font-mono">{typeof rel.from === 'string' ? rel.from : JSON.stringify(rel.from)}</span>
+                      <span className="text-muted-foreground">→</span>
+                      <span className="font-mono">{typeof rel.to === 'string' ? rel.to : JSON.stringify(rel.to)}</span>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setSchemaRelationships(schemaRelationships.filter((_, i) => i !== idx))}
+                      className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="border rounded-lg p-3 bg-background space-y-2">
+              <div className="grid grid-cols-7 gap-2">
+                <div className="col-span-3 space-y-1">
+                  <Label className="text-xs">From (local column)</Label>
+                  <Input
+                    value={newRelFrom}
+                    onChange={(e) => setNewRelFrom(e.target.value)}
+                    placeholder="e.g., customer_id"
+                    className="h-9 font-mono text-xs"
+                  />
+                </div>
+                <div className="col-span-3 space-y-1">
+                  <Label className="text-xs">To (target reference)</Label>
+                  <Input
+                    value={newRelTo}
+                    onChange={(e) => setNewRelTo(e.target.value)}
+                    placeholder="e.g., schema.table.column"
+                    className="h-9 font-mono text-xs"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Type</Label>
+                  <Select value={newRelType} onValueChange={setNewRelType}>
+                    <SelectTrigger className="h-9">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="foreignKey">foreignKey</SelectItem>
+                      <SelectItem value="reference">reference</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={!newRelFrom.trim() || !newRelTo.trim()}
+                onClick={() => {
+                  setSchemaRelationships([...schemaRelationships, { type: newRelType, from: newRelFrom.trim(), to: newRelTo.trim() }])
+                  setNewRelFrom('')
+                  setNewRelTo('')
+                  setNewRelType('foreignKey')
+                }}
+                className="h-7"
+              >
+                <Plus className="h-3 w-3 mr-1" />
+                Add Relationship
+              </Button>
+            </div>
           </div>
         </div>
 

--- a/src/frontend/src/components/data-contracts/schema-property-editor.tsx
+++ b/src/frontend/src/components/data-contracts/schema-property-editor.tsx
@@ -10,7 +10,7 @@ import { Plus, Trash2, Edit, Info } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { useTranslation } from 'react-i18next'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import type { ColumnProperty, QualityRule } from '@/types/data-contract'
+import type { ColumnProperty, QualityRule, SchemaRelationship } from '@/types/data-contract'
 import BusinessConceptsDisplay from '@/components/business-concepts/business-concepts-display'
 import QualityRuleFormDialog from './quality-rule-form-dialog'
 
@@ -28,7 +28,8 @@ const getTabsWithValues = (prop: ColumnProperty) => ({
   governance: !!(prop.classification || prop.examples || (prop as any).tags?.length),
   business: !!(prop.businessName || prop.encryptedName || prop.criticalDataElement),
   transform: !!(prop.transformLogic || prop.transformSourceObjects || prop.transformDescription),
-  semantics: !!(prop.authoritativeDefinitions?.length || (prop as any).semanticConcepts?.length)
+  semantics: !!(prop.authoritativeDefinitions?.length || (prop as any).semanticConcepts?.length),
+  relationships: !!(prop.relationships?.length)
 })
 
 // Compact 6-square indicator showing which tabs have values configured
@@ -41,6 +42,7 @@ const TabIndicator = ({ prop }: { prop: ColumnProperty }) => {
     { key: 'business', label: 'Business', active: tabs.business },
     { key: 'transform', label: 'Transform', active: tabs.transform },
     { key: 'semantics', label: 'Semantics', active: tabs.semantics },
+    { key: 'relationships', label: 'Relationships', active: tabs.relationships },
   ]
   
   return (
@@ -200,6 +202,11 @@ function SchemaPropertyEditorInner(
   const [tags, setTags] = useState('')
   const [customProps, setCustomProps] = useState<Record<string, any>>({})
 
+  // Property-level relationships (ODCS v3.1.0)
+  const [propRelationships, setPropRelationships] = useState<SchemaRelationship[]>([])
+  const [newRelTo, setNewRelTo] = useState('')
+  const [newRelType, setNewRelType] = useState('foreignKey')
+
   // Quality rule dialog state
   const [isQualityRuleDialogOpen, setIsQualityRuleDialogOpen] = useState(false)
   const [editingQualityCheckIndex, setEditingQualityCheckIndex] = useState<number | null>(null)
@@ -242,6 +249,9 @@ function SchemaPropertyEditorInner(
     setQualityChecks([])
     setTags('')
     setCustomProps({})
+    setPropRelationships([])
+    setNewRelTo('')
+    setNewRelType('foreignKey')
     setEditingIndex(null)
   }
 
@@ -290,10 +300,11 @@ function SchemaPropertyEditorInner(
     } else {
       setSemanticConcepts([])
     }
-    // Load quality checks, tags, and custom properties
+    // Load quality checks, tags, custom properties, and relationships
     setQualityChecks((prop as any).quality || [])
     setTags((prop as any).tags ? (prop as any).tags.join(', ') : '')
     setCustomProps((prop as any).customProperties || {})
+    setPropRelationships(prop.relationships || [])
   }
 
   // Build a ColumnProperty from current form state (shared by handleAddOrUpdate and getPropertiesForSubmit)
@@ -339,6 +350,7 @@ function SchemaPropertyEditorInner(
     tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : undefined,
     // @ts-ignore
     customProperties: Object.keys(customProps).length > 0 ? customProps : undefined,
+    relationships: propRelationships.length > 0 ? propRelationships : undefined,
   })
 
   useImperativeHandle(ref, () => ({
@@ -355,7 +367,7 @@ function SchemaPropertyEditorInner(
       const existing = properties[editingIndex]
       return normalizePropertyForCompare(current) !== normalizePropertyForCompare(existing)
     },
-  }), [editingIndex, properties, name, logicalType, description, physicalType, physicalName, required, unique, primaryKey, primaryKeyPosition, partitioned, partitionKeyPosition, minLength, maxLength, pattern, minimum, maximum, multipleOf, precision, dateFormat, timezone, customFormat, itemType, minItems, maxItems, classification, examples, businessName, encryptedName, criticalDataElement, transformLogic, transformSourceObjects, transformDescription, authoritativeDefinitions, semanticConcepts, qualityChecks, tags, customProps])
+  }), [editingIndex, properties, name, logicalType, description, physicalType, physicalName, required, unique, primaryKey, primaryKeyPosition, partitioned, partitionKeyPosition, minLength, maxLength, pattern, minimum, maximum, multipleOf, precision, dateFormat, timezone, customFormat, itemType, minItems, maxItems, classification, examples, businessName, encryptedName, criticalDataElement, transformLogic, transformSourceObjects, transformDescription, authoritativeDefinitions, semanticConcepts, qualityChecks, tags, customProps, propRelationships])
 
   const isDirty = editingIndex !== null && (() => {
     const current = buildPropertyFromFormState()
@@ -448,7 +460,7 @@ function SchemaPropertyEditorInner(
           )}
           
           <Tabs defaultValue="core" className="w-full">
-            <TabsList className="grid w-full grid-cols-7">
+            <TabsList className="grid w-full grid-cols-8">
               <TabsTrigger value="core">Core</TabsTrigger>
               <TabsTrigger value="constraints">Constraints</TabsTrigger>
               <TabsTrigger value="quality">Quality</TabsTrigger>
@@ -456,6 +468,12 @@ function SchemaPropertyEditorInner(
               <TabsTrigger value="business">Business</TabsTrigger>
               <TabsTrigger value="transform">Transform</TabsTrigger>
               <TabsTrigger value="semantics">Semantics</TabsTrigger>
+              <TabsTrigger value="relationships">
+                Relationships
+                {propRelationships.length > 0 && (
+                  <Badge variant="secondary" className="ml-1 text-[10px] h-4 px-1">{propRelationships.length}</Badge>
+                )}
+              </TabsTrigger>
             </TabsList>
 
             {/* Core Tab */}
@@ -941,6 +959,88 @@ function SchemaPropertyEditorInner(
                   entityId={name || 'property'}
                   conceptType="property"
                 />
+              </div>
+            </TabsContent>
+
+            {/* Relationships Tab (ODCS v3.1.0) */}
+            <TabsContent value="relationships" className="space-y-3 mt-4">
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <Label className="text-sm font-semibold flex items-center">
+                    Foreign Key Relationships
+                    <FieldTooltip content="ODCS v3.1.0 property-level relationships (e.g., foreign keys to other schema/table columns)" />
+                  </Label>
+                </div>
+
+                {propRelationships.length > 0 && (
+                  <div className="space-y-2">
+                    {propRelationships.map((rel, idx) => (
+                      <div key={idx} className="flex items-center justify-between p-3 border rounded-lg bg-background">
+                        <div className="flex items-center gap-2 flex-1">
+                          <Badge variant="outline" className="text-xs">{rel.type}</Badge>
+                          <span className="text-sm font-mono">→ {typeof rel.to === 'string' ? rel.to : JSON.stringify(rel.to)}</span>
+                        </div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => setPropRelationships(propRelationships.filter((_, i) => i !== idx))}
+                          className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <div className="border rounded-lg p-3 bg-background space-y-2">
+                  <div className="grid grid-cols-3 gap-2">
+                    <div className="col-span-2 space-y-1">
+                      <Label className="text-xs">Target Reference (to)</Label>
+                      <Input
+                        value={newRelTo}
+                        onChange={(e) => setNewRelTo(e.target.value)}
+                        placeholder="e.g., schema.table.column"
+                        className="h-9 font-mono text-xs"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Type</Label>
+                      <Select value={newRelType} onValueChange={setNewRelType}>
+                        <SelectTrigger className="h-9">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="foreignKey">foreignKey</SelectItem>
+                          <SelectItem value="reference">reference</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!newRelTo.trim()}
+                    onClick={() => {
+                      setPropRelationships([...propRelationships, { type: newRelType, to: newRelTo.trim() }])
+                      setNewRelTo('')
+                      setNewRelType('foreignKey')
+                    }}
+                    className="h-7"
+                  >
+                    <Plus className="h-3 w-3 mr-1" />
+                    Add Relationship
+                  </Button>
+                </div>
+
+                {propRelationships.length === 0 && (
+                  <div className="text-center py-4 border-2 border-dashed rounded-lg">
+                    <p className="text-sm text-muted-foreground">No relationships defined</p>
+                    <p className="text-xs text-muted-foreground mt-1">Add a foreign key reference to link this property to another entity</p>
+                  </div>
+                )}
               </div>
             </TabsContent>
           </Tabs>

--- a/src/frontend/src/components/knowledge/concepts-tab.tsx
+++ b/src/frontend/src/components/knowledge/concepts-tab.tsx
@@ -28,6 +28,7 @@ import { NodeLinksPanel } from '@/components/knowledge/node-links-panel';
 import EntityMetadataPanel from '@/components/metadata/entity-metadata-panel';
 import { OwnershipPanel } from '@/components/common/ownership-panel';
 import { resolveLabel, resolveComment } from '@/lib/ontology-utils';
+import { systemRdfNamespaceDisplayLabel } from '@/lib/system-rdf-namespace-labels';
 
 interface ConceptsTabProps {
   collections: KnowledgeCollection[];
@@ -280,8 +281,8 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
       return typeIcons[concept?.concept_type || 'concept'] || <Layers className="h-4 w-4" />;
     };
     
-    const displayName = isSourceGroup 
-      ? itemId 
+    const displayName = isSourceGroup
+      ? systemRdfNamespaceDisplayLabel(itemId, t)
       : (concept ? resolveLabel(concept, selectedLanguage) : itemId);
     
     return (
@@ -582,7 +583,12 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
 
               {/* Source Info */}
               <div className="text-sm text-muted-foreground border-t pt-4">
-                <p>Source: {selectedConcept.source_context}</p>
+                <p>
+                  {t('semantic-models:fields.source')}:{' '}
+                  {selectedConcept.source_context
+                    ? systemRdfNamespaceDisplayLabel(selectedConcept.source_context, t)
+                    : '—'}
+                </p>
                 {selectedConcept.created_at && (
                   <p>Created: {new Date(selectedConcept.created_at).toLocaleDateString()}</p>
                 )}

--- a/src/frontend/src/components/knowledge/glossary-filter-panel.tsx
+++ b/src/frontend/src/components/knowledge/glossary-filter-panel.tsx
@@ -27,6 +27,7 @@ import {
   Languages,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { systemRdfNamespaceDisplayLabel } from '@/lib/system-rdf-namespace-labels';
 import type { OntologyConcept } from '@/types/ontology';
 import { getAvailableLanguages, getLanguageDisplayName } from '@/lib/ontology-utils';
 
@@ -148,7 +149,7 @@ export const GlossaryFilterPanel: React.FC<GlossaryFilterPanelProps> = ({
                     onCheckedChange={() => onToggleSource(source)}
                     className="h-3.5 w-3.5"
                   />
-                  <span>{source}</span>
+                  <span title={source}>{systemRdfNamespaceDisplayLabel(source, t)}</span>
                   <Badge variant="secondary" className="h-4 text-[10px] px-1">
                     {conceptCount}
                   </Badge>

--- a/src/frontend/src/components/knowledge/graph-tab.tsx
+++ b/src/frontend/src/components/knowledge/graph-tab.tsx
@@ -8,6 +8,7 @@ interface GraphTabProps {
   onToggleRoot: (rootIri: string) => void;
   onNodeClick: (concept: OntologyConcept) => void;
   showRootBadges?: boolean;
+  selectedLanguage?: string;
 }
 
 export const GraphTab: React.FC<GraphTabProps> = ({
@@ -16,6 +17,7 @@ export const GraphTab: React.FC<GraphTabProps> = ({
   onToggleRoot,
   onNodeClick,
   showRootBadges = true,
+  selectedLanguage = 'en',
 }) => {
   return (
     <div className="h-[800px] flex flex-col">
@@ -27,6 +29,7 @@ export const GraphTab: React.FC<GraphTabProps> = ({
           onToggleRoot={onToggleRoot}
           onNodeClick={onNodeClick}
           showRootBadges={showRootBadges}
+          selectedLanguage={selectedLanguage}
         />
       </div>
     </div>

--- a/src/frontend/src/components/layout/layout.tsx
+++ b/src/frontend/src/components/layout/layout.tsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Sparkles } from 'lucide-react';
+import { AlertTriangle, Sparkles } from 'lucide-react';
 import { Sidebar } from './sidebar';
 import { Header } from './header';
 import { Breadcrumbs } from '@/components/ui/breadcrumbs';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { cn } from '@/lib/utils';
 import { useLayoutStore } from '@/stores/layout-store';
 import { useCopilotStore } from '@/stores/copilot-store';
 import CopilotPanel from '@/components/copilot/copilot-panel';
+
+interface HealthState {
+  db_ok: boolean;
+  ws_ok: boolean;
+  warnings: string[];
+  db_error: string | null;
+}
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -19,6 +27,16 @@ export default function Layout({ children }: LayoutProps) {
   const { toggleSidebar } = useLayoutStore((state) => state.actions);
   const isCopilotOpen = useCopilotStore((s) => s.isOpen);
   const { togglePanel } = useCopilotStore((s) => s.actions);
+  const [health, setHealth] = useState<HealthState | null>(null);
+
+  useEffect(() => {
+    fetch('/api/health')
+      .then((r) => r.json())
+      .then(setHealth)
+      .catch(() => {});
+  }, []);
+
+  const showWarning = health && (!health.ws_ok || (health.warnings && health.warnings.length > 0));
 
   return (
     <div className="flex min-h-screen bg-background">
@@ -29,6 +47,18 @@ export default function Layout({ children }: LayoutProps) {
         isCopilotOpen && "mr-[400px]"
       )}>
         <Header onToggleSidebar={toggleSidebar} isSidebarCollapsed={isSidebarCollapsed} />
+        {showWarning && (
+          <Alert variant="destructive" className="mx-6 mt-4">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>System Warning</AlertTitle>
+            <AlertDescription>
+              {!health.ws_ok && (
+                <p>Databricks workspace connection failed. Some features may be unavailable.</p>
+              )}
+              {health.warnings?.map((w, i) => <p key={i}>{w}</p>)}
+            </AlertDescription>
+          </Alert>
+        )}
         <main className="flex-1 overflow-y-auto p-6">
           <Breadcrumbs className="mb-6" />
           {children}

--- a/src/frontend/src/components/semantic-models/knowledge-graph.tsx
+++ b/src/frontend/src/components/semantic-models/knowledge-graph.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useEffect, useMemo, useCallback, useState } from 'react'
 import CytoscapeComponent from 'react-cytoscapejs';
 import type { Core, ElementDefinition, LayoutOptions } from 'cytoscape';
 import type { OntologyConcept } from '@/types/ontology';
+import { resolveLabel } from '@/lib/ontology-utils';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -49,6 +50,7 @@ interface RootNodeFilterProps {
   hiddenRoots: Set<string>;
   onToggleRoot: (iri: string) => void;
   getRootDescendants: (rootIri: string) => Set<string>;
+  selectedLanguage: string;
 }
 
 // Internal component for filtering root nodes - handles both badge and dropdown modes
@@ -58,6 +60,7 @@ const RootNodeFilter: React.FC<RootNodeFilterProps> = ({
   hiddenRoots,
   onToggleRoot,
   getRootDescendants,
+  selectedLanguage,
 }) => {
   const visibleCount = rootNodes.filter(r => !hiddenRoots.has(r.iri)).length;
   const totalCount = rootNodes.length;
@@ -86,7 +89,7 @@ const RootNodeFilter: React.FC<RootNodeFilterProps> = ({
       <div className="flex flex-wrap gap-2 text-xs">
         {rootNodes.map(root => {
           const color = rootColors.get(root.iri) || '#64748b';
-          const label = root.label || root.iri.split(/[/#]/).pop() || 'Unknown';
+          const label = resolveLabel(root, selectedLanguage);
           const isHidden = hiddenRoots.has(root.iri);
           const descendants = getRootDescendants(root.iri);
           
@@ -164,7 +167,7 @@ const RootNodeFilter: React.FC<RootNodeFilterProps> = ({
             <div className="p-2 space-y-1">
               {rootNodes.map(root => {
                 const color = rootColors.get(root.iri) || '#64748b';
-                const label = root.label || root.iri.split(/[/#]/).pop() || 'Unknown';
+                const label = resolveLabel(root, selectedLanguage);
                 const isVisible = !hiddenRoots.has(root.iri);
                 const descendants = getRootDescendants(root.iri);
                 
@@ -213,7 +216,8 @@ interface KnowledgeGraphProps {
   hiddenRoots: Set<string>;
   onToggleRoot: (rootIri: string) => void;
   onNodeClick: (concept: OntologyConcept) => void;
-  showRootBadges?: boolean; // Controls visibility of root node filter badges (tied to Group by Source)
+  showRootBadges?: boolean;
+  selectedLanguage?: string;
 }
 
 interface GraphData {
@@ -229,6 +233,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
   onToggleRoot,
   onNodeClick,
   showRootBadges = true,
+  selectedLanguage = 'en',
 }) => {
   const cyRef = useRef<Core | null>(null);
   const fullscreenCyRef = useRef<Core | null>(null);
@@ -380,7 +385,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
           elements.push({
             data: {
               id: `domain_${root.iri}`,
-              label: root.label || root.iri.split(/[/#]/).pop() || 'Unknown',
+              label: resolveLabel(root, selectedLanguage),
               type: 'domain',
               color: rootColors.get(root.iri),
             },
@@ -399,7 +404,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
       const nodeData: ElementDefinition = {
         data: {
           id: concept.iri,
-          label: concept.label || concept.iri.split(/[/#]/).pop() || 'Unknown',
+          label: resolveLabel(concept, selectedLanguage),
           type: 'concept',
           conceptType: concept.concept_type,
           color: color,
@@ -437,7 +442,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
     });
 
     return { elements, rootNodes, rootColors, getRootDescendants };
-  }, [concepts, hiddenRoots, showDomainBoxes]);
+  }, [concepts, hiddenRoots, showDomainBoxes, selectedLanguage]);
 
   // Create stylesheet based on dark mode
   // Cytoscape stylesheet - using any[] due to complex type definitions
@@ -743,6 +748,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
             hiddenRoots={hiddenRoots}
             onToggleRoot={onToggleRoot}
             getRootDescendants={graphData.getRootDescendants}
+            selectedLanguage={selectedLanguage}
           />
         </div>
       )}
@@ -903,6 +909,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
                 hiddenRoots={hiddenRoots}
                 onToggleRoot={onToggleRoot}
                 getRootDescendants={graphData.getRootDescendants}
+                selectedLanguage={selectedLanguage}
               />
             </div>
           )}

--- a/src/frontend/src/components/settings/semantic-models-settings.tsx
+++ b/src/frontend/src/components/settings/semantic-models-settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Upload, ChevronDown, RefreshCw, Trash2, Loader2, Library, Eye, Copy, Check, Network, FileCode2 } from 'lucide-react';
+import { Upload, ChevronDown, RefreshCw, Trash2, Loader2, Library, Eye, Copy, Check, Network, FileCode2, Pencil } from 'lucide-react';
 import type { SemanticModel } from '@/types/ontology';
 import {
   AlertDialog,
@@ -30,11 +30,49 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import OntologyLibraryDialog from '@/components/settings/ontology-library-dialog';
+import { usePermissions } from '@/stores/permissions-store';
+import { FeatureAccessLevel } from '@/types/settings';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { systemRdfNamespaceDisplayLabel } from '@/lib/system-rdf-namespace-labels';
+import type { TFunction } from 'i18next';
 
 const SYSTEM_CONTEXTS = ['urn:meta:sources', 'urn:semantic-links'];
 
+interface TitleCandidateRow {
+  iri: string;
+  kind: string;
+  text: string;
+  lang?: string;
+}
+
+function semanticModelDisplayTitle(m: SemanticModel, t: TFunction<'semantic-models', undefined>): string {
+  const d = m.display_name?.trim();
+  if (d) return d;
+  return systemRdfNamespaceDisplayLabel(m.name, t);
+}
+
+/** Serialization (syntax) for table — prefer API `serialization`, not vocabulary. */
+function semanticModelSerializationLabel(m: SemanticModel, tr: (key: string) => string): string {
+  const fromApi = m.serialization?.trim();
+  if (fromApi) return fromApi;
+  const fn = (m.original_filename || m.name || '').toLowerCase();
+  if (fn.endsWith('.ttl') || fn.endsWith('.n3')) return tr('rdfSources.serializationTurtle');
+  if (fn.endsWith('.owl') || fn.endsWith('.rdf') || fn.endsWith('.xml')) return tr('rdfSources.serializationRdfXml');
+  if (fn.endsWith('.jsonld') || fn.endsWith('.json-ld') || fn.endsWith('.json')) return tr('rdfSources.serializationJsonLd');
+  if (fn.endsWith('.nt')) return tr('rdfSources.serializationNTriples');
+  if (fn.endsWith('.trig')) return tr('rdfSources.serializationTriG');
+  const fmt = (m.format || '').toLowerCase();
+  if (fmt === 'skos') return tr('rdfSources.serializationTurtle');
+  if (fmt === 'rdfs') return tr('rdfSources.serializationRdfXml');
+  if (fmt === 'ttl') return tr('rdfSources.serializationTurtle');
+  return tr('rdfSources.serializationUnknown');
+}
+
 export default function SemanticModelsSettings() {
-  const { t } = useTranslation('semantic-models');
+  const { t } = useTranslation(['semantic-models', 'common']);
+  const { hasPermission, isLoading: permissionsLoading } = usePermissions();
+  const canWriteSemantic = !permissionsLoading && hasPermission('semantic-models', FeatureAccessLevel.READ_WRITE);
   const { get, post, delete: deleteApi } = useApi();
   const { toast } = useToast();
   const [items, setItems] = useState<SemanticModel[]>([]);
@@ -50,11 +88,28 @@ export default function SemanticModelsSettings() {
   const [copied, setCopied] = useState(false);
   const [isRefreshingGraph, setIsRefreshingGraph] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  
+  const [listSearch, setListSearch] = useState('');
+  const [titleDialogOpen, setTitleDialogOpen] = useState(false);
+  const [titleEditModel, setTitleEditModel] = useState<SemanticModel | null>(null);
+  const [titleCandidates, setTitleCandidates] = useState<TitleCandidateRow[]>([]);
+  const [titleCandidatesLoading, setTitleCandidatesLoading] = useState(false);
+  const [titleChoice, setTitleChoice] = useState<string>('custom');
+  const [titleCustom, setTitleCustom] = useState('');
+  const [titleSaving, setTitleSaving] = useState(false);
+
   const filteredItems = useMemo(() => 
     items.filter(m => !SYSTEM_CONTEXTS.includes(m.name)),
     [items]
   );
+
+  const tableData = useMemo(() => {
+    const q = listSearch.trim().toLowerCase();
+    if (!q) return filteredItems;
+    return filteredItems.filter((m) => {
+      const title = semanticModelDisplayTitle(m, t).toLowerCase();
+      return title.includes(q) || m.name.toLowerCase().includes(q);
+    });
+  }, [filteredItems, listSearch, t]);
 
   const fetchItems = async () => {
     setIsLoading(true);
@@ -199,15 +254,132 @@ export default function SemanticModelsSettings() {
     }
   };
 
+  const openTitleDialog = useCallback(
+    async (model: SemanticModel) => {
+      setTitleEditModel(model);
+      setTitleDialogOpen(true);
+      setTitleCandidatesLoading(true);
+      setTitleCandidates([]);
+      setTitleChoice('custom');
+      setTitleCustom(model.display_name?.trim() || '');
+      try {
+        const res = await get<{ candidates: TitleCandidateRow[] }>(
+          `/api/semantic-models/${encodeURIComponent(model.id)}/title-candidates`
+        );
+        if (res.error) {
+          toast({ title: t('messages.error'), description: res.error, variant: 'destructive' });
+          setTitleCandidatesLoading(false);
+          return;
+        }
+        const candidates = res.data?.candidates ?? [];
+        setTitleCandidates(candidates);
+        const cur = model.display_name?.trim();
+        if (cur) {
+          const idx = candidates.findIndex((c) => c.text.trim() === cur);
+          if (idx >= 0) {
+            setTitleChoice(`c:${idx}`);
+          } else {
+            setTitleChoice('custom');
+            setTitleCustom(cur);
+          }
+        } else if (candidates.length > 0) {
+          setTitleChoice('c:0');
+          setTitleCustom(candidates[0].text);
+        }
+      } catch (e: any) {
+        toast({
+          title: t('messages.error'),
+          description: e.message || t('rdfSources.loadSuggestionsFailed'),
+          variant: 'destructive',
+        });
+      } finally {
+        setTitleCandidatesLoading(false);
+      }
+    },
+    [get, toast, t]
+  );
+
+  const saveTitleDialog = async () => {
+    if (!titleEditModel) return;
+    let displayName = '';
+    if (titleChoice.startsWith('c:')) {
+      const idx = parseInt(titleChoice.slice(2), 10);
+      displayName = (titleCandidates[idx]?.text ?? '').trim();
+    } else {
+      displayName = titleCustom.trim();
+    }
+    setTitleSaving(true);
+    try {
+      const response = await fetch(`/api/semantic-models/${encodeURIComponent(titleEditModel.id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ display_name: displayName }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.detail || 'Failed to update title');
+      }
+      toast({ title: t('messages.success'), description: t('rdfSources.titleSaved') });
+      setTitleDialogOpen(false);
+      setTitleEditModel(null);
+      await fetchItems();
+    } catch (e: any) {
+      toast({ title: t('messages.error'), description: e.message || 'Failed to save', variant: 'destructive' });
+    } finally {
+      setTitleSaving(false);
+    }
+  };
+
+  const clearDisplayTitle = async () => {
+    if (!titleEditModel) return;
+    setTitleSaving(true);
+    try {
+      const response = await fetch(`/api/semantic-models/${encodeURIComponent(titleEditModel.id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ display_name: '' }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.detail || 'Failed to clear title');
+      }
+      toast({ title: t('messages.success'), description: t('rdfSources.titleSaved') });
+      setTitleDialogOpen(false);
+      setTitleEditModel(null);
+      await fetchItems();
+    } catch (e: any) {
+      toast({ title: t('messages.error'), description: e.message || 'Failed to clear', variant: 'destructive' });
+    } finally {
+      setTitleSaving(false);
+    }
+  };
+
   const columns = useMemo<ColumnDef<SemanticModel>[]>(() => [
     {
-      accessorKey: 'name',
+      id: 'displayTitle',
+      accessorFn: (row) => semanticModelDisplayTitle(row, t),
       header: ({ column }: { column: Column<SemanticModel, unknown> }) => (
         <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
-          Name <ChevronDown className="ml-2 h-4 w-4" />
+          {t('rdfSources.nameColumn')} <ChevronDown className="ml-2 h-4 w-4" />
         </Button>
       ),
-      cell: ({ row }) => <div className="font-medium">{row.getValue('name')}</div>,
+      cell: ({ row }) => {
+        const model = row.original;
+        const title = semanticModelDisplayTitle(model, t);
+        const showFileHint = Boolean(model.display_name?.trim());
+        return (
+          <div className="min-w-0">
+            <div className="font-medium truncate" title={title}>
+              {title}
+            </div>
+            {showFileHint && (
+              <div className="text-xs text-muted-foreground truncate" title={model.name}>
+                {model.name}
+              </div>
+            )}
+          </div>
+        );
+      },
     },
     { 
       id: 'source',
@@ -239,17 +411,20 @@ export default function SemanticModelsSettings() {
         return <Badge variant={variant}>{label}</Badge>;
       }
     },
-    { 
-      accessorKey: 'format', 
-      header: 'Format', 
-      cell: ({ row }) => <Badge variant="secondary">{(row.getValue('format') as string)?.toUpperCase()}</Badge> 
+    {
+      id: 'serialization',
+      accessorFn: (row) => semanticModelSerializationLabel(row, t),
+      header: t('rdfSources.syntaxColumn'),
+      cell: ({ row }) => (
+        <Badge variant="secondary">{semanticModelSerializationLabel(row.original, t)}</Badge>
+      ),
     },
     { 
       accessorKey: 'size_bytes', 
       header: 'Size', 
       cell: ({ row }) => {
-        const bytes = row.getValue('size_bytes') as number | undefined;
-        if (!bytes) return <span>-</span>;
+        const bytes = row.getValue('size_bytes') as number | undefined | null;
+        if (bytes === undefined || bytes === null) return <span>-</span>;
         const kb = (bytes / 1024).toFixed(1);
         return <span>{kb} KB</span>;
       }
@@ -292,9 +467,21 @@ export default function SemanticModelsSettings() {
         const createdBy = model.created_by || '';
         const isSystemManaged = createdBy.startsWith('system@') && createdBy !== 'system@startup';
         const canDelete = !isFileBased && !isSystemManaged;
+        const canEditTitle = canWriteSemantic && !isFileBased && !isSystemManaged;
         
         return (
           <div className="flex items-center justify-end gap-1">
+            {canEditTitle && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => openTitleDialog(model)}
+                title={t('rdfSources.editDisplayTitle')}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="icon"
@@ -320,7 +507,7 @@ export default function SemanticModelsSettings() {
       },
       enableSorting: false,
     },
-  ], [uploadingId]);
+  ], [uploadingId, canWriteSemantic, t, openTitleDialog]);
 
   return (
     <>
@@ -336,8 +523,11 @@ export default function SemanticModelsSettings() {
 
       <DataTable
         columns={columns}
-        data={filteredItems}
+        data={tableData}
         searchColumn="name"
+        searchValue={listSearch}
+        onSearchChange={setListSearch}
+        defaultSortColumn="displayTitle"
         isLoading={isLoading}
         storageKey="rdf-sources-sort"
         toolbarActions={
@@ -387,7 +577,8 @@ export default function SemanticModelsSettings() {
           <AlertDialogHeader>
             <AlertDialogTitle>Delete RDF Source</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete <strong>{modelToDelete?.name}</strong>? 
+              Are you sure you want to delete{' '}
+              <strong>{modelToDelete ? semanticModelDisplayTitle(modelToDelete, t) : ''}</strong>?
               This action cannot be undone and will remove the model from the semantic graph.
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -399,6 +590,99 @@ export default function SemanticModelsSettings() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <Dialog
+        open={titleDialogOpen}
+        onOpenChange={(open) => {
+          setTitleDialogOpen(open);
+          if (!open) {
+            setTitleEditModel(null);
+            setTitleCandidates([]);
+            setTitleChoice('custom');
+            setTitleCustom('');
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{t('rdfSources.titleDialog')}</DialogTitle>
+            <DialogDescription>{t('rdfSources.titleDialogDescription')}</DialogDescription>
+          </DialogHeader>
+          {titleCandidatesLoading ? (
+            <div className="flex items-center gap-2 text-muted-foreground py-8 justify-center">
+              <Loader2 className="h-6 w-6 animate-spin" />
+            </div>
+          ) : (
+            <RadioGroup value={titleChoice} onValueChange={setTitleChoice} className="space-y-4">
+              {titleCandidates.length > 0 && (
+                <div className="space-y-3">
+                  <Label className="text-muted-foreground text-xs uppercase tracking-wide">
+                    {t('rdfSources.suggestedFromFile')}
+                  </Label>
+                  {titleCandidates.map((c, i) => (
+                    <div key={`${c.iri}-${c.text}-${i}`} className="flex items-start gap-3">
+                      <RadioGroupItem value={`c:${i}`} id={`title-c-${i}`} className="mt-1 shrink-0" />
+                      <Label htmlFor={`title-c-${i}`} className="font-normal cursor-pointer leading-snug min-w-0">
+                        <span className="font-medium block">{c.text}</span>
+                        <span className="block text-xs text-muted-foreground break-all">
+                          {c.kind}
+                          {c.lang ? ` · ${c.lang}` : ''}
+                        </span>
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="flex items-start gap-3">
+                <RadioGroupItem value="custom" id="title-custom" className="mt-1 shrink-0" />
+                <div className="grid gap-2 flex-1 min-w-0">
+                  <Label htmlFor="title-custom-input" className="font-normal cursor-pointer">
+                    {t('rdfSources.customTitle')}
+                  </Label>
+                  <Input
+                    id="title-custom-input"
+                    value={titleCustom}
+                    onChange={(e) => setTitleCustom(e.target.value)}
+                    onFocus={() => setTitleChoice('custom')}
+                    placeholder={titleEditModel?.name ?? ''}
+                  />
+                </div>
+              </div>
+            </RadioGroup>
+          )}
+          <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between sm:space-x-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full sm:w-auto"
+              onClick={() => void clearDisplayTitle()}
+              disabled={titleSaving || !titleEditModel?.display_name?.trim()}
+            >
+              {t('rdfSources.useFilename')}
+            </Button>
+            <div className="flex gap-2 justify-end w-full sm:w-auto">
+              <Button type="button" variant="ghost" onClick={() => setTitleDialogOpen(false)}>
+                {t('common:actions.cancel')}
+              </Button>
+              <Button
+                type="button"
+                className="inline-flex items-center gap-2"
+                onClick={() => void saveTitleDialog()}
+                disabled={titleSaving}
+              >
+                {titleSaving ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+                    {t('common:actions.saving')}
+                  </>
+                ) : (
+                  t('common:actions.save')
+                )}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <OntologyLibraryDialog
         isOpen={libraryDialogOpen}
@@ -417,10 +701,14 @@ export default function SemanticModelsSettings() {
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Eye className="h-5 w-5" />
-              {viewingModel?.name || 'View Ontology'}
+              {viewingModel ? semanticModelDisplayTitle(viewingModel, t) : 'View Ontology'}
             </DialogTitle>
             <DialogDescription>
-              Raw content of the semantic model ({viewingModel?.format?.toUpperCase() || 'Unknown format'})
+              {viewingModel
+                ? t('rdfSources.viewRawDescription', {
+                    syntax: semanticModelSerializationLabel(viewingModel, t),
+                  })
+                : t('rdfSources.viewRawDescriptionFallback')}
             </DialogDescription>
           </DialogHeader>
           <div className="flex-1 min-h-0">

--- a/src/frontend/src/i18n/locales/en/semantic-models.json
+++ b/src/frontend/src/i18n/locales/en/semantic-models.json
@@ -166,5 +166,33 @@
       "title": "Create Link",
       "description": "Define a relationship between two concepts"
     }
+  },
+  "rdfSources": {
+    "syntaxColumn": "Syntax",
+    "serializationUnknown": "—",
+    "serializationTurtle": "Turtle",
+    "serializationRdfXml": "RDF/XML",
+    "serializationJsonLd": "JSON-LD",
+    "serializationNTriples": "N-Triples",
+    "serializationTriG": "TriG",
+    "viewRawDescription": "Raw RDF content ({{syntax}}).",
+    "viewRawDescriptionFallback": "Raw RDF content.",
+    "nameColumn": "Name",
+    "editDisplayTitle": "Edit display title",
+    "titleDialog": "RDF source title",
+    "titleDialogDescription": "Pick a label from the ontology header or enter a custom title. The file name remains the internal graph key.",
+    "suggestedFromFile": "Suggested from file",
+    "customTitle": "Custom title",
+    "useFilename": "Use file name",
+    "titleSaved": "Display title updated",
+    "loadSuggestionsFailed": "Failed to load title suggestions",
+    "fileBackedReadOnly": "Built-in file sources use the file name as the title.",
+    "systemNamespaces": {
+      "metaSources": "Source registry metadata",
+      "semanticLinks": "Semantic links",
+      "rdflibDefault": "Default graph",
+      "appEntities": "App Entities",
+      "demoGraph": "Demo business concepts"
+    }
   }
 }

--- a/src/frontend/src/lib/system-rdf-namespace-labels.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.ts
@@ -1,0 +1,42 @@
+import type { TFunction } from 'i18next';
+
+/**
+ * Known internal graph names / API pseudo-row `name` values (not user taxonomies).
+ * Keys use the semantic-models namespace as default when calling `t`.
+ */
+const SYSTEM_RDF_NAMESPACE_KEYS: Record<string, { i18nKey: string; defaultLabel: string }> = {
+  'urn:meta:sources': {
+    i18nKey: 'rdfSources.systemNamespaces.metaSources',
+    defaultLabel: 'Source registry metadata',
+  },
+  'urn:semantic-links': {
+    i18nKey: 'rdfSources.systemNamespaces.semanticLinks',
+    defaultLabel: 'Semantic links',
+  },
+  'urn:x-rdflib:default': {
+    i18nKey: 'rdfSources.systemNamespaces.rdflibDefault',
+    defaultLabel: 'Default graph',
+  },
+  /** Same human-facing intent as bundled collection metadata (Collections tab labels). */
+  'urn:app-entities': {
+    i18nKey: 'rdfSources.systemNamespaces.appEntities',
+    defaultLabel: 'App Entities',
+  },
+  'urn:demo': {
+    i18nKey: 'rdfSources.systemNamespaces.demoGraph',
+    defaultLabel: 'Demo business concepts',
+  },
+};
+
+/**
+ * Human-readable label for internal RDF graph keys, or the original key if unknown.
+ * Pass `t` from `useTranslation('semantic-models')` (or ['semantic-models', …] with semantic-models first).
+ */
+export function systemRdfNamespaceDisplayLabel(
+  graphKey: string,
+  t: TFunction<'semantic-models', undefined> | TFunction,
+): string {
+  const entry = SYSTEM_RDF_NAMESPACE_KEYS[graphKey];
+  if (!entry) return graphKey;
+  return t(entry.i18nKey, { defaultValue: entry.defaultLabel });
+}

--- a/src/frontend/src/types/data-contract.ts
+++ b/src/frontend/src/types/data-contract.ts
@@ -34,10 +34,32 @@ export type DataContractListItem = {
   description?: ContractDescription
 }
 
+// ODCS v3.1.0 relationship (foreign key) at schema or property level
+export type SchemaRelationship = {
+  id?: string
+  type: string
+  from?: string | string[] // schema-level only; absent for property-level
+  to: string | string[]
+  customProperties?: { property: string; value: any }[]
+}
+
+// ODCS v3.1.0 Team object metadata
+export type TeamMetadata = {
+  id?: string
+  contract_id?: string
+  stable_id?: string
+  name?: string
+  description?: string
+  tags?: string[]
+  customProperties?: { property: string; value: any }[]
+  authoritativeDefinitions?: { url: string; type: string }[]
+}
+
 // ODCS compliant column property
 export type ColumnProperty = {
   name: string
   logicalType: string
+  stableId?: string // ODCS v3.1.0 StableId
   physicalType?: string // Physical data type (VARCHAR(50), INT, etc.)
   physicalName?: string // Physical column name
   required?: boolean
@@ -82,11 +104,14 @@ export type ColumnProperty = {
   quality?: QualityRule[]  // Property-level quality checks
   tags?: string[]  // ODCS tags for categorization
   customProperties?: Record<string, any>  // ODCS custom properties
+  // ODCS v3.1.0 relationships (property-level FKs)
+  relationships?: SchemaRelationship[]
 }
 
 // ODCS compliant schema object
 export type SchemaObject = {
   name: string
+  stableId?: string // ODCS v3.1.0 StableId
   physicalName?: string
   properties: ColumnProperty[]
   propertyCount?: number
@@ -105,6 +130,8 @@ export type SchemaObject = {
   authoritativeDefinitions?: { url: string; type: string }[]
   // Optional local helper used by wizard/editor to collect concepts
   semanticConcepts?: { iri: string; label?: string }[]
+  // ODCS v3.1.0 relationships (schema-level FKs)
+  relationships?: SchemaRelationship[]
 }
 
 // Lightweight schema summary for listing (no properties loaded)

--- a/src/frontend/src/types/ontology.ts
+++ b/src/frontend/src/types/ontology.ts
@@ -153,7 +153,12 @@ export interface ConceptUpdate {
 export interface SemanticModel {
   id: string;
   name: string;
-  format: 'rdfs' | 'skos';
+  /** User-facing title; graph key remains `name` (filename / stable id). */
+  display_name?: string | null;
+  /** Legacy DB parse branch — not vocabulary. Prefer `serialization` for UI. */
+  format?: 'rdfs' | 'skos' | string | null;
+  /** RDF syntax label from API (Turtle, RDF/XML, …). */
+  serialization?: string | null;
   original_filename?: string;
   content_type?: string;
   size_bytes?: number;

--- a/src/frontend/src/views/data-contract-details.tsx
+++ b/src/frontend/src/views/data-contract-details.tsx
@@ -4,10 +4,11 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { AlertCircle, Download, Pencil, Trash2, Loader2, ArrowLeft, FileText, KeyRound, CopyPlus, Plus, Shapes, Columns2, Database, Sparkles, Package, ChevronLeft, ChevronRight, ShieldCheck, Globe } from 'lucide-react'
+import { AlertCircle, Download, Pencil, Trash2, Loader2, ArrowLeft, FileText, KeyRound, CopyPlus, Plus, Shapes, Columns2, Database, Sparkles, Package, ChevronLeft, ChevronRight, ShieldCheck, Globe, Link2 } from 'lucide-react'
 import { DetailViewSkeleton } from '@/components/common/list-view-skeleton'
 import { Badge } from '@/components/ui/badge'
 import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DataTable } from '@/components/ui/data-table'
 import { ColumnDef } from '@tanstack/react-table'
@@ -58,6 +59,8 @@ import { DirectCertifyDialog, DirectPublishDialog } from '@/components/common/di
 import type { CertificationLevel, PublicationScope } from '@/types/lifecycle'
 import { userHasApprovalPrivilege } from '@/lib/permissions'
 import { ApprovalEntity } from '@/types/settings'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 
 // Status-based editability constants
 // Only draft/proposed contracts can be edited in place
@@ -75,6 +78,8 @@ type SchemaProperty = {
   required: boolean
   unique: boolean
   description?: string
+  stableId?: string
+  relationships?: { id?: string; type: string; to: string | string[]; from?: string | string[]; customProperties?: any[] }[]
 }
 
 // Define this as a function to access component state
@@ -96,6 +101,9 @@ const createSchemaPropertyColumns = (
       return (
         <div>
           <span className="font-mono font-medium">{property.name}</span>
+          {property.stableId && (
+            <span className="ml-2 text-[10px] font-mono text-muted-foreground/60" title="ODCS StableId">{property.stableId}</span>
+          )}
           {links.length > 0 && (
             <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-2">
               {links.map((link, idx) => {
@@ -151,6 +159,35 @@ const createSchemaPropertyColumns = (
     ),
   },
   {
+    id: 'fk',
+    header: '',
+    size: 32,
+    cell: ({ row }) => {
+      const rels = row.original.relationships
+      if (!rels || rels.length === 0) return null
+      return (
+        <Popover>
+          <PopoverTrigger asChild>
+            <span className="cursor-pointer" title="Foreign key relationship">
+              <Link2 className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+            </span>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto max-w-xs p-3" side="right">
+            <div className="space-y-1.5">
+              <p className="text-xs font-semibold">Relationships</p>
+              {rels.map((rel, i) => (
+                <div key={i} className="text-xs flex items-center gap-1.5">
+                  <Badge variant="outline" className="text-[10px] px-1 py-0">{rel.type}</Badge>
+                  <span className="font-mono">→ {typeof rel.to === 'string' ? rel.to : JSON.stringify(rel.to)}</span>
+                </div>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      )
+    },
+  },
+  {
     accessorKey: 'description',
     header: 'Description',
     cell: ({ row }) => (
@@ -194,7 +231,7 @@ export default function DataContractDetails() {
     availableRoles,
     appliedRoleId,
   } = usePermissions()
-  const { post, get } = useApi()
+  const { post, get, put } = useApi()
   const { userInfo, fetchUserInfo } = useUserStore()
 
   const setStaticSegments = useBreadcrumbStore((state) => state.setStaticSegments)
@@ -234,6 +271,12 @@ export default function DataContractDetails() {
 
   // Team import state
   const [isImportTeamMembersOpen, setIsImportTeamMembersOpen] = useState(false)
+
+  // Team metadata (ODCS v3.1.0)
+  const [teamMetadata, setTeamMetadata] = useState<{ name?: string; description?: string }>({})
+  const [teamMetaName, setTeamMetaName] = useState('')
+  const [teamMetaDesc, setTeamMetaDesc] = useState('')
+  const [teamMetaDirty, setTeamMetaDirty] = useState(false)
 
   // Link product dialog state
   const [isLinkProductDialogOpen, setIsLinkProductDialogOpen] = useState(false)
@@ -496,6 +539,17 @@ export default function DataContractDetails() {
       })
       setContract(contractData)
       setDynamicTitle(contractData.name)
+
+      // Fetch team metadata (ODCS v3.1.0)
+      try {
+        const tmRes = await fetch(`/api/data-contracts/${contractId}/team-metadata`)
+        if (tmRes.ok) {
+          const tm = await tmRes.json()
+          setTeamMetadata(tm || {})
+          setTeamMetaName(tm?.name || '')
+          setTeamMetaDesc(tm?.description || '')
+        }
+      } catch { /* ignore */ }
 
       if (linksRes.ok) {
         const linksData = await linksRes.json()
@@ -1540,6 +1594,21 @@ export default function DataContractDetails() {
     }
   }
 
+  const handleSaveTeamMetadata = async () => {
+    if (!contractId) return
+    try {
+      await put(`/api/data-contracts/${contractId}/team-metadata`, {
+        name: teamMetaName || null,
+        description: teamMetaDesc || null
+      })
+      setTeamMetadata({ name: teamMetaName, description: teamMetaDesc })
+      setTeamMetaDirty(false)
+      toast({ title: 'Team metadata saved' })
+    } catch {
+      toast({ title: 'Failed to save team metadata', variant: 'destructive' })
+    }
+  }
+
   // Helper functions for conditional rendering based on view mode
   const shouldShowSection = (section: string): boolean => {
     switch (viewMode) {
@@ -2218,6 +2287,15 @@ export default function DataContractDetails() {
                   <div className="flex items-center gap-4 justify-between">
                     <div>
                       <Label className="text-base font-semibold">{contract.schema[selectedSchemaIndex]?.name || `Table ${selectedSchemaIndex + 1}`}</Label>
+                      {contract.schema[selectedSchemaIndex]?.stableId && (
+                        <span className="ml-2 text-xs font-mono text-muted-foreground" title="ODCS StableId">{contract.schema[selectedSchemaIndex].stableId}</span>
+                      )}
+                      {contract.schema[selectedSchemaIndex]?.relationships && contract.schema[selectedSchemaIndex].relationships!.length > 0 && (
+                        <Badge variant="outline" className="ml-2 text-xs">
+                          <Link2 className="h-3 w-3 mr-1" />
+                          {contract.schema[selectedSchemaIndex].relationships!.length} FK{contract.schema[selectedSchemaIndex].relationships!.length > 1 ? 's' : ''}
+                        </Badge>
+                      )}
                       {contract.schema[selectedSchemaIndex]?.name && schemaLinks[contract.schema[selectedSchemaIndex].name] && schemaLinks[contract.schema[selectedSchemaIndex].name].length > 0 && (
                         <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-2">
                           {schemaLinks[contract.schema[selectedSchemaIndex].name].map((link, idx) => (
@@ -2359,6 +2437,15 @@ export default function DataContractDetails() {
                   <div className="flex items-center gap-4 justify-between">
                     <div>
                       <Label className="text-base font-semibold">{contract.schema[selectedSchemaIndex]?.name || `Table ${selectedSchemaIndex + 1}`}</Label>
+                      {contract.schema[selectedSchemaIndex]?.stableId && (
+                        <span className="ml-2 text-xs font-mono text-muted-foreground" title="ODCS StableId">{contract.schema[selectedSchemaIndex].stableId}</span>
+                      )}
+                      {contract.schema[selectedSchemaIndex]?.relationships && contract.schema[selectedSchemaIndex].relationships!.length > 0 && (
+                        <Badge variant="outline" className="ml-2 text-xs">
+                          <Link2 className="h-3 w-3 mr-1" />
+                          {contract.schema[selectedSchemaIndex].relationships!.length} FK{contract.schema[selectedSchemaIndex].relationships!.length > 1 ? 's' : ''}
+                        </Badge>
+                      )}
                       {contract.schema[selectedSchemaIndex]?.name && schemaLinks[contract.schema[selectedSchemaIndex].name] && schemaLinks[contract.schema[selectedSchemaIndex].name].length > 0 && (
                         <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-2">
                           {schemaLinks[contract.schema[selectedSchemaIndex].name].map((link, idx) => (
@@ -2665,7 +2752,44 @@ export default function DataContractDetails() {
             </div>
           </div>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
+          {/* Team metadata (ODCS v3.1.0) */}
+          <div className="grid grid-cols-2 gap-4 border rounded-lg p-4 bg-muted/30">
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Team Name</Label>
+              {canEditInPlace ? (
+                <Input
+                  value={teamMetaName}
+                  onChange={(e) => { setTeamMetaName(e.target.value); setTeamMetaDirty(true) }}
+                  placeholder="e.g. Data Engineering"
+                  className="h-8"
+                />
+              ) : (
+                <p className="text-sm">{teamMetaName || '—'}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Team Description</Label>
+              {canEditInPlace ? (
+                <Textarea
+                  value={teamMetaDesc}
+                  onChange={(e) => { setTeamMetaDesc(e.target.value); setTeamMetaDirty(true) }}
+                  placeholder="Brief description of the team"
+                  className="min-h-[32px] resize-none"
+                  rows={1}
+                />
+              ) : (
+                <p className="text-sm">{teamMetaDesc || '—'}</p>
+              )}
+            </div>
+            {canEditInPlace && teamMetaDirty && (
+              <div className="col-span-2 flex justify-end">
+                <Button size="sm" onClick={handleSaveTeamMetadata}>Save Team Info</Button>
+              </div>
+            )}
+          </div>
+
+          {/* Team members list */}
           {contract.team && contract.team.length > 0 ? (
             <div className="space-y-2">
               {contract.team.map((member, idx) => (

--- a/src/frontend/src/views/ontology-home.tsx
+++ b/src/frontend/src/views/ontology-home.tsx
@@ -220,6 +220,7 @@ export default function OntologyHomeView() {
             onToggleRoot={handleToggleRoot}
             onNodeClick={handleNodeClick}
             showRootBadges={!groupBySource}
+            selectedLanguage={selectedLanguage}
           />
         </div>
       )}


### PR DESCRIPTION
Replays four commits from local main onto `origin/main` (no squash):

- feat(startup): graceful degradation for database and workspace client failures
- feat(contracts): persist and surface ODCS v3.1.0 relationships, team metadata, and stable IDs
- feat(knowledge-graph): add label toggle, property shapes, and language-aware labels
- feat(semantic-models): RDF display titles, serialization, and graph i18n