### PR TITLE
feat(workflows): wire missing trigger types across entity lifecycle

### DIFF
--- a/src/backend/src/common/workflow_triggers.py
+++ b/src/backend/src/common/workflow_triggers.py
@@ -925,12 +925,61 @@ class TriggerRegistry:
 
 def get_trigger_registry(db: Session) -> TriggerRegistry:
     """Get a trigger registry instance.
-    
+
     Args:
         db: Database session
-        
+
     Returns:
         TriggerRegistry instance
     """
     return TriggerRegistry(db)
+
+
+def fire_trigger_safe(
+    db: Session,
+    method: str,
+    *,
+    entity_type: EntityType,
+    entity_id: str,
+    entity_name: Optional[str] = None,
+    entity_data: Optional[Dict[str, Any]] = None,
+    user_email: Optional[str] = None,
+    from_status: Optional[str] = None,
+    to_status: Optional[str] = None,
+    blocking: bool = False,
+) -> None:
+    """Fire a trigger method on the registry, logging and swallowing errors.
+
+    Convenience wrapper that eliminates repetitive try/except blocks in routes.
+
+    Args:
+        db: Database session
+        method: Name of the TriggerRegistry method (e.g. "on_create", "on_delete")
+        entity_type: Entity type enum value
+        entity_id: ID of the entity
+        entity_name: Display name of the entity
+        entity_data: Additional entity data dict
+        user_email: User performing the action
+        from_status: Previous status (for status-change triggers)
+        to_status: New status (for status-change triggers)
+        blocking: Whether to execute synchronously
+    """
+    try:
+        registry = get_trigger_registry(db)
+        kwargs: Dict[str, Any] = {
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "entity_name": entity_name,
+            "entity_data": entity_data,
+            "user_email": user_email,
+        }
+        if from_status is not None:
+            kwargs["from_status"] = from_status
+        if to_status is not None:
+            kwargs["to_status"] = to_status
+        if method not in ("before_create", "before_update", "before_status_change"):
+            kwargs["blocking"] = blocking
+        getattr(registry, method)(**kwargs)
+    except Exception as e:
+        logger.warning(f"{method} trigger failed for {entity_type.value} {entity_id}: {e}")
 

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -3774,21 +3774,18 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             db.refresh(updated)
 
             # Fire on_status_change workflow trigger
-            try:
-                from src.common.workflow_triggers import get_trigger_registry as _get_tr
-                from src.models.process_workflows import EntityType as _WFEntityType
-                _get_tr(db).on_status_change(
-                    entity_type=_WFEntityType.DATA_CONTRACT,
-                    entity_id=contract_id,
-                    from_status=current_status,
-                    to_status=new_status,
-                    entity_name=contract.name,
-                    entity_data={"name": contract.name, "status": new_status},
-                    user_email=current_user,
-                    blocking=False,
-                )
-            except Exception as e:
-                logger.warning(f"on_status_change trigger failed for contract {contract_id}: {e}")
+            from src.common.workflow_triggers import fire_trigger_safe
+            from src.models.process_workflows import EntityType
+            fire_trigger_safe(
+                db, "on_status_change",
+                entity_type=EntityType.DATA_CONTRACT,
+                entity_id=contract_id,
+                from_status=current_status,
+                to_status=new_status,
+                entity_name=contract.name,
+                entity_data={"name": contract.name, "status": new_status},
+                user_email=current_user,
+            )
 
             return updated
         except Exception as e:

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -3772,6 +3772,24 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             )
             db.commit()
             db.refresh(updated)
+
+            # Fire on_status_change workflow trigger
+            try:
+                from src.common.workflow_triggers import get_trigger_registry as _get_tr
+                from src.models.process_workflows import EntityType as _WFEntityType
+                _get_tr(db).on_status_change(
+                    entity_type=_WFEntityType.DATA_CONTRACT,
+                    entity_id=contract_id,
+                    from_status=current_status,
+                    to_status=new_status,
+                    entity_name=contract.name,
+                    entity_data={"name": contract.name, "status": new_status},
+                    user_email=current_user,
+                    blocking=False,
+                )
+            except Exception as e:
+                logger.warning(f"on_status_change trigger failed for contract {contract_id}: {e}")
+
             return updated
         except Exception as e:
             db.rollback()

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -609,22 +609,18 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             )
             
             # Fire on_status_change workflow trigger
-            try:
-                from src.common.workflow_triggers import get_trigger_registry
-                from src.models.process_workflows import EntityType as WFEntityType
-                tr = get_trigger_registry(self._db)
-                tr.on_status_change(
-                    entity_type=WFEntityType.DATA_PRODUCT,
-                    entity_id=product_id,
-                    from_status=current_status,
-                    to_status=new_status_lower,
-                    entity_name=product_db.name,
-                    entity_data={"name": product_db.name, "status": new_status_lower},
-                    user_email=current_user,
-                    blocking=False,
-                )
-            except Exception as e:
-                logger.warning(f"on_status_change trigger failed for product {product_id}: {e}")
+            from src.common.workflow_triggers import fire_trigger_safe
+            from src.models.process_workflows import EntityType
+            fire_trigger_safe(
+                self._db, "on_status_change",
+                entity_type=EntityType.DATA_PRODUCT,
+                entity_id=product_id,
+                from_status=current_status,
+                to_status=new_status_lower,
+                entity_name=product_db.name,
+                entity_data={"name": product_db.name, "status": new_status_lower},
+                user_email=current_user,
+            )
 
             result = self._load_product_with_tags(product_db)
             self._update_search_index(result)

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -608,10 +608,28 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 new_status=new_status_lower
             )
             
+            # Fire on_status_change workflow trigger
+            try:
+                from src.common.workflow_triggers import get_trigger_registry
+                from src.models.process_workflows import EntityType as WFEntityType
+                tr = get_trigger_registry(self._db)
+                tr.on_status_change(
+                    entity_type=WFEntityType.DATA_PRODUCT,
+                    entity_id=product_id,
+                    from_status=current_status,
+                    to_status=new_status_lower,
+                    entity_name=product_db.name,
+                    entity_data={"name": product_db.name, "status": new_status_lower},
+                    user_email=current_user,
+                    blocking=False,
+                )
+            except Exception as e:
+                logger.warning(f"on_status_change trigger failed for product {product_id}: {e}")
+
             result = self._load_product_with_tags(product_db)
             self._update_search_index(result)
             return result
-            
+
         except SQLAlchemyError as e:
             logger.error(f"Database error transitioning product {product_id} status: {e}")
             raise

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -767,23 +767,20 @@ async def handle_contract_certification(
         db.commit()
         db.refresh(contract_db)
 
-        from src.common.workflow_triggers import get_trigger_registry
+        from src.common.workflow_triggers import fire_trigger_safe
         from src.models.process_workflows import EntityType
-
-        try:
-            get_trigger_registry(db).on_certify(
-                entity_type=EntityType.DATA_CONTRACT,
-                entity_id=contract_id,
-                entity_name=contract_db.name,
-                entity_data={
-                    "certification_level": certification_level,
-                    "certification_notes": notes,
-                    "certified_by": contract_db.certified_by,
-                },
-                user_email=current_user.email if current_user else None,
-            )
-        except Exception as wf_err:
-            logger.warning("on_certify trigger error (non-fatal): %s", wf_err, exc_info=True)
+        fire_trigger_safe(
+            db, "on_certify",
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id=contract_id,
+            entity_name=contract_db.name,
+            entity_data={
+                "certification_level": certification_level,
+                "certification_notes": notes,
+                "certified_by": contract_db.certified_by,
+            },
+            user_email=current_user.email if current_user else None,
+        )
 
         manager._update_search_index(contract_db, db)
 
@@ -869,19 +866,16 @@ async def certify_contract_direct(
         propagate_certification(db, "DataContract", contract_id)
         db.commit()
 
-        from src.common.workflow_triggers import get_trigger_registry
+        from src.common.workflow_triggers import fire_trigger_safe
         from src.models.process_workflows import EntityType
-
-        try:
-            get_trigger_registry(db).on_certify(
-                EntityType.DATA_CONTRACT,
-                contract_id,
-                entity_name=contract_db.name,
-                entity_data={"certification_level": contract_db.certification_level},
-                user_email=current_user.username if current_user else None,
-            )
-        except Exception as trigger_err:
-            logger.warning("on_certify trigger error (non-fatal): %s", trigger_err)
+        fire_trigger_safe(
+            db, "on_certify",
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id=contract_id,
+            entity_name=contract_db.name,
+            entity_data={"certification_level": contract_db.certification_level},
+            user_email=current_user.username if current_user else None,
+        )
 
         manager._update_search_index(contract_db, db)
 
@@ -924,18 +918,15 @@ async def decertify_contract(
         db.add(contract_db)
         db.commit()
 
-        from src.common.workflow_triggers import get_trigger_registry
+        from src.common.workflow_triggers import fire_trigger_safe
         from src.models.process_workflows import EntityType
-
-        try:
-            get_trigger_registry(db).on_decertify(
-                EntityType.DATA_CONTRACT,
-                contract_id,
-                entity_name=contract_db.name,
-                user_email=current_user.username,
-            )
-        except Exception as trigger_err:
-            logger.warning("on_decertify trigger error (non-fatal): %s", trigger_err)
+        fire_trigger_safe(
+            db, "on_decertify",
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id=contract_id,
+            entity_name=contract_db.name,
+            user_email=current_user.username,
+        )
 
         audit_manager.log_action(
             db=db,
@@ -1003,17 +994,15 @@ async def set_contract_publication_scope(
 
         # Fire on_unpublish trigger when transitioning from published to unpublished
         if scope == "none" and was_published:
-            try:
-                from src.common.workflow_triggers import get_trigger_registry
-                from src.models.process_workflows import EntityType
-                get_trigger_registry(db).on_unpublish(
-                    EntityType.DATA_CONTRACT,
-                    contract_id,
-                    entity_name=contract_db.name,
-                    user_email=current_user.username if current_user else None,
-                )
-            except Exception as e:
-                logger.warning(f"on_unpublish trigger error (non-fatal): {e}")
+            from src.common.workflow_triggers import fire_trigger_safe
+            from src.models.process_workflows import EntityType
+            fire_trigger_safe(
+                db, "on_unpublish",
+                entity_type=EntityType.DATA_CONTRACT,
+                entity_id=contract_id,
+                entity_name=contract_db.name,
+                user_email=current_user.username if current_user else None,
+            )
 
         audit_manager.log_action(
             db=db,
@@ -1203,20 +1192,16 @@ async def create_contract(
         created_contract_id = created.id
 
         # Fire on_create workflow trigger
-        try:
-            from src.common.workflow_triggers import get_trigger_registry
-            from src.models.process_workflows import EntityType
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_create(
-                entity_type=EntityType.DATA_CONTRACT,
-                entity_id=str(created.id),
-                entity_name=created.name,
-                entity_data={"contract_id": str(created.id), "name": created.name, "status": getattr(created, 'status', 'draft')},
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_create trigger failed for contract {created.id}: {e}")
+        from src.common.workflow_triggers import fire_trigger_safe
+        from src.models.process_workflows import EntityType
+        fire_trigger_safe(
+            db, "on_create",
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id=str(created.id),
+            entity_name=created.name,
+            entity_data={"contract_id": str(created.id), "name": created.name, "status": getattr(created, 'status', 'draft')},
+            user_email=current_user.email if current_user else None,
+        )
 
         # Load with relationships for response
         created_with_relations = data_contract_repo.get_with_all(db, id=created.id)
@@ -1372,20 +1357,16 @@ async def update_contract(
         success = True
 
         # Fire on_update workflow trigger
-        try:
-            from src.common.workflow_triggers import get_trigger_registry
-            from src.models.process_workflows import EntityType
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_update(
-                entity_type=EntityType.DATA_CONTRACT,
-                entity_id=contract_id,
-                entity_name=getattr(updated, 'name', None),
-                entity_data=contract_data.model_dump(exclude_unset=True),
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_update trigger failed for contract {contract_id}: {e}")
+        from src.common.workflow_triggers import fire_trigger_safe
+        from src.models.process_workflows import EntityType
+        fire_trigger_safe(
+            db, "on_update",
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id=contract_id,
+            entity_name=getattr(updated, 'name', None),
+            entity_data=contract_data.model_dump(exclude_unset=True),
+            user_email=current_user.email if current_user else None,
+        )
 
         # Load with relationships for full response
         updated_with_relations = data_contract_repo.get_with_all(db, id=contract_id)
@@ -1445,19 +1426,15 @@ async def delete_contract(
         response_status_code = 204
 
         # Fire on_delete workflow trigger
-        try:
-            from src.common.workflow_triggers import get_trigger_registry
-            from src.models.process_workflows import EntityType
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_delete(
-                entity_type=EntityType.DATA_CONTRACT,
-                entity_id=contract_id,
-                entity_data={"contract_id": contract_id},
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_delete trigger failed for contract {contract_id}: {e}")
+        from src.common.workflow_triggers import fire_trigger_safe
+        from src.models.process_workflows import EntityType
+        fire_trigger_safe(
+            db, "on_delete",
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id=contract_id,
+            entity_data={"contract_id": contract_id},
+            user_email=current_user.email if current_user else None,
+        )
 
         return None
     except ValueError as e:

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -899,6 +899,65 @@ async def certify_contract_direct(
         raise HTTPException(status_code=500, detail="Failed to certify contract")
 
 
+@router.post('/data-contracts/{contract_id}/decertify')
+async def decertify_contract(
+    contract_id: str,
+    request: Request,
+    db: DBSessionDep,
+    audit_manager: AuditManagerDep,
+    current_user: AuditCurrentUserDep,
+    manager: DataContractsManager = Depends(get_data_contracts_manager),
+    _: bool = Depends(ApprovalChecker('CONTRACTS')),
+):
+    """Remove certification from a data contract."""
+    try:
+        contract_db = data_contract_repo.get(db, id=contract_id)
+        if not contract_db:
+            raise HTTPException(status_code=404, detail="Contract not found")
+
+        old_level = contract_db.certification_level
+        contract_db.certification_level = None
+        contract_db.certified_at = None
+        contract_db.certified_by = None
+        contract_db.certification_expires_at = None
+        contract_db.certification_notes = None
+        db.add(contract_db)
+        db.commit()
+
+        from src.common.workflow_triggers import get_trigger_registry
+        from src.models.process_workflows import EntityType
+
+        try:
+            get_trigger_registry(db).on_decertify(
+                EntityType.DATA_CONTRACT,
+                contract_id,
+                entity_name=contract_db.name,
+                user_email=current_user.username,
+            )
+        except Exception as trigger_err:
+            logger.warning("on_decertify trigger error (non-fatal): %s", trigger_err)
+
+        audit_manager.log_action(
+            db=db,
+            username=current_user.username,
+            ip_address=request.client.host if request.client else None,
+            feature="data-contracts",
+            action='DECERTIFY',
+            success=True,
+            details={'contract_id': contract_id, 'previous_level': old_level},
+        )
+
+        manager._update_search_index(contract_db, db)
+
+        return {'certification_level': None}
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.exception("Decertify contract failed for contract_id=%s", contract_id)
+        raise HTTPException(status_code=500, detail="Failed to decertify contract")
+
+
 @router.post('/data-contracts/{contract_id}/set-publication-scope')
 async def set_contract_publication_scope(
     contract_id: str,
@@ -928,6 +987,8 @@ async def set_contract_publication_scope(
                 detail=f"Contract must be active or approved to publish. Current status: {contract_db.status}",
             )
 
+        was_published = (contract_db.publication_scope or "none").lower() != "none"
+
         if scope != "none":
             contract_db.publication_scope = scope
             contract_db.published_at = datetime.now(timezone.utc)
@@ -939,6 +1000,20 @@ async def set_contract_publication_scope(
         db.add(contract_db)
         db.commit()
         db.refresh(contract_db)
+
+        # Fire on_unpublish trigger when transitioning from published to unpublished
+        if scope == "none" and was_published:
+            try:
+                from src.common.workflow_triggers import get_trigger_registry
+                from src.models.process_workflows import EntityType
+                get_trigger_registry(db).on_unpublish(
+                    EntityType.DATA_CONTRACT,
+                    contract_id,
+                    entity_name=contract_db.name,
+                    user_email=current_user.username if current_user else None,
+                )
+            except Exception as e:
+                logger.warning(f"on_unpublish trigger error (non-fatal): {e}")
 
         audit_manager.log_action(
             db=db,
@@ -1127,6 +1202,22 @@ async def create_contract(
         success = True
         created_contract_id = created.id
 
+        # Fire on_create workflow trigger
+        try:
+            from src.common.workflow_triggers import get_trigger_registry
+            from src.models.process_workflows import EntityType
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_create(
+                entity_type=EntityType.DATA_CONTRACT,
+                entity_id=str(created.id),
+                entity_name=created.name,
+                entity_data={"contract_id": str(created.id), "name": created.name, "status": getattr(created, 'status', 'draft')},
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_create trigger failed for contract {created.id}: {e}")
+
         # Load with relationships for response
         created_with_relations = data_contract_repo.get_with_all(db, id=created.id)
         return manager._build_contract_api_model(db, created_with_relations)
@@ -1241,6 +1332,34 @@ async def update_contract(
                         )
                         # Continue with update - admin override in effect
 
+        # Run before_update workflow validation
+        try:
+            from src.common.workflow_triggers import get_trigger_registry
+            from src.models.process_workflows import EntityType
+            trigger_registry = get_trigger_registry(db)
+            pre_passed, pre_executions = trigger_registry.before_update(
+                entity_type=EntityType.DATA_CONTRACT,
+                entity_id=contract_id,
+                entity_name=getattr(db_obj, 'name', None),
+                entity_data=contract_data.model_dump(exclude_unset=True),
+                user_email=current_user.email if current_user else None,
+            )
+            if not pre_passed:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        'message': 'Pre-update validation failed',
+                        'workflows': [
+                            {'workflow_name': exe.workflow_name, 'status': exe.status.value}
+                            for exe in pre_executions
+                        ],
+                    }
+                )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning(f"before_update trigger failed for contract {contract_id}: {e}")
+
         # Business logic now in manager (delivery handled via DeliveryMixin)
         updated = manager.update_contract_with_relations(
             db=db,
@@ -1251,6 +1370,22 @@ async def update_contract(
         )
 
         success = True
+
+        # Fire on_update workflow trigger
+        try:
+            from src.common.workflow_triggers import get_trigger_registry
+            from src.models.process_workflows import EntityType
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_update(
+                entity_type=EntityType.DATA_CONTRACT,
+                entity_id=contract_id,
+                entity_name=getattr(updated, 'name', None),
+                entity_data=contract_data.model_dump(exclude_unset=True),
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_update trigger failed for contract {contract_id}: {e}")
 
         # Load with relationships for full response
         updated_with_relations = data_contract_repo.get_with_all(db, id=contract_id)
@@ -1308,6 +1443,22 @@ async def delete_contract(
         db.commit()
         success = True
         response_status_code = 204
+
+        # Fire on_delete workflow trigger
+        try:
+            from src.common.workflow_triggers import get_trigger_registry
+            from src.models.process_workflows import EntityType
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_delete(
+                entity_type=EntityType.DATA_CONTRACT,
+                entity_id=contract_id,
+                entity_data={"contract_id": contract_id},
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_delete trigger failed for contract {contract_id}: {e}")
+
         return None
     except ValueError as e:
         response_status_code = 404

--- a/src/backend/src/routes/data_domains_routes.py
+++ b/src/backend/src/routes/data_domains_routes.py
@@ -18,7 +18,7 @@ from src.common.dependencies import (
 ) 
 from src.models.users import UserInfo # To type hint current_user
 from src.common.errors import NotFoundError, ConflictError
-from src.common.workflow_triggers import get_trigger_registry
+from src.common.workflow_triggers import get_trigger_registry, fire_trigger_safe
 from src.models.process_workflows import EntityType
 
 from src.common.logging import get_logger
@@ -69,18 +69,15 @@ async def create_data_domain(
         created_domain_id = str(created_domain.id)
 
         # Fire on_create workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_create(
-                entity_type=EntityType.DOMAIN,
-                entity_id=str(created_domain.id),
-                entity_name=created_domain.name,
-                entity_data={"domain_id": str(created_domain.id), "name": created_domain.name},
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_create trigger failed for domain {created_domain.id}: {e}")
+        fire_trigger_safe(
+            db, "on_create",
+            entity_type=EntityType.DOMAIN,
+            entity_id=str(created_domain.id),
+            entity_name=created_domain.name,
+            entity_data={"domain_id": str(created_domain.id), "name": created_domain.name},
+            user_email=current_user.email if current_user else None,
+            blocking=False,
+        )
 
         return created_domain
     except ConflictError as e:
@@ -179,18 +176,15 @@ async def update_data_domain(
         success = True
 
         # Fire on_update workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_update(
-                entity_type=EntityType.DOMAIN,
-                entity_id=str(domain_id),
-                entity_name=getattr(updated_domain, 'name', None),
-                entity_data=domain_in.model_dump(exclude_unset=True),
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_update trigger failed for domain {domain_id}: {e}")
+        fire_trigger_safe(
+            db, "on_update",
+            entity_type=EntityType.DOMAIN,
+            entity_id=str(domain_id),
+            entity_name=getattr(updated_domain, 'name', None),
+            entity_data=domain_in.model_dump(exclude_unset=True),
+            user_email=current_user.email if current_user else None,
+            blocking=False,
+        )
 
         return updated_domain
     except NotFoundError as e:
@@ -248,18 +242,15 @@ def delete_data_domain(
         success = True
 
         # Fire on_delete workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_delete(
-                entity_type=EntityType.DOMAIN,
-                entity_id=str(domain_id),
-                entity_name=getattr(deleted_domain, 'name', None),
-                entity_data={"domain_id": str(domain_id)},
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_delete trigger failed for domain {domain_id}: {e}")
+        fire_trigger_safe(
+            db, "on_delete",
+            entity_type=EntityType.DOMAIN,
+            entity_id=str(domain_id),
+            entity_name=getattr(deleted_domain, 'name', None),
+            entity_data={"domain_id": str(domain_id)},
+            user_email=current_user.email if current_user else None,
+            blocking=False,
+        )
 
         return deleted_domain
     except NotFoundError as e:

--- a/src/backend/src/routes/data_domains_routes.py
+++ b/src/backend/src/routes/data_domains_routes.py
@@ -18,6 +18,8 @@ from src.common.dependencies import (
 ) 
 from src.models.users import UserInfo # To type hint current_user
 from src.common.errors import NotFoundError, ConflictError
+from src.common.workflow_triggers import get_trigger_registry
+from src.models.process_workflows import EntityType
 
 from src.common.logging import get_logger
 logger = get_logger(__name__)
@@ -65,7 +67,21 @@ async def create_data_domain(
         db.commit()
         success = True
         created_domain_id = str(created_domain.id)
-        
+
+        # Fire on_create workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_create(
+                entity_type=EntityType.DOMAIN,
+                entity_id=str(created_domain.id),
+                entity_name=created_domain.name,
+                entity_data={"domain_id": str(created_domain.id), "name": created_domain.name},
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_create trigger failed for domain {created_domain.id}: {e}")
+
         return created_domain
     except ConflictError as e:
         db.rollback()
@@ -161,7 +177,21 @@ async def update_data_domain(
         )
         db.commit()
         success = True
-        
+
+        # Fire on_update workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_update(
+                entity_type=EntityType.DOMAIN,
+                entity_id=str(domain_id),
+                entity_name=getattr(updated_domain, 'name', None),
+                entity_data=domain_in.model_dump(exclude_unset=True),
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_update trigger failed for domain {domain_id}: {e}")
+
         return updated_domain
     except NotFoundError as e:
         db.rollback()
@@ -216,6 +246,21 @@ def delete_data_domain(
         deleted_domain = manager.delete_domain(db=db, domain_id=domain_id, current_user_id=current_user.email)
         db.commit()
         success = True
+
+        # Fire on_delete workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_delete(
+                entity_type=EntityType.DOMAIN,
+                entity_id=str(domain_id),
+                entity_name=getattr(deleted_domain, 'name', None),
+                entity_data={"domain_id": str(domain_id)},
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_delete trigger failed for domain {domain_id}: {e}")
+
         return deleted_domain
     except NotFoundError as e:
         db.rollback()

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -39,7 +39,7 @@ from src.common.dependencies import (
     AuditCurrentUserDep,
     ChangeLogManagerDep,
 )
-from src.common.workflow_triggers import get_trigger_registry
+from src.common.workflow_triggers import get_trigger_registry, fire_trigger_safe
 from src.models.process_workflows import EntityType
 from src.models.notifications import NotificationType
 from src.common.dependencies import NotificationsManagerDep, CurrentUserDep, DBSessionDep
@@ -1587,18 +1587,14 @@ async def create_data_product(
         success = True
 
         # Fire on_create workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_create(
-                entity_type=EntityType.DATA_PRODUCT,
-                entity_id=str(created_product_response.id) if created_product_response else str(payload.get('id', '')),
-                entity_name=getattr(created_product_response, 'name', None),
-                entity_data={"product_id": str(created_product_response.id), "name": getattr(created_product_response, 'name', None)},
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_create trigger failed for product: {e}")
+        fire_trigger_safe(
+            db, "on_create",
+            entity_type=EntityType.DATA_PRODUCT,
+            entity_id=str(created_product_response.id) if created_product_response else str(payload.get('id', '')),
+            entity_name=getattr(created_product_response, 'name', None),
+            entity_data={"product_id": str(created_product_response.id), "name": getattr(created_product_response, 'name', None)},
+            user_email=current_user.email if current_user else None,
+        )
 
         if created_product_response and hasattr(created_product_response, 'id'):
             details_for_audit["created_resource_id"] = str(created_product_response.id)
@@ -1842,18 +1838,14 @@ async def update_data_product(
         response_status_code = 200
 
         # Fire on_update workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_update(
-                entity_type=EntityType.DATA_PRODUCT,
-                entity_id=product_id,
-                entity_name=getattr(updated_product_response, 'name', None),
-                entity_data=product_dict,
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_update trigger failed for product {product_id}: {e}")
+        fire_trigger_safe(
+            db, "on_update",
+            entity_type=EntityType.DATA_PRODUCT,
+            entity_id=product_id,
+            entity_name=getattr(updated_product_response, 'name', None),
+            entity_data=product_dict,
+            user_email=current_user.email if current_user else None,
+        )
 
         logger.info(f"Successfully updated data product with ID: {product_id}")
 
@@ -1933,17 +1925,13 @@ async def delete_data_product(
         response_status_code = 204 # Standard for successful DELETE
 
         # Fire on_delete workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_delete(
-                entity_type=EntityType.DATA_PRODUCT,
-                entity_id=product_id,
-                entity_data={"product_id": product_id},
-                user_email=current_user.email if current_user else None,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_delete trigger failed for product {product_id}: {e}")
+        fire_trigger_safe(
+            db, "on_delete",
+            entity_type=EntityType.DATA_PRODUCT,
+            entity_id=product_id,
+            entity_data={"product_id": product_id},
+            user_email=current_user.email if current_user else None,
+        )
 
         logger.info(f"Successfully deleted data product with ID: {product_id}")
         # No response body for 204, so no updated_product_response or response_preview
@@ -2099,18 +2087,14 @@ async def subscribe_to_product(
         success = True
 
         # Fire on_subscribe workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_subscribe(
-                entity_type=EntityType.SUBSCRIPTION,
-                entity_id=str(result.subscription_id) if hasattr(result, 'subscription_id') else product_id,
-                entity_name=product_id,
-                entity_data={"product_id": product_id, "subscriber_email": current_user.username, "reason": reason},
-                user_email=current_user.username,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_subscribe trigger failed for product {product_id}: {e}")
+        fire_trigger_safe(
+            db, "on_subscribe",
+            entity_type=EntityType.SUBSCRIPTION,
+            entity_id=str(result.subscription_id) if hasattr(result, 'subscription_id') else product_id,
+            entity_name=product_id,
+            entity_data={"product_id": product_id, "subscriber_email": current_user.username, "reason": reason},
+            user_email=current_user.username,
+        )
 
         return result
 
@@ -2156,18 +2140,14 @@ async def unsubscribe_from_product(
         success = True
 
         # Fire on_unsubscribe workflow trigger
-        try:
-            trigger_registry = get_trigger_registry(db)
-            trigger_registry.on_unsubscribe(
-                entity_type=EntityType.SUBSCRIPTION,
-                entity_id=product_id,
-                entity_name=product_id,
-                entity_data={"product_id": product_id, "subscriber_email": current_user.username},
-                user_email=current_user.username,
-                blocking=False,
-            )
-        except Exception as e:
-            logger.warning(f"on_unsubscribe trigger failed for product {product_id}: {e}")
+        fire_trigger_safe(
+            db, "on_unsubscribe",
+            entity_type=EntityType.SUBSCRIPTION,
+            entity_id=product_id,
+            entity_name=product_id,
+            entity_data={"product_id": product_id, "subscriber_email": current_user.username},
+            user_email=current_user.username,
+        )
 
         return result
 

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1586,6 +1586,20 @@ async def create_data_product(
         created_product_response = manager.create_product(payload, db=db, user=current_user.username if current_user else None)
         success = True
 
+        # Fire on_create workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_create(
+                entity_type=EntityType.DATA_PRODUCT,
+                entity_id=str(created_product_response.id) if created_product_response else str(payload.get('id', '')),
+                entity_name=getattr(created_product_response, 'name', None),
+                entity_data={"product_id": str(created_product_response.id), "name": getattr(created_product_response, 'name', None)},
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_create trigger failed for product: {e}")
+
         if created_product_response and hasattr(created_product_response, 'id'):
             details_for_audit["created_resource_id"] = str(created_product_response.id)
 
@@ -1826,10 +1840,25 @@ async def update_data_product(
 
         success = True
         response_status_code = 200
+
+        # Fire on_update workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_update(
+                entity_type=EntityType.DATA_PRODUCT,
+                entity_id=product_id,
+                entity_name=getattr(updated_product_response, 'name', None),
+                entity_data=product_dict,
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_update trigger failed for product {product_id}: {e}")
+
         logger.info(f"Successfully updated data product with ID: {product_id}")
-        
+
         # Delivery is now handled in the manager via DeliveryMixin
-        
+
         return updated_product_response
 
     except PermissionError as e:
@@ -1902,9 +1931,23 @@ async def delete_data_product(
 
         success = True
         response_status_code = 204 # Standard for successful DELETE
+
+        # Fire on_delete workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_delete(
+                entity_type=EntityType.DATA_PRODUCT,
+                entity_id=product_id,
+                entity_data={"product_id": product_id},
+                user_email=current_user.email if current_user else None,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_delete trigger failed for product {product_id}: {e}")
+
         logger.info(f"Successfully deleted data product with ID: {product_id}")
         # No response body for 204, so no updated_product_response or response_preview
-        return None 
+        return None
 
     except HTTPException as http_exc:
         success = False
@@ -1913,7 +1956,7 @@ async def delete_data_product(
         raise
     except Exception as e:
         success = False
-        response_status_code = 500 
+        response_status_code = 500
         error_msg = f"Unexpected error deleting data product {product_id}: {e!s}"
         details_for_audit["exception"] = {"type": type(e).__name__, "message": str(e)}
         logger.exception(error_msg)
@@ -2052,10 +2095,25 @@ async def subscribe_to_product(
             reason=reason,
             db=db
         )
-        
+
         success = True
+
+        # Fire on_subscribe workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_subscribe(
+                entity_type=EntityType.SUBSCRIPTION,
+                entity_id=str(result.subscription_id) if hasattr(result, 'subscription_id') else product_id,
+                entity_name=product_id,
+                entity_data={"product_id": product_id, "subscriber_email": current_user.username, "reason": reason},
+                user_email=current_user.username,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_subscribe trigger failed for product {product_id}: {e}")
+
         return result
-        
+
     except ValueError as e:
         logger.error("Validation error subscribing to product %s: %s", product_id, e)
         raise HTTPException(status_code=400, detail=str(e))
@@ -2094,10 +2152,25 @@ async def unsubscribe_from_product(
             subscriber_email=current_user.username,
             db=db
         )
-        
+
         success = True
+
+        # Fire on_unsubscribe workflow trigger
+        try:
+            trigger_registry = get_trigger_registry(db)
+            trigger_registry.on_unsubscribe(
+                entity_type=EntityType.SUBSCRIPTION,
+                entity_id=product_id,
+                entity_name=product_id,
+                entity_data={"product_id": product_id, "subscriber_email": current_user.username},
+                user_email=current_user.username,
+                blocking=False,
+            )
+        except Exception as e:
+            logger.warning(f"on_unsubscribe trigger failed for product {product_id}: {e}")
+
         return result
-        
+
     except Exception as e:
         logger.error("Error unsubscribing from product %s: %s", product_id, e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to unsubscribe from product")

--- a/src/backend/src/tests/unit/test_workflow_triggers_wiring.py
+++ b/src/backend/src/tests/unit/test_workflow_triggers_wiring.py
@@ -1,0 +1,314 @@
+# Set test environment variables BEFORE any app imports
+import os
+os.environ['TESTING'] = 'true'
+os.environ['SKIP_STARTUP_TASKS'] = 'true'
+
+"""
+Tests for workflow trigger wiring — verifies that trigger registry methods
+are called with correct entity types and parameters.
+
+Part of issue #200: wire missing trigger types across entity lifecycle.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+from uuid import uuid4
+
+from src.common.workflow_triggers import TriggerRegistry
+from src.models.process_workflows import TriggerType, EntityType
+
+
+class TestTriggerWiringDataContract:
+    """Verify that data_contract triggers fire with correct EntityType."""
+
+    def test_on_create_fires_for_data_contract(self):
+        """on_create should fire with EntityType.DATA_CONTRACT."""
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_create(
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id="contract-123",
+            entity_name="Test Contract",
+            entity_data={"name": "Test Contract"},
+            user_email="user@example.com",
+            blocking=False,
+        )
+
+        registry.fire_trigger.assert_called_once()
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_CREATE
+        assert event.entity_type == EntityType.DATA_CONTRACT
+        assert event.entity_id == "contract-123"
+
+    def test_on_update_fires_for_data_contract(self):
+        """on_update should fire with EntityType.DATA_CONTRACT."""
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_update(
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id="contract-123",
+            entity_name="Test Contract",
+            entity_data={"name": "Updated"},
+            user_email="user@example.com",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_UPDATE
+        assert event.entity_type == EntityType.DATA_CONTRACT
+
+    def test_on_delete_fires_for_data_contract(self):
+        """on_delete should fire with EntityType.DATA_CONTRACT."""
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_delete(
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id="contract-123",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_DELETE
+        assert event.entity_type == EntityType.DATA_CONTRACT
+
+    def test_before_update_fires_for_data_contract(self):
+        """before_update should fire with EntityType.DATA_CONTRACT and return tuple."""
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        all_passed, executions = registry.before_update(
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id="contract-123",
+            entity_name="Test",
+            entity_data={"name": "Updated"},
+            user_email="user@example.com",
+        )
+
+        assert all_passed is True  # No workflows = pass
+        assert executions == []
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.BEFORE_UPDATE
+
+    def test_on_status_change_fires_for_data_contract(self):
+        """on_status_change should fire with from/to status."""
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_status_change(
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id="contract-123",
+            from_status="draft",
+            to_status="active",
+            entity_name="Test",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_STATUS_CHANGE
+        assert event.entity_type == EntityType.DATA_CONTRACT
+        assert event.from_status == "draft"
+        assert event.to_status == "active"
+
+
+class TestTriggerWiringDataProduct:
+    """Verify that data_product triggers fire with correct EntityType."""
+
+    def test_on_create_fires_for_data_product(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_create(
+            entity_type=EntityType.DATA_PRODUCT,
+            entity_id="product-123",
+            entity_name="Test Product",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_CREATE
+        assert event.entity_type == EntityType.DATA_PRODUCT
+
+    def test_on_update_fires_for_data_product(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_update(
+            entity_type=EntityType.DATA_PRODUCT,
+            entity_id="product-123",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_UPDATE
+        assert event.entity_type == EntityType.DATA_PRODUCT
+
+    def test_on_delete_fires_for_data_product(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_delete(
+            entity_type=EntityType.DATA_PRODUCT,
+            entity_id="product-123",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_DELETE
+        assert event.entity_type == EntityType.DATA_PRODUCT
+
+    def test_on_status_change_fires_for_data_product(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_status_change(
+            entity_type=EntityType.DATA_PRODUCT,
+            entity_id="product-123",
+            from_status="draft",
+            to_status="published",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_STATUS_CHANGE
+        assert event.entity_type == EntityType.DATA_PRODUCT
+        assert event.from_status == "draft"
+        assert event.to_status == "published"
+
+
+class TestTriggerWiringDomain:
+    """Verify that domain triggers fire with correct EntityType."""
+
+    def test_on_create_fires_for_domain(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_create(
+            entity_type=EntityType.DOMAIN,
+            entity_id="domain-123",
+            entity_name="Customer Analytics",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_CREATE
+        assert event.entity_type == EntityType.DOMAIN
+
+    def test_on_update_fires_for_domain(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_update(
+            entity_type=EntityType.DOMAIN,
+            entity_id="domain-123",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_UPDATE
+        assert event.entity_type == EntityType.DOMAIN
+
+    def test_on_delete_fires_for_domain(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_delete(
+            entity_type=EntityType.DOMAIN,
+            entity_id="domain-123",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_DELETE
+        assert event.entity_type == EntityType.DOMAIN
+
+
+class TestTriggerWiringSubscription:
+    """Verify that subscription triggers fire with correct EntityType."""
+
+    def test_on_subscribe_fires_for_subscription(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_subscribe(
+            entity_type=EntityType.SUBSCRIPTION,
+            entity_id="sub-123",
+            entity_name="product-456",
+            entity_data={"product_id": "product-456", "subscriber_email": "user@test.com"},
+            user_email="user@test.com",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_SUBSCRIBE
+        assert event.entity_type == EntityType.SUBSCRIPTION
+        assert event.entity_data["subscriber_email"] == "user@test.com"
+
+    def test_on_unsubscribe_fires_for_subscription(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_unsubscribe(
+            entity_type=EntityType.SUBSCRIPTION,
+            entity_id="product-456",
+            user_email="user@test.com",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_UNSUBSCRIBE
+        assert event.entity_type == EntityType.SUBSCRIPTION
+
+
+class TestTriggerWiringCertification:
+    """Verify decertify trigger for data_contract (newly wired)."""
+
+    def test_on_decertify_fires_for_data_contract(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_decertify(
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id="contract-123",
+            entity_name="Test Contract",
+            user_email="admin@test.com",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_DECERTIFY
+        assert event.entity_type == EntityType.DATA_CONTRACT
+
+    def test_on_unpublish_fires_for_data_contract(self):
+        db = MagicMock()
+        registry = TriggerRegistry(db)
+        registry.fire_trigger = MagicMock(return_value=[])
+
+        registry.on_unpublish(
+            entity_type=EntityType.DATA_CONTRACT,
+            entity_id="contract-123",
+            entity_name="Test Contract",
+            user_email="admin@test.com",
+            blocking=False,
+        )
+
+        event = registry.fire_trigger.call_args[0][0]
+        assert event.trigger_type == TriggerType.ON_UNPUBLISH
+        assert event.entity_type == EntityType.DATA_CONTRACT

--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -98,10 +98,11 @@ import type {
   HttpConnectionRef,
 } from '@/types/process-workflow';
 import { 
-  getTriggerTypeLabel, 
-  getEntityTypeLabel, 
-  ALL_TRIGGER_TYPES, 
-  ALL_ENTITY_TYPES 
+  getTriggerTypeLabel,
+  getEntityTypeLabel,
+  ALL_TRIGGER_TYPES,
+  ALL_ENTITY_TYPES,
+  isTriggerEntitySupported,
 } from '@/lib/workflow-labels';
 
 // Node types registry (default = fallback for unknown step_type e.g. generate_pdf)
@@ -988,6 +989,11 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
                       ))}
                     </div>
                   </div>
+                  {entityTypes.length > 0 && entityTypes.some(et => !isTriggerEntitySupported(triggerType, et)) && (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+                      <span className="font-medium">Warning:</span> This trigger–entity combination is not wired in the backend. The workflow will save but never fire automatically.
+                    </div>
+                  )}
                   {(triggerType === 'on_status_change' || triggerType === 'before_status_change' || triggerType === 'on_request_status_change') && (
                     <div className="grid grid-cols-2 gap-2">
                       <div>

--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -1470,9 +1470,6 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
                             <SelectItem value="requester">Requester (Original User)</SelectItem>
                           </SelectContent>
                         </Select>
-                        <p className="text-xs text-muted-foreground mt-1">
-                          Role UUIDs ensure referential integrity if roles are renamed.
-                        </p>
                       </div>
                       <div>
                         <Label>Timeout (days)</Label>

--- a/src/frontend/src/lib/workflow-labels.ts
+++ b/src/frontend/src/lib/workflow-labels.ts
@@ -212,6 +212,59 @@ export const ALL_STEP_TYPES: StepType[] = [
 ];
 
 /**
+ * Maps each trigger type to the entity types it is wired to fire for in the backend.
+ * Used to warn users when they configure a workflow with an unwired combination.
+ *
+ * Updated for issue #200 — reflects all wired triggers as of this commit.
+ */
+export const SUPPORTED_TRIGGER_ENTITY_MAP: Record<string, string[]> = {
+  // CRUD triggers
+  on_create: ['catalog', 'schema', 'table', 'data_contract', 'data_product', 'domain'],
+  on_update: ['data_contract', 'data_product', 'domain'],
+  on_delete: ['data_contract', 'data_product', 'domain'],
+  before_create: ['catalog', 'schema', 'table'],
+  before_update: ['data_contract'],
+  // Status & lifecycle
+  before_status_change: ['data_contract', 'data_product'],
+  on_status_change: ['data_contract', 'data_product', 'data_asset_review'],
+  on_publish: ['data_contract', 'data_product'],
+  on_unpublish: ['data_contract', 'data_product'],
+  // Certification
+  on_request_certify: ['data_contract', 'data_product'],
+  on_certify: ['data_contract', 'data_product'],
+  on_decertify: ['data_contract', 'data_product'],
+  // Request triggers
+  on_request_review: ['data_contract', 'data_product', 'data_asset_review'],
+  on_request_access: ['access_grant', 'role', 'project'],
+  on_request_publish: ['data_contract', 'data_product'],
+  on_request_status_change: ['data_product'],
+  // Job triggers
+  on_job_success: ['job'],
+  on_job_failure: ['job'],
+  // Subscription triggers
+  on_subscribe: ['subscription'],
+  on_unsubscribe: ['subscription'],
+  // Access lifecycle
+  on_expiring: ['access_grant'],
+  on_revoke: ['access_grant'],
+  // Manual/scheduled — always supported (no entity dependency)
+  scheduled: [],
+  manual: [],
+};
+
+/**
+ * Check if a trigger-entity combination is wired in the backend.
+ * Returns true if supported, false if the combination will silently do nothing.
+ */
+export function isTriggerEntitySupported(triggerType: string, entityType: string): boolean {
+  const supported = SUPPORTED_TRIGGER_ENTITY_MAP[triggerType];
+  if (!supported) return false;
+  // Empty array means all entities are valid (scheduled, manual)
+  if (supported.length === 0) return true;
+  return supported.includes(entityType);
+}
+
+/**
  * Special recipient values that are not role UUIDs.
  */
 export const SPECIAL_RECIPIENTS: Record<string, string> = {


### PR DESCRIPTION
## Summary

  Wires 17 missing workflow trigger types across the data_contract, data_product, domain, and subscription entity
  lifecycles. Adds UI validation to warn users when they configure an unsupported trigger–entity combination. Also
  removes an internal developer note from the workflow designer UI.

  Closes #200
  Closes #163

  ## Changes

  ### Backend — trigger wiring (5 files)

  **Routes:**
  - `data_contracts_routes.py`: `on_create`, `before_update`, `on_update`, `on_delete`, new `decertify` endpoint +
  `on_decertify`, `on_unpublish` (on publication scope change to "none")
  - `data_product_routes.py`: `on_create`, `on_update`, `on_delete`, `on_subscribe`, `on_unsubscribe`
  - `data_domains_routes.py`: `on_create`, `on_update`, `on_delete`
- `workflow_triggers.py`: added `fire_trigger_safe()` reusable wrapper that handles registry lookup,
    method dispatch, and error logging in one call. All 16 trigger call sites refactored to use it.
    Eliminates repetitive try/except blocks, provides single point of change for future trigger behavior.

  **Managers:**
  - `data_contracts_manager.py`: `on_status_change` in `transition_status()`
  - `data_products_manager.py`: `on_status_change` in `transition_status()`

  All trigger calls are wrapped in try/except with warning logs — trigger failures never break CRUD operations.

  ### Frontend — UI validation (2 files)

  - `workflow-labels.ts`: added `SUPPORTED_TRIGGER_ENTITY_MAP` constant and `isTriggerEntitySupported()` helper
  mapping each trigger type to supported entity types
  - `workflow-designer.tsx`: amber warning banner when user selects an unsupported trigger–entity pair; removed
  internal helper text "Role UUIDs ensure referential integrity…" from approvers dropdown (#163)

  ### Tests (1 file)

  - `test_workflow_triggers_wiring.py`: 16 unit tests across 5 test classes verifying trigger registry methods fire
  with correct EntityType, TriggerType, and parameters

  ## Wiring matrix (after this PR)

  Previously unwired triggers that are now wired:
  - **4 completely unwired trigger types** → 0 (on_update, on_delete, on_subscribe, on_unsubscribe)
  - **3 completely unwired entity types** → 1 (domain and subscription now wired; view remains — no CRUD routes exist)

  ## Not in scope

  - **`view` entity**: No create/update/delete routes exist in Ontos — views are UC securables managed directly via
  Databricks
  - **`before_create` for contracts/products/domains**: Changes creation flow behavior (product decision)
  - **`SCHEDULED`/`MANUAL` triggers**: Don't need entity-based wiring

  ## Test plan

  - [x] Backend unit tests: 55 passed (16 new + 39 existing workflow tests)
  - [x] Frontend type-check: 0 new errors
  - [x] API-driven E2E testing on deployed app (15/15 scenarios passed):
    - on_create for data_product, data_contract, domain
    - on_update for data_product, data_contract, domain
    - on_delete for data_product, data_contract, domain
    - on_subscribe / on_unsubscribe for subscription
    - on_status_change for data_product, data_contract
    - Multi-step workflow (validation + notification) on product creation
    - before_update blocking gate on contract update
  - [x] UI warning banner verified for unsupported trigger–entity combinations
  - [x] Internal helper text removed from approvers dropdown (#163)

  This pull request and its description were written by Isaac.