### PR TITLE
fix(alembic): merge aa9_is_approver and e2_semantic_display_name heads

### DIFF
--- a/src/backend/alembic/versions/f1_merge_aa9_e2_heads.py
+++ b/src/backend/alembic/versions/f1_merge_aa9_e2_heads.py
@@ -1,0 +1,28 @@
+"""merge aa9_is_approver and e2_semantic_display_name heads
+
+Revision ID: f1_merge_aa9_e2
+Revises: aa9_is_approver, e2_semantic_display_name
+Create Date: 2026-04-22
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1_merge_aa9_e2'
+down_revision: Union[str, None] = ('aa9_is_approver', 'e2_semantic_display_name')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
- Adds a no-op alembic merge revision (`f1_merge_aa9_e2`) that collapses the two heads `aa9_is_approver` and `e2_semantic_display_name` back into a single head.
- Unblocks `init_db` on fresh databases (provisioned Lakebase reproduced the failure with `MultipleHeads` at `src/backend/src/common/database.py:762`).
- Mirrors the existing `cfd416adf7bd` merge pattern; no schema changes, no risk to existing `alembic_version` rows on either branch.

## Why a merge (and not re-parenting aa9)
Re-parenting `aa9_is_approver` onto `e2_semantic_display_name` would silently desync any environment that already stamped `aa9_is_approver` directly on top of `z8_fix_nulls`. A merge revision is the standard alembic remedy and keeps every previously-applied path valid.

## Test plan
- [x] `alembic heads` returns a single head (`f1_merge_aa9_e2`).
- [ ] Fresh DB: `init_db` startup runs `upgrade head` cleanly (verify on Lakebase).
- [ ] Existing dev DB on `e2_semantic_display_name` upgrades to merge revision only.
- [ ] Existing env on `aa9_is_approver`-only branch upgrades through `a3…e2` then merge.

Fixes #281