### PR TITLE
fix(schema-importer): stop recursive schema listing under table nodes

### DIFF
--- a/docs/notes/work-item-schema-importer-table-expand-recursion.md
+++ b/docs/notes/work-item-schema-importer-table-expand-recursion.md
@@ -1,0 +1,42 @@
+# Work item: Schema Importer — expanding a table shows the schema again
+
+## Problem Statement
+
+In the Schema Importer resource tree (Databricks UC connections), expanding a **table** node does not show columns. Instead, the UI lists the same set of **tables** as under the parent schema, as if the table were another schema container. This breaks selection and mental model: users cannot browse to columns under a table, and the tree looks recursively wrong.
+
+## Solution
+
+Treat a fully qualified table (or other leaf) path as **non-listable** via the same code path that lists all objects in `catalog.schema`. Return no sibling assets from listing for that depth, and populate children from **table metadata** (schema / column list) so expansion shows **columns** (or an empty list if none), consistent with how import preview already avoids re-listing siblings for leaf assets.
+
+## User stories
+
+1. As a governance user browsing UC for import, when I expand a **catalog**, I want to see **schemas**, so that I can navigate the hierarchy.
+2. As a governance user, when I expand a **schema**, I want to see **tables, views, and other assets** in that schema, so that I can choose what to import.
+3. As a governance user, when I expand a **table** (or view with a column schema), I want to see **columns**, so that I can optionally include column-level paths in my selection.
+4. As a governance user, when I expand a **table**, I do **not** want to see other tables from the same schema again, so that I am not confused or misled by duplicate structure.
+5. As an operator of BigQuery-backed connections, when I expand a table, I want the same **column** behavior where metadata exists, so that behavior is consistent across connector types that expose `schema_info`.
+
+## Implementation decisions
+
+- **Root cause:** For Databricks, `list_assets` interprets any path with at least two dot-separated segments as `catalog` + `schema` and lists all schema-level assets, ignoring a third segment (the table name). Browse merges that result into children for `path=catalog.schema.table`, producing duplicate tables.
+- **Connector fix:** For Unity Catalog paths with **three or more** segments, `list_assets` must return an empty list (leaf FQN: no structural children from listing APIs). This aligns with existing BigQuery connector semantics documented in that connector.
+- **Browse API fix:** After container and asset listing in schema import browse, when `get_asset_metadata` for the browsed path returns `schema_info` with columns, append browse nodes for each column (stable path pattern: parent path + `.` + column name, `node_type` column, no further children). Deduplicate against nodes already returned.
+- **Import / preview:** No change required; `_collect_items` already documents that leaf assets must not recurse via `list_assets` for siblings.
+- **Frontend:** No change expected; the tree already requests children by path from the browse endpoint.
+
+## Testing decisions
+
+- **Good tests:** Assert **observable behavior** — given a three-part UC path, listing must not return schema-wide siblings; given metadata with columns, browse must expose column nodes with correct paths and no `has_children` (or equivalent).
+- **Modules to test:** Databricks connector `list_assets` (unit test with mocked workspace client or patched list helpers); optionally `SchemaImportManager.browse` with a stub connector returning canned metadata.
+- **Prior art:** Look for existing connector or controller unit tests in the backend test tree; mirror patterns used for other Databricks or connection tests if present.
+
+## Out of scope
+
+- Changing import depth semantics, preview UI, or asset mapping rules.
+- Snowflake connector (stub) until implemented.
+- Renaming or restructuring the Schema Importer UI beyond correct tree data.
+
+## Further notes
+
+- Screenshot / repro: expand `catalog.schema.table_n` under a UC connection; previously showed sibling tables under the expanded table node.
+- Related internal plan (optional): `.cursor/plans/fix_schema_importer_tree_*.plan.md` if present in the environment used for implementation.

--- a/docs/prds/prd-schema-importer-table-expand-recursion.md
+++ b/docs/prds/prd-schema-importer-table-expand-recursion.md
@@ -1,0 +1,122 @@
+# PRD: Fix Schema Importer table expansion (Databricks UC tree recursion)
+
+## Problem Statement
+
+When a user opens the Schema Importer, picks a Databricks Unity Catalog connection, and drills into the resource tree, the hierarchy works correctly down to the schema level. The bug appears at the **table** level: clicking the chevron on a table node re-renders the **same set of tables** that already appears under the parent schema. Visually it looks as if the table is itself a schema and contains all of its siblings (and itself) again. Users cannot:
+
+- See the table's columns under the table node.
+- Trust the tree structure when picking what to import.
+- Tell, at a glance, whether a deeper expansion has produced new content or just a duplicate of the schema.
+
+The result is confusing UX and selection mistakes during import.
+
+## Solution
+
+Make the tree match the conceptual hierarchy:
+
+- Catalog → Schema → Table/View/Function/Model/Volume → Column.
+- Expanding a leaf asset (table, view, materialized view, streaming table) shows its **columns** when the connector exposes column metadata, and shows nothing otherwise.
+- Expanding a leaf asset never shows other assets from the same schema.
+
+This is achieved by:
+
+1. Teaching the Databricks connector that a fully qualified asset path (three or more dot-separated segments) is a leaf for **listing** purposes — it returns no children from the listing API. This matches the BigQuery connector, which already encodes that semantic.
+2. Teaching the schema-import browse layer to fetch the leaf asset's metadata and, when columns are present in `schema_info`, surface them as child browse nodes so expansion is visibly meaningful.
+
+## User Stories
+
+1. As a Data Producer using the Schema Importer, I want expanding a catalog to reveal its schemas, so that I can navigate down the platform hierarchy.
+2. As a Data Producer, I want expanding a schema to reveal its tables, views, materialized views, streaming tables, functions, models, and volumes, so that I can choose any asset to import.
+3. As a Data Producer, I want expanding a table to reveal its columns when column metadata is available, so that I can optionally include column-level paths in my selection.
+4. As a Data Producer, I want expanding a view, materialized view, or streaming table to behave like a table (show columns when metadata is available), so that the tree is consistent across leaf asset types.
+5. As a Data Producer, I do not want to see schema-level siblings under a table node, so that the tree does not look recursive or duplicated.
+6. As a Data Producer, when a leaf asset has no column metadata available (e.g., a function), I want the node to either be non-expandable or expand to an empty list, so that the UI clearly indicates "nothing more to drill into".
+7. As a Data Producer, I want expansion of leaf nodes to be fast (a single metadata fetch), so that browsing remains responsive even on connections with many tables.
+8. As a Data Producer using a BigQuery connection, I want the same column-level expansion behavior on tables, views, and materialized views, so that the Schema Importer feels uniform across connector types.
+9. As a Data Consumer browsing assets via the importer, I want the visual tree to faithfully represent the platform structure, so that what I select is what gets imported.
+10. As a developer extending Schema Importer with a new connector, I want a single, documented contract for "what does listing return at depth N" and "where do columns come from", so that I can implement new connectors without re-introducing this bug.
+11. As a developer running unit tests, I want regression coverage that explicitly asserts a deep path returns no listed children and that columns appear via metadata, so that future refactors cannot silently re-introduce the recursion.
+12. As an Admin operating Ontos, I want existing imports started before the fix to continue producing the same Ontos asset hierarchy after the fix, so that there is no migration or backfill required.
+
+## Implementation Decisions
+
+### Path semantics for connector listing
+
+- The path passed to a connector's listing call is dot-separated and represents the **container** whose direct children should be listed.
+- For Databricks UC: zero segments → catalogs; one segment → schemas in that catalog; two segments → assets in that schema; **three or more segments → empty list** (the path identifies a leaf asset, not a container).
+- This brings the Databricks connector in line with the explicit contract documented in the BigQuery connector and with the existing leaf-detection logic in the import-preview path.
+
+### Column children come from metadata, not from listing
+
+- Columns are not "listable" siblings — they are **structural children** that live inside an asset's metadata.
+- The schema-import browse layer is the single place that knows how to project columns into the navigable tree. It calls the connector's metadata accessor for the current path and, if `schema_info` returns columns, emits one browse node per column with:
+  - A stable, predictable path: parent path joined to the column name with `.`.
+  - A node type indicating "column".
+  - No further expandability.
+- Existing nodes returned by listing are deduplicated against these column nodes by path.
+
+### Browse response shape
+
+- No new fields are introduced on the browse response or on individual browse nodes.
+- The existing `node_type`, `path`, `has_children`, and `description` fields are sufficient. Column nodes simply use `node_type = "column"` and `has_children = false`.
+
+### Failure modes
+
+- If the metadata call fails (transient platform error, permission denied for the specific asset), the browse call returns the listing-only nodes as today and degrades gracefully — the expansion is empty rather than the tree being broken.
+- The browse response's existing `error` / `error_detail` channel is reserved for hard listing failures; metadata failures for column enrichment are logged but do not surface as a top-level browse error.
+
+### Connectors in scope
+
+- **Databricks UC**: bug fix landed in the connector's listing branch; column enrichment benefits this connector immediately because UC tables/views expose `schema_info`.
+- **BigQuery**: already correct on listing; column enrichment in the browse layer adds the same UX benefit for BigQuery tables/views/materialized views.
+- **Snowflake**: stub today; nothing to change.
+- **Kafka, Power BI**: out of scope for column-level expansion; their leaf assets either have no schema or use a different shape.
+
+### No frontend changes
+
+- The schema-browser tree component already requests children by path from the browse endpoint and renders whatever nodes come back.
+- Icons for the new "column" node type are already mapped in the existing icon table.
+- No prop, state, or layout changes are required on the frontend.
+
+### No data migration
+
+- This bug only affects in-memory tree construction during browsing. There is no persisted state that needs to be migrated. Already-completed imports are unaffected.
+
+### Backwards compatibility
+
+- The change is conservative: deep paths that previously returned schema-level siblings now return an empty list (or columns when metadata is available). Any caller that depended on the buggy behavior would already have been producing wrong asset hierarchies.
+
+## Testing Decisions
+
+### What makes a good test here
+
+- Tests target **observable behavior** at the connector and browse-controller boundary, not internal helpers.
+- Tests do not mock the workspace client at API method-name granularity unless necessary; they prefer patching the connector's narrow `_list_*` helpers or its `get_asset_metadata` so the test reads as a behavioral assertion ("given path X, return Y").
+- Tests are deterministic and do not require network or Databricks credentials.
+
+### Modules under test
+
+- The Databricks connector's listing entry point: a path with three or more segments returns an empty list, regardless of the asset types filter.
+- The schema-import browse controller: when the connector reports column metadata for the current path, the browse response includes one node per column, deduplicated against listing nodes, with the expected path convention and `has_children = false`.
+- A regression-style test: a two-segment path still returns the schema's tables/views/etc. (i.e., we did not over-correct).
+
+### Prior art
+
+- Existing backend test patterns for connectors and controllers in the project — mirror the most lightweight pattern in use (stub connector, in-memory session) rather than introducing a new test framework.
+- The BigQuery connector's listing docstring is the de facto prior art for the path-depth contract; tests should treat it as the canonical specification.
+
+## Out of Scope
+
+- Any change to the Schema Importer UI beyond what falls out of correct browse data (no redesign, no new controls, no copy changes).
+- Any change to import depth, preview semantics, asset creation, or relationship wiring.
+- Snowflake connector implementation.
+- Column-level expansion for connectors that do not expose column metadata (Kafka, Power BI).
+- Caching of metadata calls; if metadata fetches become a hotspot, that is a follow-up.
+- Permissions changes; the existing `schema-importer` feature gating remains as is.
+
+## Further Notes
+
+- Repro: open Schema Importer, pick a UC connection, expand any catalog → schema → table; the previous behavior re-listed the schema's assets under the table.
+- Root cause was localized to the Databricks connector's listing branch ignoring path segments beyond catalog and schema; the BigQuery connector documents and implements the correct semantic.
+- A short engineering work-item note already exists at `docs/notes/work-item-schema-importer-table-expand-recursion.md`; this PRD supersedes it as the canonical artifact for tracking the fix.
+- Follow-up worth considering, but not required for this PRD: a single shared "path → depth role" helper across connectors so the catalog/schema/leaf contract is encoded once instead of per connector.

--- a/plans/schema-importer-table-expand-recursion.md
+++ b/plans/schema-importer-table-expand-recursion.md
@@ -1,0 +1,49 @@
+# Plan: Fix Schema Importer table expansion (Databricks UC tree recursion)
+
+> Source PRD: [docs/prds/prd-schema-importer-table-expand-recursion.md](../docs/prds/prd-schema-importer-table-expand-recursion.md) — GitHub [#286](https://github.com/databrickslabs/ontos/issues/286)
+> Tracking issue: [#287](https://github.com/databrickslabs/ontos/issues/287)
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Path-depth contract for connector listing** (single source of truth across connectors):
+  - 0 segments → list catalogs / projects / databases.
+  - 1 segment → list schemas / datasets in that container.
+  - 2 segments → list assets (tables, views, materialized views, streaming tables, functions, models, volumes, routines, etc.) in that schema.
+  - **3 or more segments → return empty list** (path identifies a leaf asset; not a container).
+- **Where columns come from**: never from listing. Columns are projected into the navigable tree by the **schema-import browse layer**, sourced from the connector's metadata accessor (`schema_info.columns`).
+- **Browse node shape**: no new fields on the existing browse-node contract. Column rows reuse `node_type = "column"`, `has_children = false`, and a stable path of `parent_path + "." + column_name`.
+- **Failure model**: hard listing failures continue to surface via the existing `error` / `error_detail` channel on the browse response. Metadata-fetch failures during column enrichment are logged and degrade silently to listing-only nodes — never a top-level error.
+- **No persistence changes**: the bug is purely in-memory tree construction; no migrations, no backfill, no change to imported asset shape.
+- **No frontend changes**: the schema-browser tree already requests children by path and renders whatever browse returns; the column icon is already mapped.
+- **In-scope connectors**: Databricks UC (bug fix + column enrichment) and BigQuery (column enrichment only — listing already correct). Snowflake remains a stub. Kafka and Power BI are out of scope for column enrichment.
+
+---
+
+## Phase 1: Stop recursive table expansion and surface columns instead
+
+**User stories**: 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12 (from PRD)
+
+### What to build
+
+A single end-to-end vertical slice that fixes the visible bug and lands the supporting structure for column-level browsing:
+
+- Bring the Databricks UC connector's listing entry point in line with the path-depth contract above. A path with three or more dot-separated segments returns an empty list regardless of any asset-types filter. Two-segment behavior is preserved exactly as today.
+- Extend the schema-import browse layer so that, after the existing container and asset listing for the current path, it also fetches the connector's metadata for that path and, when `schema_info` exposes columns, appends one column node per column. Apply the standard path convention, mark non-expandable, and deduplicate against listing nodes by path. Wrap the metadata fetch in the same defensive try/except pattern already used for listing — failures are logged and produce a listing-only response.
+- No frontend code changes. The existing schema-browser tree, icon map, and search behavior already render the new column nodes correctly.
+- Regression and behavior tests as below.
+
+### Acceptance criteria
+
+- [ ] In the Schema Importer UI, expanding a Databricks UC table no longer renders a duplicated list of the parent schema's tables.
+- [ ] In the Schema Importer UI, expanding a Databricks UC table that exposes column metadata renders one row per column under the table; column rows are non-expandable.
+- [ ] In the Schema Importer UI, expanding a Databricks UC view, materialized view, or streaming table behaves the same as a table when column metadata is available.
+- [ ] In the Schema Importer UI, expanding a BigQuery table, view, or materialized view that exposes column metadata renders one row per column under it.
+- [ ] In the Schema Importer UI, expanding a Databricks UC schema still renders all of its tables, views, materialized views, streaming tables, functions, models, and volumes (no over-correction / no regression at the schema level).
+- [ ] When the metadata fetch for the current path fails, the browse response still returns the listing nodes; no top-level error is surfaced; the failure is logged.
+- [ ] Backend unit test: Databricks connector listing call with a three-segment path returns an empty list, regardless of asset-types filter.
+- [ ] Backend unit test: Databricks connector listing call with a two-segment path returns the expected schema-level assets (regression guard).
+- [ ] Backend unit test: schema-import browse, given a stub connector that returns column metadata for the current path, includes one column node per column with the documented path convention and `has_children = false`, and deduplicates against listing nodes by path.
+- [ ] No persisted-data migration introduced; previously imported assets are unchanged.
+- [ ] Issue [#287](https://github.com/databrickslabs/ontos/issues/287) acceptance checklist is satisfied.

--- a/src/backend/src/connectors/databricks.py
+++ b/src/backend/src/connectors/databricks.py
@@ -183,11 +183,13 @@ class DatabricksConnector(AssetConnector):
     ) -> List[AssetInfo]:
         """
         List Unity Catalog assets.
-        
+
         The path format determines what is listed:
         - None or "": List all catalogs
         - "catalog": List schemas in catalog
-        - "catalog.schema": List tables/views/functions in schema
+        - "catalog.schema": List tables/views/functions/models/volumes in schema
+        - "catalog.schema.object" (or deeper): empty — leaf FQN. Columns come
+          from get_asset_metadata().schema_info, not from listing.
         """
         ws = self._ensure_client()
         options = options or ListAssetsOptions()
@@ -205,7 +207,12 @@ class DatabricksConnector(AssetConnector):
             elif len(parts) == 1:
                 # List schemas in catalog
                 results.extend(self._list_schemas(ws, parts[0], options, limit))
-            elif len(parts) >= 2:
+            elif len(parts) >= 3:
+                # Leaf FQN (catalog.schema.object[.column...]) — no children to list.
+                # Columns are sourced from get_asset_metadata().schema_info, not from listing.
+                # Mirrors the BigQuery connector's documented contract.
+                return []
+            elif len(parts) == 2:
                 # List objects in schema
                 catalog = parts[0]
                 schema = parts[1]

--- a/src/backend/src/controller/schema_import_manager.py
+++ b/src/backend/src/controller/schema_import_manager.py
@@ -178,6 +178,33 @@ class SchemaImportManager:
         except Exception as exc:
             logger.debug(f"list_assets at path '{path}' failed (OK for top-level): {exc}")
 
+        # Enrich with column nodes when the current path identifies a leaf asset
+        # whose metadata exposes a column schema. Columns are not "listable"
+        # siblings — they live inside the asset's metadata. Failures here must
+        # degrade silently to listing-only nodes (see PRD: Failure model).
+        if path:
+            try:
+                metadata = connector.get_asset_metadata(path)
+                schema_info = getattr(metadata, "schema_info", None) if metadata else None
+                columns = getattr(schema_info, "columns", None) if schema_info else None
+                if columns:
+                    existing_paths = {n.path for n in nodes}
+                    for col in columns:
+                        col_path = f"{path}.{col.name}"
+                        if col_path in existing_paths:
+                            continue
+                        nodes.append(BrowseNode(
+                            name=col.name,
+                            node_type="column",
+                            path=col_path,
+                            has_children=False,
+                            description=getattr(col, "description", None),
+                            connector_type=connector.connector_type,
+                        ))
+                        existing_paths.add(col_path)
+            except Exception as exc:
+                logger.debug(f"Column enrichment for path '{path}' failed: {exc}")
+
         return BrowseResponse(
             connection_id=connection_id,
             path=path,

--- a/src/backend/tests/test_schema_importer_browse.py
+++ b/src/backend/tests/test_schema_importer_browse.py
@@ -1,0 +1,315 @@
+"""Tests for the Schema Importer browse layer and the Databricks connector
+listing contract that backs it.
+
+These tests pin the path-depth contract documented in the Schema Importer PRD
+([docs/prds/prd-schema-importer-table-expand-recursion.md]):
+
+  * 0 segments -> catalogs
+  * 1 segment  -> schemas
+  * 2 segments -> assets in schema
+  * 3+ segments -> empty list (leaf FQN; columns come from metadata)
+
+…and that the browse layer enriches leaf-asset paths with column nodes sourced
+from `get_asset_metadata().schema_info`.
+"""
+
+from typing import List, Optional
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.connectors.base import (
+    AssetConnector,
+    ConnectorCapabilities,
+    ListAssetsOptions,
+)
+from src.connectors.databricks import (
+    DatabricksConnector,
+    DatabricksConnectorConfig,
+)
+from src.controller.schema_import_manager import SchemaImportManager
+from src.models.assets import (
+    AssetInfo,
+    AssetMetadata,
+    AssetValidationResult,
+    ColumnInfo,
+    SchemaInfo,
+    UnifiedAssetType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Databricks connector path-depth contract
+# ---------------------------------------------------------------------------
+
+
+def _make_databricks_connector_with_listers() -> DatabricksConnector:
+    """Build a DatabricksConnector wired to a mock WorkspaceClient.
+
+    We patch the internal `_list_*` helpers per test so we never touch the
+    SDK and so test failures are about behavior, not network mocks.
+    """
+    ws = MagicMock()
+    connector = DatabricksConnector(
+        config=DatabricksConnectorConfig(),
+        workspace_client=ws,
+    )
+    return connector
+
+
+class TestDatabricksListAssetsPathDepth:
+    """The Databricks connector must respect the path-depth contract used by
+    the Schema Importer tree, otherwise expanding a table re-lists schema
+    siblings (the original recursion bug)."""
+
+    def test_three_segment_path_returns_empty(self):
+        """`catalog.schema.table` is a leaf FQN — listing must return []."""
+        connector = _make_databricks_connector_with_listers()
+        # Fail loudly if any listing helper is invoked at all.
+        connector._list_catalogs = MagicMock(side_effect=AssertionError("must not list catalogs"))
+        connector._list_schemas = MagicMock(side_effect=AssertionError("must not list schemas"))
+        connector._list_tables = MagicMock(side_effect=AssertionError("must not list tables"))
+        connector._list_functions = MagicMock(side_effect=AssertionError("must not list functions"))
+        connector._list_models = MagicMock(side_effect=AssertionError("must not list models"))
+        connector._list_volumes = MagicMock(side_effect=AssertionError("must not list volumes"))
+        connector._list_metrics = MagicMock(side_effect=AssertionError("must not list metrics"))
+
+        result = connector.list_assets(ListAssetsOptions(path="cat.sch.table"))
+
+        assert result == []
+
+    def test_four_segment_path_returns_empty(self):
+        """A column-level FQN must also be treated as a leaf for listing."""
+        connector = _make_databricks_connector_with_listers()
+        connector._list_tables = MagicMock(side_effect=AssertionError("must not list tables"))
+
+        result = connector.list_assets(ListAssetsOptions(path="cat.sch.table.col"))
+
+        assert result == []
+
+    def test_three_segment_path_ignores_asset_types_filter(self):
+        """The leaf guard must trigger regardless of any asset-types filter."""
+        connector = _make_databricks_connector_with_listers()
+        connector._list_tables = MagicMock(side_effect=AssertionError("must not list tables"))
+
+        result = connector.list_assets(
+            ListAssetsOptions(
+                path="cat.sch.table",
+                asset_types=[UnifiedAssetType.UC_TABLE, UnifiedAssetType.UC_VIEW],
+            )
+        )
+
+        assert result == []
+
+    def test_two_segment_path_still_lists_schema_assets(self):
+        """Regression guard: schema-level browsing must still work — we did
+        not over-correct and break the normal expand-schema flow."""
+        connector = _make_databricks_connector_with_listers()
+
+        sample_table = AssetInfo(
+            identifier="cat.sch.table_a",
+            name="table_a",
+            asset_type=UnifiedAssetType.UC_TABLE,
+            connector_type="databricks",
+            path="cat.sch.table_a",
+            catalog="cat",
+            schema_name="sch",
+        )
+        connector._list_tables = MagicMock(return_value=[sample_table])
+        connector._list_functions = MagicMock(return_value=[])
+        connector._list_models = MagicMock(return_value=[])
+        connector._list_volumes = MagicMock(return_value=[])
+        connector._list_metrics = MagicMock(return_value=[])
+
+        result = connector.list_assets(ListAssetsOptions(path="cat.sch"))
+
+        assert result == [sample_table]
+        connector._list_tables.assert_called_once()
+
+    def test_zero_segment_path_lists_catalogs(self):
+        """Sanity check on the other end of the contract."""
+        connector = _make_databricks_connector_with_listers()
+        connector._list_catalogs = MagicMock(return_value=[])
+
+        connector.list_assets(ListAssetsOptions(path=""))
+
+        connector._list_catalogs.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Schema Importer browse: column enrichment
+# ---------------------------------------------------------------------------
+
+
+class _StubConnector(AssetConnector):
+    """Minimal connector that returns canned listing + metadata for browse tests.
+
+    Only the methods actually called by `SchemaImportManager.browse` are
+    implemented; the abstract surface is satisfied with no-ops.
+    """
+
+    connector_type = "stub"
+    display_name = "Stub Connector"
+
+    def __init__(
+        self,
+        containers_by_path: Optional[dict] = None,
+        assets_by_path: Optional[dict] = None,
+        metadata_by_path: Optional[dict] = None,
+        metadata_raises: bool = False,
+    ):
+        super().__init__()
+        self._containers = containers_by_path or {}
+        self._assets = assets_by_path or {}
+        self._metadata = metadata_by_path or {}
+        self._metadata_raises = metadata_raises
+
+    def _get_capabilities(self) -> ConnectorCapabilities:
+        return ConnectorCapabilities()
+
+    def list_assets(self, options: Optional[ListAssetsOptions] = None) -> List[AssetInfo]:
+        path = (options.path if options else "") or ""
+        return list(self._assets.get(path, []))
+
+    def list_containers(self, parent_path: Optional[str] = None) -> List[dict]:
+        return list(self._containers.get(parent_path or "", []))
+
+    def get_asset_metadata(self, identifier: str) -> Optional[AssetMetadata]:
+        if self._metadata_raises:
+            raise RuntimeError("simulated metadata failure")
+        return self._metadata.get(identifier)
+
+    def validate_asset_exists(self, identifier: str) -> AssetValidationResult:
+        return AssetValidationResult(identifier=identifier, exists=True, validated=True)
+
+
+def _make_manager_with_stub_connector(stub: _StubConnector) -> SchemaImportManager:
+    """Wrap a stub connector so the manager can fetch it like a real one."""
+    connections_manager = MagicMock()
+    connections_manager.get_connector_for_connection.return_value = stub
+    assets_manager = MagicMock()
+    return SchemaImportManager(
+        connections_manager=connections_manager,
+        assets_manager=assets_manager,
+    )
+
+
+def _table_metadata(path: str, columns: List[ColumnInfo]) -> AssetMetadata:
+    return AssetMetadata(
+        identifier=path,
+        name=path.split(".")[-1],
+        asset_type=UnifiedAssetType.UC_TABLE,
+        connector_type="stub",
+        schema_info=SchemaInfo(columns=columns),
+    )
+
+
+class TestSchemaImporterBrowseColumnEnrichment:
+    """The browse layer must expose columns under a leaf asset path so the UI
+    tree shows columns instead of nothing (or, before the fix, schema siblings)."""
+
+    def test_columns_appear_under_table_path(self):
+        path = "cat.sch.table_a"
+        cols = [
+            ColumnInfo(name="id", data_type="int", nullable=False, description="Primary id"),
+            ColumnInfo(name="info", data_type="string", nullable=True),
+        ]
+        stub = _StubConnector(
+            containers_by_path={path: []},
+            assets_by_path={path: []},
+            metadata_by_path={path: _table_metadata(path, cols)},
+        )
+        manager = _make_manager_with_stub_connector(stub)
+
+        response = manager.browse(db=MagicMock(), connection_id=uuid4(), path=path)
+
+        col_nodes = [n for n in response.nodes if n.node_type == "column"]
+        assert [n.name for n in col_nodes] == ["id", "info"]
+        assert [n.path for n in col_nodes] == [f"{path}.id", f"{path}.info"]
+        assert all(n.has_children is False for n in col_nodes)
+        # Description carries through from ColumnInfo
+        assert col_nodes[0].description == "Primary id"
+
+    def test_no_metadata_means_no_column_nodes(self):
+        """When the connector returns no metadata for a path, the browse
+        response is just listing nodes — never invented columns."""
+        path = "cat.sch.table_b"
+        stub = _StubConnector(
+            assets_by_path={path: []},
+            metadata_by_path={},  # nothing for this path
+        )
+        manager = _make_manager_with_stub_connector(stub)
+
+        response = manager.browse(db=MagicMock(), connection_id=uuid4(), path=path)
+
+        assert all(n.node_type != "column" for n in response.nodes)
+
+    def test_metadata_fetch_failure_degrades_silently(self):
+        """A failing metadata call must not break browsing or surface a
+        top-level error — the listing-only response still comes back."""
+        path = "cat.sch.table_c"
+        sample_asset = AssetInfo(
+            identifier="cat.sch.table_c.x",  # placeholder leaf inside, would be deduped
+            name="x",
+            asset_type=UnifiedAssetType.UC_TABLE,
+            connector_type="stub",
+        )
+        stub = _StubConnector(
+            assets_by_path={path: [sample_asset]},
+            metadata_raises=True,
+        )
+        manager = _make_manager_with_stub_connector(stub)
+
+        response = manager.browse(db=MagicMock(), connection_id=uuid4(), path=path)
+
+        assert response.error is None
+        # Listing nodes still present despite the metadata failure
+        assert any(n.path == "cat.sch.table_c.x" for n in response.nodes)
+        assert all(n.node_type != "column" for n in response.nodes)
+
+    def test_column_node_dedupes_against_listing_node(self):
+        """If the listing already produced a node at the same path as a column
+        (defensive corner case), enrichment must not duplicate it."""
+        path = "cat.sch.table_d"
+        # A pre-existing node at the would-be column path
+        clashing_asset = AssetInfo(
+            identifier=f"{path}.id",
+            name="id",
+            asset_type=UnifiedAssetType.UC_TABLE,  # bogus type, just for path clash
+            connector_type="stub",
+        )
+        stub = _StubConnector(
+            assets_by_path={path: [clashing_asset]},
+            metadata_by_path={
+                path: _table_metadata(
+                    path,
+                    [ColumnInfo(name="id", data_type="int")],
+                )
+            },
+        )
+        manager = _make_manager_with_stub_connector(stub)
+
+        response = manager.browse(db=MagicMock(), connection_id=uuid4(), path=path)
+
+        matching = [n for n in response.nodes if n.path == f"{path}.id"]
+        assert len(matching) == 1
+
+    def test_no_metadata_call_for_root_browse(self):
+        """Browsing the root (no path) must not even attempt column enrichment.
+
+        This keeps the top-level catalog list cheap and avoids spurious
+        metadata calls on connectors that error on empty identifiers.
+        """
+        stub = _StubConnector(
+            containers_by_path={"": [
+                {"name": "cat", "type": "catalog", "path": "cat", "has_children": True},
+            ]},
+            metadata_raises=True,  # would explode if called
+        )
+        manager = _make_manager_with_stub_connector(stub)
+
+        response = manager.browse(db=MagicMock(), connection_id=uuid4(), path=None)
+
+        assert response.error is None
+        assert [n.path for n in response.nodes] == ["cat"]


### PR DESCRIPTION
## Summary

Fixes the Schema Importer bug where expanding a table node re-listed every sibling table from the parent schema (recursive listing).

- **Connector contract:** `DatabricksConnector.list_assets` now returns `[]` for paths with 3+ segments (leaf FQN: `catalog.schema.object[.column...]`), matching the documented BigQuery connector contract. Previously, anything with `len(parts) >= 2` fell into the schema-listing branch using `parts[0]` / `parts[1]`, causing the recursion.
- **Browse enrichment:** `SchemaImportManager.browse` now sources columns from `connector.get_asset_metadata(path).schema_info.columns` and appends them as `column` browse nodes when expanding a leaf asset. Failures degrade silently to listing-only nodes (per PRD failure model). Root browses (`path is None or ""`) skip metadata to stay cheap.
- **No frontend, schema, or persistence changes.** `BrowseNode` shape is unchanged (already supports `node_type`, `path`, `has_children`, `description`).

Closes #287
Refs PRD #286 (`docs/prds/prd-schema-importer-table-expand-recursion.md`)
Plan: `plans/schema-importer-table-expand-recursion.md`

## Changes

| File | Change |
| --- | --- |
| `src/backend/src/connectors/databricks.py` | Add `len(parts) >= 3 → return []` guard in `list_assets`; update docstring |
| `src/backend/src/controller/schema_import_manager.py` | Append column nodes from `get_asset_metadata().schema_info` after listing; dedupe; silent-degrade on errors |
| `src/backend/tests/test_schema_importer_browse.py` | New: 10 unit tests (path-depth contract + column enrichment) |
| `docs/prds/prd-schema-importer-table-expand-recursion.md` | PRD |
| `plans/schema-importer-table-expand-recursion.md` | Implementation plan |
| `docs/notes/work-item-schema-importer-table-expand-recursion.md` | Initial scoping note |

## Test plan

- [x] Unit: \`hatch -e dev run pytest src/backend/tests/test_schema_importer_browse.py\` (10 passed)
- [ ] Manual UI: Schema Importer → Databricks connection → expand catalog → schema → table; confirm columns render (with descriptions where available) and **no** sibling tables appear under the table node
- [ ] Manual UI: Re-collapse / re-expand the table; tree state remains consistent
- [ ] Manual UI: Connection where \`get_asset_metadata\` fails (or returns no schema_info) — table expands cleanly to no children, no error toast/log spam
- [ ] Regression: Schema-level browse (\`catalog.schema\`) still lists tables/views/functions/models/volumes
- [ ] Regression: Root browse still lists catalogs without triggering metadata fetches

## Out of scope

- BigQuery / Snowflake connector changes (their contracts already correct)
- Frontend tree UX changes
- Persisting column selections in the import payload