### PR TITLE
fix(frontend): webhook Mode dropdown shows correct value after select…

### DIFF
--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -1572,7 +1572,7 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
                       <div>
                         <Label>Mode</Label>
                         <Select 
-                          value={(selectedStep.config as { connection_name?: string })?.connection_name ? 'connection' : 'inline'}
+                          value={(selectedStep.config as { connection_name?: string })?.connection_name !== undefined ? 'connection' : 'inline'}
                           onValueChange={(v) => {
                             if (v === 'connection') {
                               updateStep(selectedStep.step_id, { 


### PR DESCRIPTION
## What changed
  One-line fix in `src/frontend/src/components/workflows/workflow-designer.tsx`. The WebHook step's "Mode" `Select` now uses
   `connection_name !== undefined` instead of a truthy check to derive its displayed value.                                 
                                                                                                                            
  ## Why
  Closes #290.                                                                                                              
                                                                                                                          
  The `onValueChange` handler seeds `connection_name: ''` (empty string) when the user picks "UC Connection (Recommended)".
  The old truthy check treated empty string as "not set", so the trigger snapped back to "Inline URL" even though the       
  connection input fields below rendered correctly — those already used `!== undefined`. The two mode-inference checks in
  the same block were using different rules; now they agree.                                                                
                                                                                                                          
  ## How to test
  1. Go to Settings → Workflows → open or create a Process Workflow
  2. Add a WebHook step to the canvas                              
  3. Click the step to open the sidebar properties panel                                                                    
  4. In the "Mode" dropdown, select "UC Connection (Recommended)"
  5. Expected: dropdown shows "UC Connection (Recommended)" and the connection name + path fields appear below              
  6. Switch back to "Inline URL" — dropdown and URL field should both update                                                
                                                                                                                            
  Also verified existing behavior is preserved:                                                                             
  - Legacy webhook step with neither field set → dropdown defaults to "Inline URL"                                          
  - WebHook step with a real `connection_name` value → dropdown shows "UC Connection (Recommended)"                         
                                                                                                                            
  ## Screenshots                                                                                                            
  _Before:_ [paste your repro screenshot here]                                                                              
  _After:_ [paste a screenshot of the dropdown correctly showing "UC Connection (Recommended)" here]                        
                                                                                                                            
  ## Notes                                                                                                                  
  - No type changes, no migration.                                                                                          
  - Follow-up refactor candidate: replace field-definedness-as-enum with an explicit `mode: 'connection' | 'inline'` on     
  webhook step config, so all three checks (Select value, connection-fields render, URL-field render) read from a single  
  source of truth. Happy to file as a separate issue if worth it.