### PR TITLE
feat(contracts): persist ODCS v3.1.0 SLA schedule fields

### DIFF
--- a/src/backend/alembic/versions/g1_add_sla_schedule_fields.py
+++ b/src/backend/alembic/versions/g1_add_sla_schedule_fields.py
@@ -1,0 +1,37 @@
+"""Add description, schedule, scheduler to data_contract_sla_properties
+
+ODCS v3.1.0 defines three fields on ServiceLevelAgreementProperty that were
+not yet persisted:
+
+- description: human-readable description of the SLA
+- scheduler:   name of the scheduling tool (e.g. "cron", "Airflow")
+- schedule:    scheduling configuration (e.g. "0 20 * * *")
+
+Reference: https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.1.0.json
+
+Revision ID: g1_sla_schedule_fields
+Revises: f1_merge_aa9_e2
+Create Date: 2026-04-27
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "g1_sla_schedule_fields"
+down_revision: Union[str, None] = "f1_merge_aa9_e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("data_contract_sla_properties", sa.Column("description", sa.Text(), nullable=True))
+    op.add_column("data_contract_sla_properties", sa.Column("scheduler", sa.String(), nullable=True))
+    op.add_column("data_contract_sla_properties", sa.Column("schedule", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("data_contract_sla_properties", "schedule")
+    op.drop_column("data_contract_sla_properties", "scheduler")
+    op.drop_column("data_contract_sla_properties", "description")

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -1441,6 +1441,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     sla_item['element'] = prop.element
                 if prop.driver:
                     sla_item['driver'] = prop.driver
+                if getattr(prop, 'description', None):
+                    sla_item['description'] = prop.description
+                if getattr(prop, 'scheduler', None):
+                    sla_item['scheduler'] = prop.scheduler
+                if getattr(prop, 'schedule', None):
+                    sla_item['schedule'] = prop.schedule
 
                 sla_properties.append(sla_item)
             odcs['slaProperties'] = sla_properties
@@ -2077,7 +2083,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 value_ext=json.dumps(sla_prop_data.get('valueExt')) if sla_prop_data.get('valueExt') else None,
                 unit=sla_prop_data.get('unit'),
                 element=sla_prop_data.get('element'),
-                driver=sla_prop_data.get('driver')
+                driver=sla_prop_data.get('driver'),
+                description=sla_prop_data.get('description'),
+                scheduler=sla_prop_data.get('scheduler'),
+                schedule=sla_prop_data.get('schedule'),
             )
             db.add(sla_prop)
     

--- a/src/backend/src/db_models/data_contracts.py
+++ b/src/backend/src/db_models/data_contracts.py
@@ -226,6 +226,9 @@ class DataContractSlaPropertyDb(Base):
     unit = Column(String, nullable=True)
     element = Column(String, nullable=True)
     driver = Column(String, nullable=True)
+    description = Column(Text, nullable=True)  # ODCS v3.1.0 SLA description
+    schedule = Column(String, nullable=True)   # ODCS v3.1.0 scheduling config (e.g. cron)
+    scheduler = Column(String, nullable=True)  # ODCS v3.1.0 scheduler name
     contract = relationship("DataContractDb", back_populates="sla_properties")
 
 

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -238,13 +238,16 @@ class AuthoritativeDefinition(BaseModel):
 
 
 class SLAProperty(BaseModel):
-    """ODCS SLA Property"""
+    """ODCS v3.1.0 SLA Property — https://github.com/bitol-io/open-data-contract-standard"""
     property: str
     value: Union[str, int, float]
     valueExt: Optional[Union[str, int, float]] = None
     unit: Optional[str] = None
     element: Optional[str] = None
-    driver: Optional[str] = None  # regulatory, analytics, operational
+    driver: Optional[str] = None          # regulatory, analytics, operational
+    description: Optional[str] = None    # human-readable description of the SLA
+    scheduler: Optional[str] = None      # scheduler name (e.g. cron, Airflow)
+    schedule: Optional[str] = None       # scheduling config (e.g. "0 20 * * *")
 
     class Config:
         populate_by_name = True


### PR DESCRIPTION
## Problem

ODCS v3.1.0 defines three fields on [`ServiceLevelAgreementProperty`](https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.1.0.json) that are not currently persisted:

| Field | Type | ODCS description |
|-------|------|-----------------|
| `description` | string | Human-readable description of the SLA |
| `scheduler` | string | Name of the scheduling tool (e.g. "cron", "Airflow") |
| `schedule` | string | Scheduling configuration (e.g. `"0 20 * * *"`) |

These fields are already defined in the spec and are commonly used alongside `property`/`value` to describe *when* and *how* an SLA is measured. Without persistence, they are silently dropped on import and omitted from export, breaking round-trip fidelity.

## Changes

- **Migration** (`g1_add_sla_schedule_fields`): adds `description` (Text), `scheduler` (String), `schedule` (String) to `data_contract_sla_properties`. Revises `f1_merge_aa9_e2`.
- **DB model** (`DataContractSlaPropertyDb`): adds the three columns.
- **Pydantic model** (`SLAProperty`): adds `description`, `scheduler`, `schedule` as optional fields.
- **Manager** (`_create_sla_properties` + export): reads and writes the three fields on import/export.

## Reference

- ODCS v3.1.0 JSON schema: https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.1.0.json
- Upstream issue identified while deploying `d1_odcs_v310_full_persistence` (commit `6cfa315`) — that migration added `stable_id` to `sla_properties` but the three schedule fields remained missing.