### PR TITLE
ci(e2e): run Playwright with 2 workers to avoid 20-min timeout

### DIFF
--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
     '**/cuj-8-data-products*',
   ] : [],
   retries: process.env.CI ? 1 : 0,
+  // Default Playwright CI workers=1 serialized 72 specs and hit the 20-min job
+  // timeout. Bump to 2 in CI; the existing retries: 1 covers any flake from
+  // workers contending on the shared Postgres service.
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? 'html' : 'list',
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',


### PR DESCRIPTION
## Summary
The E2E job on \`main\` ([run 25053733375](https://github.com/databrickslabs/ontos/actions/runs/25053733375/job/73388163551)) was killed by \`timeout-minutes: 20\` mid-suite. Root cause from the log: \`Running 72 tests using 1 worker\` — Playwright's default on CI is \`workers: 1\`, so the 72 specs serialized.

This PR bumps \`workers\` to \`2\` in CI only. Local runs (\`workers: undefined\`) are unaffected.

## Why workers=2 (and not auto/4)
Tests share the seeded Postgres service for CRUD flows, so high parallelism risks collisions. \`2\` is the smallest bump that meaningfully cuts wall-clock time while keeping the existing \`retries: 1\` as a safety net for any contention. If it stabilizes, we can bump higher in a follow-up.

## Out of scope
- Increasing \`timeout-minutes\` (alternative fix). Left at 20 deliberately so we get a signal if 2 workers still aren't enough.
- Restructuring tests for true parallel isolation (per-worker DB schema, etc.). That's a bigger lift.

## Test plan
- [ ] Next \`main\` push triggers E2E and finishes well under 20 min
- [ ] No new flakes attributable to two workers writing to the shared DB (retries: 1 should absorb single-attempt flakes)
- [ ] If flakes appear, revert to \`workers: 1\` and bump \`timeout-minutes\` instead

This pull request and its description were written by Isaac.