### PR TITLE
fix(settings): use requester_email in role-request decision audit (#66)

### DIFF
--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -361,7 +361,7 @@ async def handle_role_request_decision(
             feature='settings',
             action='HANDLE_ROLE_REQUEST',
             success=True,
-            details={'role_id': request_data.role_id, 'approved': request_data.approved, 'user_email': request_data.user_email}
+            details={'role_id': request_data.role_id, 'approved': request_data.approved, 'user_email': request_data.requester_email}
         )
         
         return result


### PR DESCRIPTION
Fixes #66. `POST /settings/roles/handle-request` returned HTTP 500 because the audit log line referenced `request_data.user_email`, but the `HandleRoleRequest` model (`src/backend/src/models/settings.py:132`) declares the field as `requester_email`. The `AttributeError` propagated to the generic `except Exception` and surfaced to the user as the 'internal error' toast — confirmed reproducible by another reporter on the same issue.

## Change

`src/backend/src/routes/settings_routes.py:364` — `request_data.user_email` → `request_data.requester_email`. The audit log key (`'user_email'`) is preserved so existing audit consumers don't break.

## Test plan

- [x] AST parse on `settings_routes.py` is clean
- [x] Field name now matches `HandleRoleRequest` schema; the only previous reference path was the audit log line that triggered the 500