### PR TITLE
ci: use PAT for lockfile auto-commit so CI re-runs on the new SHA

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -429,7 +429,11 @@ jobs:
           # Falls back to the default ref for push events.
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (LOCKFILE_BOT_TOKEN) so that auto-commits trigger CI on
+          # the new SHA. Pushes made with the default GITHUB_TOKEN do NOT
+          # re-trigger workflows. Falls back to GITHUB_TOKEN for read-only
+          # checkout when the secret isn't configured (older forks, etc.).
+          token: ${{ secrets.LOCKFILE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Get JFrog OIDC token
         run: |
@@ -496,9 +500,10 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add src/requirements.txt src/backend/requirements.txt src/e2e/requirements.txt
-          git commit -m "chore: regenerate requirements lockfiles [skip ci]"
+          git commit -m "chore: regenerate requirements lockfiles"
           git push origin HEAD:${{ github.event.pull_request.head.ref }}
           echo "Pushed regenerated lockfiles to ${{ github.event.pull_request.head.ref }}."
+          echo "CI will re-run on the new SHA (requires LOCKFILE_BOT_TOKEN secret to be a PAT)."
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.drift.outputs.drifted == 'true' && steps.fork.outputs.is_fork == 'false'


### PR DESCRIPTION
## Summary
- Drops `[skip ci]` from the auto-commit message added in #313 and switches the auto-commit push from `secrets.GITHUB_TOKEN` to a fine-grained PAT (`secrets.LOCKFILE_BOT_TOKEN`), with `secrets.GITHUB_TOKEN` as a fallback.
- Net effect: after the lockfile job auto-regenerates and pushes the fix, **CI re-runs on the new SHA** so `backend-tests`, `frontend-tests`, `type-check`, and `e2e-tests` validate against the regenerated pins.

## Why
#313 shipped the auto-commit behavior but uses the default `GITHUB_TOKEN`, which by GitHub's own security model **does not trigger workflow runs on the resulting commit**. So the rest of the pipeline never re-runs on the bot's regen, and the merge-time signal reflects the pre-fix SHA, not the final one. This PR closes that gap.

## One-time setup required after merge
A maintainer must add a repo secret:

1. Generate a **fine-grained PAT** at https://github.com/settings/personal-access-tokens
   - Resource owner: `databrickslabs`
   - Repository access: only `databrickslabs/ontos`
   - Repository permissions: `Contents: Read and write`
2. Add it as a repo secret named **`LOCKFILE_BOT_TOKEN`** under Settings → Secrets and variables → Actions

Until that secret exists, the workflow gracefully falls back to `GITHUB_TOKEN` (the auto-commit still works, it just won't re-trigger CI, same behavior as #313 alone).

Alternative: a GitHub App token via `actions/create-github-app-token`. Happy to do that instead if you'd rather not manage a long-lived PAT.

## Test plan
- [ ] Add the `LOCKFILE_BOT_TOKEN` secret per the setup steps
- [ ] Open a test PR that bumps a pin in `src/requirements.in` without re-running the lock script
- [ ] Confirm: lockfile job regenerates, auto-commits, **CI re-runs** on the bot's commit, and the rest of the pipeline executes against the regenerated pins
- [ ] Remove the secret temporarily, repeat, confirm graceful fallback (auto-commit works, no re-trigger)

This pull request and its description were written by Isaac.