### PR TITLE
ci: skip Test Coverage workflow on fork PRs

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -18,6 +18,11 @@ jobs:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     timeout-minutes: 15
+    # Skip on fork PRs: the protected runner group has no public internet
+    # egress and GitHub doesn't issue OIDC tokens for fork PRs, so JFrog
+    # auth and registry access both fail. Maintainers must pull fork
+    # branches into the upstream repo to run CI.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code
@@ -113,6 +118,7 @@ jobs:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code
@@ -360,6 +366,7 @@ jobs:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code
@@ -420,6 +427,7 @@ jobs:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code
@@ -526,6 +534,7 @@ jobs:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code
@@ -586,7 +595,7 @@ jobs:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     needs: [backend-tests, frontend-tests]
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Adds an `if:` guard on each Test Coverage job so the workflow is **skipped** on PRs from forks instead of crashing with cryptic `ACTIONS_ID_TOKEN_REQUEST_TOKEN: unbound variable` errors at the JFrog OIDC step.

Affected jobs: `backend-tests`, `frontend-tests`, `type-check`, `check-lockfiles`, `frontend-build`, plus an updated guard on `coverage-report`. `e2e-tests` was already gated to push events on main.

The condition:
```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

## Why
PR #315 (from `mvkonchits-db:feature/ontos-approval-workflows-ux`, a fork) is the trigger. Every Test Coverage job fails immediately at the OIDC step:

```
/home/runner/work/_temp/.../sh: line 5: ACTIONS_ID_TOKEN_REQUEST_TOKEN: unbound variable
##[error]Process completed with exit code 1.
```

GitHub deliberately does not issue OIDC tokens for fork PR contexts (it would let untrusted code mint cloud credentials via the repo's OIDC trust policy). And even working around the OIDC issue wouldn't help here, because the `databrickslabs-protected-runner-group` has no public internet egress, so falling back to public PyPI/npm registries would also fail.

There's no clean fix that lets fork PRs run on the existing protected runner with the existing JFrog dependency. The honest move is to skip CI on fork PRs and surface that clearly.

## Implications for fork contributors
After this lands, fork PRs will show "Test Coverage / Backend Tests, Frontend Tests, ..." as **skipped** instead of failed. Skipped checks count as passing for required-status branch protection (per [GitHub's 2022 change](https://github.blog/changelog/2022-09-21-skipped-required-status-checks-treated-as-successful/)), so fork PRs are no longer in a permanent red state.

To actually run CI on a fork PR, a maintainer must pull the branch into the upstream repo:
```bash
git fetch git@github.com:mvkonchits-db/ontos.git feature/ontos-approval-workflows-ux:fork/mvkonchits-db/approval-workflows-ux
git push origin fork/mvkonchits-db/approval-workflows-ux
```
…then open or retarget the PR to that same-repo branch. This is the standard pattern for OSS repos with private package mirrors.

## Out of scope (worth a follow-up if it bites)
- Auto-mirroring fork branches via a `pull_request_target` workflow (security tradeoffs, needs careful review)
- Falling back to GitHub-hosted public runners on fork PRs and depending only on public registries (would require a separate dep stack and probably isn't worth it for a small minority of fork PRs)

## Test plan
- [ ] Confirm PR #315 (fork PR) shows skipped checks instead of failing red
- [ ] Confirm same-repo PRs (e.g. any new branch off main) still run CI as before
- [ ] Confirm direct pushes to `main`/`develop` still run CI

This pull request and its description were written by Isaac.