### PR TITLE
fix(contracts): accept ODCS v3.1.0 transformSourceObjects array

### DIFF
--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -69,7 +69,9 @@ class ColumnProperty(BaseModel):
     encryptedName: Optional[str] = None
     criticalDataElement: Optional[bool] = None
     transformLogic: Optional[str] = None
-    transformSourceObjects: Optional[str] = None
+    # ODCS v3.1.0 defines transformSourceObjects as an array of strings; accept a
+    # plain string for backward compatibility with earlier Ontos uploads.
+    transformSourceObjects: Optional[Union[List[str], str]] = None
     transformDescription: Optional[str] = None
 
     # ODCS v3.1.0 relationships (property-level FKs)

--- a/src/backend/src/tests/unit/test_data_contracts_api_models.py
+++ b/src/backend/src/tests/unit/test_data_contracts_api_models.py
@@ -1,0 +1,37 @@
+"""Unit tests for ODCS Pydantic models in data_contracts_api."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.data_contracts_api import ColumnProperty
+
+
+def test_column_property_transform_source_objects_accepts_list():
+    """ODCS v3.1.0 defines transformSourceObjects as an array of strings.
+
+    Regression test for issue #285: ODCS-compliant uploads with
+    transformSourceObjects as a list previously failed Pydantic validation
+    with HTTP 422 ("Input should be a valid string").
+    """
+    prop = ColumnProperty(
+        name='col',
+        logicalType='string',
+        transformSourceObjects=['table_a', 'table_b'],
+    )
+    assert prop.transformSourceObjects == ['table_a', 'table_b']
+
+
+def test_column_property_transform_source_objects_accepts_string_for_backcompat():
+    """Plain-string input remains valid for backward compatibility."""
+    prop = ColumnProperty(
+        name='col',
+        logicalType='string',
+        transformSourceObjects='table_a',
+    )
+    assert prop.transformSourceObjects == 'table_a'
+
+
+def test_column_property_transform_source_objects_optional():
+    """Field is optional and may be omitted."""
+    prop = ColumnProperty(name='col', logicalType='string')
+    assert prop.transformSourceObjects is None


### PR DESCRIPTION
Fixes #285.

`ColumnProperty.transformSourceObjects` was typed as `Optional[str]`, so ODCS v3.1.0-compliant uploads using the spec's array form (e.g. `["tbl_a"]`) failed at `POST /api/data-contracts` with HTTP 422 ("Input should be a valid string") even though they passed the GitHub-workflow JSON-schema validation. Widening the type to `Union[List[str], str]` matches the [ODCS v3.1.0 `SchemaBaseProperty`](https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.1.0.json) definition while keeping legacy string inputs valid; persistence (`data_contracts_manager.py:1766`) and export (`:999`) already handle both shapes.