### PR TITLE
fix: commit singleton session mutations to prevent data loss on restart

### DIFF
--- a/src/backend/src/controller/connections_manager.py
+++ b/src/backend/src/controller/connections_manager.py
@@ -91,7 +91,7 @@ class ConnectionsManager:
             created_by=created_by or "",
         )
         self._db.add(db_obj)
-        self._db.flush()
+        self._db.commit()
         self._db.refresh(db_obj)
         logger.info(f"Created connection '{data.name}' (type={data.connector_type})")
         return ConnectionResponse.model_validate(db_obj)
@@ -116,7 +116,7 @@ class ConnectionsManager:
         for field, value in update_data.items():
             setattr(db_obj, field, value)
 
-        self._db.flush()
+        self._db.commit()
         self._db.refresh(db_obj)
         logger.info(f"Updated connection '{db_obj.name}' (id={connection_id})")
         return ConnectionResponse.model_validate(db_obj)
@@ -128,7 +128,7 @@ class ConnectionsManager:
         if db_obj.created_by == SYSTEM_CREATED_BY:
             raise ValueError("System connections cannot be deleted")
         self._db.delete(db_obj)
-        self._db.flush()
+        self._db.commit()
         logger.info(f"Deleted connection '{db_obj.name}' (id={connection_id})")
         return True
 
@@ -258,7 +258,7 @@ class ConnectionsManager:
             created_by=SYSTEM_CREATED_BY,
         )
         self._db.add(db_obj)
-        self._db.flush()
+        self._db.commit()
         logger.info("Created system Databricks UC connection")
 
     def migrate_from_app_settings(self) -> int:
@@ -298,7 +298,7 @@ class ConnectionsManager:
                     created_by="",
                 )
                 self._db.add(db_obj)
-                self._db.flush()
+                self._db.commit()
                 migrated += 1
 
                 # Remove the old key

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -574,7 +574,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             old_status = product_db.status
             product_db.status = new_status_lower
             self._db.add(product_db)
-            self._db.flush()
+            self._db.commit()
             
             logger.info(
                 f"Product {product_id} status transitioned: {old_status} → {new_status_lower}"
@@ -757,7 +757,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             product_db.published_at = datetime.now(timezone.utc)
             product_db.published_by = current_user
             self._db.add(product_db)
-            self._db.flush()
+            self._db.commit()
 
             # Fire on_publish trigger
             try:

--- a/src/backend/src/controller/semantic_links_manager.py
+++ b/src/backend/src/controller/semantic_links_manager.py
@@ -195,7 +195,7 @@ class SemanticLinksManager:
         if created_by:
             db_obj.created_by = created_by
             self._db.add(db_obj)
-        self._db.flush()
+        self._db.commit()
         self._db.refresh(db_obj)
         
         # Incrementally update the in-memory RDF graph via the shared manager on app.state

--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -1654,11 +1654,10 @@ class SettingsManager:
                         updated_any = True
 
             if updated_any:
-                # Flush once after backfill
                 try:
-                    self._db.flush()
+                    self._db.commit()
                 except Exception:
-                    pass
+                    self._db.rollback()
 
             return [self._map_db_to_api(role_db) for role_db in roles_db]
         except SQLAlchemyError as e:
@@ -1726,9 +1725,7 @@ class SettingsManager:
                     self._db, str(role_db.id), role.approver_roles
                 )
             
-            # Commit is handled by the request lifecycle or calling function
-            # self._db.commit() # Remove commit from manager method
-            # self._db.refresh(role_db) # Refresh is handled in repo
+            self._db.commit()
             logger.info(f"Successfully created role '{role.name}' with ID {role_db.id}")
             result = self._map_db_to_api(role_db)
             
@@ -1873,7 +1870,7 @@ class SettingsManager:
                     self._db, role_id, role_update.approver_roles
                 )
             
-            # Commit handled by request lifecycle
+            self._db.commit()
             logger.info(f"Successfully updated role (ID: {role_id})")
             result = self._map_db_to_api(updated_role_db)
             
@@ -1913,8 +1910,7 @@ class SettingsManager:
             #    raise ValueError("Cannot delete the default Admin role.")
 
             self.app_role_repo.remove(db=self._db, id=role_id)
-            # Commit handled by request lifecycle
-            # self._db.commit()
+            self._db.commit()
             logger.info(f"Successfully deleted role with ID: {role_id}")
             return True
         except SQLAlchemyError as e:


### PR DESCRIPTION
## Summary

- **Bug**: All singleton managers (`SettingsManager`, `ConnectionsManager`, `DataProductsManager`, `SemanticLinksManager`) use a long-lived `self._db` session created at startup. Their mutation methods only called `flush()` — which sends SQL to the DB within the transaction — but never `commit()`. On app restart, PostgreSQL rolls back the uncommitted transaction, silently reverting all API-made changes (role group assignments, connection configs, product status transitions, etc.).
- **Fix**: Replace `flush()` with `commit()` in all singleton-session mutation paths across 4 manager files.
- **Impact**: Fixes data loss observed in Marketplace deployments where admin role groups reverted to defaults after every restart.

## Changed Files

| File | Changes |
|------|---------|
| `settings_manager.py` | `create_app_role`, `update_app_role`, `delete_app_role`, list backfill |
| `connections_manager.py` | `create_connection`, `update_connection`, `delete_connection`, `ensure_system_connection`, `migrate_from_app_settings` |
| `data_products_manager.py` | `transition_status`, `publish_product` |
| `semantic_links_manager.py` | `create_link` |

## Test plan

- [ ] Update admin role groups via Settings UI, restart app, verify groups persist
- [ ] Create/update/delete a connection, restart app, verify changes persist
- [ ] Transition a data product status, restart app, verify status persists
- [ ] Verify no regressions in request-scoped session paths (normal CRUD via API)