### PR TITLE
fix(schema-importer): expand functions/MVs/streaming tables; preserve source-system labels

### DIFF
--- a/src/backend/src/controller/schema_import_manager.py
+++ b/src/backend/src/controller/schema_import_manager.py
@@ -866,31 +866,97 @@ class SchemaImportManager:
 # Module-level helpers
 # ---------------------------------------------------------------------------
 
+# Per-asset-type display labels for the browse tree (drives the
+# `node_type` field on BrowseNode and the icon picked by the frontend).
+#
+# Distinct from `_TYPE_MAP` on purpose: `_TYPE_MAP` collapses source-system
+# concepts to a smaller Ontos asset-type vocabulary used at *import* time
+# (e.g. UC_FUNCTION/UC_VOLUME -> "System"), but at *browse* time we want
+# to preserve the source label so users can tell a function from a volume.
+_DISPLAY_TYPE_MAP: Dict[str, str] = {
+    # Databricks / Unity Catalog
+    UnifiedAssetType.UC_CATALOG.value: "catalog",
+    UnifiedAssetType.UC_SCHEMA.value: "schema",
+    UnifiedAssetType.UC_TABLE.value: "table",
+    UnifiedAssetType.UC_VIEW.value: "view",
+    UnifiedAssetType.UC_MATERIALIZED_VIEW.value: "view",
+    UnifiedAssetType.UC_STREAMING_TABLE.value: "table",
+    UnifiedAssetType.UC_FUNCTION.value: "function",
+    UnifiedAssetType.UC_MODEL.value: "model",
+    UnifiedAssetType.UC_VOLUME.value: "volume",
+    # BigQuery
+    UnifiedAssetType.BQ_PROJECT.value: "project",
+    UnifiedAssetType.BQ_DATASET.value: "dataset",
+    UnifiedAssetType.BQ_TABLE.value: "table",
+    UnifiedAssetType.BQ_VIEW.value: "view",
+    UnifiedAssetType.BQ_MATERIALIZED_VIEW.value: "view",
+    UnifiedAssetType.BQ_EXTERNAL_TABLE.value: "table",
+    UnifiedAssetType.BQ_ROUTINE.value: "routine",
+    UnifiedAssetType.BQ_MODEL.value: "model",
+    # Snowflake
+    UnifiedAssetType.SNOWFLAKE_DATABASE.value: "database",
+    UnifiedAssetType.SNOWFLAKE_SCHEMA.value: "schema",
+    UnifiedAssetType.SNOWFLAKE_TABLE.value: "table",
+    UnifiedAssetType.SNOWFLAKE_VIEW.value: "view",
+    UnifiedAssetType.SNOWFLAKE_MATERIALIZED_VIEW.value: "view",
+    UnifiedAssetType.SNOWFLAKE_FUNCTION.value: "function",
+    UnifiedAssetType.SNOWFLAKE_PROCEDURE.value: "procedure",
+}
+
+
 def _display_type(asset_type: Optional[UnifiedAssetType]) -> str:
-    """Human-friendly type label for browse nodes."""
+    """Human-friendly type label for browse nodes.
+
+    Drives the `node_type` field returned to the UI, which selects the
+    Lucide icon and the small label printed next to each node name.
+    """
     if asset_type is None:
         return "unknown"
-    mapping = _TYPE_MAP.get(asset_type.value)
-    if mapping:
-        return mapping[0].lower()
+    label = _DISPLAY_TYPE_MAP.get(asset_type.value)
+    if label:
+        return label
+    # Last-resort fallback for newly-added asset types: take the trailing
+    # segment of the enum value (e.g. "powerbi_dashboard" -> "dashboard").
     return asset_type.value.split("_")[-1].lower()
 
 
 def _has_children(asset_type: Optional[UnifiedAssetType]) -> bool:
-    """Whether an asset type may have child nodes (e.g., columns)."""
+    """Whether an asset type may have child nodes (e.g., columns).
+
+    Used to set ``BrowseNode.has_children`` so the UI renders an expand
+    chevron. The set must include every leaf type whose
+    ``get_asset_metadata().schema_info`` is populated by the connector,
+    otherwise the user has no way to drill into its columns/parameters.
+
+    Excluded by design: models, volumes, datasets — they have no
+    column-level schema, so an expand chevron would yield an empty list.
+    """
     if asset_type is None:
         return False
     return asset_type.value in {
+        # Containers
         UnifiedAssetType.UC_CATALOG.value,
         UnifiedAssetType.UC_SCHEMA.value,
-        UnifiedAssetType.UC_TABLE.value,
-        UnifiedAssetType.UC_VIEW.value,
         UnifiedAssetType.BQ_PROJECT.value,
         UnifiedAssetType.BQ_DATASET.value,
-        UnifiedAssetType.BQ_TABLE.value,
-        UnifiedAssetType.BQ_VIEW.value,
         UnifiedAssetType.SNOWFLAKE_DATABASE.value,
         UnifiedAssetType.SNOWFLAKE_SCHEMA.value,
+        # UC leaves with column-bearing metadata
+        UnifiedAssetType.UC_TABLE.value,
+        UnifiedAssetType.UC_VIEW.value,
+        UnifiedAssetType.UC_MATERIALIZED_VIEW.value,
+        UnifiedAssetType.UC_STREAMING_TABLE.value,
+        UnifiedAssetType.UC_FUNCTION.value,
+        # BigQuery leaves with column-bearing metadata
+        UnifiedAssetType.BQ_TABLE.value,
+        UnifiedAssetType.BQ_VIEW.value,
+        UnifiedAssetType.BQ_MATERIALIZED_VIEW.value,
+        UnifiedAssetType.BQ_EXTERNAL_TABLE.value,
+        UnifiedAssetType.BQ_ROUTINE.value,
+        # Snowflake leaves with column-bearing metadata
         UnifiedAssetType.SNOWFLAKE_TABLE.value,
         UnifiedAssetType.SNOWFLAKE_VIEW.value,
+        UnifiedAssetType.SNOWFLAKE_MATERIALIZED_VIEW.value,
+        UnifiedAssetType.SNOWFLAKE_FUNCTION.value,
+        UnifiedAssetType.SNOWFLAKE_PROCEDURE.value,
     }

--- a/src/backend/tests/test_schema_importer_browse.py
+++ b/src/backend/tests/test_schema_importer_browse.py
@@ -28,7 +28,11 @@ from src.connectors.databricks import (
     DatabricksConnector,
     DatabricksConnectorConfig,
 )
-from src.controller.schema_import_manager import SchemaImportManager
+from src.controller.schema_import_manager import (
+    SchemaImportManager,
+    _display_type,
+    _has_children,
+)
 from src.models.assets import (
     AssetInfo,
     AssetMetadata,
@@ -313,3 +317,81 @@ class TestSchemaImporterBrowseColumnEnrichment:
 
         assert response.error is None
         assert [n.path for n in response.nodes] == ["cat"]
+
+    def test_listing_marks_column_bearing_leaves_as_expandable(self):
+        """`_has_children` must return True for leaf types whose
+        `get_asset_metadata().schema_info` is populated, otherwise the UI
+        renders no expand chevron and the user can never see columns or
+        function parameters.
+
+        Anchored to the bug in https://github.com/databrickslabs/ontos/pull/289
+        where `system.ai.python_exec` (a UC function) appeared as `has_children=false`.
+        """
+        expandable = {
+            # UC: tables + view variants + function parameters
+            UnifiedAssetType.UC_TABLE,
+            UnifiedAssetType.UC_VIEW,
+            UnifiedAssetType.UC_MATERIALIZED_VIEW,
+            UnifiedAssetType.UC_STREAMING_TABLE,
+            UnifiedAssetType.UC_FUNCTION,
+            # BigQuery
+            UnifiedAssetType.BQ_TABLE,
+            UnifiedAssetType.BQ_VIEW,
+            UnifiedAssetType.BQ_MATERIALIZED_VIEW,
+            UnifiedAssetType.BQ_EXTERNAL_TABLE,
+            UnifiedAssetType.BQ_ROUTINE,
+            # Snowflake
+            UnifiedAssetType.SNOWFLAKE_TABLE,
+            UnifiedAssetType.SNOWFLAKE_VIEW,
+            UnifiedAssetType.SNOWFLAKE_MATERIALIZED_VIEW,
+            UnifiedAssetType.SNOWFLAKE_FUNCTION,
+            UnifiedAssetType.SNOWFLAKE_PROCEDURE,
+        }
+        for at in expandable:
+            assert _has_children(at) is True, f"expected {at} to be expandable"
+
+    def test_listing_marks_non_column_leaves_as_non_expandable(self):
+        """Models, volumes, datasets etc. must stay non-expandable — there is
+        nothing under them, and a chevron would just yield an empty list."""
+        non_expandable = {
+            UnifiedAssetType.UC_MODEL,
+            UnifiedAssetType.UC_VOLUME,
+            UnifiedAssetType.BQ_MODEL,
+            # None case
+        }
+        for at in non_expandable:
+            assert _has_children(at) is False, f"expected {at} to be non-expandable"
+        assert _has_children(None) is False
+
+    def test_display_type_distinguishes_functions_models_volumes(self):
+        """Browse-time labels must preserve source-system semantics.
+
+        Before this fix `_display_type` went through `_TYPE_MAP` which
+        collapses functions/volumes/procedures to the import-time
+        Ontos type "System" — leaving the user with a tree that
+        labels every UC function and volume as "system". The display
+        map keeps them distinct so the right icon is picked and the
+        label next to the name is meaningful.
+        """
+        cases = {
+            # UC
+            UnifiedAssetType.UC_TABLE: "table",
+            UnifiedAssetType.UC_VIEW: "view",
+            UnifiedAssetType.UC_MATERIALIZED_VIEW: "view",
+            UnifiedAssetType.UC_STREAMING_TABLE: "table",
+            UnifiedAssetType.UC_FUNCTION: "function",
+            UnifiedAssetType.UC_MODEL: "model",
+            UnifiedAssetType.UC_VOLUME: "volume",
+            # BQ
+            UnifiedAssetType.BQ_ROUTINE: "routine",
+            UnifiedAssetType.BQ_MODEL: "model",
+            UnifiedAssetType.BQ_EXTERNAL_TABLE: "table",
+            # Snowflake
+            UnifiedAssetType.SNOWFLAKE_FUNCTION: "function",
+            UnifiedAssetType.SNOWFLAKE_PROCEDURE: "procedure",
+            UnifiedAssetType.SNOWFLAKE_MATERIALIZED_VIEW: "view",
+        }
+        for at, expected in cases.items():
+            assert _display_type(at) == expected, f"{at} -> {_display_type(at)}, want {expected}"
+
+        assert _display_type(None) == "unknown"

--- a/src/frontend/src/components/schema-importer/schema-browser.tsx
+++ b/src/frontend/src/components/schema-importer/schema-browser.tsx
@@ -11,6 +11,7 @@ import {
   FolderOpen,
   Braces,
   Library,
+  HardDrive,
   X,
   Search,
   AlertCircle,
@@ -57,7 +58,10 @@ const nodeIconMap: Record<string, typeof Database> = {
   view: Eye,
   column: Columns3,
   routine: Braces,
+  function: Braces,
+  procedure: Braces,
   model: Box,
+  volume: HardDrive,
 };
 
 function getNodeIcon(nodeType: string) {


### PR DESCRIPTION
## Summary

Follow-up to #289. Two coupled gaps in the Schema Importer were preventing users from drilling into the columns level for non-table leaf assets.

### Bug 1: `has_children=false` on column-bearing leaves

`_has_children` only included `UC_TABLE`, `UC_VIEW`, `BQ_TABLE`, `BQ_VIEW`, `SNOWFLAKE_TABLE`, `SNOWFLAKE_VIEW` — so the UI never rendered an expand chevron on:

- UC: materialized views, streaming tables, **functions** (parameters)
- BigQuery: materialized views, external tables, routines
- Snowflake: materialized views, functions, procedures

All of these populate `schema_info` via `get_asset_metadata()`, so they should be expandable. Models, volumes, and datasets stay non-expandable on purpose — they have no column-level schema.

### Bug 2: `node_type` collapsed to "system" / "ml model"

`_display_type` went through `_TYPE_MAP`, which intentionally collapses source-system concepts to a smaller Ontos asset-type vocabulary used at *import* time (e.g. `UC_FUNCTION` / `UC_VOLUME` -> `"System"`). At *browse* time we want the source label so users can tell a function from a volume, and so the frontend picks the right icon.

Introduces `_DISPLAY_TYPE_MAP` that preserves: `function`, `procedure`, `model`, `volume`, `view`, `table`, `routine`, `dataset`, `project`, `database`.

### Frontend

`nodeIconMap` extended:
- `function` / `procedure` -> Braces (same as routine — code-like)
- `volume` -> HardDrive

## Files

| File | Change |
| --- | --- |
| `src/backend/src/controller/schema_import_manager.py` | New `_DISPLAY_TYPE_MAP`; rewrite `_display_type`; extend `_has_children` |
| `src/backend/tests/test_schema_importer_browse.py` | +3 tests: expandable types, non-expandable types, display labels |
| `src/frontend/src/components/schema-importer/schema-browser.tsx` | Add `function` / `procedure` / `volume` icons |

## Test plan

- [x] Unit: `hatch -e dev run pytest backend/tests/test_schema_importer_browse.py` (13/13 passed)
- [x] Playwright E2E: navigated to `system.ai.python_exec` (UC function); chevron rendered, expanding showed `code` parameter as a column node, row label reads `function` (not `system`); `bge_*` models read `model` (not `ml model`)
- [ ] Regression: `samples.tpch.customer` still expands cleanly to its 8 columns (verified in #289, no logic change to the table path)
- [ ] Manual: BigQuery / Snowflake connections (no live test envs in this run; covered by code review of the connector contracts)

## Out of scope

- Backend cache invalidation when display labels change (current dev reload + page refresh works fine)
- Persisting column selections in the import payload
