### PR TITLE
feat(demo-data): split demo data into 5 standalone vertical presets

### DIFF
--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -116,7 +116,9 @@ ucapp/
 - Purpose: Store seed data, demo fixtures, ontology definitions
 - Contains:
   - `taxonomies/` — RDF ontologies (e.g., `ontos-ontology.ttl`)
-  - Demo data files (loaded via POST /api/settings/demo-data/load)
+  - Demo data files: one self-contained pack per preset, named `demo_data_{preset}.sql`
+    (presets: `retail` (default), `hls`, `fsi`, `mfg`, `auto`).
+    Loaded via `POST /api/settings/demo-data/load?preset=<name>`.
 
 **`src/backend/src/tests/`** (Test Suite)
 - Purpose: Unit and integration tests

--- a/docs/Ontos Setup.md
+++ b/docs/Ontos Setup.md
@@ -283,7 +283,26 @@ Once the app is up, click on the app's URL to open it.
 
 ## Step #5: (Optionally) Load Demo Data
 
-Ontos ships with demo data, which can be loaded on demand. Navigate to the `/docs` page in Ontos (by editing the URL in the browser's address bar):
+Ontos ships with five **standalone demo packs** — one per industry — and the
+`POST /api/settings/demo-data/load` endpoint accepts a `preset` query
+parameter to pick exactly one of them:
+
+| `preset`  | File                       | Vertical flavour                                |
+| --------- | -------------------------- | ----------------------------------------------- |
+| `retail`  | `demo_data_retail.sql`     | Retail / e‑commerce (default)                   |
+| `hls`     | `demo_data_hls.sql`        | Healthcare & Life Sciences (clinical, claims)   |
+| `fsi`     | `demo_data_fsi.sql`        | Financial Services (banking, capital markets)   |
+| `mfg`     | `demo_data_mfg.sql`        | Manufacturing (production, quality, EHS)        |
+| `auto`    | `demo_data_auto.sql`       | Automotive (connected vehicle, ADAS, warranty)  |
+
+Each preset is fully self‑contained: it brings its own data domains, business
+roles, delivery methods, ontology concepts, vertical asset types, tag
+namespaces, workflows, assets, lineage, owners, comments, compliance runs and
+cost items. You can load any preset on top of an empty database without
+needing the retail base.
+
+Navigate to the `/docs` page in Ontos (by editing the URL in the browser's
+address bar) to use them interactively:
 
 ![](images/setup/eab238b2452e97910df4a5f3058e9717.png)
 
@@ -291,9 +310,17 @@ Search for "demo":
 
 ![](images/setup/ea898dadcd3936d9431ce6b8a92eccf9.png)
 
-The two endpoints available are to load and, later, unload the demo data. 
+The two endpoints available are to load and, later, unload the demo data.
 
-Note: The [demo data](https://github.com/databrickslabs/ontos/blob/48167bd2ddb2a9f56971f67bd1ec0e7aa9d275bc/src/backend/src/data/demo_data.sql#L24) is smart about using very specific codes in the UUIDs of the data. That way, we can discern between demo data, and data entered manually by users.
+`POST /api/settings/demo-data/load` accepts a single `preset` query parameter
+(`retail` | `hls` | `fsi` | `mfg` | `auto`, default `retail`). The matching
+`demo_data_{preset}.sql` is the only file executed — there is no implicit
+"base + overlay" layering, so each preset is loaded standalone.
+
+Note: All demo data uses very specific codes in its UUIDs (a per‑preset
+segment such as `0000`, `0001`, `0002`, …) so that we can discern demo
+records from data entered manually by users, and so that `DELETE demo-data`
+can clean up exactly what was inserted.
 
 Open the `POST load` endpoint and click on "Try it out":
 
@@ -311,9 +338,14 @@ Reload the app, it now has demo data:
 
 ![](images/setup/f2d90a46da4aa95addcceceb2931a4d2.png)
 
-Note: The [demo data](https://github.com/databrickslabs/ontos/blob/48167bd2ddb2a9f56971f67bd1ec0e7aa9d275bc/src/backend/src/data/demo_data.sql) comes as SQL file and could be changed to reflect other industries or even individual customers.
+Note: Each preset is delivered as a standalone SQL file under
+`src/backend/src/data/demo_data_{preset}.sql` and can be edited or extended
+to reflect other industries or individual customers without affecting the
+other packs.
 
-Use the `DELETE demo-data` endpoint shown above to delete the demo data.
+Use the `DELETE demo-data` endpoint shown above to clear all demo records
+across every preset (it deletes by demo UUID prefix, so any combination of
+loaded packs is removed).
 
 ## Troubleshooting
 

--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -181,8 +181,9 @@ async def startup_event():
         logger.warning(f"Failed initializing Delivery Service: {e}", exc_info=True)
         app.state.delivery_service = None
     
-    # Demo data is loaded on-demand via POST /api/settings/demo-data/load
-    # See: src/backend/src/data/demo_data.sql
+    # Demo data is loaded on-demand via POST /api/settings/demo-data/load?preset=<retail|hls|fsi|mfg|auto>
+    # Each preset is a fully self-contained vertical demo (no implicit content from other packs).
+    # Default preset is 'retail' (file: src/backend/src/data/demo_data_retail.sql).
     
     # Ensure SearchManager is initialized and index built
     try:

--- a/src/backend/src/data/demo_data_auto.sql
+++ b/src/backend/src/data/demo_data_auto.sql
@@ -1,17 +1,30 @@
 -- ============================================================================
--- Industry Demo Data: Automotive (AUTO)
+-- AUTO Demo Data — preset=auto
 -- ============================================================================
--- Additive overlay loaded via: POST /api/settings/demo-data/load?industry=auto
+-- Standalone demo pack loaded via:
+--   POST /api/settings/demo-data/load?preset=auto
 --
--- Adds automotive-specific data domains, teams, contracts, products, and
--- compliance policies covering connected vehicles, ADAS, supply chain quality,
--- warranty analytics, and vehicle configuration management.
+-- This pack is fully self-contained: loading it on an empty database produces
+-- a complete Automotive vertical demo with no implicit content from any other
+-- preset.
 --
 -- Dataset identifier: 0004 (second UUID group)
 -- UUID Format: {type:3}{seq:5}-0004-4000-8000-00000000000N
 -- ============================================================================
 
 BEGIN;
+
+-- ============================================================================
+-- 0. SHARED PARENT ROWS (idempotent foundation)
+-- ============================================================================
+-- AUTO data_domains FK to base "Core" parent below. Inserted ON CONFLICT DO
+-- NOTHING so it is safe to load this preset on top of an empty DB or alongside
+-- other presets.
+
+INSERT INTO data_domains (id, name, description, parent_id, created_by, created_at, updated_at) VALUES
+('00000001-0000-4000-8000-000000000001', 'Core', 'General, cross-company business concepts.', NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
 
 -- ============================================================================
 -- 1. DATA DOMAINS (AUTO-specific, children of Core)
@@ -334,8 +347,322 @@ INSERT INTO link_metadata (id, entity_id, entity_type, title, short_description,
 ON CONFLICT (id) DO NOTHING;
 
 
+-- ============================================================================
+-- 9. BUSINESS ROLES (AUTO-specific, type=0f0)
+-- ============================================================================
+
+INSERT INTO business_roles (id, name, description, category, is_system, is_approver, status, created_by, created_at, updated_at) VALUES
+('0f000001-0004-4000-8000-000000000001', 'Vehicle Program Manager',     'Owns end-to-end vehicle program data governance and milestone gates.',                                'business',    false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000002-0004-4000-8000-000000000002', 'Functional Safety Manager',   'Accountable for ISO 26262 functional safety compliance for ADAS / autonomous systems.',               'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000003-0004-4000-8000-000000000003', 'Cybersecurity Officer',       'Owns UNECE R155/R156 vehicle cybersecurity management.',                                               'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000004-0004-4000-8000-000000000004', 'Quality Engineer (PPAP)',     'Manages IATF 16949 PPAP submissions for production parts approval.',                                   'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000005-0004-4000-8000-000000000005', 'Connected Services Lead',     'Owns connected vehicle telematics, OTA orchestration, and customer data privacy.',                     'business',    false, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 10. DELIVERY METHODS (AUTO-specific, type=0f4)
+-- ============================================================================
+
+INSERT INTO delivery_methods (id, name, description, category, is_system, status, created_by, created_at, updated_at) VALUES
+('0f400001-0004-4000-8000-000000000001', 'CAN Bus Telemetry',  'In-vehicle CAN/CAN-FD signals streamed via telematics control unit.',                            'streaming', false, 'active', 'system@demo', NOW(), NOW()),
+('0f400002-0004-4000-8000-000000000002', 'OTA Update Channel', 'Delivers software/data assets to fleet vehicles via secure OTA.',                                 'endpoint',  false, 'active', 'system@demo', NOW(), NOW()),
+('0f400003-0004-4000-8000-000000000003', 'Tier-N EDI Feed',    'Receives parts and shipment data from Tier-1/2/N suppliers via EDI / API.',                       'access',    false, 'active', 'system@demo', NOW(), NOW()),
+('0f400004-0004-4000-8000-000000000004', 'Dealer Service API', 'Surfaces vehicle history and warranty data to dealer service systems.',                           'endpoint',  false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 11. VERTICAL ASSET TYPES (AUTO-specific, is_system=false)
+-- ============================================================================
+
+INSERT INTO asset_types (id, name, description, category, icon, required_fields, optional_fields, is_system, status, created_by, created_at, updated_at) VALUES
+('0f200101-0004-4000-8000-000000000001', 'Vehicle Fleet',     'Logical grouping of connected vehicles (model line, region, MY).',          'data', 'truck',     NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200102-0004-4000-8000-000000000002', 'ECU Software',      'Electronic Control Unit firmware/software image with version metadata.',    'data', 'cpu',       NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200103-0004-4000-8000-000000000003', 'Warranty Claim',    'Individual warranty claim record with VIN, parts, and labour codes.',       'data', 'wrench',    NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200104-0004-4000-8000-000000000004', 'PPAP Submission',   'Production Part Approval Process submission package (Level 1-5).',          'data', 'check-circle',NULL, NULL, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+
+-- ============================================================================
+-- 12. TAG NAMESPACES + TAGS (AUTO governance vocabulary)
+-- ============================================================================
+
+INSERT INTO tag_namespaces (id, name, description, created_by, created_at, updated_at) VALUES
+('02601001-0004-4000-8000-000000000001', 'auto-safety',      'Functional safety classification (ISO 26262 ASIL).',          'system@demo', NOW(), NOW()),
+('02601002-0004-4000-8000-000000000002', 'auto-cybersec',    'Vehicle cybersecurity (UNECE R155, ISO/SAE 21434).',          'system@demo', NOW(), NOW()),
+('02601003-0004-4000-8000-000000000003', 'auto-program',     'Vehicle program / lifecycle stage classification.',           'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO tags (id, name, description, possible_values, status, version, namespace_id, parent_id, created_by, created_at, updated_at) VALUES
+-- Functional safety (ASIL)
+('02700101-0004-4000-8000-000000000001', 'asil-d',         'ASIL-D classification — highest functional safety integrity.',  NULL, 'active', 'v1.0', '02601001-0004-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700102-0004-4000-8000-000000000002', 'asil-b',         'ASIL-B classification — moderate functional safety integrity.', NULL, 'active', 'v1.0', '02601001-0004-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700103-0004-4000-8000-000000000003', 'qm-rated',       'Quality-managed (no ASIL).',                                     NULL, 'active', 'v1.0', '02601001-0004-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+-- Cybersecurity
+('02700104-0004-4000-8000-000000000004', 'r155-in-scope',  'In scope for UNECE R155 CSMS.',                                  NULL, 'active', 'v1.0', '02601002-0004-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+('02700105-0004-4000-8000-000000000005', 'iso-21434',      'Subject to ISO/SAE 21434 cybersecurity engineering.',            NULL, 'active', 'v1.0', '02601002-0004-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+-- Program lifecycle
+('02700106-0004-4000-8000-000000000006', 'series-production','Vehicle in series production.',                                NULL, 'active', 'v1.0', '02601003-0004-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW()),
+('02700107-0004-4000-8000-000000000007', 'pre-series',     'Pre-series / engineering build vehicles.',                       NULL, 'active', 'v1.0', '02601003-0004-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW()),
+('02700108-0004-4000-8000-000000000008', 'connected-services','Subject to connected services privacy and consent flows.',     NULL, 'active', 'v1.0', '02601003-0004-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, name) DO NOTHING;
+
+INSERT INTO tag_namespace_permissions (id, namespace_id, group_id, access_level, created_by, created_at, updated_at) VALUES
+('02800101-0004-4000-8000-000000000001', '02601001-0004-4000-8000-000000000001', 'safety-team',          'admin',     'system@demo', NOW(), NOW()),
+('02800102-0004-4000-8000-000000000002', '02601002-0004-4000-8000-000000000002', 'cybersec-team',        'admin',     'system@demo', NOW(), NOW()),
+('02800103-0004-4000-8000-000000000003', '02601003-0004-4000-8000-000000000003', 'program-management',   'admin',     'system@demo', NOW(), NOW()),
+('02800104-0004-4000-8000-000000000004', '02601001-0004-4000-8000-000000000001', 'engineering',          'read_only', 'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, group_id) DO NOTHING;
+
+
+-- ============================================================================
+-- 13. RDF TRIPLES — AUTO concept graph (type=020)
+-- ============================================================================
+
+INSERT INTO rdf_triples (id, subject_uri, predicate_uri, object_value, object_is_uri, context_name, source_type, source_identifier, created_by, created_at) VALUES
+('02000101-0004-4000-8000-000000000001', 'http://demo.ontos.app/auto#Vehicle',          'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000102-0004-4000-8000-000000000002', 'http://demo.ontos.app/auto#Vehicle',          'http://www.w3.org/2000/01/rdf-schema#label',       'Vehicle',                                       false, 'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000103-0004-4000-8000-000000000003', 'http://demo.ontos.app/auto#ECU',              'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000104-0004-4000-8000-000000000004', 'http://demo.ontos.app/auto#ECU',              'http://www.w3.org/2000/01/rdf-schema#label',       'Electronic Control Unit',                       false, 'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000105-0004-4000-8000-000000000005', 'http://demo.ontos.app/auto#OTAUpdate',        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000106-0004-4000-8000-000000000006', 'http://demo.ontos.app/auto#OTAUpdate',        'http://www.w3.org/2000/01/rdf-schema#label',       'Over-the-Air Update',                           false, 'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000107-0004-4000-8000-000000000007', 'http://demo.ontos.app/auto#WarrantyClaim',    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000108-0004-4000-8000-000000000008', 'http://demo.ontos.app/auto#WarrantyClaim',    'http://www.w3.org/2000/01/rdf-schema#label',       'Warranty Claim',                                false, 'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('02000109-0004-4000-8000-000000000009', 'http://demo.ontos.app/auto#ADASScenario',     'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('0200010a-0004-4000-8000-000000000010', 'http://demo.ontos.app/auto#ADASScenario',     'http://www.w3.org/2000/01/rdf-schema#label',       'ADAS Scenario',                                 false, 'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('0200010b-0004-4000-8000-000000000011', 'http://demo.ontos.app/auto#Recall',           'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('0200010c-0004-4000-8000-000000000012', 'http://demo.ontos.app/auto#Recall',           'http://www.w3.org/2000/01/rdf-schema#label',       'Recall Campaign',                               false, 'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('0200010d-0004-4000-8000-000000000013', 'http://demo.ontos.app/auto#Supplier',         'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW()),
+('0200010e-0004-4000-8000-000000000014', 'http://demo.ontos.app/auto#Supplier',         'http://www.w3.org/2000/01/rdf-schema#label',       'Supplier',                                      false, 'urn:demo', 'demo', 'demo_data_auto.sql', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 14. ENTITY SEMANTIC LINKS (type=015)
+-- ============================================================================
+
+INSERT INTO entity_semantic_links (id, entity_id, entity_type, iri, label, created_by, created_at) VALUES
+('01500101-0004-4000-8000-000000000001', '00700001-0004-4000-8000-000000000001', 'data_product', 'http://demo.ontos.app/auto#Vehicle',       'Vehicle',                  'system@demo', NOW()),
+('01500102-0004-4000-8000-000000000002', '00700001-0004-4000-8000-000000000001', 'data_product', 'http://demo.ontos.app/auto#ECU',           'Electronic Control Unit',  'system@demo', NOW()),
+('01500103-0004-4000-8000-000000000003', '00700002-0004-4000-8000-000000000002', 'data_product', 'http://demo.ontos.app/auto#ADASScenario',  'ADAS Scenario',            'system@demo', NOW()),
+('01500104-0004-4000-8000-000000000004', '00700003-0004-4000-8000-000000000003', 'data_product', 'http://demo.ontos.app/auto#Supplier',      'Supplier',                 'system@demo', NOW()),
+('01500105-0004-4000-8000-000000000005', '00700004-0004-4000-8000-000000000004', 'data_product', 'http://demo.ontos.app/auto#WarrantyClaim', 'Warranty Claim',           'system@demo', NOW()),
+('01500106-0004-4000-8000-000000000006', '00700005-0004-4000-8000-000000000005', 'data_product', 'http://demo.ontos.app/auto#OTAUpdate',     'Over-the-Air Update',      'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15. ASSETS — AUTO catalog objects (type=0f3)
+-- ============================================================================
+
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
+-- Vehicle Fleet (vertical asset type)
+('0f300101-0004-4000-8000-000000000001',
+ 'fleet.evx-2026.eu',
+ 'EVX-2026 European fleet (~120,000 vehicles).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Vehicle Fleet' LIMIT 1), '0f200101-0004-4000-8000-000000000001'), 'Connected Cloud', 'fleet://evx-2026/eu',
+ '00000002-0004-4000-8000-000000000002',
+ '{"model": "EVX-2026", "region": "EU", "vehicle_count": 120000, "model_year": 2026}',
+ '["series-production", "connected-services", "r155-in-scope"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- ECU Software (vertical asset type)
+('0f300102-0004-4000-8000-000000000002',
+ 'ecu.adas.cam_perception.v4.2.1',
+ 'ADAS camera perception ECU firmware v4.2.1 — supports L2+ assist.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'ECU Software' LIMIT 1), '0f200102-0004-4000-8000-000000000002'), 'OTA Backend', 'ecu://adas/cam_perception/4.2.1',
+ '00000003-0004-4000-8000-000000000003',
+ '{"ecu_id": "cam_perception", "version": "4.2.1", "asil": "ASIL-D", "release_date": "2026-04-12"}',
+ '["asil-d", "iso-21434", "r155-in-scope"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Telemetry table
+('0f300103-0004-4000-8000-000000000003',
+ 'lakehouse.auto.telemetry.can_signals',
+ 'CAN bus signal telemetry from connected vehicles (resampled to 1Hz curated grid).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.auto.telemetry.can_signals',
+ '00000002-0004-4000-8000-000000000002',
+ '{"catalog": "lakehouse", "schema": "auto_telemetry", "table_name": "can_signals", "row_count": 4500000000, "format": "delta"}',
+ '["connected-services"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Stream
+('0f300104-0004-4000-8000-000000000004',
+ 'kafka.fleet.events.diagnostic_trouble_codes',
+ 'Real-time DTC stream from on-vehicle diagnostics.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.fleet:9093/events.dtc',
+ '00000005-0004-4000-8000-000000000005',
+ '{"topic": "events.dtc", "throughput_msgs_per_sec": 9000}',
+ '["connected-services"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Warranty Claim (vertical asset type)
+('0f300105-0004-4000-8000-000000000005',
+ 'WC-2026-EU-89432',
+ 'Warranty claim WC-2026-EU-89432 — replacement of suspect HV battery module pack.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Warranty Claim' LIMIT 1), '0f200103-0004-4000-8000-000000000003'), 'Dealer Portal', 'warranty://claims/WC-2026-EU-89432',
+ '00000005-0004-4000-8000-000000000005',
+ '{"vin_prefix": "WBA****", "claim_amount_eur": 4500, "labor_hours": 8.5, "status": "approved"}',
+ '[]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- PPAP Submission (vertical asset type)
+('0f300106-0004-4000-8000-000000000006',
+ 'PPAP-2026-04-CRANK-EVX',
+ 'PPAP Level 3 submission for EVX-2026 crankshaft assembly (Tier-1 supplier ABC).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'PPAP Submission' LIMIT 1), '0f200104-0004-4000-8000-000000000004'), 'Quality Portal', 'ppap://submissions/2026-04-CRANK-EVX',
+ '00000004-0004-4000-8000-000000000004',
+ '{"ppap_level": 3, "supplier": "ABC", "part_number": "CRANK-EVX-001", "status": "approved"}',
+ '[]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Recall dashboard
+('0f300107-0004-4000-8000-000000000007',
+ 'Recall Risk Dashboard',
+ 'Field failure trends, claim clusters, and recall risk indicators by VIN cohort.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.oem.com/dashboards/recall-risk-v1',
+ '00000005-0004-4000-8000-000000000005',
+ '{"refresh_schedule": "daily", "audience": "quality-recall-board"}',
+ '["connected-services"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Supplier table
+('0f300108-0004-4000-8000-000000000008',
+ 'lakehouse.auto.supply.tier_n_inventory',
+ 'Tier-1 to Tier-N supplier inventory and shipment status.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory',
+ '00000004-0004-4000-8000-000000000004',
+ '{"catalog": "lakehouse", "schema": "auto_supply", "table_name": "tier_n_inventory", "row_count": 280000, "format": "delta"}',
+ '[]',
+ 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 16. ENTITY RELATIONSHIPS — AUTO lineage (type=0fa)
+-- ============================================================================
+
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, created_by, created_at) VALUES
+('0fa00101-0004-4000-8000-000000000001', 'data_product', '00700001-0004-4000-8000-000000000001', 'asset', '0f300103-0004-4000-8000-000000000003', 'derives_from', 'system@demo', NOW()),
+('0fa00102-0004-4000-8000-000000000002', 'data_product', '00700001-0004-4000-8000-000000000001', 'asset', '0f300104-0004-4000-8000-000000000004', 'derives_from', 'system@demo', NOW()),
+('0fa00103-0004-4000-8000-000000000003', 'data_product', '00700002-0004-4000-8000-000000000002', 'asset', '0f300102-0004-4000-8000-000000000002', 'consumes',     'system@demo', NOW()),
+('0fa00104-0004-4000-8000-000000000004', 'data_product', '00700003-0004-4000-8000-000000000003', 'asset', '0f300108-0004-4000-8000-000000000008', 'derives_from', 'system@demo', NOW()),
+('0fa00105-0004-4000-8000-000000000005', 'data_product', '00700003-0004-4000-8000-000000000003', 'asset', '0f300106-0004-4000-8000-000000000006', 'consumes',     'system@demo', NOW()),
+('0fa00106-0004-4000-8000-000000000006', 'data_product', '00700004-0004-4000-8000-000000000004', 'asset', '0f300105-0004-4000-8000-000000000005', 'derives_from', 'system@demo', NOW()),
+('0fa00107-0004-4000-8000-000000000007', 'data_product', '00700004-0004-4000-8000-000000000004', 'asset', '0f300107-0004-4000-8000-000000000007', 'produces',     'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 17. ENTITY TAG ASSOCIATIONS (AUTO, type=029)
+-- ============================================================================
+
+INSERT INTO entity_tag_associations (id, tag_id, entity_id, entity_type, assigned_value, assigned_by, assigned_at) VALUES
+('02900101-0004-4000-8000-000000000001', '02700106-0004-4000-8000-000000000006', '00700001-0004-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW()),
+('02900102-0004-4000-8000-000000000002', '02700108-0004-4000-8000-000000000008', '00700001-0004-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW()),
+('02900103-0004-4000-8000-000000000003', '02700101-0004-4000-8000-000000000001', '00700002-0004-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900104-0004-4000-8000-000000000004', '02700105-0004-4000-8000-000000000005', '00700002-0004-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900105-0004-4000-8000-000000000005', '02700106-0004-4000-8000-000000000006', '00700004-0004-4000-8000-000000000004', 'data_product', NULL, 'system@demo', NOW()),
+('02900106-0004-4000-8000-000000000006', '02700104-0004-4000-8000-000000000004', '00700001-0004-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW())
+ON CONFLICT (tag_id, entity_id, entity_type) DO NOTHING;
+
+
+-- ============================================================================
+-- 18. PROCESS WORKFLOWS + STEPS (AUTO-specific)
+-- ============================================================================
+
+INSERT INTO process_workflows (id, name, description, trigger_config, scope_config, is_active, is_default, version, created_by, updated_by, created_at, updated_at) VALUES
+('02a00101-0004-4000-8000-000000000001', 'OTA / Connected Services Release Gate',
+ 'Multi-stage approval gate before any connected-vehicle release: cybersecurity review, functional safety sign-off, program manager approval.',
+ '{"type": "before_publish", "entity_types": ["data_product"]}',
+ '{"type": "domain", "ids": ["00000002-0004-4000-8000-000000000002"]}',
+ true, true, 1, 'system@demo', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, on_pass, on_fail, "order", position, created_at, updated_at) VALUES
+('02b00101-0004-4000-8000-000000000001', '02a00101-0004-4000-8000-000000000001', 'cybersec_review', 'Cybersecurity Officer Review',
+ 'manual_approval',
+ '{"approver_role": "0f000003-0004-4000-8000-000000000003"}',
+ 'safety_review', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
+('02b00102-0004-4000-8000-000000000002', '02a00101-0004-4000-8000-000000000001', 'safety_review',   'Functional Safety Sign-off',
+ 'manual_approval',
+ '{"approver_role": "0f000002-0004-4000-8000-000000000002"}',
+ 'pgm_approval',  'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW()),
+('02b00103-0004-4000-8000-000000000003', '02a00101-0004-4000-8000-000000000001', 'pgm_approval',    'Program Manager Approval',
+ 'manual_approval',
+ '{"approver_role": "0f000001-0004-4000-8000-000000000001"}',
+ 'approve',       'reject', 3, '{"x": 500, "y": 100}', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 19. COMPLIANCE RUNS + RESULTS (AUTO)
+-- ============================================================================
+
+INSERT INTO compliance_runs (id, policy_id, status, started_at, finished_at, success_count, failure_count, score) VALUES
+('01200101-0004-4000-8000-000000000001', '01100001-0004-4000-8000-000000000001', 'completed', NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days' + INTERVAL '11 minutes', 4, 1, 0.800),
+('01200102-0004-4000-8000-000000000002', '01100002-0004-4000-8000-000000000002', 'completed', NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days' + INTERVAL '9 minutes',  3, 0, 1.000),
+('01200103-0004-4000-8000-000000000003', '01100004-0004-4000-8000-000000000004', 'completed', NOW() - INTERVAL '1 days', NOW() - INTERVAL '1 days' + INTERVAL '5 minutes',  2, 1, 0.667)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO compliance_results (id, run_id, object_type, object_id, object_name, passed, message, created_at) VALUES
+('01300101-0004-4000-8000-000000000001', '01200101-0004-4000-8000-000000000001', 'data_product', '00700001-0004-4000-8000-000000000001', 'Connected Vehicle Analytics v1', true,  'CSMS controls validated for telematics pipeline.', NOW() - INTERVAL '6 days'),
+('01300102-0004-4000-8000-000000000002', '01200101-0004-4000-8000-000000000001', 'data_product', '00700005-0004-4000-8000-000000000005', 'Vehicle Configuration Intelligence v1', false, 'Threat model for OTA backend not refreshed in last 12 months.', NOW() - INTERVAL '6 days'),
+('01300103-0004-4000-8000-000000000003', '01200102-0004-4000-8000-000000000002', 'data_product', '00700003-0004-4000-8000-000000000003', 'Supplier Quality Scorecard v1',         true,  'PPAP coverage at 100% for active production parts.', NOW() - INTERVAL '3 days'),
+('01300104-0004-4000-8000-000000000004', '01200103-0004-4000-8000-000000000003', 'data_product', '00700002-0004-4000-8000-000000000002', 'ADAS Training Data Pipeline v1',        false, 'One scenario subset lacks ASIL-D evidence package.', NOW() - INTERVAL '1 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 20. COST ITEMS (AUTO)
+-- ============================================================================
+
+INSERT INTO cost_items (id, entity_type, entity_id, title, description, cost_center, custom_center_name, amount_cents, currency, start_month, created_by, created_at, updated_at) VALUES
+('01400101-0004-4000-8000-000000000001', 'data_product', '00700001-0004-4000-8000-000000000001', 'Telemetry Compute',     'Daily Databricks compute for CAN telemetry curation.',           'infrastructure', NULL, 7600000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400102-0004-4000-8000-000000000002', 'data_product', '00700002-0004-4000-8000-000000000002', 'Sensor Storage',         'Petabyte-scale storage for ADAS sensor logs.',                  'infrastructure', NULL, 5300000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400103-0004-4000-8000-000000000003', 'data_product', '00700003-0004-4000-8000-000000000003', 'Supplier Portal License','Annual supplier collaboration portal license.',                  'tools',          NULL, 1100000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 21. COMMENTS & RATINGS (AUTO)
+-- ============================================================================
+
+INSERT INTO comments (id, entity_type, entity_id, comment, comment_type, rating, status, created_by, created_at, updated_at) VALUES
+('02c00101-0004-4000-8000-000000000001', 'data_product', '00700001-0004-4000-8000-000000000001', 'Telemetry curation has solved our prior data-quality headaches.',                'rating', 5, 'active', 'connected-svcs@oem.com',  NOW() - INTERVAL '14 days', NOW() - INTERVAL '14 days'),
+('02c00102-0004-4000-8000-000000000002', 'data_product', '00700002-0004-4000-8000-000000000002', 'ASIL traceability is excellent; ground-truth coverage could be deeper.',         'rating', 4, 'active', 'safety-mgr@oem.com',      NOW() - INTERVAL '9 days',  NOW() - INTERVAL '9 days'),
+('02c00103-0004-4000-8000-000000000003', 'data_product', '00700004-0004-4000-8000-000000000004', 'Best warranty analytics product we''ve had — recall predictive value is high.', 'rating', 5, 'active', 'after-sales@oem.com',     NOW() - INTERVAL '5 days',  NOW() - INTERVAL '5 days'),
+('02c00104-0004-4000-8000-000000000004', 'data_product', '00700003-0004-4000-8000-000000000003', 'PPAP coverage view across Tier-1/2/N suppliers is exactly what we need.',         'rating', 4, 'active', 'ppap-engineer@oem.com',   NOW() - INTERVAL '2 days',  NOW() - INTERVAL '2 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 22. BUSINESS OWNERS (AUTO)
+-- ============================================================================
+
+INSERT INTO business_owners (id, object_type, object_id, user_email, user_name, role_id, is_active, assigned_at, removed_at, removal_reason, created_by, created_at, updated_at) VALUES
+('0fb00101-0004-4000-8000-000000000001', 'data_product',  '00700001-0004-4000-8000-000000000001', 'connected-svcs@oem.com',  'Connected Services Lead',     '0f000005-0004-4000-8000-000000000005', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00102-0004-4000-8000-000000000002', 'data_product',  '00700002-0004-4000-8000-000000000002', 'safety-mgr@oem.com',      'Functional Safety Manager',   '0f000002-0004-4000-8000-000000000002', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00103-0004-4000-8000-000000000003', 'data_product',  '00700003-0004-4000-8000-000000000003', 'ppap-engineer@oem.com',   'Quality Engineer (PPAP)',     '0f000004-0004-4000-8000-000000000004', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00104-0004-4000-8000-000000000004', 'data_product',  '00700004-0004-4000-8000-000000000004', 'after-sales@oem.com',     'After-Sales Director',        '0f000001-0004-4000-8000-000000000001', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00105-0004-4000-8000-000000000005', 'data_product',  '00700005-0004-4000-8000-000000000005', 'cybersec@oem.com',        'Cybersecurity Officer',       '0f000003-0004-4000-8000-000000000003', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 23. ENTITY SUBSCRIPTIONS (AUTO)
+-- ============================================================================
+
+INSERT INTO entity_subscriptions (id, entity_type, entity_id, subscriber_email, subscription_reason, created_at) VALUES
+('02200101-0004-4000-8000-000000000001', 'data_product', '00700001-0004-4000-8000-000000000001', 'connected-svcs@oem.com', 'owner',    NOW() - INTERVAL '60 days'),
+('02200102-0004-4000-8000-000000000002', 'data_product', '00700002-0004-4000-8000-000000000002', 'safety-mgr@oem.com',     'owner',    NOW() - INTERVAL '60 days'),
+('02200103-0004-4000-8000-000000000003', 'data_product', '00700005-0004-4000-8000-000000000005', 'cybersec@oem.com',       'consumer', NOW() - INTERVAL '20 days')
+ON CONFLICT DO NOTHING;
+
+
 COMMIT;
 
 -- ============================================================================
--- End of Automotive Industry Demo Data
+-- End of AUTO Demo Data — preset=auto
 -- ============================================================================

--- a/src/backend/src/data/demo_data_fsi.sql
+++ b/src/backend/src/data/demo_data_fsi.sql
@@ -1,16 +1,30 @@
 -- ============================================================================
--- Industry Demo Data: Financial Services Industry (FSI)
+-- FSI Demo Data — preset=fsi
 -- ============================================================================
--- Additive overlay loaded via: POST /api/settings/demo-data/load?industry=fsi
+-- Standalone demo pack loaded via:
+--   POST /api/settings/demo-data/load?preset=fsi
 --
--- Adds FSI-specific data domains, teams, contracts, products, and compliance
--- policies covering banking, capital markets, risk, and regulatory reporting.
+-- This pack is fully self-contained: loading it on an empty database produces
+-- a complete Financial Services vertical demo with no implicit content from
+-- any other preset.
 --
 -- Dataset identifier: 0002 (second UUID group)
 -- UUID Format: {type:3}{seq:5}-0002-4000-8000-00000000000N
 -- ============================================================================
 
 BEGIN;
+
+-- ============================================================================
+-- 0. SHARED PARENT ROWS (idempotent foundation)
+-- ============================================================================
+-- FSI data_domains FK to base "Core" parent below. Inserted ON CONFLICT DO
+-- NOTHING so it is safe to load this preset on top of an empty DB or alongside
+-- other presets.
+
+INSERT INTO data_domains (id, name, description, parent_id, created_by, created_at, updated_at) VALUES
+('00000001-0000-4000-8000-000000000001', 'Core', 'General, cross-company business concepts.', NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
 
 -- ============================================================================
 -- 1. DATA DOMAINS (FSI-specific, children of Core)
@@ -322,8 +336,332 @@ INSERT INTO link_metadata (id, entity_id, entity_type, title, short_description,
 ON CONFLICT (id) DO NOTHING;
 
 
+-- ============================================================================
+-- 9. BUSINESS ROLES (FSI-specific, type=0f0)
+-- ============================================================================
+
+INSERT INTO business_roles (id, name, description, category, is_system, is_approver, status, created_by, created_at, updated_at) VALUES
+('0f000001-0002-4000-8000-000000000001', 'Chief Risk Officer',          'Accountable for the firm-wide risk framework and BCBS 239 attestation.',                                'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000002-0002-4000-8000-000000000002', 'Head of Compliance',          'Owns AML/KYC, sanctions screening, and MAR/MiFID II surveillance programmes.',                          'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000003-0002-4000-8000-000000000003', 'Model Risk Manager',          'Validates and monitors quantitative models per SR 11-7 and EU model risk guidance.',                     'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000004-0002-4000-8000-000000000004', 'Trading Desk Head',           'Senior trader accountable for desk P&L, risk limits, and best execution.',                              'business',    false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000005-0002-4000-8000-000000000005', 'Regulatory Reporting Lead',   'Owns submissions for FR Y-14, Call Report, LCR/NSFR, FRTB and other prudential filings.',                'operational', false, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 10. DELIVERY METHODS (FSI-specific, type=0f4)
+-- ============================================================================
+
+INSERT INTO delivery_methods (id, name, description, category, is_system, status, created_by, created_at, updated_at) VALUES
+('0f400001-0002-4000-8000-000000000001', 'FIX Protocol Feed',     'Delivers execution and order events via Financial Information eXchange (FIX 4.4/5.0SP2).',         'streaming', false, 'active', 'system@demo', NOW(), NOW()),
+('0f400002-0002-4000-8000-000000000002', 'SWIFT MT Messages',     'Delivers payments and securities messages via SWIFT MT/MX.',                                       'streaming', false, 'active', 'system@demo', NOW(), NOW()),
+('0f400003-0002-4000-8000-000000000003', 'Regulatory Portal Submission', 'Submits XBRL-tagged regulatory reports to supervisor portals (Fed, FFIEC, EBA).',          'export',    false, 'active', 'system@demo', NOW(), NOW()),
+('0f400004-0002-4000-8000-000000000004', 'Risk Aggregation Cube', 'Materialised cube exposing aggregated risk metrics for CRO dashboards and stress tests.',          'access',    false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 11. VERTICAL ASSET TYPES (FSI-specific, is_system=false)
+-- ============================================================================
+
+INSERT INTO asset_types (id, name, description, category, icon, required_fields, optional_fields, is_system, status, created_by, created_at, updated_at) VALUES
+('0f200101-0002-4000-8000-000000000001', 'Trading Position',  'Open trading position carried on the firm''s books.',                                              'data', 'trending-up',   NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200102-0002-4000-8000-000000000002', 'Risk Limit',        'Configured risk limit (notional, VaR, sensitivity-based) attached to a desk or book.',             'data', 'gauge',         NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200103-0002-4000-8000-000000000003', 'Regulatory Filing', 'Discrete regulatory filing (FR Y-14, FFIEC Call Report, LCR, etc.) with submission lifecycle.',     'data', 'file-text',     NULL, NULL, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+
+-- ============================================================================
+-- 12. TAG NAMESPACES + TAGS (FSI governance vocabulary)
+-- ============================================================================
+
+INSERT INTO tag_namespaces (id, name, description, created_by, created_at, updated_at) VALUES
+('02601001-0002-4000-8000-000000000001', 'fsi-regulatory', 'Banking and capital markets regulatory frameworks.', 'system@demo', NOW(), NOW()),
+('02601002-0002-4000-8000-000000000002', 'fsi-risk',       'Risk types and tiering conventions.',                'system@demo', NOW(), NOW()),
+('02601003-0002-4000-8000-000000000003', 'fsi-data',       'FSI data classification and lifecycle.',             'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO tags (id, name, description, possible_values, status, version, namespace_id, parent_id, created_by, created_at, updated_at) VALUES
+-- Regulatory
+('02700101-0002-4000-8000-000000000001', 'bcbs-239',       'Subject to Basel BCBS 239 risk data aggregation principles.', NULL, 'active', 'v1.0', '02601001-0002-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700102-0002-4000-8000-000000000002', 'mifid-ii',       'Subject to MiFID II / MiFIR transaction reporting.',          NULL, 'active', 'v1.0', '02601001-0002-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700103-0002-4000-8000-000000000003', 'frtb',           'Subject to Fundamental Review of the Trading Book rules.',    NULL, 'active', 'v1.0', '02601001-0002-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700104-0002-4000-8000-000000000004', 'aml-monitored',  'Subject to AML/transaction-monitoring obligations.',          NULL, 'active', 'v1.0', '02601001-0002-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+-- Risk
+('02700105-0002-4000-8000-000000000005', 'risk-tier-1',    'Tier-1 critical for daily risk reporting.',                   NULL, 'active', 'v1.0', '02601002-0002-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+('02700106-0002-4000-8000-000000000006', 'market-risk',    'Market risk relevant.',                                       NULL, 'active', 'v1.0', '02601002-0002-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+('02700107-0002-4000-8000-000000000007', 'credit-risk',    'Credit risk relevant.',                                       NULL, 'active', 'v1.0', '02601002-0002-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+-- Data
+('02700108-0002-4000-8000-000000000008', 'mnpi',           'Material non-public information.',                            NULL, 'active', 'v1.0', '02601003-0002-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW()),
+('02700109-0002-4000-8000-000000000009', 'transaction-data','Atomic transaction-level data (no aggregation).',            NULL, 'active', 'v1.0', '02601003-0002-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, name) DO NOTHING;
+
+INSERT INTO tag_namespace_permissions (id, namespace_id, group_id, access_level, created_by, created_at, updated_at) VALUES
+('02800101-0002-4000-8000-000000000001', '02601001-0002-4000-8000-000000000001', 'reg-reporting',     'admin',     'system@demo', NOW(), NOW()),
+('02800102-0002-4000-8000-000000000002', '02601002-0002-4000-8000-000000000002', 'risk-quant',        'admin',     'system@demo', NOW(), NOW()),
+('02800103-0002-4000-8000-000000000003', '02601002-0002-4000-8000-000000000002', 'trading-desk',      'read_only', 'system@demo', NOW(), NOW()),
+('02800104-0002-4000-8000-000000000004', '02601003-0002-4000-8000-000000000003', 'compliance',        'admin',     'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, group_id) DO NOTHING;
+
+
+-- ============================================================================
+-- 13. RDF TRIPLES — FSI concept graph (type=020)
+-- ============================================================================
+
+INSERT INTO rdf_triples (id, subject_uri, predicate_uri, object_value, object_is_uri, context_name, source_type, source_identifier, created_by, created_at) VALUES
+('02000101-0002-4000-8000-000000000001', 'http://demo.ontos.app/fsi#Trade',           'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000102-0002-4000-8000-000000000002', 'http://demo.ontos.app/fsi#Trade',           'http://www.w3.org/2000/01/rdf-schema#label',       'Trade',                                         false, 'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000103-0002-4000-8000-000000000003', 'http://demo.ontos.app/fsi#Position',        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000104-0002-4000-8000-000000000004', 'http://demo.ontos.app/fsi#Position',        'http://www.w3.org/2000/01/rdf-schema#label',       'Position',                                      false, 'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000105-0002-4000-8000-000000000005', 'http://demo.ontos.app/fsi#Counterparty',    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000106-0002-4000-8000-000000000006', 'http://demo.ontos.app/fsi#Counterparty',    'http://www.w3.org/2000/01/rdf-schema#label',       'Counterparty',                                  false, 'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000107-0002-4000-8000-000000000007', 'http://demo.ontos.app/fsi#MarketRisk',      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000108-0002-4000-8000-000000000008', 'http://demo.ontos.app/fsi#MarketRisk',      'http://www.w3.org/2000/01/rdf-schema#label',       'Market Risk',                                   false, 'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('02000109-0002-4000-8000-000000000009', 'http://demo.ontos.app/fsi#CreditRisk',      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('0200010a-0002-4000-8000-000000000010', 'http://demo.ontos.app/fsi#CreditRisk',      'http://www.w3.org/2000/01/rdf-schema#label',       'Credit Risk',                                   false, 'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('0200010b-0002-4000-8000-000000000011', 'http://demo.ontos.app/fsi#AMLAlert',        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('0200010c-0002-4000-8000-000000000012', 'http://demo.ontos.app/fsi#AMLAlert',        'http://www.w3.org/2000/01/rdf-schema#label',       'AML Alert',                                     false, 'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('0200010d-0002-4000-8000-000000000013', 'http://demo.ontos.app/fsi#RegulatoryFiling','http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW()),
+('0200010e-0002-4000-8000-000000000014', 'http://demo.ontos.app/fsi#RegulatoryFiling','http://www.w3.org/2000/01/rdf-schema#label',       'Regulatory Filing',                             false, 'urn:demo', 'demo', 'demo_data_fsi.sql', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 14. ENTITY SEMANTIC LINKS (type=015)
+-- ============================================================================
+
+INSERT INTO entity_semantic_links (id, entity_id, entity_type, iri, label, created_by, created_at) VALUES
+('01500101-0002-4000-8000-000000000001', '00700001-0002-4000-8000-000000000001', 'data_product', 'http://demo.ontos.app/fsi#Trade',            'Trade',             'system@demo', NOW()),
+('01500102-0002-4000-8000-000000000002', '00700001-0002-4000-8000-000000000001', 'data_product', 'http://demo.ontos.app/fsi#Position',         'Position',          'system@demo', NOW()),
+('01500103-0002-4000-8000-000000000003', '00700002-0002-4000-8000-000000000002', 'data_product', 'http://demo.ontos.app/fsi#MarketRisk',       'Market Risk',       'system@demo', NOW()),
+('01500104-0002-4000-8000-000000000004', '00700002-0002-4000-8000-000000000002', 'data_product', 'http://demo.ontos.app/fsi#CreditRisk',       'Credit Risk',       'system@demo', NOW()),
+('01500105-0002-4000-8000-000000000005', '00700003-0002-4000-8000-000000000003', 'data_product', 'http://demo.ontos.app/fsi#AMLAlert',         'AML Alert',         'system@demo', NOW()),
+('01500106-0002-4000-8000-000000000006', '00700004-0002-4000-8000-000000000004', 'data_product', 'http://demo.ontos.app/fsi#RegulatoryFiling', 'Regulatory Filing', 'system@demo', NOW()),
+('01500107-0002-4000-8000-000000000007', '00700005-0002-4000-8000-000000000005', 'data_product', 'http://demo.ontos.app/fsi#Counterparty',     'Counterparty',      'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15. ASSETS — FSI catalog objects (type=0f3)
+-- ============================================================================
+
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
+-- Trading
+('0f300101-0002-4000-8000-000000000001',
+ 'lakehouse.fsi.trading.executions',
+ 'FIX-protocol execution reports for equities and FX desks (intraday, sub-second).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.fsi.trading.executions',
+ '00000002-0002-4000-8000-000000000002',
+ '{"catalog": "lakehouse", "schema": "fsi_trading", "table_name": "executions", "row_count": 92000000, "format": "delta"}',
+ '["transaction-data", "mifid-ii"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Trading Position (vertical asset type)
+('0f300102-0002-4000-8000-000000000002',
+ 'positions.equities.eod_2026_05_01',
+ 'End-of-day equity positions snapshot for May 1 2026.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Trading Position' LIMIT 1), '0f200101-0002-4000-8000-000000000001'), 'Databricks', 'positions.equities.eod_2026_05_01',
+ '00000002-0002-4000-8000-000000000002',
+ '{"asset_class": "equities", "snapshot_date": "2026-05-01", "instrument_count": 8400}',
+ '["risk-tier-1", "market-risk"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Risk Limit (vertical asset type)
+('0f300103-0002-4000-8000-000000000003',
+ 'limit.equities.var_99_1d',
+ 'Equities desk 99% / 1-day VaR limit.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Risk Limit' LIMIT 1), '0f200102-0002-4000-8000-000000000002'), 'Risk System', 'limits/equities/var_99_1d',
+ '00000003-0002-4000-8000-000000000003',
+ '{"limit_type": "VaR", "confidence": 0.99, "horizon_days": 1, "limit_usd": 25000000}',
+ '["risk-tier-1", "market-risk"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Risk aggregation table
+('0f300104-0002-4000-8000-000000000004',
+ 'lakehouse.fsi.risk.aggregated_var',
+ 'Aggregated VaR metrics (firm-wide, by desk, by asset class) feeding CRO dashboard.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.fsi.risk.aggregated_var',
+ '00000003-0002-4000-8000-000000000003',
+ '{"catalog": "lakehouse", "schema": "fsi_risk", "table_name": "aggregated_var", "format": "delta"}',
+ '["bcbs-239", "risk-tier-1"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- AML stream
+('0f300105-0002-4000-8000-000000000005',
+ 'kafka.fsi.aml.transaction_alerts',
+ 'Real-time stream of AML scenario hits and ML anomaly alerts.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts',
+ '00000004-0002-4000-8000-000000000004',
+ '{"topic": "aml.transaction_alerts", "throughput_msgs_per_sec": 600}',
+ '["aml-monitored", "transaction-data"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Regulatory Filing (vertical asset type)
+('0f300106-0002-4000-8000-000000000006',
+ 'FFIEC-Call-Report-2026-Q1',
+ 'FFIEC Call Report quarterly submission for 2026 Q1.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Regulatory Filing' LIMIT 1), '0f200103-0002-4000-8000-000000000003'), 'Reg Portal', 'filings/ffiec/2026-Q1',
+ '00000004-0002-4000-8000-000000000004',
+ '{"filing_type": "FFIEC Call Report", "period": "2026-Q1", "status": "submitted", "submission_date": "2026-04-30"}',
+ '["bcbs-239"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Customer table
+('0f300107-0002-4000-8000-000000000007',
+ 'lakehouse.fsi.banking.customer_master',
+ 'Banking customer master with KYC tier and segment classifications.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.fsi.banking.customer_master',
+ '00000001-0002-4000-8000-000000000001',
+ '{"catalog": "lakehouse", "schema": "fsi_banking", "table_name": "customer_master", "row_count": 4200000, "format": "delta"}',
+ '["aml-monitored"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Dashboard
+('0f300108-0002-4000-8000-000000000008',
+ 'CRO Risk Dashboard',
+ 'Daily firm-wide risk metrics, breach summary, and stress test results.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.bank.com/dashboards/cro-risk-v1',
+ '00000003-0002-4000-8000-000000000003',
+ '{"refresh_schedule": "hourly", "audience": "cro-team"}',
+ '["bcbs-239", "risk-tier-1"]',
+ 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 16. ENTITY RELATIONSHIPS — FSI lineage (type=0fa)
+-- ============================================================================
+
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, created_by, created_at) VALUES
+('0fa00101-0002-4000-8000-000000000001', 'data_product', '00700001-0002-4000-8000-000000000001', 'asset', '0f300101-0002-4000-8000-000000000001', 'derives_from', 'system@demo', NOW()),
+('0fa00102-0002-4000-8000-000000000002', 'data_product', '00700001-0002-4000-8000-000000000001', 'asset', '0f300102-0002-4000-8000-000000000002', 'derives_from', 'system@demo', NOW()),
+('0fa00103-0002-4000-8000-000000000003', 'data_product', '00700002-0002-4000-8000-000000000002', 'asset', '0f300104-0002-4000-8000-000000000004', 'derives_from', 'system@demo', NOW()),
+('0fa00104-0002-4000-8000-000000000004', 'data_product', '00700002-0002-4000-8000-000000000002', 'asset', '0f300103-0002-4000-8000-000000000003', 'consumes',     'system@demo', NOW()),
+('0fa00105-0002-4000-8000-000000000005', 'data_product', '00700003-0002-4000-8000-000000000003', 'asset', '0f300105-0002-4000-8000-000000000005', 'derives_from', 'system@demo', NOW()),
+('0fa00106-0002-4000-8000-000000000006', 'data_product', '00700004-0002-4000-8000-000000000004', 'asset', '0f300106-0002-4000-8000-000000000006', 'produces',     'system@demo', NOW()),
+('0fa00107-0002-4000-8000-000000000007', 'data_product', '00700005-0002-4000-8000-000000000005', 'asset', '0f300107-0002-4000-8000-000000000007', 'derives_from', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 17. ENTITY TAG ASSOCIATIONS (FSI, type=029)
+-- ============================================================================
+
+INSERT INTO entity_tag_associations (id, tag_id, entity_id, entity_type, assigned_value, assigned_by, assigned_at) VALUES
+-- Trading Analytics
+('02900101-0002-4000-8000-000000000001', '02700102-0002-4000-8000-000000000002', '00700001-0002-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW()),
+('02900102-0002-4000-8000-000000000002', '02700106-0002-4000-8000-000000000006', '00700001-0002-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW()),
+-- Enterprise Risk Aggregation
+('02900103-0002-4000-8000-000000000003', '02700101-0002-4000-8000-000000000001', '00700002-0002-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900104-0002-4000-8000-000000000004', '02700105-0002-4000-8000-000000000005', '00700002-0002-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900105-0002-4000-8000-000000000005', '02700103-0002-4000-8000-000000000003', '00700002-0002-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+-- AML Monitoring
+('02900106-0002-4000-8000-000000000006', '02700104-0002-4000-8000-000000000004', '00700003-0002-4000-8000-000000000003', 'data_product', NULL, 'system@demo', NOW()),
+-- Regulatory Reporting
+('02900107-0002-4000-8000-000000000007', '02700101-0002-4000-8000-000000000001', '00700004-0002-4000-8000-000000000004', 'data_product', NULL, 'system@demo', NOW()),
+-- Customer 360 Banking
+('02900108-0002-4000-8000-000000000008', '02700104-0002-4000-8000-000000000004', '00700005-0002-4000-8000-000000000005', 'data_product', NULL, 'system@demo', NOW())
+ON CONFLICT (tag_id, entity_id, entity_type) DO NOTHING;
+
+
+-- ============================================================================
+-- 18. PROCESS WORKFLOWS + STEPS (FSI-specific)
+-- ============================================================================
+
+INSERT INTO process_workflows (id, name, description, trigger_config, scope_config, is_active, is_default, version, created_by, updated_by, created_at, updated_at) VALUES
+('02a00101-0002-4000-8000-000000000001', 'BCBS 239 Pre-Publish Attestation',
+ 'Requires CRO sign-off before any risk product is published, per BCBS 239 principles.',
+ '{"type": "before_publish", "entity_types": ["data_product"]}',
+ '{"type": "domain", "ids": ["00000003-0002-4000-8000-000000000003"]}',
+ true, true, 1, 'system@demo', 'system@demo', NOW(), NOW()),
+('02a00102-0002-4000-8000-000000000002', 'AML Model Validation Gate',
+ 'Blocks deployment of AML monitoring updates without independent model validation.',
+ '{"type": "before_update", "entity_types": ["data_product"]}',
+ '{"type": "domain", "ids": ["00000004-0002-4000-8000-000000000004"]}',
+ true, false, 1, 'system@demo', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, on_pass, on_fail, "order", position, created_at, updated_at) VALUES
+('02b00101-0002-4000-8000-000000000001', '02a00101-0002-4000-8000-000000000001', 'lineage_check',     'BCBS 239 Lineage Coverage',
+ 'policy_check',
+ '{"policy_id": "01100001-0002-4000-8000-000000000001"}',
+ 'cro_attest', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
+('02b00102-0002-4000-8000-000000000002', '02a00101-0002-4000-8000-000000000001', 'cro_attest',        'CRO Attestation',
+ 'manual_approval',
+ '{"approver_role": "0f000001-0002-4000-8000-000000000001"}',
+ 'approve', 'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW()),
+('02b00103-0002-4000-8000-000000000003', '02a00102-0002-4000-8000-000000000002', 'mrm_review',        'Model Risk Manager Review',
+ 'manual_approval',
+ '{"approver_role": "0f000003-0002-4000-8000-000000000003"}',
+ 'approve', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 19. COMPLIANCE RUNS + RESULTS (FSI)
+-- ============================================================================
+
+INSERT INTO compliance_runs (id, policy_id, status, started_at, finished_at, success_count, failure_count, score) VALUES
+('01200101-0002-4000-8000-000000000001', '01100001-0002-4000-8000-000000000001', 'completed', NOW() - INTERVAL '4 days', NOW() - INTERVAL '4 days' + INTERVAL '15 minutes', 5, 1, 0.833),
+('01200102-0002-4000-8000-000000000002', '01100002-0002-4000-8000-000000000002', 'completed', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days' + INTERVAL '6 minutes',  3, 0, 1.000)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO compliance_results (id, run_id, object_type, object_id, object_name, passed, message, created_at) VALUES
+('01300101-0002-4000-8000-000000000001', '01200101-0002-4000-8000-000000000001', 'data_product', '00700002-0002-4000-8000-000000000002', 'Enterprise Risk Aggregation v1', true,  'Risk aggregation lineage covers all 11 BCBS 239 principles.', NOW() - INTERVAL '4 days'),
+('01300102-0002-4000-8000-000000000002', '01200101-0002-4000-8000-000000000001', 'data_product', '00700001-0002-4000-8000-000000000001', 'Trading Analytics Dashboard v1', false, 'Reconciliation lineage missing between FIX feed and EOD positions snapshot.', NOW() - INTERVAL '4 days'),
+('01300103-0002-4000-8000-000000000003', '01200102-0002-4000-8000-000000000002', 'data_product', '00700003-0002-4000-8000-000000000003', 'AML Transaction Monitoring v1', true,  'Sanctions screening cycle within 1-day SLA.', NOW() - INTERVAL '2 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 20. COST ITEMS (FSI)
+-- ============================================================================
+
+INSERT INTO cost_items (id, entity_type, entity_id, title, description, cost_center, custom_center_name, amount_cents, currency, start_month, created_by, created_at, updated_at) VALUES
+('01400101-0002-4000-8000-000000000001', 'data_product', '00700001-0002-4000-8000-000000000001', 'Market Data Subscriptions', 'Refinitiv + Bloomberg market-data feeds for trading analytics.', 'tools', NULL, 9800000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400102-0002-4000-8000-000000000002', 'data_product', '00700002-0002-4000-8000-000000000002', 'Risk Compute (DBU)',        'Daily Monte Carlo VaR + stress scenarios.',                       'infrastructure', NULL, 4200000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400103-0002-4000-8000-000000000003', 'data_product', '00700003-0002-4000-8000-000000000003', 'AML Tooling License',       'Annual AML detection and case management tooling.',               'tools', NULL, 1800000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 21. COMMENTS & RATINGS (FSI)
+-- ============================================================================
+
+INSERT INTO comments (id, entity_type, entity_id, comment, comment_type, rating, status, created_by, created_at, updated_at) VALUES
+('02c00101-0002-4000-8000-000000000001', 'data_product', '00700001-0002-4000-8000-000000000001', 'Real-time TCA is best in class. Latency is excellent.',                       'rating', 5, 'active', 'desk-head@bank.com',         NOW() - INTERVAL '12 days', NOW() - INTERVAL '12 days'),
+('02c00102-0002-4000-8000-000000000002', 'data_product', '00700002-0002-4000-8000-000000000002', 'BCBS 239 lineage gaps still tracked in Jira; product otherwise excellent.',  'rating', 4, 'active', 'cro@bank.com',               NOW() - INTERVAL '8 days',  NOW() - INTERVAL '8 days'),
+('02c00103-0002-4000-8000-000000000003', 'data_product', '00700003-0002-4000-8000-000000000003', 'False-positive rate dropped 38% after ML migration.',                          'rating', 5, 'active', 'aml-lead@bank.com',          NOW() - INTERVAL '5 days',  NOW() - INTERVAL '5 days'),
+('02c00104-0002-4000-8000-000000000004', 'data_product', '00700005-0002-4000-8000-000000000005', 'Customer 360 RM desktop loads quickly; KYC tier integration is great.',       'rating', 4, 'active', 'rm-lead@bank.com',           NOW() - INTERVAL '2 days',  NOW() - INTERVAL '2 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 22. BUSINESS OWNERS (FSI)
+-- ============================================================================
+
+INSERT INTO business_owners (id, object_type, object_id, user_email, user_name, role_id, is_active, assigned_at, removed_at, removal_reason, created_by, created_at, updated_at) VALUES
+('0fb00101-0002-4000-8000-000000000001', 'data_product',  '00700001-0002-4000-8000-000000000001', 'desk-head@bank.com',     'Trading Desk Head',          '0f000004-0002-4000-8000-000000000004', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00102-0002-4000-8000-000000000002', 'data_product',  '00700002-0002-4000-8000-000000000002', 'cro@bank.com',           'Chief Risk Officer',         '0f000001-0002-4000-8000-000000000001', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00103-0002-4000-8000-000000000003', 'data_product',  '00700003-0002-4000-8000-000000000003', 'aml-lead@bank.com',      'Head of Compliance',         '0f000002-0002-4000-8000-000000000002', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00104-0002-4000-8000-000000000004', 'data_product',  '00700004-0002-4000-8000-000000000004', 'reg-reporting@bank.com', 'Regulatory Reporting Lead',  '0f000005-0002-4000-8000-000000000005', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 23. ENTITY SUBSCRIPTIONS (FSI)
+-- ============================================================================
+
+INSERT INTO entity_subscriptions (id, entity_type, entity_id, subscriber_email, subscription_reason, created_at) VALUES
+('02200101-0002-4000-8000-000000000001', 'data_product', '00700002-0002-4000-8000-000000000002', 'cro@bank.com',           'owner',    NOW() - INTERVAL '60 days'),
+('02200102-0002-4000-8000-000000000002', 'data_product', '00700004-0002-4000-8000-000000000004', 'reg-reporting@bank.com', 'owner',    NOW() - INTERVAL '60 days'),
+('02200103-0002-4000-8000-000000000003', 'data_product', '00700001-0002-4000-8000-000000000001', 'risk-quant@bank.com',    'consumer', NOW() - INTERVAL '15 days')
+ON CONFLICT DO NOTHING;
+
+
 COMMIT;
 
 -- ============================================================================
--- End of FSI Industry Demo Data
+-- End of FSI Demo Data — preset=fsi
 -- ============================================================================

--- a/src/backend/src/data/demo_data_hls.sql
+++ b/src/backend/src/data/demo_data_hls.sql
@@ -1,16 +1,31 @@
 -- ============================================================================
--- Industry Demo Data: Health & Life Sciences (HLS)
+-- HLS Demo Data — preset=hls
 -- ============================================================================
--- Additive overlay loaded via: POST /api/settings/demo-data/load?industry=hls
+-- Standalone demo pack loaded via:
+--   POST /api/settings/demo-data/load?preset=hls
 --
--- Adds HLS-specific data domains, teams, contracts, products, and compliance
--- policies. References base demo teams where appropriate.
+-- This pack is fully self-contained: loading it on an empty database produces
+-- a complete Health & Life Sciences vertical demo with no implicit content from
+-- any other preset.
 --
 -- Dataset identifier: 0001 (second UUID group)
 -- UUID Format: {type:3}{seq:5}-0001-4000-8000-00000000000N
 -- ============================================================================
 
 BEGIN;
+
+-- ============================================================================
+-- 0. SHARED PARENT ROWS (idempotent foundation)
+-- ============================================================================
+-- HLS data_domains FK to base "Core" and "Finance" parents below.
+-- Inserted with ON CONFLICT DO NOTHING so it is safe to load this preset on
+-- top of an empty DB or alongside other presets.
+
+INSERT INTO data_domains (id, name, description, parent_id, created_by, created_at, updated_at) VALUES
+('00000001-0000-4000-8000-000000000001', 'Core', 'General, cross-company business concepts.', NULL, 'system@demo', NOW(), NOW()),
+('00000002-0000-4000-8000-000000000002', 'Finance', 'Financial accounting, reporting, and metrics.', '00000001-0000-4000-8000-000000000001', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
 
 -- ============================================================================
 -- 1. DATA DOMAINS (HLS-specific, children of Core)
@@ -330,8 +345,365 @@ INSERT INTO link_metadata (id, entity_id, entity_type, title, short_description,
 ON CONFLICT (id) DO NOTHING;
 
 
+-- ============================================================================
+-- 9. BUSINESS ROLES (HLS-specific, type=0f0)
+-- ============================================================================
+-- Vertical-specific ownership/contributor roles. is_system=false marks them as
+-- demo content (cleared with the rest of the HLS pack).
+
+INSERT INTO business_roles (id, name, description, category, is_system, is_approver, status, created_by, created_at, updated_at) VALUES
+('0f000001-0001-4000-8000-000000000001', 'Clinical Data Steward', 'Maintains clinical data quality, terminology mapping (ICD-10, LOINC, SNOMED), and HIPAA-compliant access policies.', 'governance', false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000002-0001-4000-8000-000000000002', 'Principal Investigator', 'Lead clinician/scientist accountable for a clinical trial protocol and its data.', 'business', false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000003-0001-4000-8000-000000000003', 'IRB Coordinator', 'Manages Institutional Review Board approvals and consent tracking.', 'governance', false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000004-0001-4000-8000-000000000004', 'Privacy Officer (HIPAA)', 'Ensures Protected Health Information handling complies with HIPAA Privacy and Security Rules.', 'governance', false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000005-0001-4000-8000-000000000005', 'Pharmacovigilance Lead', 'Owns adverse event signal detection, ICSR reporting, and PSUR/PBRER submissions.', 'operational', false, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 10. DELIVERY METHODS (HLS-specific, type=0f4)
+-- ============================================================================
+
+INSERT INTO delivery_methods (id, name, description, category, is_system, status, created_by, created_at, updated_at) VALUES
+('0f400001-0001-4000-8000-000000000001', 'HL7 FHIR API',         'Delivers clinical resources via HL7 FHIR R4 REST API (Patient, Observation, Condition, Encounter).', 'endpoint',  false, 'active', 'system@demo', NOW(), NOW()),
+('0f400002-0001-4000-8000-000000000002', 'EDI 837 Claims Feed',  'Delivers claims data via X12 EDI 837 institutional/professional transactions.',                       'export',    false, 'active', 'system@demo', NOW(), NOW()),
+('0f400003-0001-4000-8000-000000000003', 'REDCap Export',        'Pulls case-report-form data from REDCap study databases via API export.',                              'access',    false, 'active', 'system@demo', NOW(), NOW()),
+('0f400004-0001-4000-8000-000000000004', 'CDISC Define-XML',     'Submission package formatted as Define-XML 2.0 with SDTM/ADaM datasets.',                              'export',    false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 11. VERTICAL ASSET TYPES (HLS-specific, is_system=false)
+-- ============================================================================
+-- Asset types unique to HLS that aren't in the shared ontology. These survive
+-- ontology re-syncs because they are NOT marked is_system. Use lookups by name
+-- in subsequent INSERTs (with COALESCE fallback to literal id) to make the
+-- file resilient to manual edits.
+
+INSERT INTO asset_types (id, name, description, category, icon, required_fields, optional_fields, is_system, status, created_by, created_at, updated_at) VALUES
+('0f200101-0001-4000-8000-000000000001', 'Patient Cohort',         'A defined group of patients with shared inclusion/exclusion criteria for clinical research or analytics.', 'data', 'users',     NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200102-0001-4000-8000-000000000002', 'Clinical Trial Dataset', 'CDISC SDTM/ADaM dataset associated with a clinical trial protocol.',                                      'data', 'flask',     NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200103-0001-4000-8000-000000000003', 'Adverse Event Case',     'Individual Case Safety Report (ICSR) capturing a single adverse drug event.',                             'data', 'shield',    NULL, NULL, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+
+-- ============================================================================
+-- 12. TAG NAMESPACES + TAGS (HLS governance vocabulary)
+-- ============================================================================
+
+INSERT INTO tag_namespaces (id, name, description, created_by, created_at, updated_at) VALUES
+('02601001-0001-4000-8000-000000000001', 'hls-phi',          'Protected Health Information sensitivity classifications.',          'system@demo', NOW(), NOW()),
+('02601002-0001-4000-8000-000000000002', 'hls-regulatory',   'HLS regulatory frameworks (HIPAA, 21 CFR Part 11, GxP).',           'system@demo', NOW(), NOW()),
+('02601003-0001-4000-8000-000000000003', 'hls-clinical',     'Clinical data context and lifecycle stage.',                         'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO tags (id, name, description, possible_values, status, version, namespace_id, parent_id, created_by, created_at, updated_at) VALUES
+-- PHI sensitivity
+('02700101-0001-4000-8000-000000000001', 'phi-direct',         'Contains direct PHI identifiers (name, MRN, DOB, etc.).', NULL, 'active', 'v1.0', '02601001-0001-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700102-0001-4000-8000-000000000002', 'phi-deidentified',   'PHI removed via Safe Harbor or Expert Determination.',     NULL, 'active', 'v1.0', '02601001-0001-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700103-0001-4000-8000-000000000003', 'phi-limited',        'Limited Data Set per HIPAA \u00a7164.514(e).',                NULL, 'active', 'v1.0', '02601001-0001-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+-- Regulatory
+('02700104-0001-4000-8000-000000000004', 'hipaa',              'Subject to HIPAA Privacy and Security Rules.',             NULL, 'active', 'v1.0', '02601002-0001-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+('02700105-0001-4000-8000-000000000005', '21cfr-part-11',      'Subject to FDA 21 CFR Part 11 electronic records rule.',   NULL, 'active', 'v1.0', '02601002-0001-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+('02700106-0001-4000-8000-000000000006', 'gcp-validated',      'Validated under Good Clinical Practice guidelines.',       NULL, 'active', 'v1.0', '02601002-0001-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+-- Clinical context
+('02700107-0001-4000-8000-000000000007', 'cohort-eligible',    'Suitable for cohort-building queries.',                     NULL, 'active', 'v1.0', '02601003-0001-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW()),
+('02700108-0001-4000-8000-000000000008', 'submission-ready',   'Submission-ready CDISC dataset.',                          NULL, 'active', 'v1.0', '02601003-0001-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW()),
+('02700109-0001-4000-8000-000000000009', 'rwe-source',         'Real-world evidence data source.',                          NULL, 'active', 'v1.0', '02601003-0001-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, name) DO NOTHING;
+
+INSERT INTO tag_namespace_permissions (id, namespace_id, group_id, access_level, created_by, created_at, updated_at) VALUES
+('02800101-0001-4000-8000-000000000001', '02601001-0001-4000-8000-000000000001', 'clinical-informatics', 'admin',      'system@demo', NOW(), NOW()),
+('02800102-0001-4000-8000-000000000002', '02601001-0001-4000-8000-000000000001', 'biostatisticians',     'read_only',  'system@demo', NOW(), NOW()),
+('02800103-0001-4000-8000-000000000003', '02601002-0001-4000-8000-000000000002', 'regulatory-team',      'admin',      'system@demo', NOW(), NOW()),
+('02800104-0001-4000-8000-000000000004', '02601003-0001-4000-8000-000000000003', 'clinical-informatics', 'read_write', 'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, group_id) DO NOTHING;
+
+
+-- ============================================================================
+-- 13. RDF TRIPLES — HLS concept graph (type=020)
+-- ============================================================================
+-- A small SKOS concept graph for the HLS knowledge graph view. Each concept has
+-- (rdf:type, rdfs:label) pair. Linked from data_contracts/products via section 14.
+
+INSERT INTO rdf_triples (id, subject_uri, predicate_uri, object_value, object_is_uri, context_name, source_type, source_identifier, created_by, created_at) VALUES
+-- Patient (Clinical concept root)
+('02000101-0001-4000-8000-000000000001', 'http://demo.ontos.app/hls#Patient',          'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000102-0001-4000-8000-000000000002', 'http://demo.ontos.app/hls#Patient',          'http://www.w3.org/2000/01/rdf-schema#label',       'Patient',                                       false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000103-0001-4000-8000-000000000003', 'http://demo.ontos.app/hls#Encounter',        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000104-0001-4000-8000-000000000004', 'http://demo.ontos.app/hls#Encounter',        'http://www.w3.org/2000/01/rdf-schema#label',       'Encounter',                                     false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000105-0001-4000-8000-000000000005', 'http://demo.ontos.app/hls#Diagnosis',        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000106-0001-4000-8000-000000000006', 'http://demo.ontos.app/hls#Diagnosis',        'http://www.w3.org/2000/01/rdf-schema#label',       'Diagnosis',                                     false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000107-0001-4000-8000-000000000007', 'http://demo.ontos.app/hls#Medication',       'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000108-0001-4000-8000-000000000008', 'http://demo.ontos.app/hls#Medication',       'http://www.w3.org/2000/01/rdf-schema#label',       'Medication',                                    false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000109-0001-4000-8000-000000000009', 'http://demo.ontos.app/hls#AdverseEvent',     'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('0200010a-0001-4000-8000-000000000010', 'http://demo.ontos.app/hls#AdverseEvent',     'http://www.w3.org/2000/01/rdf-schema#label',       'Adverse Event',                                 false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('0200010b-0001-4000-8000-000000000011', 'http://demo.ontos.app/hls#ClinicalTrial',    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('0200010c-0001-4000-8000-000000000012', 'http://demo.ontos.app/hls#ClinicalTrial',    'http://www.w3.org/2000/01/rdf-schema#label',       'Clinical Trial',                                false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('0200010d-0001-4000-8000-000000000013', 'http://demo.ontos.app/hls#Claim',            'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('0200010e-0001-4000-8000-000000000014', 'http://demo.ontos.app/hls#Claim',            'http://www.w3.org/2000/01/rdf-schema#label',       'Insurance Claim',                               false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('0200010f-0001-4000-8000-000000000015', 'http://demo.ontos.app/hls#Cohort',           'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW()),
+('02000110-0001-4000-8000-000000000016', 'http://demo.ontos.app/hls#Cohort',           'http://www.w3.org/2000/01/rdf-schema#label',       'Patient Cohort',                                false, 'urn:demo', 'demo', 'demo_data_hls.sql', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 14. ENTITY SEMANTIC LINKS — HLS contracts/products → concepts (type=015)
+-- ============================================================================
+
+INSERT INTO entity_semantic_links (id, entity_id, entity_type, iri, label, created_by, created_at) VALUES
+('01500101-0001-4000-8000-000000000001', '00400001-0001-4000-8000-000000000001', 'data_contract', 'http://demo.ontos.app/hls#Patient',       'Patient',        'system@demo', NOW()),
+('01500102-0001-4000-8000-000000000002', '00400001-0001-4000-8000-000000000001', 'data_contract', 'http://demo.ontos.app/hls#Encounter',     'Encounter',      'system@demo', NOW()),
+('01500103-0001-4000-8000-000000000003', '00400002-0001-4000-8000-000000000002', 'data_contract', 'http://demo.ontos.app/hls#ClinicalTrial', 'Clinical Trial', 'system@demo', NOW()),
+('01500104-0001-4000-8000-000000000004', '00400003-0001-4000-8000-000000000003', 'data_contract', 'http://demo.ontos.app/hls#AdverseEvent',  'Adverse Event',  'system@demo', NOW()),
+('01500105-0001-4000-8000-000000000005', '00400005-0001-4000-8000-000000000005', 'data_contract', 'http://demo.ontos.app/hls#Claim',         'Insurance Claim','system@demo', NOW()),
+('01500106-0001-4000-8000-000000000006', '00700001-0001-4000-8000-000000000001', 'data_product',  'http://demo.ontos.app/hls#Patient',       'Patient',        'system@demo', NOW()),
+('01500107-0001-4000-8000-000000000007', '00700002-0001-4000-8000-000000000002', 'data_product',  'http://demo.ontos.app/hls#ClinicalTrial', 'Clinical Trial', 'system@demo', NOW()),
+('01500108-0001-4000-8000-000000000008', '00700003-0001-4000-8000-000000000003', 'data_product',  'http://demo.ontos.app/hls#AdverseEvent',  'Adverse Event',  'system@demo', NOW()),
+('01500109-0001-4000-8000-000000000009', '00700004-0001-4000-8000-000000000004', 'data_product',  'http://demo.ontos.app/hls#Cohort',        'Patient Cohort', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15. ASSETS — concrete HLS catalog objects (type=0f3)
+-- ============================================================================
+-- Datasets (021), physical tables (025), and dashboards/streams referenced by
+-- the HLS data products. asset_type_id is resolved by name; falls back to a
+-- known ontology UUID if the type name is missing.
+
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
+-- Tables (Clinical)
+('0f300101-0001-4000-8000-000000000001',
+ 'lakehouse.hls.curated.patients',
+ 'De-identified patient master record (HIPAA Safe Harbor).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.hls.curated.patients',
+ '00000001-0001-4000-8000-000000000001',
+ '{"catalog": "lakehouse", "schema": "hls_curated", "table_name": "patients", "row_count": 2400000, "format": "delta"}',
+ '["curated", "phi-deidentified"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+('0f300102-0001-4000-8000-000000000002',
+ 'lakehouse.hls.curated.encounters',
+ 'Inpatient and outpatient encounters with billing codes.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.hls.curated.encounters',
+ '00000001-0001-4000-8000-000000000001',
+ '{"catalog": "lakehouse", "schema": "hls_curated", "table_name": "encounters", "row_count": 18500000, "format": "delta"}',
+ '["curated", "phi-limited"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Patient Cohort (vertical asset type)
+('0f300103-0001-4000-8000-000000000003',
+ 'cohort.oncology.her2_positive_2024',
+ 'HER2-positive breast cancer cohort for 2024 RWE study (~12,400 patients).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Patient Cohort' LIMIT 1), '0f200101-0001-4000-8000-000000000001'), 'Databricks', 'cohort.oncology.her2_positive_2024',
+ '00000002-0001-4000-8000-000000000002',
+ '{"cohort_size": 12400, "inclusion_criteria": ["HER2+", "stage_II_or_III"], "study_id": "ONCO-RWE-2024-08"}',
+ '["cohort-eligible", "rwe-source"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Clinical Trial Dataset (vertical asset type)
+('0f300104-0001-4000-8000-000000000004',
+ 'sdtm.onco-2025-001.dm',
+ 'CDISC SDTM DM (Demographics) dataset for protocol ONCO-2025-001.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Clinical Trial Dataset' LIMIT 1), '0f200102-0001-4000-8000-000000000002'), 'Databricks', 'sdtm.onco-2025-001.dm',
+ '00000002-0001-4000-8000-000000000002',
+ '{"protocol": "ONCO-2025-001", "cdisc_standard": "SDTM", "version": "3.3", "dataset": "DM"}',
+ '["submission-ready", "21cfr-part-11"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Dashboard
+('0f300105-0001-4000-8000-000000000005',
+ 'Trial Monitoring Dashboard',
+ 'Site enrollment, screen failure rate, and SAE summary across active oncology trials.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.pharma.com/dashboards/trial-monitoring',
+ '00000002-0001-4000-8000-000000000002',
+ '{"refresh_schedule": "daily", "audience": "study-team"}',
+ '["analytics"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Streaming source (FAERS feed)
+('0f300106-0001-4000-8000-000000000006',
+ 'kafka.pharma.faers.case_events',
+ 'Real-time stream of incoming FAERS adverse-event case submissions.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.pharma:9093/faers.case_events',
+ '00000003-0001-4000-8000-000000000003',
+ '{"topic": "faers.case_events", "throughput_msgs_per_sec": 1200}',
+ '["real-time"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Adverse Event Case (vertical asset type)
+('0f300107-0001-4000-8000-000000000007',
+ 'ICSR-2025-4521',
+ 'Individual Case Safety Report — serious adverse event, drug XYZ.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Adverse Event Case' LIMIT 1), '0f200103-0001-4000-8000-000000000003'), 'Pharma Safety DB', 'safety://cases/ICSR-2025-4521',
+ '00000003-0001-4000-8000-000000000003',
+ '{"seriousness": "serious", "expectedness": "unexpected", "days_to_report": 12, "regulatory_status": "submitted"}',
+ '["hipaa", "21cfr-part-11"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Claims table
+('0f300108-0001-4000-8000-000000000008',
+ 'lakehouse.hls.claims.adjudicated',
+ 'Adjudicated medical and pharmacy claims (commercial + Medicare Advantage).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.hls.claims.adjudicated',
+ '00000006-0001-4000-8000-000000000006',
+ '{"catalog": "lakehouse", "schema": "hls_claims", "table_name": "adjudicated", "row_count": 45000000, "format": "delta"}',
+ '["curated"]',
+ 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 16. ENTITY RELATIONSHIPS — HLS lineage (type=0fa for business lineage)
+-- ============================================================================
+
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, created_by, created_at) VALUES
+-- Patient 360 product → underlying tables (lineage)
+('0fa00101-0001-4000-8000-000000000001', 'data_product', '00700001-0001-4000-8000-000000000001', 'asset', '0f300101-0001-4000-8000-000000000001', 'derives_from', 'system@demo', NOW()),
+('0fa00102-0001-4000-8000-000000000002', 'data_product', '00700001-0001-4000-8000-000000000001', 'asset', '0f300102-0001-4000-8000-000000000002', 'derives_from', 'system@demo', NOW()),
+-- Clinical Trial Analytics product → SDTM dataset
+('0fa00103-0001-4000-8000-000000000003', 'data_product', '00700002-0001-4000-8000-000000000002', 'asset', '0f300104-0001-4000-8000-000000000004', 'derives_from', 'system@demo', NOW()),
+-- Drug Safety Signal Detection product → FAERS stream + ICSR cases
+('0fa00104-0001-4000-8000-000000000004', 'data_product', '00700003-0001-4000-8000-000000000003', 'asset', '0f300106-0001-4000-8000-000000000006', 'derives_from', 'system@demo', NOW()),
+('0fa00105-0001-4000-8000-000000000005', 'data_product', '00700003-0001-4000-8000-000000000003', 'asset', '0f300107-0001-4000-8000-000000000007', 'consumes', 'system@demo', NOW()),
+-- RWE Platform product → claims + cohort
+('0fa00106-0001-4000-8000-000000000006', 'data_product', '00700004-0001-4000-8000-000000000004', 'asset', '0f300108-0001-4000-8000-000000000008', 'derives_from', 'system@demo', NOW()),
+('0fa00107-0001-4000-8000-000000000007', 'data_product', '00700004-0001-4000-8000-000000000004', 'asset', '0f300103-0001-4000-8000-000000000003', 'consumes', 'system@demo', NOW()),
+-- Claims Analytics product → claims table
+('0fa00108-0001-4000-8000-000000000008', 'data_product', '00700005-0001-4000-8000-000000000005', 'asset', '0f300108-0001-4000-8000-000000000008', 'derives_from', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 17. ENTITY TAG ASSOCIATIONS (HLS, type=029)
+-- ============================================================================
+
+INSERT INTO entity_tag_associations (id, tag_id, entity_id, entity_type, assigned_value, assigned_by, assigned_at) VALUES
+-- Patient 360 product
+('02900101-0001-4000-8000-000000000001', '02700102-0001-4000-8000-000000000002', '00700001-0001-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW()),
+('02900102-0001-4000-8000-000000000002', '02700104-0001-4000-8000-000000000004', '00700001-0001-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW()),
+-- Clinical Trial Analytics product
+('02900103-0001-4000-8000-000000000003', '02700105-0001-4000-8000-000000000005', '00700002-0001-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900104-0001-4000-8000-000000000004', '02700108-0001-4000-8000-000000000008', '00700002-0001-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900105-0001-4000-8000-000000000005', '02700106-0001-4000-8000-000000000006', '00700002-0001-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+-- Drug Safety
+('02900106-0001-4000-8000-000000000006', '02700104-0001-4000-8000-000000000004', '00700003-0001-4000-8000-000000000003', 'data_product', NULL, 'system@demo', NOW()),
+('02900107-0001-4000-8000-000000000007', '02700105-0001-4000-8000-000000000005', '00700003-0001-4000-8000-000000000003', 'data_product', NULL, 'system@demo', NOW()),
+-- RWE
+('02900108-0001-4000-8000-000000000008', '02700109-0001-4000-8000-000000000009', '00700004-0001-4000-8000-000000000004', 'data_product', NULL, 'system@demo', NOW()),
+('02900109-0001-4000-8000-000000000009', '02700107-0001-4000-8000-000000000007', '00700004-0001-4000-8000-000000000004', 'data_product', NULL, 'system@demo', NOW()),
+-- Contracts
+('0290010a-0001-4000-8000-000000000010', '02700101-0001-4000-8000-000000000001', '00400001-0001-4000-8000-000000000001', 'data_contract', NULL, 'system@demo', NOW()),
+('0290010b-0001-4000-8000-000000000011', '02700104-0001-4000-8000-000000000004', '00400001-0001-4000-8000-000000000001', 'data_contract', NULL, 'system@demo', NOW())
+ON CONFLICT (tag_id, entity_id, entity_type) DO NOTHING;
+
+
+-- ============================================================================
+-- 18. PROCESS WORKFLOWS + STEPS (HLS-specific)
+-- ============================================================================
+
+INSERT INTO process_workflows (id, name, description, trigger_config, scope_config, is_active, is_default, version, created_by, updated_by, created_at, updated_at) VALUES
+('02a00101-0001-4000-8000-000000000001', 'IRB Approval Gate',
+ 'Block publishing of clinical research data products until IRB approval is on file.',
+ '{"type": "before_publish", "entity_types": ["data_product"]}',
+ '{"type": "domain", "ids": ["00000002-0001-4000-8000-000000000002"]}',
+ true, true, 1, 'system@demo', 'system@demo', NOW(), NOW()),
+('02a00102-0001-4000-8000-000000000002', 'HIPAA PHI Pre-Publish Check',
+ 'Validates that PHI is de-identified or covered by a signed BAA before any HLS data product is exposed to consumers.',
+ '{"type": "before_publish", "entity_types": ["data_product", "data_contract"]}',
+ '{"type": "all"}',
+ true, true, 1, 'system@demo', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, on_pass, on_fail, "order", position, created_at, updated_at) VALUES
+('02b00101-0001-4000-8000-000000000001', '02a00101-0001-4000-8000-000000000001', 'irb_doc_check', 'IRB Document Present',
+ 'policy_check',
+ '{"policy_id": "01100002-0001-4000-8000-000000000002"}',
+ 'irb_active', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
+('02b00102-0001-4000-8000-000000000002', '02a00101-0001-4000-8000-000000000001', 'irb_active',     'IRB Approval Active',
+ 'manual_approval',
+ '{"approver_role": "0f000003-0001-4000-8000-000000000003"}',
+ 'approve', 'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW()),
+('02b00103-0001-4000-8000-000000000003', '02a00102-0001-4000-8000-000000000002', 'phi_classification', 'PHI Classification',
+ 'policy_check',
+ '{"policy_id": "01100001-0001-4000-8000-000000000001"}',
+ 'phi_review', 'block', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
+('02b00104-0001-4000-8000-000000000004', '02a00102-0001-4000-8000-000000000002', 'phi_review', 'Privacy Officer Review',
+ 'manual_approval',
+ '{"approver_role": "0f000004-0001-4000-8000-000000000004"}',
+ 'approve', 'block', 2, '{"x": 300, "y": 100}', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 19. COMPLIANCE RUNS + RESULTS (HLS, types 012 / 013)
+-- ============================================================================
+
+INSERT INTO compliance_runs (id, policy_id, status, started_at, finished_at, success_count, failure_count, score) VALUES
+('01200101-0001-4000-8000-000000000001', '01100001-0001-4000-8000-000000000001', 'completed', NOW() - INTERVAL '7 days', NOW() - INTERVAL '7 days' + INTERVAL '12 minutes', 6, 1, 0.857),
+('01200102-0001-4000-8000-000000000002', '01100002-0001-4000-8000-000000000002', 'completed', NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days' + INTERVAL '8 minutes',  4, 0, 1.000),
+('01200103-0001-4000-8000-000000000003', '01100004-0001-4000-8000-000000000004', 'completed', NOW() - INTERVAL '1 days', NOW() - INTERVAL '1 days' + INTERVAL '4 minutes',  2, 1, 0.667)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO compliance_results (id, run_id, object_type, object_id, object_name, passed, message, created_at) VALUES
+('01300101-0001-4000-8000-000000000001', '01200101-0001-4000-8000-000000000001', 'data_product', '00700001-0001-4000-8000-000000000001', 'Patient 360 View v1',                 true,  'PHI de-identification verified.', NOW() - INTERVAL '7 days'),
+('01300102-0001-4000-8000-000000000002', '01200101-0001-4000-8000-000000000001', 'data_product', '00700004-0001-4000-8000-000000000004', 'Real-World Evidence Platform v1',     true,  'Limited Data Set certification on file.', NOW() - INTERVAL '7 days'),
+('01300103-0001-4000-8000-000000000003', '01200101-0001-4000-8000-000000000001', 'data_contract','00400003-0001-4000-8000-000000000003', 'Adverse Event Reports Contract',      false, 'Free-text narrative may contain residual PHI; manual review queued.', NOW() - INTERVAL '7 days'),
+('01300104-0001-4000-8000-000000000004', '01200102-0001-4000-8000-000000000002', 'data_product', '00700002-0001-4000-8000-000000000002', 'Clinical Trial Analytics v1',         true,  'Audit trail validated against 21 CFR Part 11.', NOW() - INTERVAL '5 days'),
+('01300105-0001-4000-8000-000000000005', '01200103-0001-4000-8000-000000000003', 'data_product', '00700003-0001-4000-8000-000000000003', 'Drug Safety Signal Detection v1',     false, 'One ICSR exceeded the 15-day reporting window (case ICSR-2025-4521).', NOW() - INTERVAL '1 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 20. COST ITEMS (HLS, type=014)
+-- ============================================================================
+
+INSERT INTO cost_items (id, entity_type, entity_id, title, description, cost_center, custom_center_name, amount_cents, currency, start_month, created_by, created_at, updated_at) VALUES
+('01400101-0001-4000-8000-000000000001', 'data_product', '00700001-0001-4000-8000-000000000001', 'Compute (DBU)',          'Monthly Databricks compute for Patient 360 pipelines.',     'infrastructure', NULL, 1820000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400102-0001-4000-8000-000000000002', 'data_product', '00700002-0001-4000-8000-000000000002', 'CDISC Validator Tooling','Annual license for CDISC SDTM/ADaM validation tooling.',    'tools',          NULL,  650000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400103-0001-4000-8000-000000000003', 'data_product', '00700003-0001-4000-8000-000000000003', 'Pharmacovigilance FTE',  'Two FTE pharmacovigilance analysts allocated to signal review.', 'hr',          NULL, 4500000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 21. COMMENTS & RATINGS (HLS, type=02c)
+-- ============================================================================
+
+INSERT INTO comments (id, entity_type, entity_id, comment, comment_type, rating, status, created_by, created_at, updated_at) VALUES
+('02c00101-0001-4000-8000-000000000001', 'data_product', '00700001-0001-4000-8000-000000000001', 'Outstanding starting point for population-health analyses; FHIR mapping is excellent.', 'rating', 5, 'active', 'dr.chen@hospital.org',         NOW() - INTERVAL '14 days', NOW() - INTERVAL '14 days'),
+('02c00102-0001-4000-8000-000000000002', 'data_product', '00700002-0001-4000-8000-000000000002', 'CDISC compliance is solid. Would love deeper ADaM coverage in v2.',                       'rating', 4, 'active', 'dr.patel@pharma.com',          NOW() - INTERVAL '10 days', NOW() - INTERVAL '10 days'),
+('02c00103-0001-4000-8000-000000000003', 'data_product', '00700003-0001-4000-8000-000000000003', 'Signal detection works well; needs better narrative summarization.',                      'rating', 4, 'active', 'sarah.compliance@pharma.com',  NOW() - INTERVAL '8 days',  NOW() - INTERVAL '8 days'),
+('02c00104-0001-4000-8000-000000000004', 'data_product', '00700004-0001-4000-8000-000000000004', 'Cohort builder UX is great. Linkage rate documented clearly.',                            'rating', 5, 'active', 'rwe-lead@pharma.com',          NOW() - INTERVAL '4 days',  NOW() - INTERVAL '4 days'),
+('02c00105-0001-4000-8000-000000000005', 'data_product', '00700005-0001-4000-8000-000000000005', 'Denial drill-down by payer + CPT is exactly what RCM needed.',                            'rating', 5, 'active', 'rcm-analyst@hospital.org',     NOW() - INTERVAL '2 days',  NOW() - INTERVAL '2 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 22. BUSINESS OWNERS (HLS, type=0fb)
+-- ============================================================================
+
+INSERT INTO business_owners (id, object_type, object_id, user_email, user_name, role_id, is_active, assigned_at, removed_at, removal_reason, created_by, created_at, updated_at) VALUES
+('0fb00101-0001-4000-8000-000000000001', 'data_product',  '00700001-0001-4000-8000-000000000001', 'dr.chen@hospital.org',         'Dr. Wei Chen',         '0f000001-0001-4000-8000-000000000001', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00102-0001-4000-8000-000000000002', 'data_product',  '00700002-0001-4000-8000-000000000002', 'dr.patel@pharma.com',          'Dr. Anita Patel',      '0f000002-0001-4000-8000-000000000002', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00103-0001-4000-8000-000000000003', 'data_product',  '00700003-0001-4000-8000-000000000003', 'sarah.compliance@pharma.com',  'Sarah Compliance',     '0f000005-0001-4000-8000-000000000005', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00104-0001-4000-8000-000000000004', 'data_contract', '00400001-0001-4000-8000-000000000001', 'dr.chen@hospital.org',         'Dr. Wei Chen',         '0f000004-0001-4000-8000-000000000004', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00105-0001-4000-8000-000000000005', 'data_contract', '00400003-0001-4000-8000-000000000003', 'sarah.compliance@pharma.com',  'Sarah Compliance',     '0f000005-0001-4000-8000-000000000005', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 23. ENTITY SUBSCRIPTIONS (HLS, type=022)
+-- ============================================================================
+
+INSERT INTO entity_subscriptions (id, entity_type, entity_id, subscriber_email, subscription_reason, created_at) VALUES
+('02200101-0001-4000-8000-000000000001', 'data_product', '00700001-0001-4000-8000-000000000001', 'dr.chen@hospital.org',     'owner',     NOW() - INTERVAL '60 days'),
+('02200102-0001-4000-8000-000000000002', 'data_product', '00700001-0001-4000-8000-000000000001', 'rwe-lead@pharma.com',      'consumer',  NOW() - INTERVAL '30 days'),
+('02200103-0001-4000-8000-000000000003', 'data_product', '00700003-0001-4000-8000-000000000003', 'sarah.compliance@pharma.com', 'owner',  NOW() - INTERVAL '60 days')
+ON CONFLICT DO NOTHING;
+
+
 COMMIT;
 
 -- ============================================================================
--- End of HLS Industry Demo Data
+-- End of HLS Demo Data — preset=hls
 -- ============================================================================

--- a/src/backend/src/data/demo_data_mfg.sql
+++ b/src/backend/src/data/demo_data_mfg.sql
@@ -1,16 +1,31 @@
 -- ============================================================================
--- Industry Demo Data: Manufacturing (MFG)
+-- MFG Demo Data — preset=mfg
 -- ============================================================================
--- Additive overlay loaded via: POST /api/settings/demo-data/load?industry=mfg
+-- Standalone demo pack loaded via:
+--   POST /api/settings/demo-data/load?preset=mfg
 --
--- Adds manufacturing-specific data domains, teams, contracts, products, and
--- compliance policies covering production, quality, maintenance, and safety.
+-- This pack is fully self-contained: loading it on an empty database produces
+-- a complete Manufacturing vertical demo with no implicit content from any
+-- other preset.
 --
 -- Dataset identifier: 0003 (second UUID group)
 -- UUID Format: {type:3}{seq:5}-0003-4000-8000-00000000000N
 -- ============================================================================
 
 BEGIN;
+
+-- ============================================================================
+-- 0. SHARED PARENT ROWS (idempotent foundation)
+-- ============================================================================
+-- MFG data_domains FK to base "Core" and "Supply Chain" parents below.
+-- Inserted ON CONFLICT DO NOTHING so it is safe to load this preset on top of
+-- an empty DB or alongside other presets.
+
+INSERT INTO data_domains (id, name, description, parent_id, created_by, created_at, updated_at) VALUES
+('00000001-0000-4000-8000-000000000001', 'Core', 'General, cross-company business concepts.', NULL, 'system@demo', NOW(), NOW()),
+('00000006-0000-4000-8000-000000000006', 'Supply Chain', 'Logistics, inventory management, reordering, and supplier relations.', '00000001-0000-4000-8000-000000000001', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
 
 -- ============================================================================
 -- 1. DATA DOMAINS (MFG-specific, children of Core)
@@ -329,8 +344,313 @@ INSERT INTO link_metadata (id, entity_id, entity_type, title, short_description,
 ON CONFLICT (id) DO NOTHING;
 
 
+-- ============================================================================
+-- 9. BUSINESS ROLES (MFG-specific, type=0f0)
+-- ============================================================================
+
+INSERT INTO business_roles (id, name, description, category, is_system, is_approver, status, created_by, created_at, updated_at) VALUES
+('0f000001-0003-4000-8000-000000000001', 'Plant Manager',           'Site leader accountable for production volume, quality, and safety.',                          'business',    false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000002-0003-4000-8000-000000000002', 'Quality Manager',         'Owns SPC, NCR/CAPA processes, and ISO 9001 compliance.',                                       'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000003-0003-4000-8000-000000000003', 'Maintenance Engineer',    'Owns asset health, predictive maintenance models, and CMMS data quality.',                     'technical',   false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000004-0003-4000-8000-000000000004', 'EHS Officer',             'Environmental, Health and Safety leadership — incident reporting, OSHA compliance.',           'governance',  false, true,  'active', 'system@demo', NOW(), NOW()),
+('0f000005-0003-4000-8000-000000000005', 'Supply Chain Coordinator','Ensures material availability, supplier OTD performance, and WIP flow.',                       'operational', false, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 10. DELIVERY METHODS (MFG-specific, type=0f4)
+-- ============================================================================
+
+INSERT INTO delivery_methods (id, name, description, category, is_system, status, created_by, created_at, updated_at) VALUES
+('0f400001-0003-4000-8000-000000000001', 'OPC UA Telemetry',  'Streams equipment telemetry from PLCs/SCADA via OPC UA.',                                 'streaming', false, 'active', 'system@demo', NOW(), NOW()),
+('0f400002-0003-4000-8000-000000000002', 'MES Integration',   'Pulls work orders, routings, and run data from the Manufacturing Execution System.',     'access',    false, 'active', 'system@demo', NOW(), NOW()),
+('0f400003-0003-4000-8000-000000000003', 'CMMS Feed',         'Synchronises asset events from the Computerised Maintenance Management System.',          'access',    false, 'active', 'system@demo', NOW(), NOW()),
+('0f400004-0003-4000-8000-000000000004', 'Shop Floor Display','Renders KPIs to plant-floor TVs and Andon boards.',                                       'endpoint',  false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 11. VERTICAL ASSET TYPES (MFG-specific, is_system=false)
+-- ============================================================================
+
+INSERT INTO asset_types (id, name, description, category, icon, required_fields, optional_fields, is_system, status, created_by, created_at, updated_at) VALUES
+('0f200101-0003-4000-8000-000000000001', 'Production Line',     'Physical production line composed of stations and equipment.',          'data', 'factory',     NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200102-0003-4000-8000-000000000002', 'Equipment Asset',     'Physical machine, motor, robot, or test cell with sensor telemetry.',   'data', 'cog',         NULL, NULL, false, 'active', 'system@demo', NOW(), NOW()),
+('0f200103-0003-4000-8000-000000000003', 'Quality Inspection',  'Discrete quality inspection record (CMM, vision, manual).',             'data', 'check-circle',NULL, NULL, false, 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+
+-- ============================================================================
+-- 12. TAG NAMESPACES + TAGS (MFG governance vocabulary)
+-- ============================================================================
+
+INSERT INTO tag_namespaces (id, name, description, created_by, created_at, updated_at) VALUES
+('02601001-0003-4000-8000-000000000001', 'mfg-quality',  'Quality system terms (SPC, NCR, CAPA, ISO).',         'system@demo', NOW(), NOW()),
+('02601002-0003-4000-8000-000000000002', 'mfg-asset',    'Asset health and maintenance lifecycle.',             'system@demo', NOW(), NOW()),
+('02601003-0003-4000-8000-000000000003', 'mfg-ehs',      'Environment, Health and Safety classification.',      'system@demo', NOW(), NOW())
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO tags (id, name, description, possible_values, status, version, namespace_id, parent_id, created_by, created_at, updated_at) VALUES
+-- Quality
+('02700101-0003-4000-8000-000000000001', 'iso-9001',       'Subject to ISO 9001 QMS scope.',                              NULL, 'active', 'v1.0', '02601001-0003-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700102-0003-4000-8000-000000000002', 'spc-controlled', 'Operates under Statistical Process Control.',                NULL, 'active', 'v1.0', '02601001-0003-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+('02700103-0003-4000-8000-000000000003', 'capa-source',    'Generates CAPA / NCR records.',                               NULL, 'active', 'v1.0', '02601001-0003-4000-8000-000000000001', NULL, 'system@demo', NOW(), NOW()),
+-- Asset
+('02700104-0003-4000-8000-000000000004', 'critical-asset', 'Critical asset for production continuity.',                   NULL, 'active', 'v1.0', '02601002-0003-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+('02700105-0003-4000-8000-000000000005', 'pm-eligible',    'Eligible for predictive maintenance modelling.',              NULL, 'active', 'v1.0', '02601002-0003-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+('02700106-0003-4000-8000-000000000006', 'iiot-instrumented','Has IIoT sensor instrumentation.',                          NULL, 'active', 'v1.0', '02601002-0003-4000-8000-000000000002', NULL, 'system@demo', NOW(), NOW()),
+-- EHS
+('02700107-0003-4000-8000-000000000007', 'osha-recordable','Records relevant to OSHA 300 reporting.',                     NULL, 'active', 'v1.0', '02601003-0003-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW()),
+('02700108-0003-4000-8000-000000000008', 'iso-14001',      'Subject to ISO 14001 environmental scope.',                   NULL, 'active', 'v1.0', '02601003-0003-4000-8000-000000000003', NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, name) DO NOTHING;
+
+INSERT INTO tag_namespace_permissions (id, namespace_id, group_id, access_level, created_by, created_at, updated_at) VALUES
+('02800101-0003-4000-8000-000000000001', '02601001-0003-4000-8000-000000000001', 'quality-team',  'admin',     'system@demo', NOW(), NOW()),
+('02800102-0003-4000-8000-000000000002', '02601002-0003-4000-8000-000000000002', 'maintenance',   'admin',     'system@demo', NOW(), NOW()),
+('02800103-0003-4000-8000-000000000003', '02601003-0003-4000-8000-000000000003', 'ehs-team',      'admin',     'system@demo', NOW(), NOW()),
+('02800104-0003-4000-8000-000000000004', '02601001-0003-4000-8000-000000000001', 'plant-ops',     'read_only', 'system@demo', NOW(), NOW())
+ON CONFLICT (namespace_id, group_id) DO NOTHING;
+
+
+-- ============================================================================
+-- 13. RDF TRIPLES — MFG concept graph (type=020)
+-- ============================================================================
+
+INSERT INTO rdf_triples (id, subject_uri, predicate_uri, object_value, object_is_uri, context_name, source_type, source_identifier, created_by, created_at) VALUES
+('02000101-0003-4000-8000-000000000001', 'http://demo.ontos.app/mfg#WorkOrder',     'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000102-0003-4000-8000-000000000002', 'http://demo.ontos.app/mfg#WorkOrder',     'http://www.w3.org/2000/01/rdf-schema#label',       'Work Order',                                    false, 'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000103-0003-4000-8000-000000000003', 'http://demo.ontos.app/mfg#Equipment',     'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000104-0003-4000-8000-000000000004', 'http://demo.ontos.app/mfg#Equipment',     'http://www.w3.org/2000/01/rdf-schema#label',       'Equipment',                                     false, 'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000105-0003-4000-8000-000000000005', 'http://demo.ontos.app/mfg#OEE',           'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000106-0003-4000-8000-000000000006', 'http://demo.ontos.app/mfg#OEE',           'http://www.w3.org/2000/01/rdf-schema#label',       'Overall Equipment Effectiveness',                false, 'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000107-0003-4000-8000-000000000007', 'http://demo.ontos.app/mfg#Defect',        'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000108-0003-4000-8000-000000000008', 'http://demo.ontos.app/mfg#Defect',        'http://www.w3.org/2000/01/rdf-schema#label',       'Defect',                                        false, 'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('02000109-0003-4000-8000-000000000009', 'http://demo.ontos.app/mfg#NCR',           'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('0200010a-0003-4000-8000-000000000010', 'http://demo.ontos.app/mfg#NCR',           'http://www.w3.org/2000/01/rdf-schema#label',       'Non-Conformance Report',                        false, 'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('0200010b-0003-4000-8000-000000000011', 'http://demo.ontos.app/mfg#SafetyIncident','http://www.w3.org/1999/02/22-rdf-syntax-ns#type',  'http://www.w3.org/2004/02/skos/core#Concept', true,  'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW()),
+('0200010c-0003-4000-8000-000000000012', 'http://demo.ontos.app/mfg#SafetyIncident','http://www.w3.org/2000/01/rdf-schema#label',       'Safety Incident',                               false, 'urn:demo', 'demo', 'demo_data_mfg.sql', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 14. ENTITY SEMANTIC LINKS (type=015)
+-- ============================================================================
+
+INSERT INTO entity_semantic_links (id, entity_id, entity_type, iri, label, created_by, created_at) VALUES
+('01500101-0003-4000-8000-000000000001', '00700001-0003-4000-8000-000000000001', 'data_product', 'http://demo.ontos.app/mfg#OEE',            'OEE',                       'system@demo', NOW()),
+('01500102-0003-4000-8000-000000000002', '00700001-0003-4000-8000-000000000001', 'data_product', 'http://demo.ontos.app/mfg#WorkOrder',      'Work Order',                'system@demo', NOW()),
+('01500103-0003-4000-8000-000000000003', '00700002-0003-4000-8000-000000000002', 'data_product', 'http://demo.ontos.app/mfg#Defect',         'Defect',                    'system@demo', NOW()),
+('01500104-0003-4000-8000-000000000004', '00700002-0003-4000-8000-000000000002', 'data_product', 'http://demo.ontos.app/mfg#NCR',            'Non-Conformance Report',    'system@demo', NOW()),
+('01500105-0003-4000-8000-000000000005', '00700003-0003-4000-8000-000000000003', 'data_product', 'http://demo.ontos.app/mfg#Equipment',      'Equipment',                 'system@demo', NOW()),
+('01500106-0003-4000-8000-000000000006', '00700005-0003-4000-8000-000000000005', 'data_product', 'http://demo.ontos.app/mfg#SafetyIncident', 'Safety Incident',           'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15. ASSETS — MFG catalog objects (type=0f3)
+-- ============================================================================
+
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
+-- Production Line (vertical asset type)
+('0f300101-0003-4000-8000-000000000001',
+ 'plant.detroit.line.assembly_3',
+ 'Assembly line 3 at Detroit plant — engine sub-assembly.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Production Line' LIMIT 1), '0f200101-0003-4000-8000-000000000001'), 'MES', 'plant://detroit/line/assembly_3',
+ '00000001-0003-4000-8000-000000000001',
+ '{"plant": "detroit", "line_id": "assembly_3", "shift_pattern": "3x8", "design_capacity_per_hr": 320}',
+ '["spc-controlled", "iso-9001"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Equipment Asset (vertical asset type)
+('0f300102-0003-4000-8000-000000000002',
+ 'eq.detroit.cnc_42',
+ 'CNC mill #42 — high-precision crankshaft machining.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Equipment Asset' LIMIT 1), '0f200102-0003-4000-8000-000000000002'), 'CMMS', 'cmms://eq/cnc_42',
+ '00000003-0003-4000-8000-000000000003',
+ '{"equipment_id": "CNC_42", "manufacturer": "DMG Mori", "install_year": 2019, "vibration_sensor": true}',
+ '["critical-asset", "pm-eligible", "iiot-instrumented"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Quality Inspection (vertical asset type)
+('0f300103-0003-4000-8000-000000000003',
+ 'qi.detroit.cmm.batch-2026-04-30',
+ 'CMM inspection batch April 30 2026 — crankshaft dimensional checks.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Quality Inspection' LIMIT 1), '0f200103-0003-4000-8000-000000000003'), 'CMM', 'cmm://detroit/batch/2026-04-30',
+ '00000002-0003-4000-8000-000000000002',
+ '{"batch_id": "2026-04-30-A", "parts_inspected": 320, "defects_found": 2, "Cpk": 1.62}',
+ '["spc-controlled", "capa-source"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Telemetry stream
+('0f300104-0003-4000-8000-000000000004',
+ 'kafka.factory.telemetry.equipment',
+ 'Real-time OPC UA equipment telemetry stream (vibration, temperature, current).',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.factory:9092/telemetry.equipment',
+ '00000003-0003-4000-8000-000000000003',
+ '{"topic": "telemetry.equipment", "throughput_msgs_per_sec": 18000}',
+ '["iiot-instrumented"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- WIP table
+('0f300105-0003-4000-8000-000000000005',
+ 'lakehouse.mfg.wip.work_orders',
+ 'Work-in-process work orders with current station and status.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.mfg.wip.work_orders',
+ '00000001-0003-4000-8000-000000000001',
+ '{"catalog": "lakehouse", "schema": "mfg_wip", "table_name": "work_orders", "row_count": 86000, "format": "delta"}',
+ '["iso-9001"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Quality table
+('0f300106-0003-4000-8000-000000000006',
+ 'lakehouse.mfg.quality.defect_log',
+ 'Defect log with classification, root cause, and CAPA linkage.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.mfg.quality.defect_log',
+ '00000002-0003-4000-8000-000000000002',
+ '{"catalog": "lakehouse", "schema": "mfg_quality", "table_name": "defect_log", "row_count": 9400, "format": "delta"}',
+ '["spc-controlled", "capa-source"]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- Dashboard
+('0f300107-0003-4000-8000-000000000007',
+ 'Plant OEE Dashboard',
+ 'Live OEE by plant, line, and shift with downtime Pareto.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.factory.com/dashboards/oee-v1',
+ '00000001-0003-4000-8000-000000000001',
+ '{"refresh_schedule": "1 minute", "audience": "plant-ops"}',
+ '[]',
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- EHS table
+('0f300108-0003-4000-8000-000000000008',
+ 'lakehouse.mfg.ehs.incidents',
+ 'EHS incident reports including near-miss observations.',
+ COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.mfg.ehs.incidents',
+ '00000004-0003-4000-8000-000000000004',
+ '{"catalog": "lakehouse", "schema": "mfg_ehs", "table_name": "incidents", "row_count": 1280, "format": "delta"}',
+ '["osha-recordable", "iso-14001"]',
+ 'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 16. ENTITY RELATIONSHIPS — MFG lineage (type=0fa)
+-- ============================================================================
+
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, created_by, created_at) VALUES
+('0fa00101-0003-4000-8000-000000000001', 'data_product', '00700001-0003-4000-8000-000000000001', 'asset', '0f300101-0003-4000-8000-000000000001', 'derives_from', 'system@demo', NOW()),
+('0fa00102-0003-4000-8000-000000000002', 'data_product', '00700001-0003-4000-8000-000000000001', 'asset', '0f300105-0003-4000-8000-000000000005', 'derives_from', 'system@demo', NOW()),
+('0fa00103-0003-4000-8000-000000000003', 'data_product', '00700002-0003-4000-8000-000000000002', 'asset', '0f300103-0003-4000-8000-000000000003', 'derives_from', 'system@demo', NOW()),
+('0fa00104-0003-4000-8000-000000000004', 'data_product', '00700002-0003-4000-8000-000000000002', 'asset', '0f300106-0003-4000-8000-000000000006', 'derives_from', 'system@demo', NOW()),
+('0fa00105-0003-4000-8000-000000000005', 'data_product', '00700003-0003-4000-8000-000000000003', 'asset', '0f300102-0003-4000-8000-000000000002', 'consumes',     'system@demo', NOW()),
+('0fa00106-0003-4000-8000-000000000006', 'data_product', '00700003-0003-4000-8000-000000000003', 'asset', '0f300104-0003-4000-8000-000000000004', 'derives_from', 'system@demo', NOW()),
+('0fa00107-0003-4000-8000-000000000007', 'data_product', '00700005-0003-4000-8000-000000000005', 'asset', '0f300108-0003-4000-8000-000000000008', 'derives_from', 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 17. ENTITY TAG ASSOCIATIONS (MFG, type=029)
+-- ============================================================================
+
+INSERT INTO entity_tag_associations (id, tag_id, entity_id, entity_type, assigned_value, assigned_by, assigned_at) VALUES
+('02900101-0003-4000-8000-000000000001', '02700101-0003-4000-8000-000000000001', '00700001-0003-4000-8000-000000000001', 'data_product', NULL, 'system@demo', NOW()),
+('02900102-0003-4000-8000-000000000002', '02700102-0003-4000-8000-000000000002', '00700002-0003-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900103-0003-4000-8000-000000000003', '02700103-0003-4000-8000-000000000003', '00700002-0003-4000-8000-000000000002', 'data_product', NULL, 'system@demo', NOW()),
+('02900104-0003-4000-8000-000000000004', '02700105-0003-4000-8000-000000000005', '00700003-0003-4000-8000-000000000003', 'data_product', NULL, 'system@demo', NOW()),
+('02900105-0003-4000-8000-000000000005', '02700106-0003-4000-8000-000000000006', '00700003-0003-4000-8000-000000000003', 'data_product', NULL, 'system@demo', NOW()),
+('02900106-0003-4000-8000-000000000006', '02700107-0003-4000-8000-000000000007', '00700005-0003-4000-8000-000000000005', 'data_product', NULL, 'system@demo', NOW()),
+('02900107-0003-4000-8000-000000000007', '02700108-0003-4000-8000-000000000008', '00700005-0003-4000-8000-000000000005', 'data_product', NULL, 'system@demo', NOW())
+ON CONFLICT (tag_id, entity_id, entity_type) DO NOTHING;
+
+
+-- ============================================================================
+-- 18. PROCESS WORKFLOWS + STEPS (MFG-specific)
+-- ============================================================================
+
+INSERT INTO process_workflows (id, name, description, trigger_config, scope_config, is_active, is_default, version, created_by, updated_by, created_at, updated_at) VALUES
+('02a00101-0003-4000-8000-000000000001', 'Quality Hold Approval',
+ 'Routes a NCR-driven quality hold to Quality Manager and Plant Manager for approval.',
+ '{"type": "on_create", "entity_types": ["data_product"]}',
+ '{"type": "domain", "ids": ["00000002-0003-4000-8000-000000000002"]}',
+ true, true, 1, 'system@demo', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, on_pass, on_fail, "order", position, created_at, updated_at) VALUES
+('02b00101-0003-4000-8000-000000000001', '02a00101-0003-4000-8000-000000000001', 'qm_review',    'Quality Manager Review',
+ 'manual_approval',
+ '{"approver_role": "0f000002-0003-4000-8000-000000000002"}',
+ 'pm_review', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
+('02b00102-0003-4000-8000-000000000002', '02a00101-0003-4000-8000-000000000001', 'pm_review',    'Plant Manager Approval',
+ 'manual_approval',
+ '{"approver_role": "0f000001-0003-4000-8000-000000000001"}',
+ 'approve', 'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 19. COMPLIANCE RUNS + RESULTS (MFG)
+-- ============================================================================
+
+INSERT INTO compliance_runs (id, policy_id, status, started_at, finished_at, success_count, failure_count, score) VALUES
+('01200101-0003-4000-8000-000000000001', '01100001-0003-4000-8000-000000000001', 'completed', NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days' + INTERVAL '7 minutes', 4, 1, 0.800),
+('01200102-0003-4000-8000-000000000002', '01100002-0003-4000-8000-000000000002', 'completed', NOW() - INTERVAL '1 days', NOW() - INTERVAL '1 days' + INTERVAL '5 minutes', 3, 0, 1.000)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO compliance_results (id, run_id, object_type, object_id, object_name, passed, message, created_at) VALUES
+('01300101-0003-4000-8000-000000000001', '01200101-0003-4000-8000-000000000001', 'data_product', '00700002-0003-4000-8000-000000000002', 'Quality Analytics Platform v1', true,  'SPC rules and Cpk thresholds documented and current.', NOW() - INTERVAL '3 days'),
+('01300102-0003-4000-8000-000000000002', '01200101-0003-4000-8000-000000000001', 'data_product', '00700003-0003-4000-8000-000000000003', 'Predictive Maintenance v1',    false, 'Vibration sensors on 3 critical assets show 12+ hours of missing data.', NOW() - INTERVAL '3 days'),
+('01300103-0003-4000-8000-000000000003', '01200102-0003-4000-8000-000000000002', 'data_product', '00700005-0003-4000-8000-000000000005', 'EHS Safety Analytics v1',     true,  'OSHA 300 log reconciles with HRIS injury records.', NOW() - INTERVAL '1 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 20. COST ITEMS (MFG)
+-- ============================================================================
+
+INSERT INTO cost_items (id, entity_type, entity_id, title, description, cost_center, custom_center_name, amount_cents, currency, start_month, created_by, created_at, updated_at) VALUES
+('01400101-0003-4000-8000-000000000001', 'data_product', '00700001-0003-4000-8000-000000000001', 'MES Integration FTE', 'Two FTE for MES connectivity and master data alignment.', 'hr',             NULL, 3600000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400102-0003-4000-8000-000000000002', 'data_product', '00700003-0003-4000-8000-000000000003', 'IIoT Sensor Refresh', 'Annual sensor refresh and calibration programme.',        'infrastructure', NULL, 1500000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW()),
+('01400103-0003-4000-8000-000000000003', 'data_product', '00700004-0003-4000-8000-000000000004', 'Supply Chain Tooling','Annual SCM platform license and integrations.',           'tools',          NULL, 1200000, 'USD', '2026-01-01', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 21. COMMENTS & RATINGS (MFG)
+-- ============================================================================
+
+INSERT INTO comments (id, entity_type, entity_id, comment, comment_type, rating, status, created_by, created_at, updated_at) VALUES
+('02c00101-0003-4000-8000-000000000001', 'data_product', '00700001-0003-4000-8000-000000000001', 'Best OEE dashboard we''ve had on the floor — drilldown to station is fast.',     'rating', 5, 'active', 'pm-detroit@factory.com',  NOW() - INTERVAL '11 days', NOW() - INTERVAL '11 days'),
+('02c00102-0003-4000-8000-000000000002', 'data_product', '00700002-0003-4000-8000-000000000002', 'SPC visualisation is excellent; would like CMM image integration.',              'rating', 4, 'active', 'qm-detroit@factory.com',  NOW() - INTERVAL '7 days',  NOW() - INTERVAL '7 days'),
+('02c00103-0003-4000-8000-000000000003', 'data_product', '00700003-0003-4000-8000-000000000003', 'Predictive lead times exceed expectations on the bearing models.',                 'rating', 5, 'active', 'maint-eng@factory.com',   NOW() - INTERVAL '4 days',  NOW() - INTERVAL '4 days'),
+('02c00104-0003-4000-8000-000000000004', 'data_product', '00700005-0003-4000-8000-000000000005', 'Near-miss reporting trends are very actionable.',                                  'rating', 4, 'active', 'ehs-officer@factory.com', NOW() - INTERVAL '2 days',  NOW() - INTERVAL '2 days')
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 22. BUSINESS OWNERS (MFG)
+-- ============================================================================
+
+INSERT INTO business_owners (id, object_type, object_id, user_email, user_name, role_id, is_active, assigned_at, removed_at, removal_reason, created_by, created_at, updated_at) VALUES
+('0fb00101-0003-4000-8000-000000000001', 'data_product',  '00700001-0003-4000-8000-000000000001', 'pm-detroit@factory.com',  'Plant Manager (Detroit)',     '0f000001-0003-4000-8000-000000000001', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00102-0003-4000-8000-000000000002', 'data_product',  '00700002-0003-4000-8000-000000000002', 'qm-detroit@factory.com',  'Quality Manager (Detroit)',   '0f000002-0003-4000-8000-000000000002', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00103-0003-4000-8000-000000000003', 'data_product',  '00700003-0003-4000-8000-000000000003', 'maint-eng@factory.com',   'Maintenance Engineer Lead',   '0f000003-0003-4000-8000-000000000003', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW()),
+('0fb00104-0003-4000-8000-000000000004', 'data_product',  '00700005-0003-4000-8000-000000000005', 'ehs-officer@factory.com', 'EHS Officer',                 '0f000004-0003-4000-8000-000000000004', true, NOW() - INTERVAL '60 days', NULL, NULL, 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 23. ENTITY SUBSCRIPTIONS (MFG)
+-- ============================================================================
+
+INSERT INTO entity_subscriptions (id, entity_type, entity_id, subscriber_email, subscription_reason, created_at) VALUES
+('02200101-0003-4000-8000-000000000001', 'data_product', '00700001-0003-4000-8000-000000000001', 'pm-detroit@factory.com', 'owner',    NOW() - INTERVAL '60 days'),
+('02200102-0003-4000-8000-000000000002', 'data_product', '00700002-0003-4000-8000-000000000002', 'qm-detroit@factory.com', 'owner',    NOW() - INTERVAL '60 days'),
+('02200103-0003-4000-8000-000000000003', 'data_product', '00700003-0003-4000-8000-000000000003', 'maint-eng@factory.com',  'owner',    NOW() - INTERVAL '60 days')
+ON CONFLICT DO NOTHING;
+
+
 COMMIT;
 
 -- ============================================================================
--- End of MFG Industry Demo Data
+-- End of MFG Demo Data — preset=mfg
 -- ============================================================================

--- a/src/backend/src/data/demo_data_retail.sql
+++ b/src/backend/src/data/demo_data_retail.sql
@@ -1,8 +1,12 @@
 -- ============================================================================
--- Demo Data SQL Script
+-- Retail Demo Data — preset=retail (default)
 -- ============================================================================
--- This file contains all demo/example data for the application.
--- Load via the /api/settings/demo-data/load endpoint (Admin only).
+-- Standalone demo pack loaded via:
+--   POST /api/settings/demo-data/load              (preset defaults to 'retail')
+--   POST /api/settings/demo-data/load?preset=retail
+--
+-- This is the default, retail-flavored demo. Each preset is fully self-contained:
+-- loading this pack produces a complete demo with no dependency on other packs.
 --
 -- Data is inserted in FK-safe order:
 -- 1. Data Domains (hierarchical, parents first)
@@ -24,12 +28,12 @@
 -- Fields:
 --   xxx   = entity type code (see below)
 --   yyyyy = record sequence number (hex)
---   zzzz  = dataset identifier
---     0000 = base/default (this file: demo_data.sql)
---     0001 = HLS (demo_data_hls.sql)
---     0002 = FSI (demo_data_fsi.sql)
---     0003 = MFG (demo_data_mfg.sql)
---     0004 = AUTO (demo_data_auto.sql)
+--   zzzz  = dataset identifier (one per preset)
+--     0000 = retail (this file: demo_data_retail.sql)  — preset=retail (default)
+--     0001 = HLS    (demo_data_hls.sql)                — preset=hls
+--     0002 = FSI    (demo_data_fsi.sql)                — preset=fsi
+--     0003 = MFG    (demo_data_mfg.sql)                — preset=mfg
+--     0004 = AUTO   (demo_data_auto.sql)               — preset=auto
 --   N     = record sequence (decimal, mirrors yyyyy)
 --
 -- Type Codes:
@@ -529,176 +533,176 @@ ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO rdf_triples (id, subject_uri, predicate_uri, object_value, object_is_uri, context_name, source_type, source_identifier, created_by, created_at) VALUES
 -- Domain Concepts (rdf:type skos:Concept)
-('02000001-0000-4000-8000-000000000001', 'http://demo.ontos.app/concepts#CustomerDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000002-0000-4000-8000-000000000002', 'http://demo.ontos.app/concepts#CustomerDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer Domain', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000003-0000-4000-8000-000000000003', 'http://demo.ontos.app/concepts#FinancialDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000004-0000-4000-8000-000000000004', 'http://demo.ontos.app/concepts#FinancialDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Financial Domain', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000005-0000-4000-8000-000000000005', 'http://demo.ontos.app/concepts#SalesDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000006-0000-4000-8000-000000000006', 'http://demo.ontos.app/concepts#SalesDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Sales Domain', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000007-0000-4000-8000-000000000007', 'http://demo.ontos.app/concepts#MarketingDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000008-0000-4000-8000-000000000008', 'http://demo.ontos.app/concepts#MarketingDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Marketing Domain', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000009-0000-4000-8000-000000000009', 'http://demo.ontos.app/concepts#RetailDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200000a-0000-4000-8000-00000000000a', 'http://demo.ontos.app/concepts#RetailDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Retail Domain', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200000b-0000-4000-8000-00000000000b', 'http://demo.ontos.app/concepts#ProductDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200000c-0000-4000-8000-00000000000c', 'http://demo.ontos.app/concepts#ProductDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Product Domain', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200000d-0000-4000-8000-00000000000d', 'http://demo.ontos.app/concepts#EmployeeDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200000e-0000-4000-8000-00000000000e', 'http://demo.ontos.app/concepts#EmployeeDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Employee Domain', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000001-0000-4000-8000-000000000001', 'http://demo.ontos.app/concepts#CustomerDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000002-0000-4000-8000-000000000002', 'http://demo.ontos.app/concepts#CustomerDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer Domain', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000003-0000-4000-8000-000000000003', 'http://demo.ontos.app/concepts#FinancialDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000004-0000-4000-8000-000000000004', 'http://demo.ontos.app/concepts#FinancialDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Financial Domain', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000005-0000-4000-8000-000000000005', 'http://demo.ontos.app/concepts#SalesDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000006-0000-4000-8000-000000000006', 'http://demo.ontos.app/concepts#SalesDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Sales Domain', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000007-0000-4000-8000-000000000007', 'http://demo.ontos.app/concepts#MarketingDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000008-0000-4000-8000-000000000008', 'http://demo.ontos.app/concepts#MarketingDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Marketing Domain', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000009-0000-4000-8000-000000000009', 'http://demo.ontos.app/concepts#RetailDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200000a-0000-4000-8000-00000000000a', 'http://demo.ontos.app/concepts#RetailDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Retail Domain', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200000b-0000-4000-8000-00000000000b', 'http://demo.ontos.app/concepts#ProductDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200000c-0000-4000-8000-00000000000c', 'http://demo.ontos.app/concepts#ProductDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Product Domain', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200000d-0000-4000-8000-00000000000d', 'http://demo.ontos.app/concepts#EmployeeDomain', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200000e-0000-4000-8000-00000000000e', 'http://demo.ontos.app/concepts#EmployeeDomain', 'http://www.w3.org/2000/01/rdf-schema#label', 'Employee Domain', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 
 -- Business Concepts (for Data Products)
-('0200000f-0000-4000-8000-00000000000f', 'http://demo.ontos.app/concepts#Sale', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000010-0000-4000-8000-000000000010', 'http://demo.ontos.app/concepts#Sale', 'http://www.w3.org/2000/01/rdf-schema#label', 'Sale', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000011-0000-4000-8000-000000000011', 'http://demo.ontos.app/concepts#Transaction', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000012-0000-4000-8000-000000000012', 'http://demo.ontos.app/concepts#Transaction', 'http://www.w3.org/2000/01/rdf-schema#label', 'Transaction', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000013-0000-4000-8000-000000000013', 'http://demo.ontos.app/concepts#Customer', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000014-0000-4000-8000-000000000014', 'http://demo.ontos.app/concepts#Customer', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000015-0000-4000-8000-000000000015', 'http://demo.ontos.app/concepts#Inventory', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000016-0000-4000-8000-000000000016', 'http://demo.ontos.app/concepts#Inventory', 'http://www.w3.org/2000/01/rdf-schema#label', 'Inventory', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000017-0000-4000-8000-000000000017', 'http://demo.ontos.app/concepts#Product', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000018-0000-4000-8000-000000000018', 'http://demo.ontos.app/concepts#Product', 'http://www.w3.org/2000/01/rdf-schema#label', 'Product', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200000f-0000-4000-8000-00000000000f', 'http://demo.ontos.app/concepts#Sale', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000010-0000-4000-8000-000000000010', 'http://demo.ontos.app/concepts#Sale', 'http://www.w3.org/2000/01/rdf-schema#label', 'Sale', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000011-0000-4000-8000-000000000011', 'http://demo.ontos.app/concepts#Transaction', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000012-0000-4000-8000-000000000012', 'http://demo.ontos.app/concepts#Transaction', 'http://www.w3.org/2000/01/rdf-schema#label', 'Transaction', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000013-0000-4000-8000-000000000013', 'http://demo.ontos.app/concepts#Customer', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000014-0000-4000-8000-000000000014', 'http://demo.ontos.app/concepts#Customer', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000015-0000-4000-8000-000000000015', 'http://demo.ontos.app/concepts#Inventory', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000016-0000-4000-8000-000000000016', 'http://demo.ontos.app/concepts#Inventory', 'http://www.w3.org/2000/01/rdf-schema#label', 'Inventory', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000017-0000-4000-8000-000000000017', 'http://demo.ontos.app/concepts#Product', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000018-0000-4000-8000-000000000018', 'http://demo.ontos.app/concepts#Product', 'http://www.w3.org/2000/01/rdf-schema#label', 'Product', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 
 -- Glossary Terms (for Data Contracts and Schemas)
-('02000019-0000-4000-8000-000000000019', 'http://demo.ontos.app/glossary#Customer', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200001a-0000-4000-8000-00000000001a', 'http://demo.ontos.app/glossary#Customer', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200001b-0000-4000-8000-00000000001b', 'http://demo.ontos.app/glossary#PersonalData', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200001c-0000-4000-8000-00000000001c', 'http://demo.ontos.app/glossary#PersonalData', 'http://www.w3.org/2000/01/rdf-schema#label', 'Personal Data', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200001d-0000-4000-8000-00000000001d', 'http://demo.ontos.app/glossary#Product', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200001e-0000-4000-8000-00000000001e', 'http://demo.ontos.app/glossary#Product', 'http://www.w3.org/2000/01/rdf-schema#label', 'Product', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200001f-0000-4000-8000-00000000001f', 'http://demo.ontos.app/glossary#Inventory', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000020-0000-4000-8000-000000000020', 'http://demo.ontos.app/glossary#Inventory', 'http://www.w3.org/2000/01/rdf-schema#label', 'Inventory', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000021-0000-4000-8000-000000000021', 'http://demo.ontos.app/glossary#Device', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000022-0000-4000-8000-000000000022', 'http://demo.ontos.app/glossary#Device', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000023-0000-4000-8000-000000000023', 'http://demo.ontos.app/glossary#Telemetry', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000024-0000-4000-8000-000000000024', 'http://demo.ontos.app/glossary#Telemetry', 'http://www.w3.org/2000/01/rdf-schema#label', 'Telemetry', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000025-0000-4000-8000-000000000025', 'http://demo.ontos.app/glossary#Transaction', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000026-0000-4000-8000-000000000026', 'http://demo.ontos.app/glossary#Transaction', 'http://www.w3.org/2000/01/rdf-schema#label', 'Transaction', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000027-0000-4000-8000-000000000027', 'http://demo.ontos.app/glossary#FinancialRecord', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000028-0000-4000-8000-000000000028', 'http://demo.ontos.app/glossary#FinancialRecord', 'http://www.w3.org/2000/01/rdf-schema#label', 'Financial Record', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000019-0000-4000-8000-000000000019', 'http://demo.ontos.app/glossary#Customer', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200001a-0000-4000-8000-00000000001a', 'http://demo.ontos.app/glossary#Customer', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200001b-0000-4000-8000-00000000001b', 'http://demo.ontos.app/glossary#PersonalData', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200001c-0000-4000-8000-00000000001c', 'http://demo.ontos.app/glossary#PersonalData', 'http://www.w3.org/2000/01/rdf-schema#label', 'Personal Data', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200001d-0000-4000-8000-00000000001d', 'http://demo.ontos.app/glossary#Product', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200001e-0000-4000-8000-00000000001e', 'http://demo.ontos.app/glossary#Product', 'http://www.w3.org/2000/01/rdf-schema#label', 'Product', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200001f-0000-4000-8000-00000000001f', 'http://demo.ontos.app/glossary#Inventory', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000020-0000-4000-8000-000000000020', 'http://demo.ontos.app/glossary#Inventory', 'http://www.w3.org/2000/01/rdf-schema#label', 'Inventory', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000021-0000-4000-8000-000000000021', 'http://demo.ontos.app/glossary#Device', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000022-0000-4000-8000-000000000022', 'http://demo.ontos.app/glossary#Device', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000023-0000-4000-8000-000000000023', 'http://demo.ontos.app/glossary#Telemetry', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000024-0000-4000-8000-000000000024', 'http://demo.ontos.app/glossary#Telemetry', 'http://www.w3.org/2000/01/rdf-schema#label', 'Telemetry', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000025-0000-4000-8000-000000000025', 'http://demo.ontos.app/glossary#Transaction', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000026-0000-4000-8000-000000000026', 'http://demo.ontos.app/glossary#Transaction', 'http://www.w3.org/2000/01/rdf-schema#label', 'Transaction', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000027-0000-4000-8000-000000000027', 'http://demo.ontos.app/glossary#FinancialRecord', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000028-0000-4000-8000-000000000028', 'http://demo.ontos.app/glossary#FinancialRecord', 'http://www.w3.org/2000/01/rdf-schema#label', 'Financial Record', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 
 -- Schema-level glossary terms
-('02000029-0000-4000-8000-000000000029', 'http://demo.ontos.app/glossary#CustomerProfile', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200002a-0000-4000-8000-00000000002a', 'http://demo.ontos.app/glossary#CustomerProfile', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer Profile', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200002b-0000-4000-8000-00000000002b', 'http://demo.ontos.app/glossary#MasterData', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200002c-0000-4000-8000-00000000002c', 'http://demo.ontos.app/glossary#MasterData', 'http://www.w3.org/2000/01/rdf-schema#label', 'Master Data', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200002d-0000-4000-8000-00000000002d', 'http://demo.ontos.app/glossary#CustomerPreference', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200002e-0000-4000-8000-00000000002e', 'http://demo.ontos.app/glossary#CustomerPreference', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer Preference', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200002f-0000-4000-8000-00000000002f', 'http://demo.ontos.app/glossary#Address', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000030-0000-4000-8000-000000000030', 'http://demo.ontos.app/glossary#Address', 'http://www.w3.org/2000/01/rdf-schema#label', 'Address', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000031-0000-4000-8000-000000000031', 'http://demo.ontos.app/glossary#ContactInformation', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000032-0000-4000-8000-000000000032', 'http://demo.ontos.app/glossary#ContactInformation', 'http://www.w3.org/2000/01/rdf-schema#label', 'Contact Information', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000033-0000-4000-8000-000000000033', 'http://demo.ontos.app/glossary#IoTDevice', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000034-0000-4000-8000-000000000034', 'http://demo.ontos.app/glossary#IoTDevice', 'http://www.w3.org/2000/01/rdf-schema#label', 'IoT Device', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000035-0000-4000-8000-000000000035', 'http://demo.ontos.app/glossary#AssetRegistry', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000036-0000-4000-8000-000000000036', 'http://demo.ontos.app/glossary#AssetRegistry', 'http://www.w3.org/2000/01/rdf-schema#label', 'Asset Registry', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000037-0000-4000-8000-000000000037', 'http://demo.ontos.app/glossary#SensorReading', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000038-0000-4000-8000-000000000038', 'http://demo.ontos.app/glossary#SensorReading', 'http://www.w3.org/2000/01/rdf-schema#label', 'Sensor Reading', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000039-0000-4000-8000-000000000039', 'http://demo.ontos.app/glossary#DeviceEvent', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200003a-0000-4000-8000-00000000003a', 'http://demo.ontos.app/glossary#DeviceEvent', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device Event', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200003b-0000-4000-8000-00000000003b', 'http://demo.ontos.app/glossary#Alert', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200003c-0000-4000-8000-00000000003c', 'http://demo.ontos.app/glossary#Alert', 'http://www.w3.org/2000/01/rdf-schema#label', 'Alert', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000029-0000-4000-8000-000000000029', 'http://demo.ontos.app/glossary#CustomerProfile', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200002a-0000-4000-8000-00000000002a', 'http://demo.ontos.app/glossary#CustomerProfile', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer Profile', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200002b-0000-4000-8000-00000000002b', 'http://demo.ontos.app/glossary#MasterData', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200002c-0000-4000-8000-00000000002c', 'http://demo.ontos.app/glossary#MasterData', 'http://www.w3.org/2000/01/rdf-schema#label', 'Master Data', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200002d-0000-4000-8000-00000000002d', 'http://demo.ontos.app/glossary#CustomerPreference', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200002e-0000-4000-8000-00000000002e', 'http://demo.ontos.app/glossary#CustomerPreference', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer Preference', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200002f-0000-4000-8000-00000000002f', 'http://demo.ontos.app/glossary#Address', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000030-0000-4000-8000-000000000030', 'http://demo.ontos.app/glossary#Address', 'http://www.w3.org/2000/01/rdf-schema#label', 'Address', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000031-0000-4000-8000-000000000031', 'http://demo.ontos.app/glossary#ContactInformation', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000032-0000-4000-8000-000000000032', 'http://demo.ontos.app/glossary#ContactInformation', 'http://www.w3.org/2000/01/rdf-schema#label', 'Contact Information', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000033-0000-4000-8000-000000000033', 'http://demo.ontos.app/glossary#IoTDevice', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000034-0000-4000-8000-000000000034', 'http://demo.ontos.app/glossary#IoTDevice', 'http://www.w3.org/2000/01/rdf-schema#label', 'IoT Device', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000035-0000-4000-8000-000000000035', 'http://demo.ontos.app/glossary#AssetRegistry', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000036-0000-4000-8000-000000000036', 'http://demo.ontos.app/glossary#AssetRegistry', 'http://www.w3.org/2000/01/rdf-schema#label', 'Asset Registry', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000037-0000-4000-8000-000000000037', 'http://demo.ontos.app/glossary#SensorReading', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000038-0000-4000-8000-000000000038', 'http://demo.ontos.app/glossary#SensorReading', 'http://www.w3.org/2000/01/rdf-schema#label', 'Sensor Reading', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000039-0000-4000-8000-000000000039', 'http://demo.ontos.app/glossary#DeviceEvent', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200003a-0000-4000-8000-00000000003a', 'http://demo.ontos.app/glossary#DeviceEvent', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device Event', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200003b-0000-4000-8000-00000000003b', 'http://demo.ontos.app/glossary#Alert', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200003c-0000-4000-8000-00000000003c', 'http://demo.ontos.app/glossary#Alert', 'http://www.w3.org/2000/01/rdf-schema#label', 'Alert', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 
 -- Property-level glossary terms
-('0200003d-0000-4000-8000-00000000003d', 'http://demo.ontos.app/glossary#CustomerId', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200003e-0000-4000-8000-00000000003e', 'http://demo.ontos.app/glossary#CustomerId', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer ID', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200003f-0000-4000-8000-00000000003f', 'http://demo.ontos.app/glossary#UniqueIdentifier', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000040-0000-4000-8000-000000000040', 'http://demo.ontos.app/glossary#UniqueIdentifier', 'http://www.w3.org/2000/01/rdf-schema#label', 'Unique Identifier', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000041-0000-4000-8000-000000000041', 'http://demo.ontos.app/glossary#EmailAddress', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000042-0000-4000-8000-000000000042', 'http://demo.ontos.app/glossary#EmailAddress', 'http://www.w3.org/2000/01/rdf-schema#label', 'Email Address', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000043-0000-4000-8000-000000000043', 'http://demo.ontos.app/glossary#PII', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000044-0000-4000-8000-000000000044', 'http://demo.ontos.app/glossary#PII', 'http://www.w3.org/2000/01/rdf-schema#label', 'PII', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000045-0000-4000-8000-000000000045', 'http://demo.ontos.app/glossary#FirstName', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000046-0000-4000-8000-000000000046', 'http://demo.ontos.app/glossary#FirstName', 'http://www.w3.org/2000/01/rdf-schema#label', 'First Name', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000047-0000-4000-8000-000000000047', 'http://demo.ontos.app/glossary#LastName', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000048-0000-4000-8000-000000000048', 'http://demo.ontos.app/glossary#LastName', 'http://www.w3.org/2000/01/rdf-schema#label', 'Last Name', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000049-0000-4000-8000-000000000049', 'http://demo.ontos.app/glossary#DateOfBirth', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200004a-0000-4000-8000-00000000004a', 'http://demo.ontos.app/glossary#DateOfBirth', 'http://www.w3.org/2000/01/rdf-schema#label', 'Date of Birth', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200004b-0000-4000-8000-00000000004b', 'http://demo.ontos.app/glossary#PhoneNumber', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200004c-0000-4000-8000-00000000004c', 'http://demo.ontos.app/glossary#PhoneNumber', 'http://www.w3.org/2000/01/rdf-schema#label', 'Phone Number', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200004d-0000-4000-8000-00000000004d', 'http://demo.ontos.app/glossary#CountryCode', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200004e-0000-4000-8000-00000000004e', 'http://demo.ontos.app/glossary#CountryCode', 'http://www.w3.org/2000/01/rdf-schema#label', 'Country Code', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('0200004f-0000-4000-8000-00000000004f', 'http://demo.ontos.app/glossary#AccountStatus', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000050-0000-4000-8000-000000000050', 'http://demo.ontos.app/glossary#AccountStatus', 'http://www.w3.org/2000/01/rdf-schema#label', 'Account Status', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000051-0000-4000-8000-000000000051', 'http://demo.ontos.app/glossary#DeviceId', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000052-0000-4000-8000-000000000052', 'http://demo.ontos.app/glossary#DeviceId', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device ID', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000053-0000-4000-8000-000000000053', 'http://demo.ontos.app/glossary#DeviceType', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000054-0000-4000-8000-000000000054', 'http://demo.ontos.app/glossary#DeviceType', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device Type', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000055-0000-4000-8000-000000000055', 'http://demo.ontos.app/glossary#DeviceStatus', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
-('02000056-0000-4000-8000-000000000056', 'http://demo.ontos.app/glossary#DeviceStatus', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device Status', false, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200003d-0000-4000-8000-00000000003d', 'http://demo.ontos.app/glossary#CustomerId', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200003e-0000-4000-8000-00000000003e', 'http://demo.ontos.app/glossary#CustomerId', 'http://www.w3.org/2000/01/rdf-schema#label', 'Customer ID', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200003f-0000-4000-8000-00000000003f', 'http://demo.ontos.app/glossary#UniqueIdentifier', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000040-0000-4000-8000-000000000040', 'http://demo.ontos.app/glossary#UniqueIdentifier', 'http://www.w3.org/2000/01/rdf-schema#label', 'Unique Identifier', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000041-0000-4000-8000-000000000041', 'http://demo.ontos.app/glossary#EmailAddress', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000042-0000-4000-8000-000000000042', 'http://demo.ontos.app/glossary#EmailAddress', 'http://www.w3.org/2000/01/rdf-schema#label', 'Email Address', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000043-0000-4000-8000-000000000043', 'http://demo.ontos.app/glossary#PII', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000044-0000-4000-8000-000000000044', 'http://demo.ontos.app/glossary#PII', 'http://www.w3.org/2000/01/rdf-schema#label', 'PII', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000045-0000-4000-8000-000000000045', 'http://demo.ontos.app/glossary#FirstName', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000046-0000-4000-8000-000000000046', 'http://demo.ontos.app/glossary#FirstName', 'http://www.w3.org/2000/01/rdf-schema#label', 'First Name', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000047-0000-4000-8000-000000000047', 'http://demo.ontos.app/glossary#LastName', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000048-0000-4000-8000-000000000048', 'http://demo.ontos.app/glossary#LastName', 'http://www.w3.org/2000/01/rdf-schema#label', 'Last Name', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000049-0000-4000-8000-000000000049', 'http://demo.ontos.app/glossary#DateOfBirth', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200004a-0000-4000-8000-00000000004a', 'http://demo.ontos.app/glossary#DateOfBirth', 'http://www.w3.org/2000/01/rdf-schema#label', 'Date of Birth', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200004b-0000-4000-8000-00000000004b', 'http://demo.ontos.app/glossary#PhoneNumber', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200004c-0000-4000-8000-00000000004c', 'http://demo.ontos.app/glossary#PhoneNumber', 'http://www.w3.org/2000/01/rdf-schema#label', 'Phone Number', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200004d-0000-4000-8000-00000000004d', 'http://demo.ontos.app/glossary#CountryCode', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200004e-0000-4000-8000-00000000004e', 'http://demo.ontos.app/glossary#CountryCode', 'http://www.w3.org/2000/01/rdf-schema#label', 'Country Code', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('0200004f-0000-4000-8000-00000000004f', 'http://demo.ontos.app/glossary#AccountStatus', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000050-0000-4000-8000-000000000050', 'http://demo.ontos.app/glossary#AccountStatus', 'http://www.w3.org/2000/01/rdf-schema#label', 'Account Status', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000051-0000-4000-8000-000000000051', 'http://demo.ontos.app/glossary#DeviceId', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000052-0000-4000-8000-000000000052', 'http://demo.ontos.app/glossary#DeviceId', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device ID', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000053-0000-4000-8000-000000000053', 'http://demo.ontos.app/glossary#DeviceType', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000054-0000-4000-8000-000000000054', 'http://demo.ontos.app/glossary#DeviceType', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device Type', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000055-0000-4000-8000-000000000055', 'http://demo.ontos.app/glossary#DeviceStatus', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2004/02/skos/core#Concept', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
+('02000056-0000-4000-8000-000000000056', 'http://demo.ontos.app/glossary#DeviceStatus', 'http://www.w3.org/2000/01/rdf-schema#label', 'Device Status', false, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 
 -- Hierarchy Relationships (skos:broader) - Business Concepts under their Domains
 -- Sale -> SalesDomain
-('02000101-0000-4000-8000-000000000101', 'http://demo.ontos.app/concepts#Sale', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#SalesDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000101-0000-4000-8000-000000000101', 'http://demo.ontos.app/concepts#Sale', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#SalesDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Transaction -> FinancialDomain
-('02000102-0000-4000-8000-000000000102', 'http://demo.ontos.app/concepts#Transaction', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#FinancialDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000102-0000-4000-8000-000000000102', 'http://demo.ontos.app/concepts#Transaction', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#FinancialDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Customer -> CustomerDomain
-('02000103-0000-4000-8000-000000000103', 'http://demo.ontos.app/concepts#Customer', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#CustomerDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000103-0000-4000-8000-000000000103', 'http://demo.ontos.app/concepts#Customer', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#CustomerDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Inventory -> ProductDomain
-('02000104-0000-4000-8000-000000000104', 'http://demo.ontos.app/concepts#Inventory', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#ProductDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000104-0000-4000-8000-000000000104', 'http://demo.ontos.app/concepts#Inventory', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#ProductDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Product -> ProductDomain
-('02000105-0000-4000-8000-000000000105', 'http://demo.ontos.app/concepts#Product', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#ProductDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000105-0000-4000-8000-000000000105', 'http://demo.ontos.app/concepts#Product', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#ProductDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 
 -- Glossary Terms under their parent concepts/domains
 -- Customer glossary term -> Customer concept
-('02000111-0000-4000-8000-000000000111', 'http://demo.ontos.app/glossary#Customer', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Customer', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000111-0000-4000-8000-000000000111', 'http://demo.ontos.app/glossary#Customer', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Customer', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- PersonalData -> CustomerDomain
-('02000112-0000-4000-8000-000000000112', 'http://demo.ontos.app/glossary#PersonalData', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#CustomerDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000112-0000-4000-8000-000000000112', 'http://demo.ontos.app/glossary#PersonalData', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#CustomerDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Product glossary term -> Product concept
-('02000113-0000-4000-8000-000000000113', 'http://demo.ontos.app/glossary#Product', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Product', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000113-0000-4000-8000-000000000113', 'http://demo.ontos.app/glossary#Product', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Product', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Inventory glossary term -> Inventory concept
-('02000114-0000-4000-8000-000000000114', 'http://demo.ontos.app/glossary#Inventory', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Inventory', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000114-0000-4000-8000-000000000114', 'http://demo.ontos.app/glossary#Inventory', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Inventory', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Device -> ProductDomain
-('02000115-0000-4000-8000-000000000115', 'http://demo.ontos.app/glossary#Device', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#ProductDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000115-0000-4000-8000-000000000115', 'http://demo.ontos.app/glossary#Device', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#ProductDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Telemetry -> Device
-('02000116-0000-4000-8000-000000000116', 'http://demo.ontos.app/glossary#Telemetry', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000116-0000-4000-8000-000000000116', 'http://demo.ontos.app/glossary#Telemetry', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Transaction glossary term -> Transaction concept
-('02000117-0000-4000-8000-000000000117', 'http://demo.ontos.app/glossary#Transaction', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Transaction', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000117-0000-4000-8000-000000000117', 'http://demo.ontos.app/glossary#Transaction', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#Transaction', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- FinancialRecord -> FinancialDomain
-('02000118-0000-4000-8000-000000000118', 'http://demo.ontos.app/glossary#FinancialRecord', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#FinancialDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000118-0000-4000-8000-000000000118', 'http://demo.ontos.app/glossary#FinancialRecord', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#FinancialDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- CustomerProfile -> Customer glossary
-('02000119-0000-4000-8000-000000000119', 'http://demo.ontos.app/glossary#CustomerProfile', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Customer', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000119-0000-4000-8000-000000000119', 'http://demo.ontos.app/glossary#CustomerProfile', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Customer', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- MasterData -> CustomerDomain
-('0200011a-0000-4000-8000-00000000011a', 'http://demo.ontos.app/glossary#MasterData', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#CustomerDomain', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200011a-0000-4000-8000-00000000011a', 'http://demo.ontos.app/glossary#MasterData', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/concepts#CustomerDomain', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- CustomerPreference -> CustomerProfile
-('0200011b-0000-4000-8000-00000000011b', 'http://demo.ontos.app/glossary#CustomerPreference', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#CustomerProfile', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200011b-0000-4000-8000-00000000011b', 'http://demo.ontos.app/glossary#CustomerPreference', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#CustomerProfile', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Address -> CustomerProfile
-('0200011c-0000-4000-8000-00000000011c', 'http://demo.ontos.app/glossary#Address', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#CustomerProfile', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200011c-0000-4000-8000-00000000011c', 'http://demo.ontos.app/glossary#Address', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#CustomerProfile', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- ContactInformation -> CustomerProfile
-('0200011d-0000-4000-8000-00000000011d', 'http://demo.ontos.app/glossary#ContactInformation', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#CustomerProfile', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200011d-0000-4000-8000-00000000011d', 'http://demo.ontos.app/glossary#ContactInformation', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#CustomerProfile', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- IoTDevice -> Device
-('0200011e-0000-4000-8000-00000000011e', 'http://demo.ontos.app/glossary#IoTDevice', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200011e-0000-4000-8000-00000000011e', 'http://demo.ontos.app/glossary#IoTDevice', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- AssetRegistry -> Device
-('0200011f-0000-4000-8000-00000000011f', 'http://demo.ontos.app/glossary#AssetRegistry', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200011f-0000-4000-8000-00000000011f', 'http://demo.ontos.app/glossary#AssetRegistry', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- SensorReading -> Telemetry
-('02000120-0000-4000-8000-000000000120', 'http://demo.ontos.app/glossary#SensorReading', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Telemetry', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000120-0000-4000-8000-000000000120', 'http://demo.ontos.app/glossary#SensorReading', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Telemetry', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- DeviceEvent -> Telemetry
-('02000121-0000-4000-8000-000000000121', 'http://demo.ontos.app/glossary#DeviceEvent', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Telemetry', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000121-0000-4000-8000-000000000121', 'http://demo.ontos.app/glossary#DeviceEvent', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Telemetry', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- Alert -> DeviceEvent
-('02000122-0000-4000-8000-000000000122', 'http://demo.ontos.app/glossary#Alert', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#DeviceEvent', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000122-0000-4000-8000-000000000122', 'http://demo.ontos.app/glossary#Alert', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#DeviceEvent', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- CustomerId -> Customer glossary
-('02000123-0000-4000-8000-000000000123', 'http://demo.ontos.app/glossary#CustomerId', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Customer', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000123-0000-4000-8000-000000000123', 'http://demo.ontos.app/glossary#CustomerId', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Customer', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- UniqueIdentifier -> MasterData
-('02000124-0000-4000-8000-000000000124', 'http://demo.ontos.app/glossary#UniqueIdentifier', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#MasterData', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000124-0000-4000-8000-000000000124', 'http://demo.ontos.app/glossary#UniqueIdentifier', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#MasterData', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- EmailAddress -> ContactInformation
-('02000125-0000-4000-8000-000000000125', 'http://demo.ontos.app/glossary#EmailAddress', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#ContactInformation', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000125-0000-4000-8000-000000000125', 'http://demo.ontos.app/glossary#EmailAddress', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#ContactInformation', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- PII -> PersonalData
-('02000126-0000-4000-8000-000000000126', 'http://demo.ontos.app/glossary#PII', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PersonalData', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000126-0000-4000-8000-000000000126', 'http://demo.ontos.app/glossary#PII', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PersonalData', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- FirstName -> PII
-('02000127-0000-4000-8000-000000000127', 'http://demo.ontos.app/glossary#FirstName', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PII', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000127-0000-4000-8000-000000000127', 'http://demo.ontos.app/glossary#FirstName', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PII', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- LastName -> PII
-('02000128-0000-4000-8000-000000000128', 'http://demo.ontos.app/glossary#LastName', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PII', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000128-0000-4000-8000-000000000128', 'http://demo.ontos.app/glossary#LastName', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PII', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- DateOfBirth -> PII
-('02000129-0000-4000-8000-000000000129', 'http://demo.ontos.app/glossary#DateOfBirth', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PII', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('02000129-0000-4000-8000-000000000129', 'http://demo.ontos.app/glossary#DateOfBirth', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#PII', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- PhoneNumber -> ContactInformation
-('0200012a-0000-4000-8000-00000000012a', 'http://demo.ontos.app/glossary#PhoneNumber', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#ContactInformation', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200012a-0000-4000-8000-00000000012a', 'http://demo.ontos.app/glossary#PhoneNumber', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#ContactInformation', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- CountryCode -> Address
-('0200012b-0000-4000-8000-00000000012b', 'http://demo.ontos.app/glossary#CountryCode', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Address', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200012b-0000-4000-8000-00000000012b', 'http://demo.ontos.app/glossary#CountryCode', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Address', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- AccountStatus -> Customer glossary
-('0200012c-0000-4000-8000-00000000012c', 'http://demo.ontos.app/glossary#AccountStatus', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Customer', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200012c-0000-4000-8000-00000000012c', 'http://demo.ontos.app/glossary#AccountStatus', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Customer', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- DeviceId -> Device
-('0200012d-0000-4000-8000-00000000012d', 'http://demo.ontos.app/glossary#DeviceId', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200012d-0000-4000-8000-00000000012d', 'http://demo.ontos.app/glossary#DeviceId', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- DeviceType -> Device
-('0200012e-0000-4000-8000-00000000012e', 'http://demo.ontos.app/glossary#DeviceType', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW()),
+('0200012e-0000-4000-8000-00000000012e', 'http://demo.ontos.app/glossary#DeviceType', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW()),
 -- DeviceStatus -> Device
-('0200012f-0000-4000-8000-00000000012f', 'http://demo.ontos.app/glossary#DeviceStatus', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data.sql', 'system@demo', NOW())
+('0200012f-0000-4000-8000-00000000012f', 'http://demo.ontos.app/glossary#DeviceStatus', 'http://www.w3.org/2004/02/skos/core#broader', 'http://demo.ontos.app/glossary#Device', true, 'urn:demo', 'demo', 'demo_data_retail.sql', 'system@demo', NOW())
 
 ON CONFLICT (id) DO NOTHING;
 
@@ -765,7 +769,11 @@ INSERT INTO rdf_triples (id, subject_uri, predicate_uri, object_value, object_is
 ('03000048-0000-4000-8000-000000000048', 'urn:glossary:finance-domain', 'http://ontos.app/ontology#isEditable', 'true', false, 'urn:meta:sources', 'collection', 'urn:glossary:finance-domain', 'system@demo', NOW()),
 ('03000049-0000-4000-8000-000000000049', 'urn:glossary:finance-domain', 'http://ontos.app/ontology#status', 'active', false, 'urn:meta:sources', 'collection', 'urn:glossary:finance-domain', 'system@demo', NOW())
 
-ON CONFLICT (id) DO NOTHING;
+-- The application bootstraps a baseline of urn:meta:sources collection metadata
+-- at startup with random UUIDs, so this idempotent demo block must defer to the
+-- logical (subject_uri, predicate_uri, object_value, ..., context_name) unique
+-- constraint instead of just the (id) primary key.
+ON CONFLICT DO NOTHING;
 
 
 -- ============================================================================
@@ -2052,27 +2060,27 @@ ON CONFLICT (id) DO NOTHING;
 -- ============================================================================
 -- Named roles that can be assigned as ownership roles across all object types.
 
-INSERT INTO business_roles (id, name, description, category, is_system, status, created_by, created_at, updated_at) VALUES
+INSERT INTO business_roles (id, name, description, category, is_system, is_approver, status, created_by, created_at, updated_at) VALUES
 -- Governance roles
-('0f000001-0000-4000-8000-000000000001', 'Data Owner',           'Accountable for the quality, integrity, and lifecycle of a data asset or product.',                     'governance',   true,  'active', 'system@demo', NOW(), NOW()),
-('0f000002-0000-4000-8000-000000000002', 'Domain Owner',         'Responsible for all data products and standards within a data domain.',                                'governance',   true,  'active', 'system@demo', NOW(), NOW()),
-('0f000003-0000-4000-8000-000000000003', 'Data Steward',         'Maintains metadata quality, enforces governance policies, and resolves data issues.',                   'governance',   true,  'active', 'system@demo', NOW(), NOW()),
-('0f000004-0000-4000-8000-000000000004', 'Business Term Owner',  'Defines and maintains business glossary terms and their relationships.',                               'governance',   true,  'active', 'system@demo', NOW(), NOW()),
+('0f000001-0000-4000-8000-000000000001', 'Data Owner',           'Accountable for the quality, integrity, and lifecycle of a data asset or product.',                     'governance',   true,  true,  'active', 'system@demo', NOW(), NOW()),
+('0f000002-0000-4000-8000-000000000002', 'Domain Owner',         'Responsible for all data products and standards within a data domain.',                                'governance',   true,  true,  'active', 'system@demo', NOW(), NOW()),
+('0f000003-0000-4000-8000-000000000003', 'Data Steward',         'Maintains metadata quality, enforces governance policies, and resolves data issues.',                   'governance',   true,  true,  'active', 'system@demo', NOW(), NOW()),
+('0f000004-0000-4000-8000-000000000004', 'Business Term Owner',  'Defines and maintains business glossary terms and their relationships.',                               'governance',   true,  false, 'active', 'system@demo', NOW(), NOW()),
 
 -- Technical roles
-('0f000005-0000-4000-8000-000000000005', 'Technical Owner',      'Responsible for the technical implementation, pipelines, and infrastructure of a data product.',        'technical',    true,  'active', 'system@demo', NOW(), NOW()),
-('0f000006-0000-4000-8000-000000000006', 'Pipeline Owner',       'Owns and operates the ETL/ELT pipelines that produce or transform data.',                              'technical',    false, 'active', 'system@demo', NOW(), NOW()),
+('0f000005-0000-4000-8000-000000000005', 'Technical Owner',      'Responsible for the technical implementation, pipelines, and infrastructure of a data product.',        'technical',    true,  true,  'active', 'system@demo', NOW(), NOW()),
+('0f000006-0000-4000-8000-000000000006', 'Pipeline Owner',       'Owns and operates the ETL/ELT pipelines that produce or transform data.',                              'technical',    false, false, 'active', 'system@demo', NOW(), NOW()),
 
 -- Business roles
-('0f000007-0000-4000-8000-000000000007', 'Business Sponsor',     'Executive or senior stakeholder sponsoring a data product or initiative.',                              'business',     true,  'active', 'system@demo', NOW(), NOW()),
-('0f000008-0000-4000-8000-000000000008', 'Subject Matter Expert','Provides domain expertise for defining schemas, quality rules, and business logic.',                    'business',     false, 'active', 'system@demo', NOW(), NOW()),
+('0f000007-0000-4000-8000-000000000007', 'Business Sponsor',     'Executive or senior stakeholder sponsoring a data product or initiative.',                              'business',     true,  true,  'active', 'system@demo', NOW(), NOW()),
+('0f000008-0000-4000-8000-000000000008', 'Subject Matter Expert','Provides domain expertise for defining schemas, quality rules, and business logic.',                    'business',     false, false, 'active', 'system@demo', NOW(), NOW()),
 
 -- Operational roles
-('0f000009-0000-4000-8000-000000000009', 'SLA Manager',          'Monitors and enforces service-level agreements for data products.',                                    'operational',  false, 'active', 'system@demo', NOW(), NOW()),
-('0f00000a-0000-4000-8000-000000000010', 'Compliance Officer',   'Ensures data products and assets comply with regulatory and internal policies.',                       'operational',  true,  'active', 'system@demo', NOW(), NOW()),
+('0f000009-0000-4000-8000-000000000009', 'SLA Manager',          'Monitors and enforces service-level agreements for data products.',                                    'operational',  false, false, 'active', 'system@demo', NOW(), NOW()),
+('0f00000a-0000-4000-8000-000000000010', 'Compliance Officer',   'Ensures data products and assets comply with regulatory and internal policies.',                       'operational',  true,  true,  'active', 'system@demo', NOW(), NOW()),
 
 -- Deprecated example
-('0f00000b-0000-4000-8000-000000000011', 'Data Custodian',       'Legacy role replaced by Data Steward. Kept for historical ownership records.',                         'governance',   false, 'deprecated', 'system@demo', NOW(), NOW())
+('0f00000b-0000-4000-8000-000000000011', 'Data Custodian',       'Legacy role replaced by Data Steward. Kept for historical ownership records.',                         'governance',   false, false, 'deprecated', 'system@demo', NOW(), NOW())
 
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/routes/compliance_routes.py
+++ b/src/backend/src/routes/compliance_routes.py
@@ -26,8 +26,8 @@ FEATURE_ID = 'compliance'
 
 
 # DEPRECATED: Demo data loading has been moved to SQL-based approach.
-# Demo data is now loaded via POST /api/settings/demo-data/load
-# The demo data SQL file is located at: src/backend/src/data/demo_data.sql
+# Demo data is now loaded via POST /api/settings/demo-data/load?preset=<retail|hls|fsi|mfg|auto>.
+# Each preset is a self-contained file: src/backend/src/data/demo_data_{preset}.sql.
 
 
 @router.get("/compliance/policies")

--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -376,6 +376,10 @@ async def handle_role_request_decision(
 
 # --- Demo Data Loading ---
 
+# Allowed presets — one self-contained SQL file per preset.
+DEMO_DATA_PRESETS = ("retail", "hls", "fsi", "mfg", "auto")
+
+
 @router.post("/settings/demo-data/load", status_code=status.HTTP_200_OK)
 async def load_demo_data(
     request: Request,
@@ -384,116 +388,116 @@ async def load_demo_data(
     audit_manager: AuditManagerDep,
     current_user: AuditCurrentUserDep,
     manager: SettingsManager = Depends(get_settings_manager),
-    industry: Optional[List[str]] = Query(
-        default=None,
-        description="Optional industry-specific demo data to load (e.g. 'hls', 'fsi', 'mfg', 'auto'). "
-                    "Loads demo_data_{industry}.sql in addition to the base demo_data.sql. "
-                    "Pass multiple values to load several industries.",
+    preset: str = Query(
+        default="retail",
+        description=(
+            "Demo preset to load. Each preset is a fully self-contained vertical demo "
+            "(no implicit content from other packs). Allowed values: "
+            f"{', '.join(DEMO_DATA_PRESETS)}. Defaults to 'retail'."
+        ),
     ),
 ):
     """
-    Load demo data from SQL file(s) into the database.
-    
-    Always loads the base `demo_data.sql`. When one or more `industry` query
-    parameters are supplied, the corresponding `demo_data_{industry}.sql`
-    files are loaded afterwards (additive overlay).
-    
-    Example: POST /api/settings/demo-data/load?industry=hls&industry=fsi
-    
-    The SQL uses ON CONFLICT DO NOTHING to avoid duplicate key errors on re-runs.
+    Load a single demo preset from its self-contained SQL file.
+
+    Each preset maps to exactly one SQL file (`demo_data_{preset}.sql`) and is
+    designed to be loaded standalone on an empty database. Loading a preset does
+    not pull in content from any other preset.
+
+    Example: POST /api/settings/demo-data/load?preset=hls
+
+    The SQL uses ON CONFLICT DO NOTHING to make re-runs and clear+reload safe.
     """
     success = False
-    details: Dict[str, Any] = {"action": "load_demo_data", "industries": industry or []}
-    
+    preset_slug = (preset or "").strip().lower()
+    details: Dict[str, Any] = {"action": "load_demo_data", "preset": preset_slug}
+
+    if preset_slug not in DEMO_DATA_PRESETS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Invalid preset '{preset}'. Allowed values: "
+                f"{', '.join(DEMO_DATA_PRESETS)}."
+            ),
+        )
+
     try:
         from pathlib import Path
         from sqlalchemy import text
-        import re
-        
+
         data_dir = Path(__file__).parent.parent / "data"
-        
-        # Build ordered list of SQL files: base first, then per-industry
-        sql_files: List[Path] = [data_dir / "demo_data.sql"]
-        if industry:
-            for ind in industry:
-                slug = re.sub(r'[^a-z0-9_]', '', ind.lower())
-                if not slug:
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=f"Invalid industry identifier: '{ind}'",
-                    )
-                sql_files.append(data_dir / f"demo_data_{slug}.sql")
-        
-        # Validate all files exist before executing anything
-        for sql_file in sql_files:
-            if not sql_file.exists():
-                details["exception"] = f"{sql_file.name} not found"
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Demo data SQL file not found: {sql_file.name}",
-                )
-        
+        sql_file: Path = data_dir / f"demo_data_{preset_slug}.sql"
+
+        if not sql_file.exists():
+            details["exception"] = f"{sql_file.name} not found"
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Demo data SQL file not found: {sql_file.name}",
+            )
+
         connection = db.connection()
-        total_executed = 0
-        file_results: List[Dict[str, Any]] = []
-        
-        for sql_file in sql_files:
-            sql_content = sql_file.read_text(encoding="utf-8")
-            
-            statements = []
-            current_statement = []
-            in_dollar_quote = False
-            
-            for line in sql_content.split('\n'):
-                stripped = line.strip()
-                
-                if not stripped or stripped.startswith('--'):
-                    if current_statement:
-                        current_statement.append(line)
-                    continue
-                
-                if "E'" in line or "$$" in line:
-                    in_dollar_quote = not in_dollar_quote if "$$" in line else in_dollar_quote
-                
-                current_statement.append(line)
-                
-                if stripped.endswith(';') and not in_dollar_quote:
-                    full_statement = '\n'.join(current_statement).strip()
-                    if full_statement and not full_statement.startswith('--'):
-                        if full_statement.upper() not in ('BEGIN;', 'COMMIT;'):
-                            statements.append(full_statement)
-                    current_statement = []
-            
-            executed_count = 0
-            for stmt in statements:
-                if stmt.strip():
-                    try:
-                        nested = connection.begin_nested()
-                        connection.execute(text(stmt))
-                        nested.commit()
-                        executed_count += 1
-                    except Exception as stmt_error:
-                        nested.rollback()
-                        logger.warning(f"Statement execution warning ({sql_file.name}): {stmt_error}")
-            
-            total_executed += executed_count
-            file_results.append({"file": sql_file.name, "statements_executed": executed_count})
-        
+        sql_content = sql_file.read_text(encoding="utf-8")
+
+        statements = []
+        current_statement = []
+        in_dollar_quote = False
+
+        for line in sql_content.split('\n'):
+            stripped = line.strip()
+
+            if not stripped or stripped.startswith('--'):
+                if current_statement:
+                    current_statement.append(line)
+                continue
+
+            if "E'" in line or "$$" in line:
+                in_dollar_quote = not in_dollar_quote if "$$" in line else in_dollar_quote
+
+            current_statement.append(line)
+
+            if stripped.endswith(';') and not in_dollar_quote:
+                full_statement = '\n'.join(current_statement).strip()
+                if full_statement and not full_statement.startswith('--'):
+                    if full_statement.upper() not in ('BEGIN;', 'COMMIT;'):
+                        statements.append(full_statement)
+                current_statement = []
+
+        executed_count = 0
+        for stmt in statements:
+            if stmt.strip():
+                try:
+                    nested = connection.begin_nested()
+                    connection.execute(text(stmt))
+                    nested.commit()
+                    executed_count += 1
+                except Exception as stmt_error:
+                    nested.rollback()
+                    logger.warning(
+                        f"Statement execution warning ({sql_file.name}): {stmt_error}"
+                    )
+
         db.commit()
-        
+
         success = True
-        details["statements_executed"] = total_executed
-        details["files"] = file_results
-        
-        logger.info(f"Demo data loaded successfully. Executed {total_executed} statements across {len(sql_files)} file(s).")
-        
+        details["statements_executed"] = executed_count
+        details["file"] = sql_file.name
+
+        logger.info(
+            f"Demo data loaded successfully. Preset='{preset_slug}', "
+            f"file='{sql_file.name}', statements={executed_count}."
+        )
+
         return {
             "status": "success",
-            "message": f"Demo data loaded successfully. Executed {total_executed} SQL statements across {len(sql_files)} file(s).",
-            "statements_executed": total_executed,
-            "files": file_results,
+            "message": (
+                f"Demo data loaded successfully (preset='{preset_slug}'). "
+                f"Executed {executed_count} SQL statements from {sql_file.name}."
+            ),
+            "preset": preset_slug,
+            "file": sql_file.name,
+            "statements_executed": executed_count,
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -540,8 +544,11 @@ async def clear_demo_data(
         from sqlalchemy import text
         
         # Delete in reverse dependency order
-        # UUID patterns use type codes in first 3 hex chars (see demo_data.sql for mapping)
-        # Pattern: {type:3}{seq:5}-0000-4000-8000-...
+        # UUID patterns use type codes in first 3 hex chars (see demo_data_retail.sql for mapping)
+        # Pattern: {type:3}{seq:5}-{dataset:4}-4000-8000-...
+        # Dataset segments: 0000=retail, 0001=hls, 0002=fsi, 0003=mfg, 0004=auto.
+        # The LIKE patterns below match by type-code prefix only, so they remove rows
+        # from every preset (the dataset segment is in chars 9-12, not the prefix).
         delete_statements = [
             # Suggested quality checks (02e%) - before data_profiling_runs
             "DELETE FROM suggested_quality_checks WHERE id::text LIKE '02e%'",
@@ -600,12 +607,31 @@ async def clear_demo_data(
             # Dataset assets (021%) — migrated from datasets table
             "DELETE FROM assets WHERE id::text LIKE '021%'",
             
+            # Policy assets (0f1%)
+            "DELETE FROM assets WHERE id::text LIKE '0f1%'",
+            # General catalog assets (0f3%) — Tables, Views, Dashboards, Streams,
+            # Patient Cohorts, ICSR cases, etc. (covers all preset packs).
+            "DELETE FROM assets WHERE id::text LIKE '0f3%'",
+            # Column assets (0f5%)
+            "DELETE FROM assets WHERE id::text LIKE '0f5%'",
             # Business Term assets (0f7%)
             "DELETE FROM assets WHERE id::text LIKE '0f7%'",
             # Logical Entity/Attribute assets (0f8%)
             "DELETE FROM assets WHERE id::text LIKE '0f8%'",
             # Delivery Channel assets (0f9%)
             "DELETE FROM assets WHERE id::text LIKE '0f9%'",
+            # Business Owners — must be removed before business_roles because
+            # of the role_id FK. Retail uses the legacy 0f6% prefix; the
+            # vertical packs (hls/fsi/mfg/auto) use 0fb%.
+            "DELETE FROM business_owners WHERE id::text LIKE '0f6%'",
+            "DELETE FROM business_owners WHERE id::text LIKE '0fb%'",
+            # Vertical-specific asset types (0f2%, demo-only, is_system=false)
+            "DELETE FROM asset_types WHERE id::text LIKE '0f2%' AND is_system = false AND created_by = 'system@demo'",
+            # Demo-inserted business_roles and delivery_methods (0f0%, 0f4%).
+            # Use created_by to avoid touching app-seeded reference rows that
+            # other features may depend on.
+            "DELETE FROM business_roles WHERE id::text LIKE '0f0%' AND created_by = 'system@demo'",
+            "DELETE FROM delivery_methods WHERE id::text LIKE '0f4%' AND created_by = 'system@demo'",
             
             # Legacy: dataset instances (025) and datasets (021) (if old tables still exist)
             "DELETE FROM dataset_instances WHERE id::text LIKE '025%'",
@@ -674,27 +700,67 @@ async def clear_demo_data(
             "DELETE FROM data_domains WHERE id::text LIKE '000%'",
         ]
         
-        deleted_counts = {}
+        # Run each DELETE in its own savepoint so a single failure (e.g. legacy
+        # tables that no longer exist) cannot poison the outer transaction and
+        # silently skip subsequent DELETEs.
+        connection = db.connection()
+        deleted_counts: Dict[str, int] = {}
+        skipped: List[Dict[str, str]] = []
+        # Tables that are expected to be missing on clean installs (legacy
+        # tables retained for backward-compat clears). Failures on these are
+        # reduced to debug log to keep the response clean.
+        legacy_tables = {
+            "dataset_subscriptions",
+            "dataset_custom_properties",
+            "dataset_instances",
+            "datasets",
+        }
         for stmt in delete_statements:
+            table_name = stmt.split("FROM ")[1].split(" ")[0]
             try:
-                result = db.execute(text(stmt))
-                table_name = stmt.split("FROM ")[1].split(" ")[0]
-                deleted_counts[table_name] = result.rowcount
+                nested = connection.begin_nested()
+                result = connection.execute(text(stmt))
+                nested.commit()
+                rowcount = result.rowcount or 0
+                # Only report tables that actually had rows removed; aggregate
+                # multi-statement deletes for the same table.
+                if rowcount > 0:
+                    deleted_counts[table_name] = deleted_counts.get(table_name, 0) + rowcount
             except Exception as e:
-                logger.warning(f"Delete statement warning: {e}")
-        
+                try:
+                    nested.rollback()
+                except Exception:
+                    pass
+                err_short = str(e).splitlines()[0][:200]
+                if table_name in legacy_tables and "does not exist" in str(e):
+                    logger.debug(f"Legacy table absent ({table_name}): {err_short}")
+                else:
+                    # Real failure (FK violation, schema drift, etc.) — surface it
+                    # both in the log and in the API response so it cannot hide.
+                    logger.warning(
+                        f"Delete statement FAILED ({table_name}): {err_short} | stmt={stmt}"
+                    )
+                    skipped.append({
+                        "table": table_name,
+                        "statement": stmt,
+                        "error": err_short,
+                    })
+
         db.commit()
-        
+
         success = True
         details["deleted_counts"] = deleted_counts
-        
+        details["skipped"] = skipped
+
         total_deleted = sum(deleted_counts.values())
-        logger.info(f"Demo data cleared. Deleted {total_deleted} records.")
-        
+        skipped_msg = f", {len(skipped)} statements skipped" if skipped else ""
+        logger.info(f"Demo data cleared. Deleted {total_deleted} records{skipped_msg}.")
+
         return {
-            "status": "success",
-            "message": f"Demo data cleared. Deleted {total_deleted} records.",
-            "deleted_counts": deleted_counts
+            "status": "success" if not skipped else "partial",
+            "message": f"Demo data cleared. Deleted {total_deleted} records{skipped_msg}.",
+            "deleted_counts": deleted_counts,
+            "skipped": skipped,
         }
         
     except Exception as e:

--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -72,7 +72,7 @@ from src.connectors.bigquery import BigQueryConnector
 logger = get_logger(__name__)
 
 # Demo data SQL file path
-DEMO_DATA_SQL_FILE = Path(__file__).parent.parent / "data" / "demo_data.sql"
+DEMO_DATA_SQL_FILE = Path(__file__).parent.parent / "data" / "demo_data_retail.sql"
 
 
 def load_demo_data_from_sql() -> bool:
@@ -437,8 +437,13 @@ async def startup_event_handler(app: FastAPI):
     """
     Application startup event handler.
     
-    Note: Demo data is loaded on-demand via POST /api/settings/demo-data/load
-    The demo data SQL file is located at: src/backend/src/data/demo_data.sql
+    Note: Demo data is loaded on-demand via POST /api/settings/demo-data/load.
+    Each preset is a standalone self-contained demo pack:
+        - retail (default): src/backend/src/data/demo_data_retail.sql
+        - hls:               src/backend/src/data/demo_data_hls.sql
+        - fsi:               src/backend/src/data/demo_data_fsi.sql
+        - mfg:               src/backend/src/data/demo_data_mfg.sql
+        - auto:              src/backend/src/data/demo_data_auto.sql
     """
     logger.info("Executing application startup event handler...")
     try:


### PR DESCRIPTION
## Summary

Replace the implicit "retail base + optional industry overlay" model with five fully self-contained demo packs, one per vertical, loaded via a single `preset` parameter.

- Renamed `demo_data.sql` → `demo_data_retail.sql` (default preset).
- API now takes a single preset param: `POST /api/settings/demo-data/load?preset=<retail|hls|fsi|mfg|auto>`. No more implicit "base + overlay" layering.
- Each vertical pack (`hls`, `fsi`, `mfg`, `auto`) is standalone — own data domains, business roles, delivery methods, vertical asset types, tag namespaces+tags, RDF concepts, semantic links, workflows, assets, lineage, owners, ratings, compliance runs+results, cost items, subscriptions.
- Hardened `DELETE /api/settings/demo-data`:
  - Each DELETE runs in its own savepoint so legacy-table absence cannot poison the outer transaction.
  - Real failures now surface in the response under a `skipped` array (status becomes `partial`); legacy-table absences are demoted to debug log.
  - Added missing UUID prefix patterns: `0f1%`/`0f3%`/`0f5%` (assets), `0f6%`/`0fb%` (`business_owners`), and demo-only filtered deletes for `business_roles`, `delivery_methods`, vertical `asset_types` via `created_by='system@demo'`.
- Fixed retail RDF collection-metadata block: switched from `ON CONFLICT (id)` to bare `ON CONFLICT DO NOTHING` so logical-key collisions with app-bootstrapped `urn:meta:sources` collection metadata no longer abort the INSERT batch.

## Why

Loading `hls`/`fsi`/`mfg`/`auto` previously required retail to be loaded first (or at minimum produced confusing mixed data, e.g. "POS Transaction Stream" appearing after loading HLS on an empty DB). Verticals diverge meaningfully on foundational/reference data, so a shared retail base was the wrong abstraction.

## API change

| Before | After |
| --- | --- |
| `POST /api/settings/demo-data/load` (implicit retail) and optional industry overlays | `POST /api/settings/demo-data/load?preset=<name>` — exactly one self-contained file |

The `preset` parameter defaults to `retail`, so existing scripts continue to work.

## Verification

- Cycle `clear → load → clear` for all 5 presets via REST: every preset loads standalone with **bleed=0** and clears with **skipped=0**.
- 3× repeat retail load+clear is idempotent (907 records cleared each cycle).
- Backend log inspected during the cycle — **no warnings or errors**.

| Preset | Stmts | Domains | Products | Assets |
| --- | --- | --- | --- | --- |
| retail | 63 | 13 | 7 | 78 |
| hls | 39 | 6 (+2 shared) | 5 | 8 |
| fsi | 39 | 6 (+1 shared) | 5 | 8 |
| mfg | 39 | 6 (+2 shared) | 5 | 8 |
| auto | 39 | 6 (+1 shared) | 5 | 8 |

## Test plan

- [ ] Pull branch, restart backend, hit `POST /api/settings/demo-data/load?preset=retail` then `DELETE /api/settings/demo-data` → confirm clean wipe (no `skipped` entries in response).
- [ ] Repeat for `hls`, `fsi`, `mfg`, `auto` on an empty DB — each should load standalone (no retail bleed in the UI).
- [ ] Inspect Asset Explorer / Data Products / Glossary / Workflows / Tags for each preset — content should be vertical-flavored.
- [ ] Tail `/tmp/backend.log` during load+clear cycles — confirm no `Statement execution warning` lines.

## Notes

- Vertical packs are intentionally lighter than retail (8 assets / 5 products vs. 78 / 7) — they're "one of each kind" demos, expandable later.
- Documentation updated: `docs/Ontos Setup.md` (preset table), `STRUCTURE.md`, banner comments in `app.py` / `compliance_routes.py`, `startup_tasks.py` docstrings, and all 5 SQL file headers.