### PR TITLE
docs(prds): add batch of PRDs for upcoming features

### DIFF
--- a/docs/prds/prd-approval-workflows-v2.md
+++ b/docs/prds/prd-approval-workflows-v2.md
@@ -1,0 +1,178 @@
+# PRD: Approval Workflows v2 — Step Catalog, Snapshot, PDF & Delivery
+
+## Problem Statement
+
+Approval Workflows are wizard-driven, multi-step flows that guide a user through giving consent for an action (subscribing to a data product, accepting a contract, requesting access). Today the wizard works, but it has three gaps that block real-world, legally-meaningful use:
+
+1. **The step catalog is too generic.** The only interactive step type is a free-form `user_action` with optional required fields, `requires_input`, and `minimum_input_length`. There is no first-class way to model the things an approval flow actually needs: showing a legal document and requiring acknowledgement, presenting a checklist of explicit consents (e.g. "Accept PII usage"), naming co-signers, or running non-visual side effects like generating a PDF and delivering it. Workflow designers end up wedging everything into `user_action` payloads, which is fragile and gives users an inconsistent experience.
+
+2. **Workflows are mutable while sessions are in flight.** The wizard reads `workflow.steps` live every time a user advances. If an admin reorders, renames, or tightens a workflow while a user is mid-session, the user's experience breaks (or worse, silently changes). After completion, the agreement record only stores `step_results` and a `workflow_id` — if the workflow is later edited or deleted, there is no faithful record of what the user actually agreed to. For an artifact that may be the basis of a legal contract, this is unacceptable.
+
+3. **PDF generation and delivery are partial and implicit.** A `generate_pdf` step exists but its output handling is hardcoded; there is no first-class "deliver the agreement" step that uses the notification channels (`in_app`, `email`, `webhook`) the rest of the system already supports. Designers cannot configure where the signed contract goes.
+
+## Solution
+
+Introduce a dedicated **approval-mode step catalog** in the workflow designer, an **immutable workflow snapshot** persisted on every wizard session and agreement, and **first-class non-visual steps** for persisting the agreement, generating a PDF, and delivering it through the existing notification channels.
+
+The workflow designer's toolbox becomes context-aware: when editing an approval-mode workflow, only approval-relevant steps are offered; when editing a process-mode workflow, today's catalog (validation, approval, notification, assign-tag, etc.) is shown. The Approval Wizard dialog renders each step using a step-type-specific UI component, with a uniform header (title + markdown description) so designers can give every step clear context for the signing user.
+
+The snapshot is captured once when the wizard session is created and copied verbatim onto the agreement on completion. From that point on, the wizard runtime, PDF builder, and any audit view read from the snapshot, never from the live workflow definition. Existing in-flight sessions and historical agreements remain readable via a NULL-tolerant fallback to the live workflow.
+
+## User Stories
+
+1. As a workflow designer, I want the designer toolbox to show approval-specific step types when I am editing an approval workflow, so that I am not distracted by process automation steps that do not apply.
+2. As a workflow designer, I want every visual step to have a `title` and a markdown `description`, so that the wizard shows the signing user clear context at every step without me building it into the field labels.
+3. As a workflow designer, I want a `legal_document` step where I paste markdown for a legal text, optionally require the user to scroll to the end, and optionally require an acknowledgement checkbox, so that I can model "read this and confirm" interactions cleanly.
+4. As a workflow designer, I want an `acknowledgement_checklist` step with one or more labeled checkboxes (e.g. "I accept usage of PII data", "I will not redistribute"), each markable as required, so that I can capture explicit, itemized consents.
+5. As a workflow designer, I want a `co_signers` step that lets the signer name additional principals (users or groups) by email/name, with configurable min/max counts, so that I can capture co-ownership of an agreement when an enterprise requires more than one signer on record.
+6. As a workflow designer, I want a `persist_agreement` non-visual step that materializes the agreement record at the position I place it, so that I can decide whether persistence happens before or after PDF generation and delivery.
+7. As a workflow designer, I want a `generate_pdf` non-visual step with a configurable storage destination (Databricks volume path, or no storage), so that the signed contract can be archived where my organization requires.
+8. As a workflow designer, I want a `deliver` non-visual step where I choose channels (`in_app`, `email`, `webhook`) and recipients (signer, co-signers, entity owner, literal email/group), so that the signed agreement reaches the right people through the right channel.
+9. As a signing user, I want each wizard step to show me a clear title and an informational paragraph above the controls, so that I know what I am being asked to do.
+10. As a signing user, I want non-visual steps to show a brief "Processing…" tile and auto-advance, so that the wizard does not present me with empty pages.
+11. As a signing user, I want the wizard to refuse to advance if a required checkbox is unchecked, a required field is empty, or I have not scrolled to the end of a legal document that requires it, so that I cannot accidentally consent to something I did not see.
+12. As a signing user, I want the wizard I started to remain stable even if an admin edits the underlying workflow definition while I am in the middle of it, so that my flow does not break or change unexpectedly.
+13. As an auditor, I want every signed agreement to include a faithful, immutable copy of the workflow steps as they were at the moment of signing, so that I can reconstruct exactly what the signer was asked and what they answered.
+14. As an auditor, I want the agreement PDF to be generated from the snapshot, not from the current workflow definition, so that the PDF is always consistent with what the user actually saw.
+15. As a data product owner, I want to be notified through my chosen channels when a consumer signs a subscription agreement on my product, so that I can react in a timely fashion without polling the system.
+16. As a data consumer, I want to receive an email with the PDF attachment after I sign an agreement, so that I have my own copy of what I agreed to.
+17. As an admin, I want the default Subscription workflow shipped with the product to demonstrate the new step types end-to-end (legal document → acknowledgement checklist → optional co-signers → persist → PDF → deliver), so that I have a working template to clone and adapt.
+18. As an admin, I want existing `user_action`-based workflows (the current Subscription and Approval Response defaults) to continue working unchanged, so that the upgrade does not require me to rebuild every workflow on day one.
+19. As an admin, I want a single Alembic migration to add the snapshot columns, with NULL-tolerant fallback to live workflow definitions, so that deployments are zero-downtime and historical agreements remain readable.
+20. As a workflow designer, I want a hard cap on the number of items in an `acknowledgement_checklist` step (e.g. ten), so that the wizard remains visually manageable on a single screen.
+21. As a workflow designer, I want the `co_signers` step to be record-only — naming the principals on the agreement without launching a separate counter-signature flow — so that the model stays simple and the original signer's session completes synchronously.
+22. As a signing user, I want the wizard heading to clearly label the current step's purpose (e.g. "Acceptable Use Acknowledgement"), so that I understand what I am consenting to at a glance.
+23. As an auditor, I want the agreement record to also store the workflow's name and version at signing time, so that I can identify which template was used without re-deriving it from the snapshot.
+24. As a workflow designer, I want each step type's configuration to be driven by a JSON schema served from the backend, so that the designer's properties panel renders the right form for each step type without bespoke per-type frontend code.
+25. As a developer extending the system, I want adding a new approval step type to require only (a) registering a `StepTypeSchema`, (b) adding a server-side validator, and (c) adding a frontend renderer, so that the step catalog is genuinely extensible.
+
+## Implementation Decisions
+
+### Step Catalog (Visual)
+
+All visual steps share a common header:
+
+- `title` (string) — rendered as the wizard step heading. Falls back to `step.name` if absent.
+- `description` (markdown string) — rendered as the informational paragraph below the heading.
+
+The catalog adds the following visual step types alongside the existing `user_action`:
+
+- **`legal_document`** — renders a markdown body. Configurable: `body_markdown`, `require_scroll_to_end` (boolean), `require_acknowledgement_checkbox` (boolean), `acknowledgement_label` (string). Validation: scroll-completion (frontend-tracked, sent in payload as a boolean) and/or checkbox checked, per config.
+- **`acknowledgement_checklist`** — renders one or more labeled checkboxes. Configurable: `items: [{ id, label, required }]` with a hard cap of ten items per step. Validation: every required item checked.
+- **`co_signers`** — renders a principal picker (badge-with-X, free-text email or group name in v1). Configurable: `min_count`, `max_count`, `principal_type` (`user` | `group` | `either`), `label`. Stored on the agreement as a named list. **Record-only**: no asynchronous counter-signature flow is launched; the original signer completes the wizard immediately.
+- **`user_action`** (existing) — kept unchanged for backward compatibility with the current Subscription and Approval Response defaults.
+
+### Step Catalog (Non-Visual)
+
+Non-visual steps execute server-side at the moment the wizard reaches them. The wizard UI shows a brief "Processing…" tile and auto-advances on success, propagating server errors as toast notifications.
+
+- **`persist_agreement`** — explicit step that materializes the agreement record. Today this is implicit at end-of-wizard; making it an explicit step lets the designer position it (for example, before or after PDF/delivery). When omitted from a workflow, the runtime persists the agreement implicitly at end-of-wizard, preserving today's behavior.
+- **`generate_pdf`** — generates a PDF rendition of the agreement from the snapshot and accumulated step results. Configurable: `template_id` (optional, default = built-in template), `storage` (`volume` | `none`), `volume_path` (when `storage=volume`). Side effect: sets `pdf_storage_path` on the agreement.
+- **`deliver`** — sends the agreement summary (and PDF link/attachment when present) through one or more channels. Configurable: `channels: ['in_app' | 'email' | 'webhook']`, `recipients` (an array drawn from `signer`, `co_signers`, `entity_owner`, or literal `<email>`/`<group_name>` strings), `subject_template`, `body_template`. Reuses the channel resolver and per-channel handlers already present in the workflow executor.
+
+### Workflow Snapshot
+
+Two new columns are added to both the agreement wizard sessions table and the agreements table:
+
+- `workflow_snapshot` (Text, JSON-serialized) — array of step objects shaped `{ step_id, name, step_type, config, on_pass, on_fail, order }`.
+- `workflow_name` (String, nullable) — captured for display/audit without rejoining `process_workflows`.
+
+The snapshot is captured once when the session is created and copied verbatim into the agreement when the session completes. Once written it is never modified.
+
+The wizard runtime resolves steps by reading the snapshot first and falling back to the live workflow definition only when the snapshot is NULL. This guarantees backward compatibility for in-flight sessions during the deploy window and for any agreements created before the migration.
+
+The PDF builder reads exclusively from the snapshot.
+
+### Designer Changes
+
+- The toolbox in the workflow designer is filtered by the workflow's `workflow_type`. In approval mode the palette shows: `legal_document`, `acknowledgement_checklist`, `co_signers`, `user_action`, `persist_agreement`, `generate_pdf`, `deliver`, `pass`, `fail`. In process mode today's catalog is unchanged.
+- Each new step type gets a React Flow node component with an icon and theme color registered in the designer's label/icon constants.
+- The properties panel renders a generic `title` / `description` block for any visual step, and a per-step config form driven by the `config_schema` returned from the backend's step-type-schemas endpoint.
+- The default node fallback already added in the previous iteration remains, so any future or unknown step type renders as a labeled placeholder rather than an empty box.
+
+### Wizard UI Changes
+
+The Approval Wizard dialog dispatches on `step_type` to render:
+
+- `legal_document` — scrollable markdown container with an IntersectionObserver sentinel at the bottom that flips a `scrolled_to_end` boolean in local state; an optional acknowledgement checkbox below.
+- `acknowledgement_checklist` — list of checkbox controls bound to `items[].id`.
+- `co_signers` — badge-with-X principal picker; free-text input validated as email or group name.
+- `user_action` — existing renderer.
+- `persist_agreement`, `generate_pdf`, `deliver` — auto-submitting "Processing…" tile.
+
+The step heading uses `config.title || step.name`. The help text uses `config.description` rendered as markdown. The "Next" button is disabled until the step's frontend validation passes; the backend revalidates on submit.
+
+### Backend Surface
+
+- New `StepType` enum values and `StepTypeSchema` entries in the workflows manager. Schemas are served by the existing step-type-schemas route.
+- Per-step validators in the agreement wizard manager, dispatched from `submit_step` based on `step_type`.
+- Snapshot read/write helpers on the wizard sessions and agreements repositories.
+- A delivery handler that resolves recipients (signer / co-signers / entity owner / literal) and dispatches to the existing per-channel notification code paths, without going through the full process-workflow executor.
+
+### API Contract
+
+The existing approval session endpoints (`POST /api/approvals/sessions`, `GET /api/approvals/sessions/{id}`, `POST /api/approvals/sessions/{id}/steps`, `POST /api/approvals/sessions/{id}/abort`) are unchanged in shape. The `current_step` payload already carries `step_type` and `config`; the new step types simply use new `step_type` values and richer `config` objects.
+
+### Migration
+
+A single Alembic migration revising the current head adds `workflow_snapshot` and `workflow_name` to both `agreement_wizard_sessions` and `agreements`. No data backfill is performed; the NULL-tolerant fallback covers historical rows.
+
+### Default Workflows
+
+The shipped Subscription default in the YAML is rewritten to demonstrate the new catalog end-to-end:
+
+`legal_document` (Acceptable Use) → `acknowledgement_checklist` (PII / Redistribution / Retention) → `co_signers` (optional, max 0 by default) → `persist_agreement` → `generate_pdf` (volume) → `deliver` (in_app + email).
+
+The Approval Response default keeps `user_action` for backward compatibility but adds an explicit `title` and `description` to demonstrate the header convention.
+
+### Backward Compatibility
+
+- The `user_action` step type stays in both backend and frontend.
+- Existing workflows without `workflow_snapshot` continue to run via the live-workflow fallback.
+- Workflows without an explicit `persist_agreement` step still get an implicit agreement at end-of-wizard.
+- The session and agreement API contracts do not change.
+
+## Testing Decisions
+
+Tests verify external behavior through the public interfaces (manager methods, route handlers, wizard dialog interactions). They do not assert on internal implementation details.
+
+### Backend (pytest)
+
+- **Snapshot capture and immutability**: creating a session captures the snapshot; editing the workflow afterwards does not change the session's view; completing the session copies the snapshot to the agreement.
+- **Snapshot fallback**: a session with `workflow_snapshot = NULL` resolves steps from the live workflow definition.
+- **Per-step validators**: one happy-path and one rejection-path test for each new visual step type (`legal_document` scroll-and-checkbox, `acknowledgement_checklist` required items, `co_signers` count bounds and principal-type validation).
+- **`persist_agreement` placement**: explicit-step and implicit-end-of-wizard paths both yield exactly one agreement record per session.
+- **PDF from snapshot**: the PDF builder produces output even when the underlying workflow is deleted between session creation and PDF generation.
+- **Delivery dispatch**: `deliver` resolves `signer`, `co_signers`, `entity_owner`, and literal recipients to the right channel handlers; channel selection respects the `channels` config.
+
+Prior art: existing wizard manager tests in the backend test suite, plus the workflow notification channels test for channel dispatch patterns.
+
+### Frontend
+
+- **Wizard dispatch**: the dialog renders the correct component for each `step_type` and disables "Next" until validation passes.
+- **Legal document scroll detection**: the sentinel observer flips the validation flag when scrolled to the bottom.
+- **Checklist**: required items block "Next"; optional items do not.
+- **Co-signers picker**: enforces min/max and validates principal entries.
+
+Prior art: existing wizard dialog tests for `user_action`.
+
+### End-to-End
+
+The existing Subscribe-via-marketplace happy path is updated to walk the rewritten Subscription workflow end-to-end and assert that an agreement is created, a PDF is stored, and the signer receives an in-app notification.
+
+## Out of Scope
+
+- **Asynchronous counter-signature** by co-signers. The `co_signers` step is record-only by decision; a future PRD can layer a counter-signature flow on top.
+- **SCIM / directory autocomplete** for the co-signers principal picker. v1 uses free-text input with validation. The Slack / Teams notification channels (only the channels already present in the workflow executor are wired up).
+- **WYSIWYG markdown editor** for the legal document body. v1 uses a plain markdown textarea with a preview toggle if cheap, or no preview otherwise.
+- **Versioned workflow definitions** beyond the snapshot. The snapshot is the audit unit; full workflow versioning with diff/history is a separate feature.
+- **Per-user / per-tenant overrides** of default workflows.
+- **Importing legal documents from external sources** (URL, file upload). The step takes inline markdown.
+- **Conditional branching** within an approval workflow beyond the existing `on_pass` / `on_fail` mechanics. Approval flows in v1 are linear.
+
+## Further Notes
+
+- The snapshot also doubles as the contractual basis for the PDF; the PDF render is therefore deterministic with respect to a given session/agreement, which is exactly the property an auditor or legal team needs.
+- Adopting `title` / `description` uniformly on visual steps is what unlocks a consistent wizard UX without per-step bespoke layout work, and makes future step types cheap to add.
+- Reusing the existing notification channel resolver from the workflow executor for the `deliver` step keeps a single source of truth for channel handling and respects whatever future channels (Slack, Teams) get added there.
+- The hard cap of ten items per `acknowledgement_checklist` step is ergonomic, not technical; designers needing more should split into multiple steps to keep each screen scannable.

--- a/docs/prds/prd-cdm-vertical-onboarding.md
+++ b/docs/prds/prd-cdm-vertical-onboarding.md
@@ -1,0 +1,94 @@
+# PRD: CDM / vertical onboarding helpers (e.g. telco)
+
+> **Feature request — feedback wanted.** This document is meant to be pasted into a GitHub issue (or linked from one) so maintainers and users can comment on scope, priorities, and real-world CDM sources. Please comment with: your industry, how you represent CDM today (UC only, MDM tool, spreadsheets), and whether you need in-app wizards, jobs-only automation, or file-based packs first.
+
+## Problem Statement
+
+Telco and other Customer Data Management (CDM)–heavy organizations need a **governed business catalog** view of customer data: core entities (Customer, Account, Subscription, Product, Interaction, Invoice, Consent, etc.), links to physical tables and data products, and governance metadata (ownership, quality, PII/consent context, process notes such as match/merge or survivorship). Ontos already supports much of this through Unity Catalog, semantic models, data products, glossaries/concepts, quality items, and relationships—but **onboarding is fragmented**. Customers must discover and combine UC tag–based bulk import, YAML/JSON batch data products, RDF/taxonomy import, asset bulk import (CSV/XLSX), and schema import without a **guided, repeatable path** tailored to CDM. That raises time-to-value and makes certification (readiness) harder.
+
+## Solution
+
+Introduce a **CDM / vertical onboarding** capability that **composes existing primitives** rather than replacing them:
+
+1. **Vertical packs** (telco first, others later): starter semantic content (concepts/relationships), recommended UC tag patterns for domains/products/contracts, optional batch data product templates, and a **readiness checklist** (e.g. unlinked concepts, missing owners, assets without products).
+2. **Guided onboarding** (UI and/or documented job flow): steps such as choose vertical → apply or import ontology pack → configure or confirm UC discovery patterns → preview/dry-run → execute sync → surface gaps and next actions.
+3. **Optional structured seed** (scope TBD): a single documented **entity catalog** CSV/JSON format to bootstrap concepts and external system references, avoiding one-off connectors for every MDM vendor in v1.
+
+Access control, masking, and row-level security remain **Unity Catalog’s responsibility**; Ontos surfaces and documents policy context alongside business metadata.
+
+## User Stories
+
+1. As a **data governance lead**, I want a **clear onboarding entry point** for the customer/CDM domain, so that my team does not have to hunt for every import feature separately.
+2. As a **governance lead**, I want **recommended UC tag conventions** aligned to the pack, so that bulk import from UC stays consistent across teams.
+3. As a **platform admin**, I want to **run or schedule** UC-oriented bulk import with sensible defaults for CDM, so that new tagged assets appear in Ontos reliably.
+4. As a **semantic modeler**, I want a **starter ontology** for telco customer entities, so that we do not start from an empty graph.
+5. As a **semantic modeler**, I want to **import or extend** that pack using existing RDF/Turtle or industry-ontology flows, so that we stay aligned with current Ontos capabilities.
+6. As a **data product owner**, I want **templated batch creation** of core products (e.g. Customer 360, Subscription 360), so that ownership, SLAs, and descriptions stay consistent.
+7. As a **data product owner**, I want **concepts linked to UC-backed assets** after onboarding, so that discovery is business-first.
+8. As a **data steward**, I want **prompted slots** for CDM process documentation (match/merge, survivorship, enrichment), so that curated tables are explainable in the catalog.
+9. As a **compliance stakeholder**, I want **PII, consent, and purpose** visible in the same journey as products and terms, so that usage rules are not divorced from the dataset list.
+10. As a **downstream analyst**, I want to **find certified customer-domain products** via search and hierarchy, so that I use trusted assets.
+11. As an **implementer**, I want a **readiness report** after onboarding, so that we know what still blocks certification.
+12. As an **implementer**, I want **dry-run or preview** before applying bulk changes, so that we avoid accidental catalog pollution.
+13. As a **vendor or partner**, I want the design to support **additional vertical packs** without forking the app, so that utilities, insurance, or retail can reuse the same mechanism.
+14. As an **admin**, I want **auditable onboarding actions**, so that enterprise change-control requirements are met.
+15. As an **operator**, I want **idempotent** imports and clear conflict behavior, so that retries are safe.
+16. As a **power user**, I want **documented escape hatches** to raw APIs (YAML products, RDF upload, asset CSV), so that automation is not limited to the wizard.
+17. As a **migrator with a legacy MDM export**, I want a **minimal, documented interchange** (optional), so that we can seed metadata without full vendor API support in v1.
+18. As a **product owner**, I want **feedback hooks** (what worked, what was missing), so that packs and wizards improve over time.
+
+## Implementation Decisions
+
+### Composition over new core engines
+
+Reuse UC bulk import workflows, `DataProductsManager` batch YAML/JSON, semantic model / collection RDF import, asset bulk import, and schema import where applicable. New code should favor **orchestration, pack metadata, and UI** over duplicate validation or persistence paths.
+
+### Vertical packs as data, not scattered conditionals
+
+Packs bundle: ontology fragments or import instructions, default tag patterns, optional product YAML templates, readiness rule definitions, and user-facing copy. Packs are versioned and selectable.
+
+### Wizard vs job-only
+
+Initial delivery may be **documentation + job parameters + pack files** before a full UI wizard, or the reverse—product decision. Backend contracts should allow both (same pack resolved server-side).
+
+### MDM / external interchange
+
+If included, v1 targets **one** optional CSV/JSON schema for “entity catalog” (name, description, external system, identifier type, optional parent entity)—not native APIs to each MDM vendor unless explicitly added later.
+
+### Readiness
+
+Either extend existing readiness-style checks or add CDM-specific rules driven by pack configuration; avoid one-off hard-coded checks per customer.
+
+### Security and limits
+
+File uploads for packs or entity catalogs follow existing patterns: size limits, permission checks, audit logging for mutations.
+
+## Testing Decisions
+
+### Philosophy
+
+Tests assert **observable outcomes**: created/updated products, import summaries, linked concepts, readiness flags, permission denials—not wizard implementation details.
+
+### Suggested coverage
+
+- Pack loading and validation (missing files, bad version).
+- Preset tag patterns produce expected discovery configuration (unit level where logic is pure).
+- Idempotent second run behavior aligned with existing conflict strategies.
+- Dry-run/preview returns stable diff without committing when supported.
+
+### Prior art
+
+Existing tests around bulk import, batch data product upload, and route-level integration for file uploads and permissions.
+
+## Out of Scope
+
+- **Executing** MDM match-merge, survivorship, or golden-record computation inside Ontos.
+- Replacing Unity Catalog for **enforcement** of access, masking, or row filters (documentation and links only).
+- Native real-time sync from every operational CRM or CDP.
+- Unlimited vendor-specific MDM API connectors in v1 unless explicitly rescoped.
+
+## Further Notes
+
+- **Marketplace positioning**: CDM in a business catalog aligns with Ontos as a Unity Catalog–native business catalog; packs make that story operational for vertical GTM.
+- **Open questions for comments**: (1) MVP: wizard-only, jobs + docs only, or both? (2) Is telco-only v1 acceptable or must v1 be vertical-agnostic with telco as the first pack? (3) Is a minimal MDM CSV in v1 essential or defer to v2?
+- **Using this doc**: Create a GitHub issue titled e.g. *Feature: CDM / vertical onboarding helpers*, paste the Problem + Solution + Open questions, and link to this file in the repo for the full PRD.

--- a/docs/prds/prd-comments-audience-and-mentions.md
+++ b/docs/prds/prd-comments-audience-and-mentions.md
@@ -1,0 +1,99 @@
+# PRD: Comment audience (roles & owner) and @-mention notifications
+
+## Problem Statement
+
+Comment authors cannot reliably reach the right readers. The audience picker on a comment lists role choices that do not behave like roles do everywhere else in the product, and there is no way to address the owners of the entity being discussed. As a result, authors target a "role" but the intended people never see the comment, and conversations meant for owners get sent into the void or broadcast too widely.
+
+There is also no first-class way to call out an individual in the body of a comment. Authors paste names or emails into prose and hope the right person notices. They want the same `@` convention they use in other collaboration tools, with a notification on the receiving end.
+
+## Solution
+
+Bring comment audience in line with the rest of the product:
+
+- The role list comes from the same source the workflow designer uses (canonical app roles with stable identifiers).
+- A new `Owner` audience option resolves at read time to the entity's currently assigned business owner(s).
+- The server decides "is this reader in the audience?" using the same role logic that drives feature permissions, not a narrower team-override signal.
+- Audience tokens already in the database keep working unchanged.
+
+Add `@`-mentions to comment bodies:
+
+- Typing `@` opens an inline picker scoped to plausible candidates (members of teams on the current project), with a free-form email fallback when the right person is not in the list.
+- Saving a comment fans out one in-app notification per distinct mentioned user (excluding the author).
+- Mentions never bypass entity access. Notifications carry minimal context and a deep link; whether the recipient can open the entity is governed by the existing access rules.
+
+## User Stories
+
+1. As a comment author, I see the same role list in the comment audience picker that I see in the workflow designer (with the same labels and "no groups" hint), so the two surfaces stay consistent.
+2. As a comment author, I can pick one or more roles for the audience, and only people whose effective app role matches receive the comment in their timeline.
+3. As an admin renaming a role in settings, comments previously targeted at that role still reach the right people because the audience stores a stable role identifier.
+4. As a Data Producer whose groups map to a producer role, comments addressed to that role appear in my timeline regardless of any team-level role override I happen to carry.
+5. As an admin testing the app via the existing role override, role-based audience visibility follows the override, mirroring how feature permissions already behave.
+6. As a user with no matching role, role-scoped comments stay out of my timeline.
+7. As a comment author, I can pick `Owner` as an audience, and the entity's current owners receive the comment without me having to look up their emails.
+8. As an entity owner, comments addressed to `Owner` appear in my timeline when I open the entity; when I am no longer owner, future owner-scoped comments stop reaching me.
+9. As a non-owner, owner-only comments are hidden from me unless an existing rule (such as admin) already lets me see all comments on the entity.
+10. As a comment author on an entity with no assigned owner, picking `Owner` is allowed but the UI tells me the comment will reach no one specifically and that owners assigned later will see it.
+11. As a comment author, I can combine teams, roles, and `Owner` in one audience to address, for example, "this squad and the Data Steward role and the entity owners."
+12. As a project member, leaving the audience empty keeps today's behaviour: anyone with access to the entity in the current project context can see the comment.
+13. As a comment author, when I edit a comment my previously chosen teams, roles, owner flag, and mentions are preselected so I can adjust without rebuilding the audience.
+14. As a timeline reader, audience chips show human-readable labels (role name, team name, `Owner`) regardless of which token shape the comment was stored in.
+15. As a comment author writing the body, typing `@` opens a picker filtered by the people on my current project's teams; selecting one inserts a recognisable mention into the text.
+16. As a comment author, when the person I want to tag is not in the picker, I can type their full email address after `@` and it is treated as a mention.
+17. As a comment author, mentioning the same person twice in one comment yields exactly one notification for that person.
+18. As a comment author, mentioning myself does not generate a notification for me.
+19. As a mentioned user, I receive an in-app notification titled in a way that tells me I was mentioned, names the entity, and links me to it.
+20. As a mentioned user who does not have access to the entity, the notification still arrives but contains no excerpt of the comment body, only the entity reference and the fact that I was mentioned; the link returns the standard access-denied page if I follow it.
+21. As an editor of a comment, only newly added mentions trigger notifications on save; people who were already mentioned in the previous version are not re-notified.
+22. As a timeline reader, mentioned identities in the rendered comment body are visually distinct from surrounding text so I can scan long threads.
+23. As a keyboard user, I can open the `@` picker, navigate, and confirm a selection without using the mouse.
+24. As a support engineer, when notification creation fails for a mention, the failure is logged with enough context to diagnose without writing the comment body or recipient identifiers in clear text into long-lived logs.
+
+## Implementation Decisions
+
+### Modules touched
+
+- **Comment list/timeline read path** (route, manager, repository): change the inputs the manager passes for visibility evaluation; extend the OR-clauses the repository builds for audience matching.
+- **Comment composer and timeline UI** (sidebar variant and embedded variant): switch the role source, add the owner option, render new badges, hydrate edit form. The two existing variants share enough logic that the audience option loading and badge rendering are extracted to a small shared hook/component to prevent drift.
+- **Notification fan-out on comment write** (comment route or manager, depending on where transactional commit lives today): parse mentions, deduplicate, exclude author, call the existing notifications manager once per recipient.
+- **Optional mention-candidates endpoint**: only added if the project teams payload the UI already loads does not expose member emails; otherwise the UI builds the candidate list client-side.
+
+### Audience model
+
+- Audience remains a list of opaque string tokens stored against the comment. New token literals: `role_id:<uuid>` and `owner`. Existing literals (`team:<id>`, `role:<name>`, plain group names, `user:<email>`) keep working as a read-side fallback. New writes prefer `role_id:` over `role:`.
+- "User matches a role audience" is decided server-side by the union of: roles whose assigned groups intersect the user's groups (case-insensitive, the same calculation the permissions stack already uses), plus the user's currently applied role override if any. Team-level role overrides may contribute additional matches but never replace the group-derived set.
+- "User matches `owner`" is decided by looking up active business owners for the comment's `entity_type`/`entity_id` and checking the reader's email against that list. Owner lookup happens once per list call and is reused across rows.
+
+### @-mention model
+
+- The wire format inside the comment body is the literal email surrounded by an `@` prefix and word boundaries (e.g. `@jane.doe@company.com`). The server uses a single regex to extract candidates and validates each against an email shape. No structured marker is stored; this keeps the field plain text and avoids a migration.
+- Notification payload contains: title ("You were mentioned"), entity type and entity name (where derivable cheaply), a deep link if the product already has a stable URL pattern for that entity type, and—only if the recipient passes the same access check the comment list endpoint uses—a short excerpt. Otherwise no excerpt.
+- On update, the manager diffs the mention set against the previous version and notifies only added recipients. Removed mentions do not produce a notification.
+
+### Compatibility and migration
+
+- No schema migration. All new behaviour is additive on top of the existing audience JSON column and notifications table.
+- A one-time backfill rewriting `role:<name>` into `role_id:<uuid>` is explicitly out of scope; the read path handles both indefinitely.
+
+## Testing Decisions
+
+- **Audience resolution** is covered by manager-level tests that set up: users with defined group→role mappings, an active business-owner assignment, and stored comments with various audience token shapes (legacy `role:`, new `role_id:`, `team:`, `owner`, `user:`, plain group, mixed). Assertions are on the set of comment IDs returned, not on SQL.
+- **Mention fan-out** is covered by route or manager tests that post a comment containing zero, one, several, and duplicate mentions, with the notifications manager replaced by a spy/fake. Assertions are on the count and recipient set of notifications created. Update tests assert the diff behaviour.
+- **Backwards compatibility** is asserted by seeding pre-existing comments with legacy tokens and confirming the same readers see them after the change.
+- Frontend changes are covered by component tests around the composer's audience hydration on edit and the `@` picker's keyboard navigation. Visual regression is not in scope.
+- Prior art: existing comment manager/repository tests and existing notification tests already mock the notifications dependency; new tests follow that pattern.
+
+## Out of Scope
+
+- Workspace-wide user directory search (SCIM-style lookup across the whole workspace).
+- Email, Slack, Teams, or webhook delivery of mention notifications. In-app only.
+- Rich-text comments, threading/replies, reactions, or real-time presence.
+- Backfill rewriting legacy audience tokens to the new identifier format.
+- Changing which users may author, edit, or moderate comments.
+- Mentioning roles, teams, or groups via `@` (audience picker covers that).
+- Localisation of new strings beyond following whatever pattern the comment composer already uses today.
+
+## Further Notes
+
+- The product decision on mentions to users without entity access is to **notify with minimal payload, no body excerpt, link still rendered**. This keeps the social signal working without leaking content. Security review can flip this to "suppress" before launch if needed; the manager exposes the check as a single function so the policy is one line of code.
+- The `Owner` audience does not currently include role-typed business owners as a separate concept; it resolves to the email list of all active assignments for the entity. If a future audience needs "owners of role X," that is an additive token (`owner_role:<role_id>`) and not part of this PRD.
+- Performance: the additional owner lookup is one query per timeline call (cached for the request), and audience matching adds OR-clauses bounded by the number of roles the user holds. No new indexes are anticipated; revisit if a single entity ever holds tens of thousands of comments.

--- a/docs/prds/prd-configurable-maturity-levels.md
+++ b/docs/prds/prd-configurable-maturity-levels.md
@@ -1,0 +1,133 @@
+# PRD: Configurable Data Product Maturity Levels
+
+## Problem Statement
+
+Data governance teams need a way to measure and communicate how "mature" a Data Product or Data Contract is -- not just whether it's active or certified, but how complete its metadata, documentation, lineage, quality monitoring, and governance practices are. Today, a hardcoded "Production Readiness" panel on the Data Product detail page checks six fixed criteria (ODPS metadata, output contracts, logical attribute mappings, business terms, upstream systems, delivery channels), but this is insufficient:
+
+1. The checks are hardcoded in Python -- admins cannot add, remove, or reorder them.
+2. It only applies to Data Products (not Data Contracts).
+3. There are no levels -- just a binary "ready / not ready / partial" outcome.
+4. There is no history -- the check is computed fresh on every page load with no trending.
+5. It does not account for key governance signals like certification, tagging, naming conventions, or active quality monitoring.
+
+Organizations typically define a multi-level maturity model (e.g., five levels: Accessible, Described, Defined, Monitored, Trusted), where each level requires specific governance criteria to be met. The current system cannot express this.
+
+## Solution
+
+Introduce **Maturity** as a configurable, fourth orthogonal lifecycle dimension alongside Status, Certification, and Publication. Admins define an ordered set of maturity levels per entity type (Data Products and Data Contracts independently). Each level is gated by one or more compliance policies (using the existing compliance DSL). An entity's maturity level is the highest level whose required gates all pass, evaluated cumulatively (level N requires all levels 1..N-1 to also pass).
+
+Maturity is evaluated automatically on entity changes, periodically via a Databricks background job, and manually on demand. Every evaluation persists a timestamped snapshot, enabling maturity progression tracking over time. Level changes fire a process workflow trigger (`ON_MATURITY_CHANGE`), allowing admins to wire up notifications, approvals, or any other workflow steps.
+
+The existing Production Readiness panel is replaced by a richer Maturity Panel that shows per-level gate results, the current maturity badge, and a historical progression indicator.
+
+## User Stories
+
+1. As a **Data Governance lead**, I want to define a multi-level maturity model for Data Products (e.g., Accessible, Described, Defined, Monitored, Trusted), so that product owners have a clear ladder of governance completeness to climb.
+2. As a **Data Governance lead**, I want to define a separate maturity model for Data Contracts, so that contract-specific criteria (schema completeness, SLA definitions, quality rules) are evaluated independently from product criteria.
+3. As an **Admin**, I want to create, edit, reorder, and delete maturity levels in the Settings UI, so that our maturity model can evolve as our governance practices mature.
+4. As an **Admin**, I want to assign one or more compliance policies as gates for each maturity level, so that level promotion is based on objective, auditable criteria.
+5. As an **Admin**, I want to mark individual gates as "required" or "advisory", so that advisory gates produce warnings but do not block level achievement.
+6. As an **Admin**, I want to reuse existing compliance policies as maturity gates, so that I do not have to duplicate rule definitions.
+7. As a **Data Product owner**, I want to see my product's current maturity level on the detail page, so that I know where it stands in the governance ladder.
+8. As a **Data Product owner**, I want to see which gates passed and which failed at each maturity level, so that I know exactly what to fix to reach the next level.
+9. As a **Data Product owner**, I want to click "Re-evaluate" to get a fresh maturity assessment, so that I can check progress after making changes.
+10. As a **Data Contract owner**, I want to see my contract's maturity level and gate results on the contract detail page, so that I have the same visibility as product owners.
+11. As a **Data Consumer**, I want to see a maturity badge on Data Products in the marketplace, so that I can gauge governance quality before subscribing.
+12. As a **Data Consumer**, I want to filter marketplace products by minimum maturity level, so that I can find only well-governed data products.
+13. As a **Data Governance lead**, I want maturity to be re-evaluated automatically when an entity is saved or its status changes, so that the maturity level stays current without manual intervention.
+14. As a **Data Governance lead**, I want a periodic background job to re-evaluate maturity for all products and contracts, so that maturity stays accurate even when upstream conditions change (e.g., a quality monitor is disabled).
+15. As a **Data Governance lead**, I want maturity level changes to fire a process workflow trigger, so that I can configure notifications, Slack messages, or approval workflows when maturity regresses or advances.
+16. As a **Data Governance lead**, I want to see maturity progression over time (historical snapshots), so that I can report on governance improvements across the organization.
+17. As an **Admin**, I want deletion of a maturity level to be blocked when entities have snapshots referencing it, so that historical data is not orphaned.
+18. As a **Data Product owner**, I want the maturity evaluation to consider my certification level (e.g., "certified at Silver or above"), so that certification is a signal the maturity model can build on.
+19. As a **Data Product owner**, I want the maturity evaluation to consider relationship counts (business terms linked, upstream systems defined, delivery channels), so that the model can check governance completeness beyond just column-level metadata.
+20. As a **Data Governance lead**, I want the system to ship with a default 5-level maturity model and pre-built compliance policies for each gate, so that teams have a working starting point out of the box.
+21. As a **Data Governance lead**, I want maturity level changes to be recorded in the entity change log, so that there is an audit trail.
+22. As an **Admin**, I want to sort the marketplace by maturity level, so that the most trusted products appear first.
+
+## Implementation Decisions
+
+### Data model
+
+- **Three new tables**: `maturity_levels` (admin-configurable ordered levels with `entity_type` scope), `maturity_gates` (join table linking levels to compliance policies with `required` flag and display order), `maturity_snapshots` (timestamped evaluation results with full gate-result JSON).
+- **Entity table additions**: `maturity_level_order` (Integer, nullable, cached) and `maturity_evaluated_at` (DateTime, nullable) columns on `data_products` and `data_contracts`.
+- Maturity levels are scoped per entity type. Admins configure separate level sets for Data Products vs. Data Contracts (or shared, if they create identical levels for both).
+- Maturity levels follow the same admin CRUD pattern as `certification_levels` (ordered list, reorder endpoint, delete-guard when in use).
+
+### Evaluation engine
+
+- Maturity evaluation is **cumulative**: levels are processed in `level_order` sequence; evaluation stops at the first level where any required gate fails. The achieved level is the highest level where all required gates passed.
+- Gates reference existing `compliance_policies` rows. The compliance DSL rule on each policy is evaluated via `evaluate_rule_on_object()` against an **enriched entity dictionary**.
+- The enriched entity dict includes computed fields beyond the raw entity columns: `contract_count`, `output_port_count`, `business_term_count`, `dataset_count`, `upstream_system_count`, `delivery_channel_count`, `logical_attribute_mapping_count`, `certification_level`, `certification_level_name`, `has_quality_checks`, `tag_count`, etc. This keeps the DSL simple -- rules just check `obj.certification_level >= 2` or `obj.business_term_count > 0`.
+- An entity dict builder module constructs this enriched dict by querying entity relationships, tags, quality items, and certification data. This module is the main new abstraction and should be tested in isolation.
+
+### Evaluation triggers
+
+- **On entity change**: after a Data Product or Data Contract is saved or its status changes, the maturity evaluator runs automatically. This piggybacks on the existing save/status-change code paths in `DataProductsManager` and `DataContractsManager`.
+- **Scheduled**: a new Databricks Workflow job (`maturity_evaluation`) re-evaluates all products and contracts periodically. Follows the same pattern as `compliance_checks.yaml`.
+- **Manual**: a "Re-evaluate" button on the detail page calls `POST /api/data-products/{id}/maturity/evaluate`.
+
+### Process workflow integration
+
+- A new `TriggerType.ON_MATURITY_CHANGE` is added to the trigger registry. It fires after evaluation when the achieved maturity level differs from the previously cached level. The trigger event includes `from_level` and `to_level` metadata.
+- Admins can wire this trigger to notification, webhook, or approval workflow steps just like any other trigger.
+
+### Change log integration
+
+- Maturity level changes are logged to `entity_change_log` with action type `MATURITY_CHANGED`, recording old and new level.
+
+### Seed data
+
+- The system ships with a default 5-level maturity model: Accessible (1), Described (2), Defined (3), Monitored (4), Trusted (5).
+- Pre-built compliance policies are created for each gate, with DSL rules covering the criteria from the reference model (owner known, description present, business terms linked, quality monitoring active, lineage documented, certification level, data contract complete, etc.).
+- The six existing hardcoded readiness checks are migrated to compliance policies and wired as gates on the appropriate levels.
+
+### API routes
+
+- Admin CRUD: `GET/POST /api/maturity-levels`, `PUT/DELETE /api/maturity-levels/{id}`, `PUT /api/maturity-levels/reorder`, `POST /api/maturity-levels/{id}/gates`, `DELETE /api/maturity-levels/{id}/gates/{gate_id}`
+- Evaluation: `GET /api/data-products/{id}/maturity` (returns current assessment), `POST /api/data-products/{id}/maturity/evaluate` (force re-evaluate), `GET /api/data-products/{id}/maturity/history` (snapshots list). Same pattern for `/api/data-contracts/`.
+- Marketplace: existing published endpoint gains `?min_maturity=` query param.
+
+### Frontend components
+
+- `MaturityPanel` -- replaces `ReadinessChecklist` on product and contract detail pages. Shows current level badge, per-level expandable sections with gate results (pass/warn/fail rows), re-evaluate button, and a sparkline/mini-chart of maturity over time from snapshots.
+- `MaturityBadge` -- compact inline badge for list tables and marketplace cards (level name + color dot).
+- `MaturityLevelsSettings` -- Settings page section for admins to manage levels and assign gate policies. Follows the `CertificationLevelsSettings` pattern with drag-to-reorder and a compliance policy picker for gates.
+
+### Relationship to existing Production Readiness
+
+- The `/api/data-products/{id}/readiness` endpoint and `ReadinessChecklist` component are deprecated and eventually removed once the maturity system is live.
+- The six readiness checks become compliance policies, and their results are subsumed by the maturity gate evaluation.
+
+## Testing Decisions
+
+Good tests for this feature exercise external behavior through the public API or component interface, not internal implementation details. Tests should verify that given a specific entity state and maturity configuration, the correct maturity level is computed and persisted.
+
+### Modules to test
+
+1. **Maturity evaluation engine** (`maturity_evaluator.py`): Unit tests covering cumulative level logic, required vs. advisory gates, empty configurations, edge cases (no levels defined, no gates on a level, all gates fail, all gates pass). Test via a function that accepts a level config and entity dict, returns the achieved level and gate results.
+
+2. **Entity dict enrichment** (`entity_dict_builder.py`): Unit tests verifying that given a product/contract with specific relationships, tags, certification, etc., the enriched dict contains the expected computed fields. Mock the database layer.
+
+3. **API routes** (`maturity_routes.py`): Integration tests for CRUD operations (create/update/delete levels and gates, reorder, delete guards), evaluation endpoint (returns correct level), and history endpoint (returns snapshots). Follow the existing pattern in `test_compliance_routes.py`.
+
+### Prior art
+
+- `src/backend/src/tests/integration/test_compliance_routes.py` -- route-level integration tests
+- `src/backend/src/tests/unit/test_compliance_manager.py` -- manager-level unit tests
+- `src/backend/tests/test_compliance_dsl.py` -- DSL evaluation tests
+
+## Out of Scope
+
+- Maturity for Datasets and Assets (can be added later by extending `entity_type` scope).
+- Custom DSL extensions for relationship-aware operators (the enriched entity dict approach avoids this).
+- Maturity-based access control (e.g., "only level 4+ products can be published"). This could be a future workflow gate.
+- Aggregated domain-level maturity scores (e.g., "Domain X has average maturity 3.2"). Useful but deferred.
+- UI for creating compliance policies inline from the maturity settings page (admins must create policies separately in the Compliance section first, then link them as gates).
+
+## Further Notes
+
+- The 5-level model in the seed data is inspired by common data governance maturity frameworks (DCAM, EDM Council) and the specific reference model provided (Accessible -> Described -> Defined -> Monitored -> Trusted).
+- The enriched entity dict approach was chosen over DSL extensions because it keeps the compliance DSL stable and simple, while the builder module can be extended with new computed fields as needed.
+- Maturity snapshots enable future analytics: maturity distribution dashboards, progression rates, regression alerts. These are deferred but the data model supports them.
+- The `entity_type` scoping on `maturity_levels` means admins could later extend this to Datasets or Assets without schema changes.

--- a/docs/prds/prd-entra-id-graph-integration.md
+++ b/docs/prds/prd-entra-id-graph-integration.md
@@ -1,0 +1,232 @@
+# PRD: Entra ID / Microsoft Graph Integration & Unified Principal Picker
+
+## Problem Statement
+
+Across the app, users have to type principals (user emails, Databricks group names, service-principal names) into roughly fourteen different UIs that each implement the field differently: some are plain `Input` boxes, some are comma-separated strings, some are hard-coded `Select` lists, and several wizard placeholders are not even wired to a submit handler. There is no shared component, no validation, no display-name resolution, and no defense against typos. Operators with an Entra ID (Azure AD) tenant cannot pick principals from a directory; consumers of the app are left guessing whether `data-eng` or `data_engineering` is the correct group name; and the comment-audience and workflow-designer fields silently disagree on what a "principal" even is.
+
+At the same time, the existing UC HTTP Connection plumbing — already used by the workflow webhook step — gives us a clean, secret-free way to talk to Microsoft Graph: Unity Catalog holds the OAuth client credentials and refreshes the bearer token on its own. The pieces are in place; what is missing is a single picker component, a small Graph search backend, and the migration of every existing principal-entry call site onto the new control.
+
+## Solution
+
+Add an **optional** Entra ID integration configured in Settings via a Unity Catalog HTTP Connection (the same UC `connections` listed for workflow webhooks). When configured, a new shared **PrincipalPicker** component performs Microsoft Graph lookups (Users + Groups) with both inline type-ahead and a popup search dialog, and emits the existing string identifiers expected by the backend (email for users, display name for groups). When not configured, the same component falls back to a Gmail-style badge input where typed values become removable badges and clicking a badge reverts it to editable text.
+
+The picker replaces every principal-entry field across the app — assign-owner, role `assigned_groups`/`assigned_users`, entitlements persona groups, comment audience, review reviewer email, MDM reviewer, tag ACL `group_id`, team members (when type=group), workflow recipients/approvers (as a "custom principals" toggle next to the existing role selector), data-contract wizard placeholders, and the data-product/contract `team-member` dialogs.
+
+No backend storage migration: the picker continues to read and write `string` and `List[str]` exactly as today. Type information (user vs group) is recovered at display time via Graph lookup and surfaced as a leading icon and a two-line row that always shows both the friendly `displayName` and the underlying email/UPN (for users) or group GUID (for groups) so two homonyms remain distinguishable.
+
+## User Stories
+
+### Settings configuration
+
+1. As an **Admin**, I want to pick a UC HTTP Connection from a dropdown in a new "Entra ID" tab under Settings → Integrations, so that I can wire the app to Microsoft Graph without entering a client secret in our database.
+2. As an **Admin**, I want a "Test connection" button that performs a real `/v1.0/users?$top=1` probe and tells me succinctly whether it worked, so that I can validate the UC connection before exposing the picker to users.
+3. As an **Admin**, I want to clear the configured connection at any time, so that the app reverts cleanly to manual-entry mode.
+4. As an **Admin**, I want the Settings page to explain exactly which UC HTTP Connection options to set (token URL, scope `https://graph.microsoft.com/.default`, base URL `https://graph.microsoft.com`, client-credentials grant), so that I can configure the connection in Unity Catalog without guessing.
+
+### Configured-mode picking
+
+5. As an **App user**, I want a principal field to start searching after I type 2 characters, with results debounced so that I do not hammer Graph on every keystroke.
+6. As an **App user**, I want each search result row to show the display name on top and the email/UPN (for users) or GUID (for groups) underneath, so that I can disambiguate two people or two groups with the same friendly name.
+7. As an **App user**, I want a leading icon on each result indicating whether it is a user or a group, so that I can scan the list visually.
+8. As an **App user**, I want a small icon button next to the input that opens a wider popup dialog with a search box, type-filter chips (Users / Groups), and a scrollable result list, so that I can browse comfortably when picking many principals.
+9. As an **App user**, I want my picked principals to appear as non-editable badges with the type icon and the display name, so that the form stays readable.
+10. As an **App user**, I want hovering a badge to show a tooltip with the underlying email/UPN/GUID, so that I can confirm exactly which principal I picked even when the display name is ambiguous.
+11. As an **App user**, I want to remove a badge with an X icon, so that I can correct mistakes quickly.
+12. As an **App user**, I want multi-select fields to accept many picks (one badge per pick) and single-select fields to replace the previous pick, so that the picker matches the field's data shape.
+
+### Unconfigured-mode picking
+
+13. As an **App user with no Entra integration**, I want to type a principal and press Enter/Tab/comma to convert it into a badge, so that the field still has a structured look.
+14. As an **App user with no Entra integration**, I want to click an existing badge to revert it to editable text, so that I can fix typos without deleting and re-typing.
+15. As an **App user with no Entra integration**, I want a non-blocking format hint (e.g. email regex for fields that accept users), so that I notice obvious typos without being prevented from saving.
+16. As an **App user with no Entra integration**, I want to remove a badge with an X icon, identical to the configured-mode behaviour.
+
+### Pre-existing data
+
+17. As an **App user**, I want existing principals stored before Entra was configured to render as plain badges (no error icon, no forced re-pick), so that turning on the integration does not break my historical records.
+18. As an **App user**, I want to remove and re-pick those legacy badges if I want them to be Graph-resolved, so that I can opt-in to validation per-record.
+
+### Per-feature migration (call-site coverage)
+
+19. As a **Data steward**, I want to pick a business owner via the Entra picker on the Assign Owner dialog, so that I can grant ownership without copy-pasting an email.
+20. As an **Admin**, I want to pick groups (and users, per the existing individual-user-role-assignment PRD) for App Roles via the Entra picker, so that the Roles form is consistent with the rest of the app.
+21. As an **Admin**, I want to pick groups for personas in Entitlements via the Entra picker, replacing the hard-coded demo list, so that real groups are addressable.
+22. As a **Data product author**, I want to pick a reviewer for a Data Asset Review via the Entra picker, so that I do not mistype the reviewer email.
+23. As an **MDM author**, I want the same picker for the MDM review reviewer field, so that the experience is consistent.
+24. As an **Admin**, I want to pick a Databricks group when granting tag-namespace permissions via the Entra picker, so that I cannot grant access to a non-existent group.
+25. As a **Team admin**, I want the team-members dialog to use the Entra picker for both `user` and `group` member types, so that team membership is verifiable.
+26. As a **Workflow author**, I want a "Custom principals" toggle on the workflow designer's notification recipients and approval approvers, that reveals the Entra picker so that I can target specific users/groups (not only roles), matching what the backend already accepts.
+27. As a **Comment author**, I want the comment audience field to use the Entra picker (in addition to the existing team/role checkbox lists), so that I can mention an arbitrary user or group.
+28. As a **Data contract author**, I want the data-contract wizard's owner / stakeholders / groups / primary-support-email placeholder fields to be wired to a real Entra picker, so that those fields actually persist.
+29. As a **Data product / contract author**, I want the team-member dialogs in both the products and contracts views to use the Entra picker for the email/username field, so that the team list is trustworthy.
+
+### Backwards compatibility
+
+30. As an **API consumer**, I want existing JSON payloads to keep working unchanged (still `List[str]` of emails or group names), so that integrations do not break.
+31. As an **Operator**, I want the picker to gracefully degrade to manual mode if Entra is configured but Graph is unreachable (network error or revoked credentials), so that I can keep working.
+
+## Implementation Decisions
+
+### Auth: UC HTTP Connection only
+
+The app calls `ws.serving_endpoints.http_request(conn=connection_name, method="GET", path="/v1.0/users?$filter=...&$select=id,displayName,userPrincipalName,mail&$top=20", headers=None, json=None)`. Unity Catalog handles OAuth2 client-credentials token acquisition, caching, and refresh. **The app keeps no token cache and stores no client secret** — this is the same pattern proven by `WebhookStepHandler._execute_via_uc_connection` in `src/backend/src/common/workflow_executor.py`. The TypeScript sample in the original request (with `getAccessToken` and `tokenExpiry`) is illustrative of the Graph API shape, not a model to port.
+
+### New backend module: `EntraIdManager`
+
+Located at `src/backend/src/controller/entra_id_manager.py`. Responsibilities:
+
+- `is_configured() -> bool`: reads `ENTRA_UC_HTTP_CONNECTION_NAME` from `SettingsManager`.
+- `search_users(prefix: str, top: int = 20) -> list[Principal]`: Graph `GET /v1.0/users?$filter=startswith(displayName,'{p}') or startswith(userPrincipalName,'{p}') or startswith(mail,'{p}')&$select=id,displayName,userPrincipalName,mail&$top={top}` with `ConsistencyLevel: eventual` header for `$filter`.
+- `search_groups(prefix: str, top: int = 20) -> list[Principal]`: Graph `GET /v1.0/groups?$filter=startswith(displayName,'{p}') or startswith(mailNickname,'{p}')&$select=id,displayName,mailNickname&$top={top}`.
+- `get_user(upn_or_email: str) -> Principal | None` and `get_group(id_or_displayname: str) -> Principal | None`.
+- `test() -> tuple[bool, str | None]`: a `/v1.0/users?$top=1` probe returning `(healthy, error_message)`.
+- All public methods normalise to a single `Principal` Pydantic model:
+  - `type: Literal['user', 'group']`
+  - `id: str` — `userPrincipalName` for users (fallback `mail`), `id` (GUID) for groups
+  - `display_name: str`
+  - `sub_label: str` — email/UPN for users, GUID for groups (used by the UI for the second line)
+
+Input prefixes are escaped against OData injection (single-quote doubling, no other special characters allowed in the prefix). Errors from Graph are wrapped with the response status and a short message.
+
+### New backend routes
+
+In a new file `src/backend/src/routes/entra_routes.py`, mounted at `/api/entra`:
+
+- `GET /api/entra/status` → `{ configured: bool, connection_name: str | null }` (settings READ_ONLY).
+- `GET /api/entra/search?q=&types=users,groups&limit=20` → `Principal[]` (any authenticated user; access control on the picker is governed by the surrounding form, not the search itself).
+- `POST /api/entra/test` → `{ healthy: bool, error?: string }` (settings READ_WRITE).
+
+### Settings storage
+
+Single new key `ENTRA_UC_HTTP_CONNECTION_NAME` written to the existing `app_settings` key/value table. No Alembic migration. Loaded in `SettingsManager._load_persisted_settings()`, persisted in `SettingsManager.update_settings()`, and exposed in `get_settings()` so the UI can render it.
+
+### Shared HTTP-connection helper
+
+Extract the HTTP-connection list logic currently inline at `src/backend/src/routes/workflows_routes.py` lines 259–289 into a shared helper (e.g. `src/backend/src/common/uc_connections.py::list_http_connections(ws)`) and expose it at `GET /api/settings/uc-http-connections`. The workflow route delegates to the same helper. Both routes use the OBO workspace client via `get_obo_workspace_client(request)`.
+
+### Backend cache
+
+A small in-memory TTL cache (5 minutes) keyed on `(query, type)` lives inside `EntraIdManager` to soften Graph throttling under bursts. Not persisted; not user-scoped (queries are not sensitive). Cache is cleared when the connection name changes.
+
+### Shared frontend component: `PrincipalPicker`
+
+Location: `src/frontend/src/components/common/principal-picker.tsx`. TypeScript surface:
+
+```
+type Principal = {
+  type: 'user' | 'group' | 'unknown'
+  id: string
+  displayName?: string
+  subLabel?: string
+}
+
+interface PrincipalPickerProps {
+  value: string[] | string                     // current ids (emails / group names)
+  onChange: (next: string[] | string) => void
+  multiple?: boolean                            // default false
+  accepts: ('user' | 'group')[]                 // restricts search and manual-entry hints
+  placeholder?: string
+  disabled?: boolean
+  fieldName?: string                            // for accessibility / form integration
+}
+```
+
+- On mount the component reads `/api/entra/status` from a small Zustand `entra-store` (request shared across all instances on the page).
+- **Configured mode**: typed input triggers a 250ms-debounced `/api/entra/search` after 2 chars; results render in a Combobox dropdown using `cmdk` (already a dep via shadcn). Each row is two lines: bold `displayName` on top, muted `subLabel` underneath, with a leading type icon (matches the existing Teams-view pattern: dark badge + Users icon for groups, light badge + User icon for users). When two displayed rows share `displayName`, the differing `subLabel` is highlighted.
+- A small icon button ( `Search` icon) next to the input opens a `Dialog` containing a wider search input, type-filter chips honouring `accepts`, and a scrollable list using the same row layout. Picks from the dialog also become badges and the dialog stays open for `multiple` fields.
+- Selected items render as non-editable badges with the type icon + `displayName`. Tooltip + `title` attribute on the badge expose `subLabel` so hover reveals the underlying id.
+- **Unconfigured mode**: typed value becomes a plain badge on Enter/Tab/comma. Click on badge → it reverts to editable text in place; pressing Enter/Tab/comma re-confirms; Escape cancels and restores the previous value. Email-format hint (non-blocking) when `accepts` includes `user`. X icon to remove.
+- Storage compatibility: `value` is always `string` (single) or `string[]` (multi). When the picker resolves a Graph principal, it stores `principal.id` (email/UPN for users, display name for groups — see below). When the user types manually, it stores the literal text.
+
+### Group identifier choice
+
+For groups the component stores `displayName` (not the GUID) in `value`, because the existing backend models (`assigned_groups`, persona `groups`, tag `group_id`, comment audience, etc.) all expect human-readable group names that match what Databricks SCIM exposes. The GUID is shown as `subLabel` for disambiguation but not persisted. A future PRD can introduce a parallel optional GUID column if Databricks group sync ever introduces ambiguity.
+
+### Settings UI
+
+New nav item under **Integrations** in `src/frontend/src/components/settings/settings-layout.tsx` ("Entra ID"). New view file `src/frontend/src/views/settings-entra.tsx` wrapping a new component `src/frontend/src/components/settings/entra-settings.tsx`. Component contents:
+
+- A `Select` populated from `GET /api/settings/uc-http-connections` (filtered to HTTP type) showing each connection's name and connection_type.
+- A "Test connection" button that calls `POST /api/entra/test` and shows success/failure via `useToast` (mirrors the connectors-settings test pattern).
+- A "Clear" button that nulls the setting (hits `PUT /api/settings`).
+- A help block describing the required UC HTTP Connection setup.
+
+### Migration of the 14 call sites
+
+| Group | File | Field | Picker config |
+|------|------|-------|---------------|
+| 1. Single user | `src/frontend/src/components/common/assign-owner-dialog.tsx` | `userEmail` | `multiple=false, accepts=['user']` |
+| 1. Single user | `src/frontend/src/components/data-asset-reviews/create-review-request-dialog.tsx` | `reviewer_email` | `multiple=false, accepts=['user']` |
+| 1. Single user | `src/frontend/src/components/mdm/create-review-dialog.tsx` | `reviewer_email` | `multiple=false, accepts=['user']` |
+| 1. Single user | `src/frontend/src/components/data-products/team-member-form-dialog.tsx` | `username` | `multiple=false, accepts=['user']` |
+| 1. Single user | `src/frontend/src/components/data-contracts/team-member-form-dialog.tsx` | `email`/`username` | `multiple=false, accepts=['user']` |
+| 2. Multi user/group | `src/frontend/src/components/settings/role-form-dialog.tsx` | `assigned_groups` | `multiple=true, accepts=['group']` |
+| 2. Multi user/group | `src/frontend/src/components/settings/role-form-dialog.tsx` | `assigned_users` (per individual-user-role-assignment PRD) | `multiple=true, accepts=['user']` |
+| 2. Multi user/group | `src/frontend/src/views/entitlements.tsx` | persona `groups` | `multiple=true, accepts=['group']` |
+| 2. Multi user/group | `src/frontend/src/components/comments/comment-sidebar.tsx` | `audience` (in addition to existing team/role checkboxes) | `multiple=true, accepts=['user','group']` |
+| 3. Group only | `src/frontend/src/components/settings/tags-settings.tsx` | `permissionForm.group_id` | `multiple=false, accepts=['group']` |
+| 3. Group only | `src/frontend/src/components/teams/team-form-dialog.tsx` | `member_identifier` when `member_type==='group'` | `multiple=false, accepts=['group']` |
+| 3. User only | `src/frontend/src/components/teams/team-form-dialog.tsx` | `member_identifier` when `member_type==='user'` | `multiple=false, accepts=['user']` |
+| 4. Workflow designer | `src/frontend/src/components/workflows/workflow-designer.tsx` | notification `recipients` (custom toggle) | `multiple=true, accepts=['user','group']` |
+| 4. Workflow designer | `src/frontend/src/components/workflows/workflow-designer.tsx` | approval `approvers` (custom toggle) | `multiple=true, accepts=['user','group']` |
+| 5. Wizard placeholders | `src/frontend/src/components/data-contracts/data-contract-wizard-dialog.tsx` | `dc-owner`, stakeholders, groups, primary support email (currently unwired) | per-field accepts |
+
+For the workflow designer (#4), the existing role-based `Select` is preserved — a "Custom principals…" toggle reveals the picker, and the resulting strings are sent as additional `recipients`/`approvers` entries (the backend already accepts email/group literals, the UI just did not surface them).
+
+### i18n
+
+A new `entra` namespace added to all 8 locale files under `src/frontend/src/i18n/locales/{en,de,es,fr,it,ja,nl}/entra.json` (and registered in the i18n config), mirroring the structure of `semantic-models.json`. Picker strings live under `common.principalPicker.*` so they are reusable.
+
+### Backwards compatibility
+
+- All existing API request/response shapes unchanged (still strings).
+- Existing rows in the database render as plain badges with no leading icon and no error decoration; they are distinguishable from Graph-resolved badges by the absence of the type icon.
+- If the configured Graph connection becomes unreachable, the picker logs a single console warning and falls back to manual-entry mode for the rest of the session.
+
+## Testing Decisions
+
+### Testing philosophy
+
+Tests verify external behaviour through public interfaces. We do not test the picker's internal cmdk state machine; we test what the user sees and what the backend receives.
+
+### Backend (pytest)
+
+- `EntraIdManager`: unit tests against a mocked `serving_endpoints.http_request` covering `search_users`, `search_groups`, OData-injection escaping, the eventual-consistency header, and `Principal` normalisation for both users and groups (including missing `mail` → fallback to `userPrincipalName`).
+- `EntraIdManager.test()` returns `(False, error_message)` on a non-200 Graph response and `(True, None)` on success.
+- Routes (`/api/entra/status`, `/api/entra/search`, `/api/entra/test`) integration-tested via FastAPI test client with a mocked manager: auth required, parameter validation, and shape of the response.
+- `SettingsManager`: persists and reloads `ENTRA_UC_HTTP_CONNECTION_NAME` correctly; `get_settings()` exposes it.
+- Shared `list_http_connections` helper: filters non-HTTP connections out.
+
+Prior art: `src/backend/src/tests/integration/test_knowledge_routes.py`, `src/backend/src/tests/unit/` for manager-level mocks.
+
+### Frontend (vitest + React Testing Library)
+
+- `PrincipalPicker` configured-mode: 2-char trigger, debounced search, two-line rows render `displayName` and `subLabel`, picking adds a badge, badge tooltip exposes `subLabel`, X removes.
+- `PrincipalPicker` unconfigured-mode: Enter/Tab/comma converts text → badge, click on badge reverts to text, Escape cancels.
+- `PrincipalPicker` accepts filter: requesting `accepts=['group']` only sends `types=groups` to the search endpoint.
+- `entra-settings.tsx`: Test button shows success vs destructive toast based on response.
+
+Prior art: `src/frontend/src/components/settings/role-form-dialog.test.tsx`, `src/frontend/src/components/semantic/concept-neighborhood-graph.test.tsx`.
+
+### Manual / opt-in
+
+A short manual smoke test against a real UC HTTP Connection wired to a tenant — documented in the PR description, not automated.
+
+## Out of Scope
+
+- **Service principals**: deferred. Graph supports `/servicePrincipals`; adding it later is a single new method and a new value in the `accepts` union.
+- **Storage migration to structured Principal records**: explicitly rejected — keep `string` / `List[str]`. Type info is recovered at display time.
+- **Bulk re-validation of pre-existing values**: no migration script. Legacy values keep working; users opt-in by re-picking.
+- **OBO / delegated Graph queries**: connection always uses app-level client credentials. No per-user permission checks against the directory.
+- **User profile photos, manager hierarchies, `$expand=manager`, group membership traversal**: not needed for the picker.
+- **Server-side display-name caching beyond the 5-minute query cache**: defer until rate-limit pressure is observed.
+- **Replacing the existing role/team `Select`s in the workflow designer**: kept as-is; the picker is additive via a "Custom principals" toggle.
+- **CSV import / bulk add**: not in v1.
+
+## Further Notes
+
+- **Why UC handles OAuth, not the app**: removes a class of secret-management bugs (no client secret in `app_settings`, no token cache to invalidate, no refresh logic), and keeps the integration story consistent with the workflow webhook step which already proves the pattern.
+- **Disambiguation rule recap**: every search result shows `displayName` + `subLabel`; every selected badge exposes `subLabel` via tooltip + `title` attr. This is a hard requirement — homonyms in directories of any meaningful size are common (Microsoft Graph routinely returns multiple "John Smith" entries) and silently picking the wrong one is the most expensive failure mode of any directory picker.
+- **Performance**: 250ms debounce + 2-char minimum + 5-minute backend TTL cache should keep us well under Graph's per-app throttling thresholds for normal usage.
+- **Accessibility**: badges use `aria-label` containing `displayName` + `subLabel`; the popup dialog is focus-trapped; the type filter chips are reachable via Tab.
+- **Forward path**: a v2 PRD can introduce structured Principal columns (with type discriminator) on the highest-traffic tables (e.g. `app_roles.assigned_users`) once we have data on how often homonym collisions cause real bugs.

--- a/docs/prds/prd-individual-user-role-assignment.md
+++ b/docs/prds/prd-individual-user-role-assignment.md
@@ -1,0 +1,104 @@
+# PRD: Individual User Assignment to App Roles
+
+## Problem Statement
+
+App Roles can only be assigned to Databricks groups via the `assigned_groups` field. To give a single user a specific role, an administrator must create or modify a Databricks group externally, add the user to it, then assign that group to the App Role. This creates unnecessary overhead for ad-hoc assignments, makes testing role behavior slow, prevents fine-grained targeting (e.g., giving one engineer Data Steward access for a sprint without promoting their entire team), and leaves a gap in the RBAC model since the authorization system already has access to `user_details.email` but only uses group membership for role matching.
+
+## Solution
+
+Add a parallel `assigned_users` field (list of user email strings) to App Roles that works alongside `assigned_groups`. A role matches a user if:
+
+- The user's groups intersect with the role's `assigned_groups` (existing behavior), **OR**
+- The user's email is in the role's `assigned_users` (new behavior)
+
+This is purely additive — no existing behavior changes. The implementation mirrors the `assigned_groups` pattern (JSON text column, same serialization, same case-insensitive matching).
+
+The roles table column currently labeled "Assigned Groups" is renamed to "Principals" and displays both groups and users as differentiated badges, following the same visual pattern used in the Teams view (User icon + light badge for users, Users icon + dark badge for groups).
+
+Both the groups and users inputs in the role form dialog are upgraded to a badge-with-X-to-remove pattern, replacing the current comma-separated text input for groups.
+
+## User Stories
+
+1. As an **Admin**, I want to assign an App Role directly to a specific user by email, so that I can grant them permissions without creating or modifying a Databricks group.
+2. As an **Admin**, I want to see both assigned groups and assigned users displayed together in a "Principals" column in the Roles table, so that I can audit all role assignments at a glance.
+3. As an **Admin**, I want groups and users to be visually differentiated in the Principals column (group icon + dark badge for groups, user icon + light badge for users), so that I can immediately tell them apart — matching the pattern already used in the Teams view.
+4. As an **Admin**, I want to add and remove individual users in the role form dialog using a badge-with-X pattern, so that managing assignments is quick and precise.
+5. As an **Admin**, I want the groups input in the role form dialog also upgraded to the badge-with-X pattern (replacing comma-separated text), so that both principal types have a consistent UX.
+6. As an **Admin**, I want to assign individual users to the Admin role via email, so that admin access is not limited to group-based assignment.
+7. As a **User** assigned directly via email, I want to receive the same permissions as if I were in an assigned group, so that my experience is identical regardless of how I was assigned.
+8. As a **User** with no group memberships but directly assigned to a role, I want to still be able to use the app, so that direct assignment works as a standalone mechanism (not just a supplement to groups).
+9. As an **Admin**, I want existing group-based assignments to continue working exactly as before, so that adding user-level assignment doesn't break anything.
+10. As an **Admin**, I want the "Request Access" button in the roles table to correctly reflect that I already have a role when I'm assigned via email (not just via group), so that the UI state is accurate.
+
+## Implementation Decisions
+
+### User Identifier
+
+Email address is the identifier, matching the existing `user_details.email` field already available in every authorization check. Matching is case-insensitive (`.lower()` on both sides), consistent with how group matching works today.
+
+### OR Semantics
+
+Role matches if user is in `assigned_groups` OR in `assigned_users`. These are additive. If a user matches multiple roles (via groups and/or direct assignment), permissions are merged by taking the highest level per feature — same as today.
+
+### No-Groups Guard Relaxation
+
+Currently, `PermissionChecker` denies access if `user_details.groups` is empty (hard 403). This guard must be relaxed: a user with no groups but a direct email assignment must be allowed through. The check changes from "has groups?" to "has groups OR has email that might match a role?".
+
+### Storage Pattern
+
+New `assigned_users` column on `app_roles` table, stored as JSON text (`Text` column, default `'[]'`), identical to `assigned_groups`. No junction table.
+
+### Alembic Migration
+
+Single migration adding the column. Revises the current head (`d1_odcs_v310_full_persistence`).
+
+### Backend Authorization Flow
+
+`get_user_effective_permissions()` gains an optional `user_email` parameter. The role matching loop checks both group intersection AND email membership. The email is threaded through from `PermissionChecker` and `ApprovalChecker` (which already have access to `user_details.email`) into the authorization manager.
+
+### Combined "Principals" Column
+
+The roles table replaces the "Assigned Groups" column with a "Principals" column that renders both groups and users as badges, following the Teams view pattern:
+- Groups: dark badge with `Users` (multi-person) icon
+- Users: light badge with `User` (single-person) icon
+- Truncated to 3 items with "+N more" badge if needed
+
+### Badge-with-X Input for Both Groups and Users
+
+The role form dialog replaces the comma-separated text input for groups with a badge-with-X component. The same component is used for both groups and users, with a text input to add new entries and X buttons on badges to remove them.
+
+### Direct User Assignment is Admin-Only
+
+Assigning individual users to roles is purely an admin action through the role form dialog. It does not interact with the existing "request access to role" workflow.
+
+### Audit
+
+The existing `updated_at` timestamp on the role is sufficient for now.
+
+## Testing Decisions
+
+### Testing Philosophy
+
+Tests verify external behavior through public interfaces. Minimum viable coverage for this feature:
+
+### Backend (pytest)
+
+- **Authorization Manager**: `get_user_effective_permissions()` returns correct permissions for a user matched by email only, by group only, and by both. This is the critical path.
+- **Frontend**: `checkUserHasRole()` returns true when user email matches `assigned_users`.
+
+Prior art: `test_data_products_manager.py` for manager unit tests, `test_data_product_routes.py` for integration route tests.
+
+## Out of Scope
+
+- **User autocomplete from Databricks SCIM API**: Phase 2 enhancement. The data model supports it; only the UI input changes.
+- **`is_user_admin` refactoring**: The standalone `is_user_admin()` utility function currently only checks groups and doesn't have access to `settings_manager`. Full admin checks already go through `PermissionChecker`, which will have the email-aware path.
+- **Notification on role assignment**: No email/notification is sent when a user is directly assigned.
+- **Bulk user import**: No CSV upload or SCIM sync for assigned users.
+- **Role request flow changes**: The existing "request access to role" workflow doesn't change.
+- **Separate audit log**: No per-assignment audit trail beyond the role's `updated_at`.
+
+## Further Notes
+
+- **Backward compatibility**: Fully backward compatible. The new column defaults to `'[]'`, all existing roles continue to work unchanged.
+- **Performance**: `list_app_roles()` is already called on every permission check. Adding one more JSON field to deserialize is negligible for typical role counts (<20 roles).
+- **Groups input UX upgrade**: While the primary feature is user assignment, upgrading the groups input from comma-separated text to badge-with-X is a small but valuable UX improvement that comes naturally with building the shared input component.

--- a/docs/prds/prd-knowledge-graph-view.md
+++ b/docs/prds/prd-knowledge-graph-view.md
@@ -1,0 +1,132 @@
+# PRD: Knowledge Graph View -- consolidate Concepts caching
+
+## Problem Statement
+
+The Concepts feature (collections, concepts, properties, taxonomy stats, semantic links) reads from four parallel caches inside `SemanticModelsManager`:
+
+1. The in-memory RDF `ConjunctiveGraph` (`self._graph`).
+2. Direct Python list/object references (`self._cached_concepts`, `self._cached_taxonomies`, `self._cached_stats`).
+3. Persistent JSON files under `data/cache/` (`concepts_all.json`, `taxonomies.json`, `stats.json`).
+4. A TTL-keyed dict (`self._cache: Dict[str, CachedResult]`) used by `get_concepts_by_taxonomy`.
+
+These layers were added incrementally and never reconciled. The result is observable user-facing brokenness:
+
+1. Mutations (create collection, assign term to collection, link entity to concept, save ontology to collection) update some layers but not others, so the UI shows zero terms in a collection that clearly contains them, missing collections in the graph filter, and links that "do not stick" until a full process restart.
+2. The "Rebuild Graph" action in Settings did not actually rebuild every layer -- a duplicate `_invalidate_cache` definition silently masked the canonical one.
+3. The persistent JSON files do not survive process restart in any meaningful way (they are rewritten on first read) and add disk I/O on every mutation for no measurable cold-start benefit.
+4. Source-context extraction logic (stripping `urn:ontology:`, `urn:taxonomy:`, `urn:glossary:` prefixes) was duplicated in three places and drifted, miscategorising concepts as "Unassigned".
+
+The recently-shipped bug fixes patched the symptoms (single canonical `_invalidate_cache`, helper for source-context extraction, frontend cross-view refresh nonce) but the underlying architecture still has four caches that any future contributor must remember to update in lock-step.
+
+## Solution
+
+Introduce **`KnowledgeGraphView`**: a single, owned, in-memory view layer over the RDF graph that holds all derived Concepts state (concepts list, taxonomies, properties grouped by source, stats, source-context index). The RDF `ConjunctiveGraph` remains the single source of truth for triples; `KnowledgeGraphView` is the only cache of derived projections.
+
+Key behaviours:
+
+- The view is built lazily on first read after process start or after a full invalidation, and incrementally updated on mutations where the delta is cheap to compute (single concept add/remove, single semantic link add/remove, collection rename).
+- Mutations that touch many triples (RDF source rebuild, ontology import, bulk delete) trigger a full invalidation; the next read rebuilds the view from `self._graph`.
+- `SemanticModelsManager` exposes a single `invalidate(reason: str, scope: Literal["full", "concept", "collection", "links"] = "full")` method. All write paths in `SemanticModelsManager` and `SemanticLinksManager` call it. The TTL dict, the per-attribute `_cached_*` references, and the persistent JSON files are removed.
+- The persistent JSON cache files in `data/cache/` are deleted on first run after upgrade and the directory is no longer written to by the Concepts feature.
+- The frontend `useKnowledgeGraphStore` refresh-nonce mechanism stays as-is and is documented as the contract for cross-view invalidation.
+
+## User Stories
+
+### End-user
+
+1. As a **Data Steward**, I create a new collection from the Concepts view and immediately see it appear in the collection filter on the graph tab and in the source-context dropdown without refreshing the page.
+2. As a **Data Steward**, I add a term to a newly-created collection and see the term count on the collection card update on the next render.
+3. As a **Data Producer**, I assign an entity to a concept and the link persists across page reload, browser restart, and `uvicorn` reload.
+4. As a **Data Steward**, I generate an ontology and click "Save to collection"; the new collection and its concepts appear in the Concepts view and graph within one render cycle.
+5. As an **Admin**, I click "Rebuild Graph" in Settings -> RDF Sources and every Concepts surface (collections list, concepts list, graph view, source filter) reflects the rebuilt state without restarting the server.
+6. As a **Data Consumer**, I open the Concepts view cold (first request after process start) and see the full list within the performance budget below.
+7. As a **Data Steward**, I rename a collection and the new name appears everywhere the old one was shown without a page refresh.
+8. As any user, the source-context label shown next to each concept ("Demo Data", "BITOL ODCS", a custom RDF source name) is consistent across the graph, the list, and the property panel -- never a raw `urn:` string and never the literal "Unassigned" for a concept that does belong to a known source.
+
+### Developer
+
+9. As a **Backend developer**, I add a new mutation that affects concepts, call `manager.invalidate(reason="my-mutation", scope="concept")`, and trust that every read path returns fresh data without my having to enumerate every cache layer.
+10. As a **Backend developer**, I read `KnowledgeGraphView` and find one class with one well-typed shape (concepts, taxonomies, properties_grouped, stats, source_index) -- not three sibling attributes plus a TTL dict plus on-disk JSON.
+11. As a **Backend developer**, I write a unit test for derived data by constructing an in-memory `KnowledgeGraphView` from a small triple fixture, with no SQLAlchemy session, no FastAPI app, and no temp filesystem.
+12. As a **Frontend developer**, I bump `useKnowledgeGraphStore.refreshNonce` after a mutation and trust that all subscribed views refetch.
+13. As a **Reviewer**, I see one cache-invalidation call site per mutation in `SemanticModelsManager` and `SemanticLinksManager`, not three.
+14. As an **On-call engineer**, I read a single `cache.invalidate` log line per mutation that includes `reason`, `scope`, and elapsed rebuild time when a rebuild fires.
+
+## Implementation Decisions
+
+### New module
+
+- New module `src/backend/src/controller/knowledge_graph_view.py` exposing `class KnowledgeGraphView`. The class owns: `concepts: list[ConceptDTO]`, `taxonomies: list[TaxonomyDTO]`, `properties_grouped: dict[str, list[PropertyDTO]]`, `stats: TaxonomyStatsDTO`, `source_index: dict[str, str]` (concept IRI -> source-context label), and a private `_dirty: set[Literal["concepts", "taxonomies", "properties", "stats"]]` for incremental rebuild tracking.
+- The view is constructed from a `ConjunctiveGraph` reference and a small `SourceContextResolver` (the existing `_extract_source_context` helper, promoted to a top-level function in `knowledge_graph_view.py`).
+- `KnowledgeGraphView.rebuild(scope: str)` recomputes the requested slice. `KnowledgeGraphView.snapshot()` returns an immutable named-tuple view for read paths.
+
+### `SemanticModelsManager` changes
+
+- `self._graph` (the rdflib `ConjunctiveGraph`) stays. Everything else cache-related is removed: `self._cached_concepts`, `self._cached_taxonomies`, `self._cached_stats`, `self._cache: Dict[str, CachedResult]`, the persistent JSON read/write paths, the duplicate-defended `_invalidate_cache`.
+- New attribute `self._view: KnowledgeGraphView` holds the single derived view. All `get_*` methods (`get_concepts_grouped`, `get_properties_grouped`, `get_stats`, `get_concepts_by_taxonomy`) read from `self._view.snapshot()`.
+- New method `self.invalidate(reason: str, scope: str = "full")`. All write paths call it. The legacy `_invalidate_cache` name is kept as a thin alias for one release for any external callers, then removed.
+- `rebuild_graph_from_enabled` calls `self.invalidate("rebuild-graph", scope="full")` after rebuilding `self._graph`. The defensive `db.expire_all()` stays.
+
+### `SemanticLinksManager` changes
+
+- `add` and `remove` call `manager.invalidate(reason="semantic-link-add"/"semantic-link-remove", scope="links")`. The current direct calls to `_invalidate_cache` are replaced.
+
+### Persistent cache cleanup
+
+- On first startup after upgrade, a one-shot cleanup deletes `data/cache/concepts_all.json`, `data/cache/taxonomies.json`, `data/cache/stats.json` if they exist, and removes the empty `data/cache/` directory if no other features use it. Cleanup is idempotent and gated on a startup task.
+
+### Source context
+
+- The existing `_extract_source_context` static helper moves to `knowledge_graph_view.py` as `extract_source_context`. The three previous duplicated `if/elif` blocks (already collapsed in the bug-fix round) call into the same function from one place.
+
+### Frontend
+
+- `src/frontend/src/stores/knowledge-graph-store.ts` (`useKnowledgeGraphStore`) stays. It is documented in the store file header as the contract for "I just mutated something on the backend, all Concepts-related views should refetch".
+- `business-terms.tsx`, `ontology-home.tsx`, and `ontology-generator.tsx` keep their `bumpKnowledgeGraphRefresh` calls; no UI behaviour change.
+
+### Performance targets (concrete)
+
+- Cold first-read of `GET /api/semantic-models/concepts-grouped` against a fixture of 10k concepts, 50 collections, 500 properties: <= 400 ms p95 on the dev workspace.
+- Warm read of the same endpoint after invalidation `scope="concept"` (incremental rebuild of one concept): <= 50 ms p95.
+- Warm read after `scope="full"` invalidation (lazy full rebuild on next request): <= 400 ms p95 (same as cold).
+- Steady-state warm read (no invalidation): <= 15 ms p95.
+- Memory ceiling for `KnowledgeGraphView` at the 10k-concept fixture: <= 80 MB resident.
+
+### Compatibility and migration
+
+- No schema migration. The change is internal to the manager and removes on-disk JSON files.
+- `_invalidate_cache(reason)` remains as a deprecated alias delegating to `invalidate(reason, scope="full")` for one release; it logs a deprecation warning.
+- The `/api/semantic-models/refresh-graph` route signature is unchanged.
+
+## Testing Decisions
+
+Good tests verify external behaviour (API responses, view contents after a sequence of mutations) rather than which cache attribute was touched. The new `KnowledgeGraphView` is small and pure enough to deserve dedicated unit tests independent of FastAPI and SQLAlchemy.
+
+### Modules to test
+
+1. **`KnowledgeGraphView` unit tests** (`src/backend/src/tests/unit/test_knowledge_graph_view.py`): construct from a small in-memory `ConjunctiveGraph` triple fixture; assert `snapshot()` shape; assert `rebuild(scope=...)` recomputes only the requested slice and leaves the others byte-identical; assert `extract_source_context` for every URN prefix and for the bare-IRI fallback; assert incremental add/remove of a concept and a semantic link.
+2. **`SemanticModelsManager` integration tests** (extend `src/backend/src/tests/integration/test_knowledge_routes.py`): every existing test continues to pass; add a regression test that mutates via four different routes (`POST /api/knowledge/collections`, `POST /api/knowledge/concepts`, `POST /api/semantic-links/`, `POST /api/ontology/save-to-collection`) and asserts the next `GET /api/semantic-models/concepts-grouped` reflects the mutation without a manual `refresh-graph`.
+3. **Rebuild regression** (`test_knowledge_routes.py::test_rebuild_graph_clears_view`): seed concepts, mutate the underlying RDF source, call `POST /api/semantic-models/refresh-graph`, assert `GET .../concepts-grouped` reflects the new RDF source.
+4. **Performance smoke** (`src/backend/src/tests/perf/test_knowledge_graph_view_perf.py`, opt-in via marker): asserts the four budgets in the Performance targets section against a generated 10k-concept fixture. Skipped in CI by default; run with `pytest -m perf`.
+
+### Prior art
+
+- `src/backend/src/tests/integration/test_knowledge_routes.py` -- existing 22 integration tests covering CRUD and cache freshness (added during the bug fix round).
+- `src/backend/src/tests/integration/test_compliance_routes.py` -- route-level integration test pattern.
+- Existing `_NoopAudit` stub pattern from the same test file is reused for the new tests.
+
+## Out of Scope
+
+- Persisting the rebuilt view across process restarts. The cold-read budget is tight enough that this is not needed; revisit if the 10k-concept fixture's cold read exceeds 1 s in production.
+- Replacing rdflib's `ConjunctiveGraph` with a custom store. The view consolidation is independent of the underlying triple store and we want to keep that decision reversible.
+- Cross-process cache coherence (multi-worker uvicorn). The app currently runs single-process; if/when we move to multi-worker, a pub/sub invalidation channel is a separate PRD.
+- Frontend-side caching (TanStack Query, SWR). The current refresh-nonce + on-mount fetch pattern is sufficient for now.
+- Generalising `KnowledgeGraphView` to other RDF-backed features. The class is intentionally Concepts-specific; if a second feature needs a similar view layer, factor at that point.
+
+## Further Notes
+
+- The four-cache architecture grew organically: the persistent JSON files were added as an "insurance" against cold-start cost that never materialised; the TTL dict was added before the in-memory references existed and was never removed; the per-attribute references were added when the TTL dict's serialisation cost showed up in a profile. Consolidating into one view is the smallest change that makes the right thing easy and the wrong thing impossible.
+- The recent bug-fix round ([prior session]) shipped the minimum-viable invalidation correctness. This PRD is the proper architectural follow-up; without it, the next contributor will hit the same class of bug.
+- Performance budgets above are derived from current observed warm reads (~12 ms) and cold reads (~280 ms) on the dev workspace's existing ~3k-concept fixture, scaled with headroom to 10k concepts.
+- The `extract_source_context` helper is the right place to add future URN prefixes; centralising it removes the "fix in three places" trap that produced the "Unassigned" miscategorisation bug.
+- No i18n changes -- this is a backend refactor with no new user-facing strings. The existing source-context labels and collection names are preserved.

--- a/docs/prds/prd-marketplace-multi-entity.md
+++ b/docs/prds/prd-marketplace-multi-entity.md
@@ -1,0 +1,126 @@
+# PRD: Marketplace Multi-Entity Support
+
+## Problem Statement
+
+The marketplace currently only surfaces Data Products for discovery and subscription. Users who also manage Data Contracts or curated Assets (Datasets, Dashboards, ML Models) cannot offer those items in the marketplace for consumers to discover, browse, or subscribe to. This limits the marketplace's utility as a central discovery hub — consumers must navigate separate feature views to find contracts or assets, and there is no unified "shop" experience across entity types.
+
+Additionally, the legacy "Datasets" tab in the marketplace fetches from a deprecated endpoint (`/api/datasets/published`) that is disconnected from the ontology-driven Asset model. This creates a confusing split between legacy datasets and the newer asset-backed entities.
+
+## Solution
+
+Extend the marketplace to optionally display Data Contracts and Assets alongside Data Products. An admin-configurable setting controls which entity types appear in the marketplace (default: products only). Each entity type gets its own tab in the marketplace view, with consistent card rendering, domain filtering, search, publication scope controls, and full subscription support.
+
+The legacy Datasets marketplace tab is replaced by the new Assets tab, where Dataset-type assets are one of several publishable asset types.
+
+Key behaviors:
+
+- **Admin setting** (`marketplace_entity_types`): a JSON array stored in `app_settings` controlling which tabs appear. Default `["products"]`. Options: `"products"`, `"contracts"`, `"assets"`.
+- **Publication model**: All three entity types use the same `publication_scope` enum (`none`, `domain`, `organization`, `external`). Publication requires `status == 'active'`.
+- **Subscription model**: Full subscribe/unsubscribe with notifications for all entity types on the marketplace.
+- **Domain filtering**: Works for all entity types (products have `domain`, contracts have `domain_id`, assets have `domain_id`).
+- **Asset type curation**: A predefined set of asset types is marketplace-eligible by default (Dataset, Dashboard, ML Model). Admins can toggle which asset types are publishable.
+
+## User Stories
+
+1. As an admin, I want to configure which entity types (Products, Contracts, Assets) appear in the marketplace, so that I can tailor the discovery experience to my organization's needs.
+2. As an admin, I want to configure which asset types (Dataset, Dashboard, ML Model, etc.) are eligible for marketplace publication, so that only relevant asset types are surfaced.
+3. As a data producer, I want to publish a Data Contract to the marketplace with a specific publication scope (domain, organization, external), so that consumers can discover and subscribe to my contract.
+4. As a data producer, I want to unpublish a Data Contract from the marketplace, so that it is no longer discoverable by consumers.
+5. As a data producer, I want to publish an Asset (e.g., a Dataset or Dashboard) to the marketplace, so that consumers can discover and subscribe to it.
+6. As a data producer, I want to unpublish an Asset from the marketplace.
+7. As a data consumer, I want to browse Data Contracts in the marketplace, so that I can find contracts that define data I need.
+8. As a data consumer, I want to browse Assets in the marketplace, so that I can discover datasets, dashboards, and models available in my organization.
+9. As a data consumer, I want to subscribe to a Data Contract on the marketplace, so that I receive notifications when it changes.
+10. As a data consumer, I want to subscribe to an Asset on the marketplace, so that I receive notifications about updates.
+11. As a data consumer, I want to filter marketplace items by domain, so that I can narrow results to my area of interest regardless of entity type.
+12. As a data consumer, I want to search across all marketplace entity types by name and description, so that I can quickly find what I need.
+13. As a data consumer, I want to see consistent card information (name, description, domain, status, rating, owner, certification badge) for every entity type in the marketplace, so that I can compare items easily.
+14. As a data consumer, I want to filter marketplace items by publication scope (domain, organization, external), so that I see only items relevant to my visibility level.
+15. As a data steward, I want contracts and assets to auto-unpublish when deprecated, so that stale items don't linger in the marketplace.
+16. As a data consumer, I want the marketplace to show certification badges on contracts and assets, so that I can gauge trust levels at a glance.
+17. As an admin, I want the legacy Datasets tab replaced by the new Assets tab, so that there is a single, consistent path for dataset discovery via the ontology-driven model.
+18. As a data producer, I want both the existing approval-based publish flow and the new direct publication-scope flow to coexist for contracts, so that my organization can choose which workflow to use.
+19. As a data consumer, I want the home page discovery section to optionally surface contracts and assets (based on admin config), so that the landing page reflects what's available in the marketplace.
+20. As an admin, I want the marketplace configuration to persist across app restarts, so that the setting is durable.
+
+## Implementation Decisions
+
+### Admin Configuration
+
+- A single `app_settings` key `marketplace_entity_types` stores a JSON array (e.g., `["products"]`, `["products", "contracts", "assets"]`). Default is `["products"]`.
+- A second `app_settings` key `marketplace_asset_types` stores a JSON array of asset type names eligible for publication (e.g., `["Dataset", "Dashboard", "ML Model"]`). This controls which asset types can be published and appear in the marketplace.
+- Two new endpoints: `GET /api/settings/marketplace-config` (read, any authenticated user) and `PUT /api/settings/marketplace-config` (write, admin only).
+- A new "Marketplace" subsection in Settings > Configuration with checkboxes for entity types and asset type selection.
+
+### Data Contract Publication
+
+- Contracts already have `publication_scope`, `published_at`, `published_by` columns in the DB and `domain_id` for domain filtering. No schema migration needed.
+- The ODCS API models (`DataContractRead`, `DataContractSummary`) must be extended to expose `publication_scope`, `published_at`, `published_by` (currently only expose the legacy `published` boolean).
+- The `_build_contract_api_model` builder in `DataContractsManager` must map the new columns.
+- New routes: `GET /api/data-contracts/published`, `POST /api/data-contracts/{id}/set-publication-scope`, `POST /api/data-contracts/{id}/unpublish` (direct publication, mirroring the product pattern).
+- The existing `request-publish` / `handle-publish` approval flow continues to work alongside direct publication. On approval, it sets `publication_scope` to `"organization"`.
+- New manager method `get_published_contracts()` filters by `status == 'active'` AND `publication_scope != 'none'`.
+
+### Asset Publication
+
+- New DB migration: add `publication_scope` (String, default `"none"`, indexed), `published_at` (DateTime), `published_by` (String) to the `assets` table.
+- Extend `AssetRead` Pydantic model (backend) and `AssetRead` TypeScript interface (frontend) with publication fields.
+- New routes: `GET /api/assets/published` (accepts `?asset_types=` query param to filter by type), `POST /api/assets/{id}/set-publication-scope`, `POST /api/assets/{id}/unpublish`.
+- Publication gated: only assets whose `asset_type_name` is in the `marketplace_asset_types` config can be published. Endpoint returns 400 if asset type is not eligible.
+- Default eligible asset types: `Dataset`, `Dashboard`, `ML Model`.
+
+### Marketplace Frontend
+
+- `MarketplaceAssetType` union becomes `'products' | 'contracts' | 'assets'` (legacy `'datasets'` removed).
+- Marketplace view fetches `GET /api/settings/marketplace-config` on mount to determine which tabs to show.
+- Each entity type has its own fetch, filter, and render logic. Card rendering is consistent: name, description snippet, domain badge, status badge, certification badge, rating, owner.
+- Domain filtering extends to all entity types. Contracts use `domainId`, assets use `domain_id`.
+- The dead `scopeFilter` state is wired to actual UI controls (dropdown or pill buttons for scope filtering).
+- The legacy datasets fetch (`/api/datasets/published`) and datasets toggle are removed. Asset-type datasets appear under the new Assets tab.
+
+### Publication Prerequisites
+
+- Strict: entity must have `status == 'active'` to be published (consistent across products, contracts, assets).
+- Deprecation auto-unpublishes (sets `publication_scope` to `"none"`).
+
+### Subscription Model
+
+- Full subscribe/unsubscribe for contracts and assets, using the existing `entity_subscriptions` polymorphic table with `entity_type` set to `"data_contract"` or `"asset"`.
+- Subscription endpoints: `POST /api/data-contracts/{id}/subscribe`, `DELETE /api/data-contracts/{id}/subscribe`, `GET /api/data-contracts/my-subscriptions`. Same pattern for assets.
+- The marketplace subscribe flow (approval wizard or fallback dialog) is reused for all entity types.
+
+## Testing Decisions
+
+Good tests verify external behavior (API response shapes, status codes, filter correctness) rather than internal implementation details. Tests should be resilient to refactoring — if the behavior doesn't change, the test shouldn't break.
+
+### Backend tests
+
+- **Published endpoints**: Verify `GET /api/data-contracts/published` and `GET /api/assets/published` return only active + published items. Verify query params (`asset_types`, `scope`, `domain_id`) filter correctly.
+- **Publication scope routes**: Verify `set-publication-scope` requires active status, returns 400 for non-active entities. Verify `unpublish` clears scope. Verify ineligible asset types are rejected.
+- **Settings routes**: Verify marketplace config CRUD, default values, admin-only write access.
+- **Auto-unpublish**: Verify deprecation clears publication scope.
+- Prior art: `test_data_product_routes.py::test_get_published_products` for published endpoint patterns.
+
+### Frontend component tests
+
+- **Card renderers**: Verify contract and asset cards render all expected fields (name, domain, status, certification, rating).
+- **Tab visibility**: Verify marketplace tabs are conditionally rendered based on config response.
+- **Scope filter**: Verify filtering by publication scope works correctly.
+- Prior art: existing marketplace view patterns (if any component tests exist) or general Shadcn component test patterns.
+
+## Out of Scope
+
+- **Unified search endpoint**: A single backend endpoint that searches across all entity types is not part of this PRD. Each type has its own published endpoint; search is client-side.
+- **Marketplace analytics**: Usage tracking, view counts, popularity metrics are not included.
+- **Cross-entity recommendations**: "Users who subscribed to this product also subscribed to..." is not included.
+- **Payment or access-gating**: No paywall or formal access request workflow for marketplace items.
+- **Asset certification inheritance through marketplace**: Certification propagation is handled by the separate unified-lifecycle-tracking PRD (Phase 7).
+- **Contract schema preview in marketplace**: Showing inline schema details on the contract card is deferred.
+- **Ontology concept publication**: Publishing ontology concepts to the marketplace is not included.
+
+## Further Notes
+
+- This work builds on the unified lifecycle tracking plan (Phases 4 and 5 specifically). Publication columns for contracts are already in the DB from that work. The asset publication migration is new.
+- The existing `request-publish` / `handle-publish` approval workflow for contracts coexists with the new direct publication scope model. Organizations can use either or both — the approval flow just happens to set `publication_scope` on success.
+- The `marketplace_asset_types` admin setting provides a guardrail: even if an admin enables "assets" in the marketplace, only the configured asset types can be published. This prevents accidental publication of structural entities like Catalogs or Schemas.
+- i18n: New strings needed for marketplace tabs, card labels, settings panel, and scope filter options across all supported locales.

--- a/docs/prds/prd-ui-branding-and-display-customization.md
+++ b/docs/prds/prd-ui-branding-and-display-customization.md
@@ -1,0 +1,99 @@
+# PRD: UI branding and display customization
+
+## Problem Statement
+
+Deployers of the application need to **re-skin** the product so it feels like their own organization’s tool, not a vendor-branded shell. Today, key identity signals are effectively fixed: the **product name** is embedded throughout translated copy and some views, while **logo** customization exists only as an image URL and **custom CSS** as an advanced escape hatch. The **browser tab title** and **favicon** remain static from the shipped frontend assets. Administrators can change some appearance settings, but they cannot complete a simple, guided “white label lite” flow (name + iconography + tab chrome) without hunting strings or relying solely on CSS.
+
+From an operator’s perspective, the gap is **discoverability and completeness**: branding is split between runtime settings, static build artifacts, and dozens of locale strings, so changes are fragile and incomplete across languages and surfaces.
+
+## Solution
+
+Introduce **first-class branding fields** stored with existing UI customization settings: a **global display name**, an optional **short name** for compact UI, and a **favicon URL**, alongside the existing custom logo URL, about content, i18n toggle, and custom CSS. These values are exposed on the **same unauthenticated bootstrap endpoint** the SPA already uses so every session applies branding early.
+
+Copy that currently hardcodes the vendor product name in translations is refactored to use **i18n interpolation** (a single `appName` variable resolved from settings with a safe default when unset). After load and after save, the client **updates document title** and **injects or replaces the favicon** in the document head, mirroring how custom CSS is already injected.
+
+Administrators configure everything from the **UI Customization** settings page with validation, previews, and clear guidance that some artifacts (e.g. install-time PWA manifest name) may remain static until a future enhancement.
+
+## User Stories
+
+1. As an **Administrator**, I want to set a **global application display name**, so that the product is identified consistently with my organization’s name across the UI.
+2. As an **Administrator**, I want to set an **optional short name**, so that compact areas (tabs, side labels) can show an abbreviation without redesigning layouts.
+3. As an **Administrator**, I want to set a **favicon URL** with the same safety expectations as the logo URL, so that browser tabs and bookmarks reflect our brand.
+4. As an **Administrator**, I want to **preview** logo and favicon before saving, so that I can catch broken or blocked URLs early.
+5. As an **Administrator**, I want **display name and favicon** to persist in the same place as other UI customization options, so that I do not hunt multiple configuration surfaces.
+6. As an **Administrator**, I want **validation** on URLs and reasonable limits on name length, so that I cannot accidentally break the layout or inject unsafe content through the name field.
+7. As an **Administrator**, I want saving branding to **refresh runtime appearance** without redeploying the app bundle, so that changes take effect for new loads and for my current session after save.
+8. As an **end user**, I want the **welcome and navigation copy** in my selected language to use the **configured display name** instead of a hardcoded vendor name, so that the experience feels coherent in every supported locale.
+9. As an **end user**, I want the **browser tab title** to reflect the configured name, so that I can find the correct tab among many.
+10. As an **end user**, I want the **favicon** in the tab to match the organization, so that visual scanning matches my expectation of internal tools.
+11. As a **reader-only user**, I want branding applied **without needing settings API write access**, so that I still see the tenant’s identity (bootstrap remains public read).
+12. As a **security reviewer**, I want display names treated as **plain text** and URLs restricted to safe schemes, so that branding cannot be used as an XSS vector.
+13. As an **operator**, I want fresh installs to start with the **shipped default product name** when no branding is configured, so that the app is immediately usable without setting environment variables (env-level defaults are explicitly out of scope for v1).
+14. As an **Administrator**, I want clearing the display name to fall back to a **documented default product name**, so that empty configuration does not produce blank titles or broken grammar.
+15. As an **Administrator**, I want the **About** experience to remain markdown-driven, so that legal or extended positioning text stays separate from the short display name.
+16. As an **Administrator**, I want **custom CSS** to remain supported as the advanced theming path, so that power users can still tune shadcn or layout tokens without waiting for preset pickers.
+17. As a **translator or localization owner**, I want product-name phrases in JSON to use **interpolation placeholders** instead of literal vendor strings, so that one branding setting updates all locales consistently.
+18. As a **developer**, I want a **single module** responsible for applying branding side effects (CSS injection already exists; extend with favicon and title), so that behavior stays consistent and testable.
+19. As a **QA engineer**, I want automated checks that the **public branding JSON** includes the new fields when set, so that regressions in the bootstrap contract are caught early.
+20. As an **Administrator**, I want **inline help text** explaining which surfaces update immediately vs which remain build-time static (e.g. PWA manifest), so that I set correct expectations for my organization.
+21. As an **end user** using **screen readers**, I want landmark and page titles to remain meaningful when the display name changes, so that accessibility is not degraded by customization.
+22. As an **Administrator**, I want invalid favicon or logo URLs to show **actionable error messages**, so that I can fix CDN permissions or HTTPS issues quickly.
+23. As a **multi-tab user**, I want branding updates after an admin save to apply when the store **refetches**, so that long-lived sessions can pick up changes without a full redeploy.
+24. As an **Administrator**, I want branding changes to flow through the **same settings update path** as other UI customization keys, so that any existing logging, change tracking, or governance hooks on settings updates apply automatically (no new audit subsystem in v1).
+25. As an **integrator**, I want the **admin settings update API** to accept the new keys alongside existing UI keys in one payload, so that automation scripts can configure branding idempotently.
+26. As an **end user**, I want **search / assistant / catalog** surfaces that today say “Ask &lt;vendor&gt;” to use the **configured name**, so that the copilot metaphor matches our internal assistant branding.
+27. As an **Administrator**, I want the **short name** to be optional with sensible UI when omitted, so that I am not forced to invent an acronym.
+28. As a **mobile browser user**, I want the favicon change to apply where the browser reads `link rel="icon"`, so that home-screen shortcuts look correct when the browser uses that metadata.
+29. As a **Databricks App operator**, I want branding to work in **embedded** contexts where the app runs inside another shell, so that tab title and favicon still help disambiguation (within browser constraints).
+30. As a **future maintainer**, I want the **default product name constant** defined in one conceptual place on the client, so that fallback copy does not drift across modules.
+
+## Implementation Decisions
+
+- **Single global display name** (not per-locale DB fields): all supported languages use the same configured name via i18n interpolation in strings that previously hardcoded the vendor name.
+- **Optional short name**: persisted for compact copy; UI may use it selectively where grammar allows (e.g. “Ask {{shortName}}” with fallback to display name if short name empty).
+- **v1 scope is branding-only**: no curated color preset pickers; advanced appearance remains **custom CSS** as today.
+- **Persistence model**: new keys stored in the same **app settings** key-value store pattern as existing UI customization keys, loaded into the shared **application settings** object on startup and updated on admin save (same mutation path as logo and CSS).
+- **Public read contract**: extend the existing **unauthenticated** UI customization bootstrap endpoint so the SPA can fetch names, favicon, logo, CSS, and i18n flag before interactive auth flows complete.
+- **Admin write contract**: extend the existing **authenticated** settings update endpoint to accept the new snake_case fields alongside current UI fields.
+- **Runtime application**: after successful fetch (and after save-triggered refresh), the client updates **document title**, **favicon link element(s)** in the document head, and continues to inject **custom CSS** via the existing mechanism.
+- **Interpolation strategy**: locale files use placeholders (e.g. `Welcome to {{appName}}`); React call sites pass the effective display name from client state with a **fixed default** when the setting is null or empty.
+- **Validation**: display name — plain text, max length, strip control characters; URLs — same **http/https** rules as the existing logo URL validation pattern.
+- **Deep module**: encapsulate “**apply branding side effects**” (CSS already partially there; add favicon + title) behind a small, stable interface invoked from the central client store after hydration so views do not duplicate DOM manipulation.
+- **Backward compatibility**: missing DB keys behave as today (default name, no custom favicon); no breaking change to existing API consumers beyond **additive** JSON fields.
+- **Static build limitations** documented for v1: **PWA manifest display name** and some static HTML meta remain unchanged unless a future phase adds a server-generated manifest or build-time templating.
+
+## Testing Decisions
+
+- **Good tests** assert **observable behavior and contracts**: HTTP response shapes for public bootstrap and admin update paths, and that optional fields round-trip when set and clear when nulled.
+- **Modules to test**: primarily the **settings HTTP layer** (existing integration/e2e style tests that already assert UI customization payloads); optionally pure **URL validation / string sanitization** helpers if extracted for unit testing.
+- **Prior art**: existing tests that call **GET** public UI customization and **GET/PUT** full settings; extend expectations **additively** for new keys without coupling to DOM implementation details of favicon injection.
+- **Non-goals for automated tests in v1**: pixel-diff branding, full cross-browser PWA manifest behavior, or every interpolated string in every locale (spot-check English + one non-English locale in manual QA if needed).
+
+## Acceptance Criteria
+
+A v1 implementation is complete when **all** of the following are true:
+
+1. **Settings model**: `app_display_name`, `app_short_name`, and `favicon_url` exist as optional string fields on the application settings, persisted via the same `app_settings` key-value pattern as the existing UI customization keys, and survive process restart.
+2. **Public bootstrap contract**: `GET /api/settings/ui-customization` returns the three new fields (snake_case) alongside existing UI customization fields, without authentication, and returns `null` (or an absent value, consistent with current style) when unset.
+3. **Admin write contract**: `PUT /api/settings` accepts the three new snake_case fields in the same payload as existing UI keys, persists them, and a subsequent `GET` reflects the new values; clearing a field (empty string or null per existing convention) reverts to the default behavior described in story 14.
+4. **Validation**: display name is plain text with a documented max length and stripped control characters; `favicon_url` is validated with the same scheme rules as the existing custom logo URL; invalid input returns an actionable error from the settings update endpoint and is surfaced inline in the settings form.
+5. **Runtime application**: on initial SPA load and after a successful save, the client (a) sets `document.title` to the effective display name, (b) injects or replaces the favicon `<link rel="icon">` in `<head>` when `favicon_url` is set and removes the override when cleared, and (c) continues to inject custom CSS via the existing mechanism.
+6. **i18n interpolation**: locale files no longer hardcode the vendor product name in the strings touched by this work; affected strings use an `appName` (and where applicable `shortName`) interpolation variable resolved from client state with a fixed default constant; English plus at least one additional shipped locale are spot-checked.
+7. **Default fallback**: when `app_display_name` is unset, the UI, document title, and i18n interpolations render the documented default product name; no string shows an empty placeholder or a literal `{{appName}}`.
+8. **Settings UI**: the UI Customization settings view exposes inputs for display name, short name, and favicon URL with previews for logo and favicon, inline help that names the surfaces which update immediately vs remain build-time static (PWA manifest, static `index.html` `<title>`), and respects existing permission gates for settings writes.
+9. **Backward compatibility**: existing API consumers see only **additive** JSON fields; deployments with no new keys configured behave exactly as before this change.
+10. **Tests**: integration / e2e tests for the public bootstrap and settings update endpoints are extended to assert the three new fields round-trip, including the `null`/cleared case; no test asserts low-level DOM details of favicon injection.
+
+## Out of Scope
+
+- **Per-locale marketing names** stored separately in the database.
+- **Admin UI color pickers** or preset themes that write design tokens (beyond custom CSS textarea).
+- **Server-generated `manifest.json`** or dynamic Open Graph tags for social sharing.
+- **Logo or favicon file upload** to Unity Catalog volumes or app storage (URLs only in v1).
+- **Renaming backend infrastructure identifiers** (e.g. Databricks app technical name) or Unity Catalog comments that reference an internal product name.
+- **Email / notification templates** branding unless already covered by a separate notifications PRD.
+
+## Further Notes
+
+- Problem framing and scope choices (**single global name**, **branding-only v1**) were aligned in a prior design conversation; this PRD captures them for delivery and review.
+- **Suggested issue labels** (mapped to existing repo labels): `enhancement`, `feature`, `feat/settings`, `python`, `javascript`.


### PR DESCRIPTION
## Summary

Adds nine PRDs under \`docs/prds/\` covering planned/proposed work. Documentation only — no code changes.

| PRD | Linked issue |
|-----|--------------|
| \`prd-approval-workflows-v2.md\` | #242 |
| \`prd-cdm-vertical-onboarding.md\` | — |
| \`prd-comments-audience-and-mentions.md\` | — |
| \`prd-configurable-maturity-levels.md\` | — |
| \`prd-entra-id-graph-integration.md\` | #335 |
| \`prd-individual-user-role-assignment.md\` | — |
| \`prd-knowledge-graph-view.md\` | #332 |
| \`prd-marketplace-multi-entity.md\` | #241 |
| \`prd-ui-branding-and-display-customization.md\` | — |

## Test plan

- [ ] PRDs render correctly on GitHub
- [ ] Linked issues are reachable