### PR TITLE
feat(data-catalog): server-side pagination, asset columns, hierarchy filters & expanded search

### DIFF
--- a/src/backend/src/controller/data_catalog_manager.py
+++ b/src/backend/src/controller/data_catalog_manager.py
@@ -2,30 +2,34 @@
 Data Catalog Manager
 
 Provides functionality for the Data Dictionary feature:
-- Browse columns from REGISTERED assets (Data Contracts only)
-- Search columns by name across registered assets
-- Get table details with lineage
+- Browse columns from Data Contracts AND imported Assets (Table/View/Dataset)
+- Server-side pagination with offset/limit
+- Faceted filtering by asset type, system, catalog, schema
+- Full-field search across column name, description, business terms, parents
+- Table details and lineage
 
-NOTE: This does NOT scan the entire Unity Catalog - it only shows
-assets that are already registered in the app via Data Contracts.
+Data sources are merged and deduplicated: Asset (physical) metadata is the base,
+Contract metadata enriches with business context.
 """
 
-from typing import List, Optional, Dict, Any
-from sqlalchemy.orm import Session
+from typing import List, Optional, Dict, Any, Tuple
+from sqlalchemy.orm import Session, selectinload
 
 from databricks.sdk import WorkspaceClient
 
 from src.common.logging import get_logger
 from src.common.config import Settings
+from src.db_models.assets import AssetDb, AssetTypeDb, AssetRelationshipDb
+from src.db_models.data_contracts import DataContractDb, SchemaObjectDb, SchemaPropertyDb
 from src.models.data_catalog import (
     ColumnDictionaryEntry,
     ColumnInfo,
     TableInfo,
     TableListItem,
-    ColumnSearchRequest,
     ColumnSearchResponse,
     DataDictionaryResponse,
     TableListResponse,
+    HierarchyFilters,
     LineageGraph,
     LineageDirection,
     ImpactAnalysis,
@@ -35,17 +39,23 @@ from src.controller.data_contracts_manager import DataContractsManager
 
 logger = get_logger(__name__)
 
+# Asset types that represent table-like containers with columns
+_TABLE_LIKE_TYPES = {"Table", "View", "Dataset"}
+_HIERARCHICAL_RELS = {"hasColumn", "hasTable", "hasView", "hasDataset", "hasPart",
+                      "contains", "hasCatalog", "hasSchema"}
+
 
 class DataCatalogManager:
     """
     Manager for Data Dictionary / Data Catalog operations.
-    
-    Only indexes assets that are REGISTERED in the application
-    (tables/views referenced in Data Contracts).
-    
-    Does NOT scan the entire Unity Catalog.
+
+    Merges columns from two sources:
+    1. Data Contracts (schema objects with properties)
+    2. Asset DB (Table/View/Dataset assets with Column children)
+
+    Supports server-side pagination, faceted filtering, and full-field search.
     """
-    
+
     def __init__(
         self,
         obo_client: WorkspaceClient,
@@ -53,54 +63,30 @@ class DataCatalogManager:
         contracts_manager: Optional[DataContractsManager] = None,
         settings: Optional[Settings] = None
     ):
-        """
-        Initialize DataCatalogManager.
-        
-        Args:
-            obo_client: OBO workspace client for user-specific UC access
-            db_session: Database session for querying registered assets
-            contracts_manager: Manager for Data Contracts
-            settings: Application settings
-        """
         self.client = obo_client
         self.db = db_session
         self.contracts_manager = contracts_manager
         self.settings = settings
         self.lineage_service = LineageService(obo_client)
-        
-        logger.debug("DataCatalogManager initialized (registered assets only)")
-    
+
+        logger.debug("DataCatalogManager initialized")
+
     # =========================================================================
-    # Get Registered Assets from Database
+    # Column Extraction: Contracts
     # =========================================================================
-    
+
     def _get_columns_from_contracts(self) -> List[ColumnDictionaryEntry]:
         """
-        Get all columns from Data Contracts' schema definitions.
-        
-        This extracts column information directly from the contract schemas,
-        which define the expected structure of data regardless of whether
-        the physical tables exist in Unity Catalog.
-        
-        Columns are deduplicated by (table_full_name, column_name) to avoid
-        showing the same column multiple times.
-        
-        Returns:
-            List of ColumnDictionaryEntry from all contracts (deduplicated)
+        Extract columns from Data Contract schema definitions.
+        Deduplicated by (table_full_name, column_name).
         """
-        # Use dict for deduplication: key = (table_full_name, column_name)
-        columns_map: Dict[tuple, ColumnDictionaryEntry] = {}
-        
+        columns_map: Dict[Tuple[str, str], ColumnDictionaryEntry] = {}
+
+        if not self.db:
+            logger.warning("Database session not available")
+            return []
+
         try:
-            # Query contracts directly from database with eager loading
-            from sqlalchemy.orm import selectinload
-            from src.db_models.data_contracts import DataContractDb, SchemaObjectDb, SchemaPropertyDb
-            
-            if not self.db:
-                logger.warning("Database session not available")
-                return []
-            
-            # Get all contracts with schema objects, properties, and authoritative definitions eager loaded
             db_contracts = (
                 self.db.query(DataContractDb)
                 .options(
@@ -111,24 +97,20 @@ class DataCatalogManager:
                 .all()
             )
             logger.info(f"Processing {len(db_contracts)} contracts for column extraction")
-            
+
             for db_contract in db_contracts:
-                contract_id = db_contract.id
+                contract_id = str(db_contract.id)
                 contract_name = db_contract.name
                 contract_version = db_contract.version or "1.0"
                 contract_status = db_contract.status
-                
-                # Get schema objects from database contract
+
                 schema_objects = getattr(db_contract, 'schema_objects', []) or []
-                
+
                 for schema_obj in schema_objects:
                     schema_name = getattr(schema_obj, 'name', 'unknown')
-                    physical_name = getattr(schema_obj, 'physical_name', None) or schema_name
-                    schema_description = getattr(schema_obj, 'description', None)
-                    
-                    # Get columns (properties) from schema object
+
                     properties = getattr(schema_obj, 'properties', []) or []
-                    
+
                     for idx, prop in enumerate(properties):
                         col_name = getattr(prop, 'name', 'unknown')
                         logical_type = getattr(prop, 'logical_type', 'unknown')
@@ -139,27 +121,24 @@ class DataCatalogManager:
                         is_pk = pk_position is not None and pk_position >= 0
                         classification = getattr(prop, 'classification', None)
                         business_name = getattr(prop, 'business_name', None)
-                        
-                        # Extract business terms from authoritative definitions
+
                         business_terms: List[Dict[str, str]] = []
                         auth_defs = getattr(prop, 'authoritative_definitions', []) or []
                         for auth_def in auth_defs:
                             url = getattr(auth_def, 'url', None)
                             def_type = getattr(auth_def, 'type', None)
                             if url:
-                                # Extract label from URL (last segment or after #)
                                 label = url.split('#')[-1].split('/')[-1] if url else None
                                 business_terms.append({
                                     "iri": url,
                                     "label": label or url,
                                     "type": def_type or "businessTerm"
                                 })
-                        
+
                         table_full_name = f"{contract_name}.{schema_name}"
                         dedup_key = (table_full_name, col_name)
-                        
+
                         if dedup_key in columns_map:
-                            # Merge business terms from duplicate entry
                             existing = columns_map[dedup_key]
                             existing_iris = {t.get("iri") for t in existing.business_terms}
                             for term in business_terms:
@@ -175,9 +154,10 @@ class DataCatalogManager:
                                 position=idx,
                                 table_name=schema_name,
                                 table_full_name=table_full_name,
-                                schema_name=contract_name,  # Use contract name as "schema"
-                                catalog_name=contract_version,  # Use version as "catalog"
+                                schema_name=contract_name,
+                                catalog_name=contract_version,
                                 table_type="CONTRACT",
+                                source="contract",
                                 is_primary_key=is_pk,
                                 classification=classification,
                                 contract_id=contract_id,
@@ -186,239 +166,515 @@ class DataCatalogManager:
                                 contract_status=contract_status,
                                 business_terms=business_terms,
                             )
-            
+
             columns = list(columns_map.values())
             logger.info(f"Extracted {len(columns)} unique columns from {len(db_contracts)} contracts")
-            
+
         except Exception as e:
             logger.error(f"Error extracting columns from contracts: {e}", exc_info=True)
             return []
-        
+
         return columns
-    
+
     # =========================================================================
-    # Column Dictionary Methods
+    # Column Extraction: Assets
     # =========================================================================
-    
+
+    def _get_columns_from_assets(self) -> List[ColumnDictionaryEntry]:
+        """
+        Extract columns from Asset DB (Table/View/Dataset assets with Column children).
+
+        Walks the asset hierarchy to resolve parent System/Catalog/Schema names.
+        """
+        columns: List[ColumnDictionaryEntry] = []
+
+        if not self.db:
+            logger.warning("Database session not available")
+            return []
+
+        try:
+            # Get all table-like assets with their relationships eager-loaded
+            table_like_assets = (
+                self.db.query(AssetDb)
+                .join(AssetTypeDb, AssetDb.asset_type_id == AssetTypeDb.id)
+                .filter(AssetTypeDb.name.in_(_TABLE_LIKE_TYPES))
+                .options(
+                    selectinload(AssetDb.asset_type),
+                    selectinload(AssetDb.source_relationships),
+                    selectinload(AssetDb.target_relationships)
+                    .selectinload(AssetRelationshipDb.source_asset)
+                    .selectinload(AssetDb.asset_type),
+                )
+                .all()
+            )
+            logger.info(f"Processing {len(table_like_assets)} table-like assets for column extraction")
+
+            for asset in table_like_assets:
+                asset_type_name = asset.asset_type.name if asset.asset_type else "Table"
+
+                # Resolve hierarchy: walk target_relationships to find parent Schema/Catalog/System
+                parent_info = self._resolve_asset_parents(asset)
+                system_name = parent_info.get("system")
+                catalog_name = parent_info.get("catalog", "")
+                schema_name = parent_info.get("schema", "")
+
+                # Build the FQN
+                if asset.location:
+                    table_full_name = asset.location
+                else:
+                    parts = [p for p in [catalog_name, schema_name, asset.name] if p]
+                    table_full_name = ".".join(parts) if parts else asset.name
+
+                table_name = asset.name
+
+                # Get columns from hasColumn children
+                child_columns = self._get_asset_child_columns(asset)
+
+                # Fallback: check properties.schema.columns
+                if not child_columns and asset.properties and "schema" in asset.properties:
+                    stored = asset.properties["schema"]
+                    if isinstance(stored, dict) and "columns" in stored:
+                        for idx, c in enumerate(stored["columns"]):
+                            child_columns.append({
+                                "name": c.get("name", ""),
+                                "data_type": c.get("data_type", ""),
+                                "logical_type": c.get("logical_type", "string"),
+                                "nullable": c.get("nullable", True),
+                                "description": c.get("description", ""),
+                                "is_partition_key": c.get("is_partition_key", False),
+                                "position": idx,
+                            })
+
+                for idx, col_data in enumerate(child_columns):
+                    columns.append(ColumnDictionaryEntry(
+                        column_name=col_data.get("name", "unknown"),
+                        column_label=None,
+                        column_type=col_data.get("data_type", "") or col_data.get("logical_type", "unknown"),
+                        description=col_data.get("description"),
+                        nullable=col_data.get("nullable", True),
+                        position=col_data.get("position", idx),
+                        table_name=table_name,
+                        table_full_name=table_full_name,
+                        schema_name=schema_name,
+                        catalog_name=catalog_name,
+                        table_type=asset_type_name.upper(),
+                        source="asset",
+                        asset_id=str(asset.id),
+                        system_name=system_name,
+                        is_primary_key=col_data.get("is_partition_key", False),
+                    ))
+
+            logger.info(f"Extracted {len(columns)} columns from {len(table_like_assets)} assets")
+
+        except Exception as e:
+            logger.error(f"Error extracting columns from assets: {e}", exc_info=True)
+            return []
+
+        return columns
+
+    def _get_asset_child_columns(self, asset: AssetDb) -> List[Dict[str, Any]]:
+        """Get Column children of a table-like asset via hasColumn relationships."""
+        columns: List[Dict[str, Any]] = []
+        if not asset.source_relationships:
+            return columns
+
+        for rel in asset.source_relationships:
+            if rel.relationship_type != "hasColumn":
+                continue
+            # Load the child column asset
+            child = (
+                self.db.query(AssetDb)
+                .filter(AssetDb.id == rel.target_asset_id)
+                .first()
+            )
+            if not child:
+                continue
+            props = child.properties or {}
+            columns.append({
+                "name": child.name,
+                "data_type": props.get("data_type", ""),
+                "logical_type": props.get("logical_type", "string"),
+                "nullable": props.get("nullable", True),
+                "description": child.description or "",
+                "is_partition_key": props.get("is_partition_key", False),
+                "position": props.get("position", 0),
+            })
+        return columns
+
+    def _resolve_asset_parents(self, asset: AssetDb) -> Dict[str, Optional[str]]:
+        """Walk up the hierarchy to find parent System/Catalog/Schema names."""
+        result: Dict[str, Optional[str]] = {"system": None, "catalog": None, "schema": None}
+
+        if not asset.target_relationships:
+            return result
+
+        # target_relationships: this asset is the target (child); source is the parent
+        for rel in asset.target_relationships:
+            if rel.relationship_type not in _HIERARCHICAL_RELS:
+                continue
+            parent = rel.source_asset
+            if not parent or not parent.asset_type:
+                continue
+            parent_type = parent.asset_type.name
+            if parent_type == "System":
+                result["system"] = parent.name
+            elif parent_type == "Catalog":
+                result["catalog"] = parent.name
+                # Also try to get system from catalog's parent
+                catalog_parents = self._resolve_asset_parents(parent)
+                if catalog_parents.get("system"):
+                    result["system"] = catalog_parents["system"]
+            elif parent_type == "Schema":
+                result["schema"] = parent.name
+                # Walk up from schema
+                schema_parents = self._resolve_asset_parents(parent)
+                if schema_parents.get("catalog"):
+                    result["catalog"] = schema_parents["catalog"]
+                if schema_parents.get("system"):
+                    result["system"] = schema_parents["system"]
+
+        return result
+
+    # =========================================================================
+    # Merge and Deduplication
+    # =========================================================================
+
+    def _merge_columns(
+        self,
+        contract_columns: List[ColumnDictionaryEntry],
+        asset_columns: List[ColumnDictionaryEntry],
+    ) -> List[ColumnDictionaryEntry]:
+        """
+        Merge columns from contracts and assets.
+
+        Asset metadata is the base (physical truth); Contract enriches with
+        business context. Deduplicate by (table_full_name, column_name).
+        """
+        # Index asset columns by dedup key
+        merged: Dict[Tuple[str, str], ColumnDictionaryEntry] = {}
+
+        for col in asset_columns:
+            key = (col.table_full_name.lower(), col.column_name.lower())
+            merged[key] = col
+
+        for col in contract_columns:
+            key = (col.table_full_name.lower(), col.column_name.lower())
+            if key in merged:
+                # Enrich existing asset entry with contract context
+                existing = merged[key]
+                existing.source = "both"
+                existing.contract_id = col.contract_id
+                existing.contract_name = col.contract_name
+                existing.contract_version = col.contract_version
+                existing.contract_status = col.contract_status
+                if col.column_label:
+                    existing.column_label = col.column_label
+                if col.description and not existing.description:
+                    existing.description = col.description
+                if col.classification:
+                    existing.classification = col.classification
+                # Merge business terms
+                existing_iris = {t.get("iri") for t in existing.business_terms}
+                for term in col.business_terms:
+                    if term.get("iri") not in existing_iris:
+                        existing.business_terms.append(term)
+            else:
+                merged[key] = col
+
+        return list(merged.values())
+
+    # =========================================================================
+    # Column Dictionary: Paginated + Filtered
+    # =========================================================================
+
     def get_all_columns(
         self,
         catalog_filter: Optional[str] = None,
         schema_filter: Optional[str] = None,
         table_filter: Optional[str] = None,
-        limit: int = 2000
+        asset_type_filter: Optional[str] = None,
+        system_filter: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 50,
     ) -> DataDictionaryResponse:
         """
-        Get all columns from Data Contracts for the Data Dictionary view.
-        
-        Extracts column definitions from contract schemas, which define
-        the expected data structure regardless of physical table existence.
-        
+        Get paginated columns from both Data Contracts and Assets.
+
         Args:
-            catalog_filter: Optional version/catalog to filter to
-            schema_filter: Optional contract name to filter to
-            table_filter: Optional schema object name to filter to
-            limit: Maximum columns to return
-            
-        Returns:
-            DataDictionaryResponse with columns from Data Contracts
+            catalog_filter: Filter to specific catalog
+            schema_filter: Filter to specific schema
+            table_filter: Filter to specific table (FQN or name)
+            asset_type_filter: Filter to specific asset type (Table, View, Dataset, CONTRACT)
+            system_filter: Filter to columns under a specific System
+            offset: Pagination offset
+            limit: Page size
         """
-        logger.info(f"Fetching columns from contracts (catalog={catalog_filter}, schema={schema_filter}, table={table_filter})")
-        
+        logger.info(
+            f"Fetching columns (catalog={catalog_filter}, schema={schema_filter}, "
+            f"table={table_filter}, asset_type={asset_type_filter}, system={system_filter}, "
+            f"offset={offset}, limit={limit})"
+        )
+
         try:
-            # Get all columns from contracts
-            all_columns = self._get_columns_from_contracts()
-            
+            contract_columns = self._get_columns_from_contracts()
+            asset_columns = self._get_columns_from_assets()
+
+            all_columns = self._merge_columns(contract_columns, asset_columns)
+
             # Apply filters
-            filtered_columns = []
-            for col in all_columns:
-                # Filter by version (catalog)
-                if catalog_filter and col.catalog_name != catalog_filter:
-                    continue
-                # Filter by contract name (schema)
-                if schema_filter and col.schema_name != schema_filter:
-                    continue
-                # Filter by schema object name (table)
-                if table_filter and col.table_name != table_filter:
-                    continue
-                
-                filtered_columns.append(col)
-            
-            # Count unique tables/schema objects
-            unique_tables = set(col.table_full_name for col in filtered_columns)
-            
+            filtered = self._apply_filters(
+                all_columns,
+                catalog_filter=catalog_filter,
+                schema_filter=schema_filter,
+                table_filter=table_filter,
+                asset_type_filter=asset_type_filter,
+                system_filter=system_filter,
+            )
+
+            unique_tables = set(col.table_full_name for col in filtered)
+            total_count = len(filtered)
+            has_more = (offset + limit) < total_count
+            page = filtered[offset:offset + limit]
+
             return DataDictionaryResponse(
                 table_count=len(unique_tables),
-                column_count=len(filtered_columns),
-                columns=filtered_columns[:limit],
-                table_filter=table_filter
+                column_count=total_count,
+                columns=page,
+                offset=offset,
+                limit=limit,
+                has_more=has_more,
+                table_filter=table_filter,
             )
-            
+
         except Exception as e:
             logger.error(f"Error fetching columns: {e}", exc_info=True)
             return DataDictionaryResponse(
                 table_count=0,
                 column_count=0,
                 columns=[],
-                table_filter=table_filter
+                offset=offset,
+                limit=limit,
+                has_more=False,
+                table_filter=table_filter,
             )
-    
-    def _table_to_columns(self, table_info: TableInfo) -> List[ColumnDictionaryEntry]:
-        """Convert TableInfo to list of ColumnDictionaryEntry."""
-        columns = []
-        for idx, col in enumerate(table_info.columns):
-            columns.append(ColumnDictionaryEntry(
-                column_name=col.name,
-                column_label=None,
-                column_type=col.type_text,
-                description=col.comment,
-                nullable=col.nullable,
-                position=idx,
-                table_name=table_info.name,
-                table_full_name=table_info.full_name,
-                schema_name=table_info.schema_name,
-                catalog_name=table_info.catalog_name,
-                table_type=table_info.table_type
-            ))
-        return columns
-    
+
+    def _apply_filters(
+        self,
+        columns: List[ColumnDictionaryEntry],
+        catalog_filter: Optional[str] = None,
+        schema_filter: Optional[str] = None,
+        table_filter: Optional[str] = None,
+        asset_type_filter: Optional[str] = None,
+        system_filter: Optional[str] = None,
+    ) -> List[ColumnDictionaryEntry]:
+        """Apply faceted filters to a column list."""
+        filtered = []
+        for col in columns:
+            if catalog_filter and col.catalog_name.lower() != catalog_filter.lower():
+                continue
+            if schema_filter and col.schema_name.lower() != schema_filter.lower():
+                continue
+            if table_filter:
+                if (col.table_full_name.lower() != table_filter.lower()
+                        and col.table_name.lower() != table_filter.lower()):
+                    continue
+            if asset_type_filter:
+                if col.table_type.lower() != asset_type_filter.lower():
+                    continue
+            if system_filter:
+                if not col.system_name or col.system_name.lower() != system_filter.lower():
+                    continue
+            filtered.append(col)
+        return filtered
+
+    # =========================================================================
+    # Search: Full-Field, Uncapped
+    # =========================================================================
+
     def search_columns(
         self,
         query: str,
         catalog_filter: Optional[str] = None,
         schema_filter: Optional[str] = None,
         table_filter: Optional[str] = None,
-        limit: int = 500
+        asset_type_filter: Optional[str] = None,
+        system_filter: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 50,
     ) -> ColumnSearchResponse:
         """
-        Search columns by name across Data Contracts.
-        
-        Args:
-            query: Search query (searches column name, description, label)
-            catalog_filter: Optional version filter
-            schema_filter: Optional contract name filter
-            table_filter: Optional schema object filter
-            limit: Maximum results
-            
-        Returns:
-            ColumnSearchResponse with matching columns from contracts
+        Search columns across all fields from both Contracts and Assets.
+
+        Searches: column_name, description, column_label, business_terms,
+        table_name, contract_name, system_name, catalog_name, schema_name.
         """
-        logger.info(f"Searching columns in contracts: query='{query}'")
-        
+        logger.info(f"Searching columns: query='{query}', offset={offset}, limit={limit}")
+
         query_lower = query.lower().strip()
-        
+
         if not query_lower:
             return ColumnSearchResponse(
-                query=query,
-                total_count=0,
-                columns=[],
-                has_more=False,
+                query=query, total_count=0, columns=[],
+                has_more=False, offset=offset, limit=limit,
                 filters_applied={}
             )
-        
-        # Get all columns from contracts
-        all_response = self.get_all_columns(
-            catalog_filter=catalog_filter,
-            schema_filter=schema_filter,
-            table_filter=table_filter,
-            limit=5000
+
+        try:
+            contract_columns = self._get_columns_from_contracts()
+            asset_columns = self._get_columns_from_assets()
+            all_columns = self._merge_columns(contract_columns, asset_columns)
+
+            # Apply faceted filters first
+            filtered = self._apply_filters(
+                all_columns,
+                catalog_filter=catalog_filter,
+                schema_filter=schema_filter,
+                table_filter=table_filter,
+                asset_type_filter=asset_type_filter,
+                system_filter=system_filter,
+            )
+
+            # Full-field search
+            matching = [col for col in filtered if self._matches_search(col, query_lower)]
+
+            total_count = len(matching)
+            has_more = (offset + limit) < total_count
+            page = matching[offset:offset + limit]
+
+            return ColumnSearchResponse(
+                query=query,
+                total_count=total_count,
+                columns=page,
+                has_more=has_more,
+                offset=offset,
+                limit=limit,
+                filters_applied={
+                    "catalog": catalog_filter,
+                    "schema": schema_filter,
+                    "table": table_filter,
+                    "asset_type": asset_type_filter,
+                    "system": system_filter,
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Error searching columns: {e}", exc_info=True)
+            return ColumnSearchResponse(
+                query=query, total_count=0, columns=[],
+                has_more=False, offset=offset, limit=limit,
+                filters_applied={}
+            )
+
+    def _matches_search(self, col: ColumnDictionaryEntry, query_lower: str) -> bool:
+        """Check if a column matches a search query across all relevant fields."""
+        if query_lower in col.column_name.lower():
+            return True
+        if col.description and query_lower in col.description.lower():
+            return True
+        if col.column_label and query_lower in col.column_label.lower():
+            return True
+        if col.table_name and query_lower in col.table_name.lower():
+            return True
+        if col.contract_name and query_lower in col.contract_name.lower():
+            return True
+        if col.system_name and query_lower in col.system_name.lower():
+            return True
+        if col.catalog_name and query_lower in col.catalog_name.lower():
+            return True
+        if col.schema_name and query_lower in col.schema_name.lower():
+            return True
+        # Business terms
+        for term in col.business_terms:
+            if query_lower in term.get("iri", "").lower():
+                return True
+            if query_lower in term.get("label", "").lower():
+                return True
+        return False
+
+    # =========================================================================
+    # Hierarchy Filters
+    # =========================================================================
+
+    def get_hierarchy_filters(self) -> HierarchyFilters:
+        """
+        Return available faceted filter values from both Contracts and Assets.
+        Used to populate the UI filter dropdowns.
+        """
+        asset_types: set = set()
+        systems: set = set()
+        catalogs: set = set()
+        schemas: set = set()
+
+        try:
+            contract_columns = self._get_columns_from_contracts()
+            asset_columns = self._get_columns_from_assets()
+            all_columns = self._merge_columns(contract_columns, asset_columns)
+
+            for col in all_columns:
+                if col.table_type:
+                    asset_types.add(col.table_type)
+                if col.system_name:
+                    systems.add(col.system_name)
+                if col.catalog_name:
+                    catalogs.add(col.catalog_name)
+                if col.schema_name:
+                    schemas.add(col.schema_name)
+
+        except Exception as e:
+            logger.error(f"Error computing hierarchy filters: {e}", exc_info=True)
+
+        return HierarchyFilters(
+            asset_types=sorted(asset_types),
+            systems=sorted(systems),
+            catalogs=sorted(catalogs),
+            schemas=sorted(schemas),
         )
-        
-        # Helper to check if query matches any business term
-        def matches_business_terms(col: ColumnDictionaryEntry) -> bool:
-            for term in col.business_terms:
-                iri = term.get("iri", "").lower()
-                label = term.get("label", "").lower()
-                if query_lower in iri or query_lower in label:
-                    return True
-            return False
-        
-        # Filter by query - search in name, description, label, contract name, and business terms
-        matching = [
-            col for col in all_response.columns
-            if query_lower in col.column_name.lower()
-            or (col.description and query_lower in col.description.lower())
-            or (col.column_label and query_lower in col.column_label.lower())
-            or (col.contract_name and query_lower in col.contract_name.lower())
-            or (col.table_name and query_lower in col.table_name.lower())
-            or matches_business_terms(col)
-        ]
-        
-        has_more = len(matching) > limit
-        
-        return ColumnSearchResponse(
-            query=query,
-            total_count=len(matching),
-            columns=matching[:limit],
-            has_more=has_more,
-            filters_applied={
-                "catalog": catalog_filter,
-                "schema": schema_filter,
-                "table": table_filter
-            }
-        )
-    
+
     # =========================================================================
     # Table Methods
     # =========================================================================
-    
+
     def get_table_list(
         self,
         catalog_filter: Optional[str] = None,
-        schema_filter: Optional[str] = None
+        schema_filter: Optional[str] = None,
     ) -> TableListResponse:
-        """
-        Get list of schema objects from Data Contracts for the filter dropdown.
-        
-        Returns schema objects (tables) defined in contract schemas.
-        
-        Args:
-            catalog_filter: Optional version filter
-            schema_filter: Optional contract name filter
-            
-        Returns:
-            TableListResponse with contract schema objects and column counts
-        """
-        logger.info(f"Getting schema objects from contracts (catalog={catalog_filter}, schema={schema_filter})")
-        
+        """Get list of tables/schema objects for the filter dropdown."""
+        logger.info(f"Getting table list (catalog={catalog_filter}, schema={schema_filter})")
+
         tables: List[TableListItem] = []
-        table_columns: Dict[str, int] = {}  # full_name -> column count
-        
+        table_columns: Dict[str, int] = {}
+
         try:
-            # Get all columns from contracts
-            all_columns = self._get_columns_from_contracts()
-            
-            # Group columns by table
+            contract_columns = self._get_columns_from_contracts()
+            asset_columns = self._get_columns_from_assets()
+            all_columns = self._merge_columns(contract_columns, asset_columns)
+
             for col in all_columns:
-                # Apply filters
-                if catalog_filter and col.catalog_name != catalog_filter:
+                if catalog_filter and col.catalog_name.lower() != catalog_filter.lower():
                     continue
-                if schema_filter and col.schema_name != schema_filter:
+                if schema_filter and col.schema_name.lower() != schema_filter.lower():
                     continue
-                
                 full_name = col.table_full_name
                 table_columns[full_name] = table_columns.get(full_name, 0) + 1
-            
-            # Create table list items from unique tables
-            seen_tables = set()
+
+            seen_tables: set = set()
             for col in all_columns:
                 full_name = col.table_full_name
                 if full_name in seen_tables:
                     continue
-                    
-                # Apply filters
-                if catalog_filter and col.catalog_name != catalog_filter:
+                if catalog_filter and col.catalog_name.lower() != catalog_filter.lower():
                     continue
-                if schema_filter and col.schema_name != schema_filter:
+                if schema_filter and col.schema_name.lower() != schema_filter.lower():
                     continue
-                
+
                 seen_tables.add(full_name)
-                
                 tables.append(TableListItem(
                     full_name=full_name,
                     name=col.table_name,
                     schema_name=col.schema_name,
                     catalog_name=col.catalog_name,
-                    table_type="CONTRACT",
+                    table_type=col.table_type,
                     column_count=table_columns.get(full_name, 0),
                     comment=None,
                     contract_id=col.contract_id,
@@ -426,40 +682,30 @@ class DataCatalogManager:
                     contract_version=col.contract_version,
                     contract_status=col.contract_status,
                 ))
-                
+
         except Exception as e:
             logger.error(f"Error getting table list: {e}", exc_info=True)
-        
+
         total_columns = sum(table_columns.values())
-        
+
         return TableListResponse(
             tables=tables,
             total_count=len(tables),
-            total_column_count=total_columns
+            total_column_count=total_columns,
         )
-    
+
     def get_table_details(self, full_name: str) -> Optional[TableInfo]:
-        """
-        Get full table details including all columns from Unity Catalog.
-        
-        Args:
-            full_name: Fully qualified table name (catalog.schema.table)
-            
-        Returns:
-            TableInfo or None if not found
-        """
+        """Get full table details including all columns from Unity Catalog."""
         logger.info(f"Getting table details: {full_name}")
-        
+
         try:
             table = self.client.tables.get(full_name=full_name)
-            
-            # Parse FQN
+
             parts = full_name.split(".")
             catalog_name = parts[0] if len(parts) >= 1 else ""
             schema_name = parts[1] if len(parts) >= 2 else ""
             table_name = parts[2] if len(parts) >= 3 else full_name
-            
-            # Convert columns
+
             columns = []
             if table.columns:
                 for idx, col in enumerate(table.columns):
@@ -472,12 +718,11 @@ class DataCatalogManager:
                         comment=col.comment,
                         partition_index=col.partition_index
                     ))
-            
-            # Get tags if available
+
             tags = None
             if hasattr(table, 'tags') and table.tags:
                 tags = {t.key: t.value for t in table.tags}
-            
+
             return TableInfo(
                 full_name=full_name,
                 name=table_name,
@@ -493,40 +738,27 @@ class DataCatalogManager:
                 storage_location=table.storage_location if hasattr(table, 'storage_location') else None,
                 data_source_format=str(table.data_source_format) if hasattr(table, 'data_source_format') and table.data_source_format else None,
                 columns=columns,
-                tags=tags
+                tags=tags,
             )
-            
+
         except Exception as e:
             logger.error(f"Error getting table details for {full_name}: {e}", exc_info=True)
             return None
-    
+
     # =========================================================================
     # Lineage Methods (delegated to LineageService)
     # =========================================================================
-    
-    def get_table_lineage(
-        self,
-        table_fqn: str,
-        direction: str = "both"
-    ) -> LineageGraph:
+
+    def get_table_lineage(self, table_fqn: str, direction: str = "both") -> LineageGraph:
         """Get lineage graph for a table."""
         dir_enum = LineageDirection(direction.lower())
         return self.lineage_service.get_table_lineage(table_fqn, dir_enum)
-    
-    def get_column_lineage(
-        self,
-        table_fqn: str,
-        column_name: str,
-        direction: str = "both"
-    ) -> LineageGraph:
+
+    def get_column_lineage(self, table_fqn: str, column_name: str, direction: str = "both") -> LineageGraph:
         """Get column-level lineage."""
         dir_enum = LineageDirection(direction.lower())
         return self.lineage_service.get_column_lineage(table_fqn, column_name, dir_enum)
-    
-    def get_impact_analysis(
-        self,
-        table_fqn: str,
-        column_name: Optional[str] = None
-    ) -> ImpactAnalysis:
+
+    def get_impact_analysis(self, table_fqn: str, column_name: Optional[str] = None) -> ImpactAnalysis:
         """Get impact analysis for table or column change."""
         return self.lineage_service.get_impact_analysis(table_fqn, column_name)

--- a/src/backend/src/controller/data_catalog_manager.py
+++ b/src/backend/src/controller/data_catalog_manager.py
@@ -303,12 +303,25 @@ class DataCatalogManager:
             })
         return columns
 
-    def _resolve_asset_parents(self, asset: AssetDb) -> Dict[str, Optional[str]]:
-        """Walk up the hierarchy to find parent System/Catalog/Schema names."""
+    def _resolve_asset_parents(
+        self,
+        asset: AssetDb,
+        _visited: Optional[set] = None,
+    ) -> Dict[str, Optional[str]]:
+        """Walk up the hierarchy to find parent System/Catalog/Schema names.
+
+        Guards against cyclic asset graphs via a visited-set keyed on asset id.
+        """
         result: Dict[str, Optional[str]] = {"system": None, "catalog": None, "schema": None}
 
         if not asset.target_relationships:
             return result
+
+        if _visited is None:
+            _visited = set()
+        if asset.id in _visited:
+            return result
+        _visited.add(asset.id)
 
         # target_relationships: this asset is the target (child); source is the parent
         for rel in asset.target_relationships:
@@ -323,13 +336,13 @@ class DataCatalogManager:
             elif parent_type == "Catalog":
                 result["catalog"] = parent.name
                 # Also try to get system from catalog's parent
-                catalog_parents = self._resolve_asset_parents(parent)
+                catalog_parents = self._resolve_asset_parents(parent, _visited)
                 if catalog_parents.get("system"):
                     result["system"] = catalog_parents["system"]
             elif parent_type == "Schema":
                 result["schema"] = parent.name
                 # Walk up from schema
-                schema_parents = self._resolve_asset_parents(parent)
+                schema_parents = self._resolve_asset_parents(parent, _visited)
                 if schema_parents.get("catalog"):
                     result["catalog"] = schema_parents["catalog"]
                 if schema_parents.get("system"):
@@ -644,8 +657,11 @@ class DataCatalogManager:
         """Get list of tables/schema objects for the filter dropdown."""
         logger.info(f"Getting table list (catalog={catalog_filter}, schema={schema_filter})")
 
-        tables: List[TableListItem] = []
+        # Build (table_columns count, first-row metadata) in a single pass; the
+        # final list is materialised after counting completes so column_count
+        # reflects the full filtered total.
         table_columns: Dict[str, int] = {}
+        table_meta: Dict[str, ColumnDictionaryEntry] = {}
 
         try:
             contract_columns = self._get_columns_from_contracts()
@@ -659,34 +675,28 @@ class DataCatalogManager:
                     continue
                 full_name = col.table_full_name
                 table_columns[full_name] = table_columns.get(full_name, 0) + 1
+                table_meta.setdefault(full_name, col)
 
-            seen_tables: set = set()
-            for col in all_columns:
-                full_name = col.table_full_name
-                if full_name in seen_tables:
-                    continue
-                if catalog_filter and col.catalog_name.lower() != catalog_filter.lower():
-                    continue
-                if schema_filter and col.schema_name.lower() != schema_filter.lower():
-                    continue
-
-                seen_tables.add(full_name)
-                tables.append(TableListItem(
+            tables: List[TableListItem] = [
+                TableListItem(
                     full_name=full_name,
-                    name=col.table_name,
-                    schema_name=col.schema_name,
-                    catalog_name=col.catalog_name,
-                    table_type=col.table_type,
-                    column_count=table_columns.get(full_name, 0),
+                    name=meta.table_name,
+                    schema_name=meta.schema_name,
+                    catalog_name=meta.catalog_name,
+                    table_type=meta.table_type,
+                    column_count=table_columns[full_name],
                     comment=None,
-                    contract_id=col.contract_id,
-                    contract_name=col.contract_name,
-                    contract_version=col.contract_version,
-                    contract_status=col.contract_status,
-                ))
+                    contract_id=meta.contract_id,
+                    contract_name=meta.contract_name,
+                    contract_version=meta.contract_version,
+                    contract_status=meta.contract_status,
+                )
+                for full_name, meta in table_meta.items()
+            ]
 
         except Exception as e:
             logger.error(f"Error getting table list: {e}", exc_info=True)
+            tables = []
 
         total_columns = sum(table_columns.values())
 

--- a/src/backend/src/controller/data_catalog_manager.py
+++ b/src/backend/src/controller/data_catalog_manager.py
@@ -200,7 +200,9 @@ class DataCatalogManager:
                 .filter(AssetTypeDb.name.in_(_TABLE_LIKE_TYPES))
                 .options(
                     selectinload(AssetDb.asset_type),
-                    selectinload(AssetDb.source_relationships),
+                    # Eager-load child column assets (avoids N+1 in _get_asset_child_columns)
+                    selectinload(AssetDb.source_relationships)
+                    .selectinload(AssetRelationshipDb.target_asset),
                     selectinload(AssetDb.target_relationships)
                     .selectinload(AssetRelationshipDb.source_asset)
                     .selectinload(AssetDb.asset_type),
@@ -273,7 +275,12 @@ class DataCatalogManager:
         return columns
 
     def _get_asset_child_columns(self, asset: AssetDb) -> List[Dict[str, Any]]:
-        """Get Column children of a table-like asset via hasColumn relationships."""
+        """Get Column children of a table-like asset via hasColumn relationships.
+
+        Relies on `source_relationships.target_asset` being eager-loaded by the
+        caller (see `_get_columns_from_assets`) — accessing `rel.target_asset`
+        here would otherwise trigger an N+1 lazy-load per child column.
+        """
         columns: List[Dict[str, Any]] = []
         if not asset.source_relationships:
             return columns
@@ -281,12 +288,7 @@ class DataCatalogManager:
         for rel in asset.source_relationships:
             if rel.relationship_type != "hasColumn":
                 continue
-            # Load the child column asset
-            child = (
-                self.db.query(AssetDb)
-                .filter(AssetDb.id == rel.target_asset_id)
-                .first()
-            )
+            child = rel.target_asset
             if not child:
                 continue
             props = child.properties or {}

--- a/src/backend/src/models/data_catalog.py
+++ b/src/backend/src/models/data_catalog.py
@@ -58,10 +58,15 @@ class ColumnDictionaryEntry(BaseModel):
     
     # Table/Schema context
     table_name: str = Field(..., description="Short table/schema object name")
-    table_full_name: str = Field(..., description="Fully qualified name: contract.schema_object")
+    table_full_name: str = Field(..., description="Fully qualified name: contract.schema_object or catalog.schema.table")
     schema_name: str = Field(..., description="Schema/Contract name")
     catalog_name: str = Field(..., description="Catalog/Version")
-    table_type: str = Field("TABLE", description="TABLE, VIEW, or CONTRACT")
+    table_type: str = Field("TABLE", description="TABLE, VIEW, DATASET, or CONTRACT")
+    
+    # Provenance
+    source: str = Field("contract", description="Data source: 'contract', 'asset', or 'both'")
+    asset_id: Optional[str] = Field(None, description="Source Asset ID when sourced from Asset DB")
+    system_name: Optional[str] = Field(None, description="Parent System name in the asset hierarchy")
     
     # Contract context (when sourced from Data Contracts)
     contract_id: Optional[str] = Field(None, description="ID of the source Data Contract")
@@ -172,6 +177,8 @@ class ColumnSearchResponse(BaseModel):
     total_count: int
     columns: List[ColumnDictionaryEntry]
     has_more: bool = False
+    offset: int = 0
+    limit: int = 50
     filters_applied: Dict[str, Optional[str]] = Field(default_factory=dict)
 
 
@@ -295,6 +302,11 @@ class DataDictionaryResponse(BaseModel):
     column_count: int
     columns: List[ColumnDictionaryEntry]
     
+    # Pagination
+    offset: int = 0
+    limit: int = 50
+    has_more: bool = False
+    
     # Filter state
     table_filter: Optional[str] = None
     
@@ -306,6 +318,16 @@ class TableListResponse(BaseModel):
     tables: List[TableListItem]
     total_count: int
     total_column_count: int
+    
+    model_config = {"from_attributes": True}
+
+
+class HierarchyFilters(BaseModel):
+    """Available filter values for the faceted filter UI."""
+    asset_types: List[str] = Field(default_factory=list, description="Available asset types (Table, View, Dataset)")
+    systems: List[str] = Field(default_factory=list, description="Available System names")
+    catalogs: List[str] = Field(default_factory=list, description="Available Catalog names")
+    schemas: List[str] = Field(default_factory=list, description="Available Schema names")
     
     model_config = {"from_attributes": True}
 

--- a/src/backend/src/routes/data_catalog_routes.py
+++ b/src/backend/src/routes/data_catalog_routes.py
@@ -109,7 +109,7 @@ async def get_all_columns(
 async def search_columns(
     request: Request,
     db: DBSessionDep,
-    q: str = Query(..., min_length=1, description="Search query"),
+    q: str = Query(..., min_length=2, description="Search query (min 2 chars)"),
     catalog: Optional[str] = Query(None, description="Filter to specific catalog"),
     schema: Optional[str] = Query(None, description="Filter to specific schema"),
     table: Optional[str] = Query(None, description="Filter to specific table (FQN or name)"),

--- a/src/backend/src/routes/data_catalog_routes.py
+++ b/src/backend/src/routes/data_catalog_routes.py
@@ -2,8 +2,9 @@
 Data Catalog / Data Dictionary Routes
 
 Provides REST API endpoints for:
-- Column dictionary browsing (all columns across tables)
-- Column search
+- Column dictionary browsing (paginated, multi-source)
+- Column search (full-field, uncapped)
+- Hierarchy filter values
 - Table details
 - Lineage visualization
 - Impact analysis
@@ -29,6 +30,7 @@ from src.models.data_catalog import (
     ColumnSearchResponse,
     TableListResponse,
     TableInfo,
+    HierarchyFilters,
     LineageGraph,
     ImpactAnalysis,
 )
@@ -40,44 +42,26 @@ router = APIRouter(prefix="/api/data-catalog", tags=["Data Catalog"])
 DATA_CATALOG_FEATURE_ID = "data-catalog"
 
 
-def get_data_catalog_manager(
+def _get_manager(
     request: Request,
-    db: Session = Depends(lambda: None),  # Will be replaced by route-level dep
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    db: DBSessionDep,
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> DataCatalogManager:
-    """
-    Get or create DataCatalogManager instance.
-    
-    Uses OBO client and queries ONLY registered assets from the database.
-    Does NOT scan the entire Unity Catalog.
-    """
+    """Helper to create manager with all dependencies."""
     settings = getattr(request.app.state, 'settings', None)
     contracts_manager = getattr(request.app.state, 'data_contracts_manager', None)
-    
+
     return DataCatalogManager(
         obo_client=obo_client,
         db_session=db,
         contracts_manager=contracts_manager,
-        settings=settings
+        settings=settings,
     )
 
 
 # =============================================================================
 # Column Dictionary Endpoints
 # =============================================================================
-
-def _get_manager(request: Request, db: DBSessionDep, obo_client: WorkspaceClient = Depends(get_obo_workspace_client)) -> DataCatalogManager:
-    """Helper to create manager with all dependencies."""
-    settings = getattr(request.app.state, 'settings', None)
-    contracts_manager = getattr(request.app.state, 'data_contracts_manager', None)
-    
-    return DataCatalogManager(
-        obo_client=obo_client,
-        db_session=db,
-        contracts_manager=contracts_manager,
-        settings=settings
-    )
-
 
 @router.get(
     "/columns",
@@ -89,24 +73,28 @@ async def get_all_columns(
     db: DBSessionDep,
     catalog: Optional[str] = Query(None, description="Filter to specific catalog"),
     schema: Optional[str] = Query(None, description="Filter to specific schema"),
-    table: Optional[str] = Query(None, description="Filter to specific table (FQN)"),
-    limit: int = Query(2000, ge=1, le=5000, description="Maximum columns to return"),
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    table: Optional[str] = Query(None, description="Filter to specific table (FQN or name)"),
+    asset_type: Optional[str] = Query(None, description="Filter by asset type (Table, View, Dataset, CONTRACT)"),
+    system: Optional[str] = Query(None, description="Filter by parent System name"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    limit: int = Query(50, ge=1, le=500, description="Page size"),
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> DataDictionaryResponse:
     """
-    Get all columns from REGISTERED assets for the Data Dictionary view.
-    
-    Only returns columns from tables that are registered as Datasets.
-    Does NOT scan the entire Unity Catalog.
+    Get paginated columns from registered Data Contracts and Assets.
+
+    Merges columns from both sources, deduplicates, and applies filters.
     """
     try:
         manager = _get_manager(request, db, obo_client)
-        logger.info(f"Getting columns from registered assets (catalog={catalog}, schema={schema}, table={table})")
         return manager.get_all_columns(
             catalog_filter=catalog,
             schema_filter=schema,
             table_filter=table,
-            limit=limit
+            asset_type_filter=asset_type,
+            system_filter=system,
+            offset=offset,
+            limit=limit,
         )
     except Exception as e:
         logger.error(f"Error getting columns: {e}", exc_info=True)
@@ -121,32 +109,63 @@ async def get_all_columns(
 async def search_columns(
     request: Request,
     db: DBSessionDep,
-    q: str = Query(..., min_length=1, description="Search query for column name"),
+    q: str = Query(..., min_length=1, description="Search query"),
     catalog: Optional[str] = Query(None, description="Filter to specific catalog"),
     schema: Optional[str] = Query(None, description="Filter to specific schema"),
-    table: Optional[str] = Query(None, description="Filter to specific table (FQN)"),
-    limit: int = Query(500, ge=1, le=2000, description="Maximum results"),
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    table: Optional[str] = Query(None, description="Filter to specific table (FQN or name)"),
+    asset_type: Optional[str] = Query(None, description="Filter by asset type"),
+    system: Optional[str] = Query(None, description="Filter by parent System name"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    limit: int = Query(50, ge=1, le=500, description="Page size"),
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> ColumnSearchResponse:
     """
-    Search columns by name across REGISTERED assets only.
-    
-    Use this to find all registered tables containing a column with a specific name.
-    Does NOT scan the entire Unity Catalog.
+    Search columns across all fields (name, description, business terms, parent table, etc.).
+
+    Searches the full dataset with no hidden cap.
     """
     try:
         manager = _get_manager(request, db, obo_client)
-        logger.info(f"Searching columns in registered assets: q='{q}'")
         return manager.search_columns(
             query=q,
             catalog_filter=catalog,
             schema_filter=schema,
             table_filter=table,
-            limit=limit
+            asset_type_filter=asset_type,
+            system_filter=system,
+            offset=offset,
+            limit=limit,
         )
     except Exception as e:
         logger.error(f"Error searching columns: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to search columns: {str(e)}")
+
+
+# =============================================================================
+# Hierarchy / Filter Values
+# =============================================================================
+
+@router.get(
+    "/hierarchy",
+    response_model=HierarchyFilters,
+    dependencies=[Depends(PermissionChecker(DATA_CATALOG_FEATURE_ID, FeatureAccessLevel.READ_ONLY))]
+)
+async def get_hierarchy_filters(
+    request: Request,
+    db: DBSessionDep,
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
+) -> HierarchyFilters:
+    """
+    Get available filter values for the faceted filter UI.
+
+    Returns distinct asset types, systems, catalogs, and schemas.
+    """
+    try:
+        manager = _get_manager(request, db, obo_client)
+        return manager.get_hierarchy_filters()
+    except Exception as e:
+        logger.error(f"Error getting hierarchy filters: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get hierarchy filters: {str(e)}")
 
 
 # =============================================================================
@@ -163,21 +182,12 @@ async def get_table_list(
     db: DBSessionDep,
     catalog: Optional[str] = Query(None, description="Filter to specific catalog"),
     schema: Optional[str] = Query(None, description="Filter to specific schema"),
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> TableListResponse:
-    """
-    Get list of REGISTERED tables for the filter dropdown.
-    
-    Only returns tables registered as Datasets.
-    Does NOT scan the entire Unity Catalog.
-    """
+    """Get list of tables/schema objects for the filter dropdown."""
     try:
         manager = _get_manager(request, db, obo_client)
-        logger.info(f"Getting registered table list (catalog={catalog}, schema={schema})")
-        return manager.get_table_list(
-            catalog_filter=catalog,
-            schema_filter=schema
-        )
+        return manager.get_table_list(catalog_filter=catalog, schema_filter=schema)
     except Exception as e:
         logger.error(f"Error getting table list: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to get table list: {str(e)}")
@@ -192,17 +202,11 @@ async def get_table_details(
     request: Request,
     db: DBSessionDep,
     table_fqn: str,
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> TableInfo:
-    """
-    Get full table details including all columns.
-    
-    Args:
-        table_fqn: Fully qualified table name (catalog.schema.table)
-    """
+    """Get full table details including all columns."""
     try:
         manager = _get_manager(request, db, obo_client)
-        logger.info(f"Getting table details: {table_fqn}")
         result = manager.get_table_details(table_fqn)
         if not result:
             raise HTTPException(status_code=404, detail=f"Table not found: {table_fqn}")
@@ -227,18 +231,12 @@ async def get_table_lineage(
     request: Request,
     db: DBSessionDep,
     table_fqn: str,
-    direction: str = Query("both", regex="^(upstream|downstream|both)$", description="Lineage direction"),
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    direction: str = Query("both", regex="^(upstream|downstream|both)$"),
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> LineageGraph:
-    """
-    Get lineage graph for a table.
-    
-    Returns nodes and edges for visualization of upstream and/or
-    downstream dependencies.
-    """
+    """Get lineage graph for a table."""
     try:
         manager = _get_manager(request, db, obo_client)
-        logger.info(f"Getting lineage for {table_fqn}, direction={direction}")
         return manager.get_table_lineage(table_fqn, direction)
     except Exception as e:
         logger.error(f"Error getting lineage: {e}", exc_info=True)
@@ -255,18 +253,12 @@ async def get_column_lineage(
     db: DBSessionDep,
     table_fqn: str,
     column_name: str,
-    direction: str = Query("both", regex="^(upstream|downstream|both)$", description="Lineage direction"),
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    direction: str = Query("both", regex="^(upstream|downstream|both)$"),
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> LineageGraph:
-    """
-    Get column-level lineage.
-    
-    Traces lineage for a specific column, showing how data flows
-    through transformations.
-    """
+    """Get column-level lineage."""
     try:
         manager = _get_manager(request, db, obo_client)
-        logger.info(f"Getting column lineage for {table_fqn}.{column_name}")
         return manager.get_column_lineage(table_fqn, column_name, direction)
     except Exception as e:
         logger.error(f"Error getting column lineage: {e}", exc_info=True)
@@ -274,7 +266,7 @@ async def get_column_lineage(
 
 
 # =============================================================================
-# Impact Analysis Endpoints
+# Impact Analysis
 # =============================================================================
 
 @router.get(
@@ -287,17 +279,11 @@ async def get_table_impact(
     db: DBSessionDep,
     table_fqn: str,
     column: Optional[str] = Query(None, description="Optional column for column-level impact"),
-    obo_client: WorkspaceClient = Depends(get_obo_workspace_client)
+    obo_client: WorkspaceClient = Depends(get_obo_workspace_client),
 ) -> ImpactAnalysis:
-    """
-    Get impact analysis for changing a table or column.
-    
-    Analyzes all downstream dependencies that would be affected
-    by a change to this table or column.
-    """
+    """Get impact analysis for changing a table or column."""
     try:
         manager = _get_manager(request, db, obo_client)
-        logger.info(f"Getting impact analysis for {table_fqn}" + (f".{column}" if column else ""))
         return manager.get_impact_analysis(table_fqn, column)
     except Exception as e:
         logger.error(f"Error getting impact analysis: {e}", exc_info=True)
@@ -312,4 +298,3 @@ def register_routes(app):
     """Register data catalog routes with the FastAPI app."""
     app.include_router(router)
     logger.info("Data Catalog routes registered")
-

--- a/src/backend/src/tests/unit/test_data_catalog_manager.py
+++ b/src/backend/src/tests/unit/test_data_catalog_manager.py
@@ -1,0 +1,327 @@
+"""Unit tests for DataCatalogManager.
+
+Covers the parts of PR #337 that the reviewer flagged as untested:
+
+- ``_merge_columns`` dedup precedence between contract + asset sources
+- ``_matches_search`` field coverage
+- Pagination math on ``get_all_columns`` / ``search_columns``
+- Composed filter behaviour on ``get_all_columns``
+
+These tests stub the two heavy extraction helpers (``_get_columns_from_contracts``,
+``_get_columns_from_assets``) so we exercise the pure merge/filter/search/page
+logic without spinning up a DB.
+"""
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.controller.data_catalog_manager import DataCatalogManager
+from src.models.data_catalog import ColumnDictionaryEntry
+
+
+def _entry(
+    *,
+    column_name: str,
+    table_full_name: str,
+    table_name: str = "tbl",
+    schema_name: str = "schema",
+    catalog_name: str = "catalog",
+    table_type: str = "TABLE",
+    source: str = "asset",
+    description: str | None = None,
+    column_label: str | None = None,
+    system_name: str | None = None,
+    contract_name: str | None = None,
+    business_terms: list[dict] | None = None,
+    classification: str | None = None,
+) -> ColumnDictionaryEntry:
+    """Build a minimal ColumnDictionaryEntry with sensible defaults."""
+    return ColumnDictionaryEntry(
+        column_name=column_name,
+        column_label=column_label,
+        column_type="STRING",
+        description=description,
+        nullable=True,
+        position=0,
+        table_name=table_name,
+        table_full_name=table_full_name,
+        schema_name=schema_name,
+        catalog_name=catalog_name,
+        table_type=table_type,
+        source=source,
+        system_name=system_name,
+        contract_name=contract_name,
+        business_terms=business_terms or [],
+        classification=classification,
+    )
+
+
+@pytest.fixture
+def manager() -> DataCatalogManager:
+    """Build a DataCatalogManager whose dependencies are all mocked."""
+    return DataCatalogManager(
+        obo_client=MagicMock(),
+        db_session=MagicMock(),
+        contracts_manager=MagicMock(),
+        settings=MagicMock(),
+    )
+
+
+class TestMergeColumns:
+    """_merge_columns: asset base + contract enrichment, dedup, business term union."""
+
+    def test_disjoint_sources_are_concatenated(self, manager):
+        contract_only = _entry(
+            column_name="business_id",
+            table_full_name="contracts_demo.orders",
+            source="contract",
+        )
+        asset_only = _entry(
+            column_name="customer_id",
+            table_full_name="main.sales.customers",
+            source="asset",
+        )
+
+        merged = manager._merge_columns([contract_only], [asset_only])
+
+        assert len(merged) == 2
+        sources = {col.column_name: col.source for col in merged}
+        assert sources == {"business_id": "contract", "customer_id": "asset"}
+
+    def test_same_key_in_both_sources_marks_source_both(self, manager):
+        contract = _entry(
+            column_name="order_id",
+            table_full_name="main.sales.orders",
+            source="contract",
+            column_label="Order Identifier",
+            contract_name="orders-v1",
+            classification="PII",
+            business_terms=[{"iri": "urn:bt:OrderId", "label": "OrderId"}],
+        )
+        asset = _entry(
+            column_name="order_id",
+            table_full_name="main.sales.orders",
+            source="asset",
+            description="physical column comment",
+        )
+
+        merged = manager._merge_columns([contract], [asset])
+
+        assert len(merged) == 1
+        col = merged[0]
+        assert col.source == "both"
+        # asset metadata stays the base (description from physical layer)
+        assert col.description == "physical column comment"
+        # contract context enriches it
+        assert col.column_label == "Order Identifier"
+        assert col.classification == "PII"
+        assert col.contract_name == "orders-v1"
+        assert any(t["iri"] == "urn:bt:OrderId" for t in col.business_terms)
+
+    def test_dedup_is_case_insensitive(self, manager):
+        contract = _entry(
+            column_name="ORDER_ID",
+            table_full_name="MAIN.SALES.ORDERS",
+            source="contract",
+        )
+        asset = _entry(
+            column_name="order_id",
+            table_full_name="main.sales.orders",
+            source="asset",
+        )
+
+        merged = manager._merge_columns([contract], [asset])
+
+        assert len(merged) == 1
+        assert merged[0].source == "both"
+
+    def test_business_terms_are_unioned_by_iri(self, manager):
+        contract = _entry(
+            column_name="order_id",
+            table_full_name="main.sales.orders",
+            source="contract",
+            business_terms=[
+                {"iri": "urn:bt:OrderId", "label": "OrderId"},
+                {"iri": "urn:bt:Pii", "label": "PII"},
+            ],
+        )
+        asset = _entry(
+            column_name="order_id",
+            table_full_name="main.sales.orders",
+            source="asset",
+            business_terms=[{"iri": "urn:bt:OrderId", "label": "OrderId"}],
+        )
+
+        merged = manager._merge_columns([contract], [asset])
+
+        iris = {t["iri"] for t in merged[0].business_terms}
+        assert iris == {"urn:bt:OrderId", "urn:bt:Pii"}
+
+
+class TestMatchesSearch:
+    """_matches_search: every field branch is reachable."""
+
+    @pytest.fixture
+    def col(self) -> ColumnDictionaryEntry:
+        return _entry(
+            column_name="customer_id",
+            table_full_name="main.sales.customers",
+            table_name="customers",
+            schema_name="sales",
+            catalog_name="main",
+            source="both",
+            description="The customer identifier",
+            column_label="Customer ID",
+            system_name="warehouse",
+            contract_name="customers-v1",
+            business_terms=[{"iri": "urn:bt:CustomerId", "label": "CustomerIdentifier"}],
+        )
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "customer_id",        # column_name
+            "identifier",          # description
+            "customer id",         # column_label
+            "customers",           # table_name
+            "customers-v1",        # contract_name
+            "warehouse",           # system_name
+            "main",                # catalog_name
+            "sales",               # schema_name
+            "customeridentifier",  # business term label
+            "urn:bt:customerid",   # business term IRI (prefix match)
+        ],
+    )
+    def test_each_field_branch_matches(self, manager, col, query):
+        assert manager._matches_search(col, query.lower()) is True
+
+    def test_miss_returns_false(self, manager, col):
+        assert manager._matches_search(col, "nonexistent_token") is False
+
+
+def _seed_columns() -> tuple[List[ColumnDictionaryEntry], List[ColumnDictionaryEntry]]:
+    """Build a small fixture set spanning two systems / two catalogs."""
+    contract = [
+        _entry(
+            column_name=f"c_{i}",
+            table_full_name=f"contracts.orders_{i}",
+            schema_name="orders",
+            catalog_name="contracts",
+            table_type="CONTRACT",
+            source="contract",
+        )
+        for i in range(7)
+    ]
+    asset = [
+        _entry(
+            column_name=f"a_{i}",
+            table_full_name=f"main.sales.tbl_{i}",
+            schema_name="sales",
+            catalog_name="main",
+            table_type="TABLE",
+            source="asset",
+            system_name="warehouse",
+        )
+        for i in range(8)
+    ]
+    # One overlap that should collapse to a single 'both' row
+    contract.append(_entry(
+        column_name="shared_col",
+        table_full_name="main.sales.tbl_0",
+        schema_name="sales",
+        catalog_name="main",
+        source="contract",
+    ))
+    asset.append(_entry(
+        column_name="shared_col",
+        table_full_name="main.sales.tbl_0",
+        schema_name="sales",
+        catalog_name="main",
+        source="asset",
+        system_name="warehouse",
+    ))
+    return contract, asset
+
+
+class TestPaginationAndFilters:
+    """get_all_columns: pagination math and filter composition."""
+
+    def _patch_extractors(self, manager, monkeypatch):
+        contract, asset = _seed_columns()
+        monkeypatch.setattr(manager, "_get_columns_from_contracts", lambda: contract)
+        monkeypatch.setattr(manager, "_get_columns_from_assets", lambda: asset)
+        # total unique columns after merge: 7 contract-only + 8 asset-only + 1 'both' = 16
+        return 16
+
+    def test_page_one_returns_first_slice(self, manager, monkeypatch):
+        total = self._patch_extractors(manager, monkeypatch)
+
+        resp = manager.get_all_columns(offset=0, limit=5)
+
+        assert resp.column_count == total
+        assert len(resp.columns) == 5
+        assert resp.has_more is True
+        assert resp.offset == 0
+        assert resp.limit == 5
+
+    def test_offset_skips_correct_number(self, manager, monkeypatch):
+        total = self._patch_extractors(manager, monkeypatch)
+
+        first_page = manager.get_all_columns(offset=0, limit=5).columns
+        second_page = manager.get_all_columns(offset=5, limit=5).columns
+
+        # No overlap between consecutive pages
+        first_keys = {(c.table_full_name, c.column_name) for c in first_page}
+        second_keys = {(c.table_full_name, c.column_name) for c in second_page}
+        assert first_keys.isdisjoint(second_keys)
+        # Combined coverage equals what a flat slice would produce
+        assert len(first_keys | second_keys) == 10
+        assert total == 16  # sanity
+
+    def test_has_more_false_at_boundary(self, manager, monkeypatch):
+        total = self._patch_extractors(manager, monkeypatch)
+
+        resp = manager.get_all_columns(offset=total - 3, limit=5)
+
+        assert len(resp.columns) == 3
+        assert resp.has_more is False
+
+    def test_catalog_filter_narrows_to_one_catalog(self, manager, monkeypatch):
+        self._patch_extractors(manager, monkeypatch)
+
+        resp = manager.get_all_columns(catalog_filter="contracts", offset=0, limit=100)
+
+        assert resp.column_count == 7  # contract-only entries
+        assert all(c.catalog_name == "contracts" for c in resp.columns)
+
+    def test_combined_filters_compose(self, manager, monkeypatch):
+        self._patch_extractors(manager, monkeypatch)
+
+        resp = manager.get_all_columns(
+            catalog_filter="main",
+            schema_filter="sales",
+            asset_type_filter="TABLE",
+            system_filter="warehouse",
+            offset=0,
+            limit=100,
+        )
+
+        # 8 asset-only + 1 'both' that lives under main.sales -> 9 columns
+        assert resp.column_count == 9
+        assert all(c.catalog_name == "main" for c in resp.columns)
+        assert all(c.schema_name == "sales" for c in resp.columns)
+        assert all(c.system_name == "warehouse" for c in resp.columns)
+
+    def test_search_pagination_total_count_is_full_match_set(self, manager, monkeypatch):
+        self._patch_extractors(manager, monkeypatch)
+
+        # All asset rows + the 'both' row carry system_name='warehouse' (contract-only
+        # rows don't), so the search hits exactly that 9-row subset.
+        resp = manager.search_columns(query="warehouse", offset=0, limit=3)
+
+        assert resp.total_count == 9
+        assert len(resp.columns) == 3
+        assert resp.has_more is True

--- a/src/frontend/src/types/data-catalog.ts
+++ b/src/frontend/src/types/data-catalog.ts
@@ -40,14 +40,20 @@ export interface ColumnDictionaryEntry {
   classification?: string | null;
   /** Short table/schema object name */
   table_name: string;
-  /** Fully qualified name: contract.schema_object */
+  /** Fully qualified name: contract.schema_object or catalog.schema.table */
   table_full_name: string;
   /** Schema/Contract name */
   schema_name: string;
   /** Catalog/Version */
   catalog_name: string;
-  /** TABLE, VIEW, or CONTRACT */
+  /** TABLE, VIEW, DATASET, or CONTRACT */
   table_type: string;
+  /** Data source provenance: 'contract', 'asset', or 'both' */
+  source: 'contract' | 'asset' | 'both';
+  /** Source Asset ID when from Asset DB */
+  asset_id?: string | null;
+  /** Parent System name in asset hierarchy */
+  system_name?: string | null;
   /** ID of the source Data Contract */
   contract_id?: string | null;
   /** Name of the source Data Contract */
@@ -132,6 +138,9 @@ export interface DataDictionaryResponse {
   table_count: number;
   column_count: number;
   columns: ColumnDictionaryEntry[];
+  offset: number;
+  limit: number;
+  has_more: boolean;
   table_filter?: string | null;
 }
 
@@ -143,11 +152,25 @@ export interface ColumnSearchResponse {
   total_count: number;
   columns: ColumnDictionaryEntry[];
   has_more: boolean;
+  offset: number;
+  limit: number;
   filters_applied: {
     catalog?: string | null;
     schema?: string | null;
     table?: string | null;
+    asset_type?: string | null;
+    system?: string | null;
   };
+}
+
+/**
+ * Available filter values for the faceted filter UI.
+ */
+export interface HierarchyFilters {
+  asset_types: string[];
+  systems: string[];
+  catalogs: string[];
+  schemas: string[];
 }
 
 /**

--- a/src/frontend/src/views/data-catalog.tsx
+++ b/src/frontend/src/views/data-catalog.tsx
@@ -1,36 +1,38 @@
 /**
  * Data Catalog / Data Dictionary View
- * 
- * Main view for browsing all columns across Unity Catalog tables.
+ *
+ * Column-centric view for browsing all columns across Data Contracts and Assets.
  * Features:
- * - Flat table of all columns (Data Dictionary style)
- * - Table filter dropdown
- * - Column name search
- * - Sortable columns
- * - Click-through to table details
+ * - Server-side pagination
+ * - Faceted filters (Asset Type, System, Catalog, Schema)
+ * - Full-field search
+ * - Sortable columns (client-side within page)
+ * - Source provenance badges
+ * - Click-through to table/contract details
  */
 
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { 
-  BookOpen, 
-  Search, 
-  Loader2, 
+import {
+  BookOpen,
+  Search,
+  Loader2,
   Table as TableIcon,
   Eye,
   ArrowUpDown,
-  // ChevronDown, // Available for future use
   Database,
   RefreshCw,
-  Tag
+  Tag,
+  ChevronLeft,
+  ChevronRight,
+  X,
 } from 'lucide-react';
 
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-// CardHeader, CardTitle, CardDescription - Available for future use
 import {
   Table,
   TableBody,
@@ -51,11 +53,11 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/hooks/use-toast';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 
-import type { 
-  ColumnDictionaryEntry, 
+import type {
+  ColumnDictionaryEntry,
   DataDictionaryResponse,
-  TableListResponse,
-  TableListItem
+  ColumnSearchResponse,
+  HierarchyFilters,
 } from '@/types/data-catalog';
 
 // =============================================================================
@@ -75,7 +77,6 @@ interface SortConfig {
 // =============================================================================
 
 const DataCatalog: React.FC = () => {
-  console.log("DataCatalog component rendering");
   const { t } = useTranslation(['data-catalog', 'common']);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -83,160 +84,203 @@ const DataCatalog: React.FC = () => {
   const setStaticSegments = useBreadcrumbStore((state) => state.setStaticSegments);
   const setDynamicTitle = useBreadcrumbStore((state) => state.setDynamicTitle);
 
-  // Get initial search from URL params (supports both 'search' and 'concept' for semantic links)
   const initialSearch = searchParams.get('search') || searchParams.get('concept') || '';
 
-  // State
+  // Data state
   const [columns, setColumns] = useState<ColumnDictionaryEntry[]>([]);
-  const [tables, setTables] = useState<TableListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSearching, setIsSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
-  // Filters - initialize from URL if available
+
+  // Pagination
+  const [offset, setOffset] = useState(0);
+  const [pageSize, setPageSize] = useState(50);
+  const [totalCount, setTotalCount] = useState(0);
+  const [tableCount, setTableCount] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+
+  // Filters
   const [searchQuery, setSearchQuery] = useState(initialSearch);
-  const [selectedTable, setSelectedTable] = useState<string>('all');
-  
-  // Sorting
+  const [hierarchyFilters, setHierarchyFilters] = useState<HierarchyFilters | null>(null);
+  const [selectedAssetType, setSelectedAssetType] = useState<string>('all');
+  const [selectedSystem, setSelectedSystem] = useState<string>('all');
+  const [selectedCatalog, setSelectedCatalog] = useState<string>('all');
+  const [selectedSchema, setSelectedSchema] = useState<string>('all');
+
+  // Sorting (client-side within page)
   const [sortConfig, setSortConfig] = useState<SortConfig>({
     field: 'column_name',
-    direction: 'asc'
+    direction: 'asc',
   });
-  
-  // Stats
-  const [tableCount, setTableCount] = useState(0);
-  const [columnCount, setColumnCount] = useState(0);
 
   // Set breadcrumbs
   useEffect(() => {
     setStaticSegments([
       { label: t('common:home'), path: '/' },
-      { label: t('data-catalog:title', 'Data Catalog'), path: '/data-catalog' }
+      { label: t('data-catalog:title', 'Data Catalog'), path: '/data-catalog' },
     ]);
     setDynamicTitle('');
   }, [setStaticSegments, setDynamicTitle, t]);
 
-  // Fetch table list for dropdown
-  const fetchTableList = useCallback(async () => {
+  // Fetch hierarchy filter values
+  const fetchHierarchy = useCallback(async () => {
     try {
-      const response = await fetch('/api/data-catalog/tables');
-      if (!response.ok) throw new Error('Failed to fetch tables');
-      const data: TableListResponse = await response.json();
-      setTables(data.tables);
+      const response = await fetch('/api/data-catalog/hierarchy');
+      if (!response.ok) return;
+      const data: HierarchyFilters = await response.json();
+      setHierarchyFilters(data);
     } catch (err) {
-      console.error('Error fetching table list:', err);
+      console.error('Error fetching hierarchy filters:', err);
     }
   }, []);
 
-  // Fetch columns
-  const fetchColumns = useCallback(async (tableFilter?: string) => {
+  // Build query params for API calls
+  const buildFilterParams = useCallback(() => {
+    const params = new URLSearchParams();
+    if (selectedAssetType !== 'all') params.append('asset_type', selectedAssetType);
+    if (selectedSystem !== 'all') params.append('system', selectedSystem);
+    if (selectedCatalog !== 'all') params.append('catalog', selectedCatalog);
+    if (selectedSchema !== 'all') params.append('schema', selectedSchema);
+    return params;
+  }, [selectedAssetType, selectedSystem, selectedCatalog, selectedSchema]);
+
+  // Fetch columns (paginated)
+  const fetchColumns = useCallback(async (currentOffset: number) => {
     setIsLoading(true);
     setError(null);
-    
+
     try {
-      const params = new URLSearchParams();
-      if (tableFilter && tableFilter !== 'all') {
-        params.append('table', tableFilter);
-      }
-      
-      const url = `/api/data-catalog/columns${params.toString() ? '?' + params.toString() : ''}`;
-      const response = await fetch(url);
-      
+      const params = buildFilterParams();
+      params.set('offset', String(currentOffset));
+      params.set('limit', String(pageSize));
+
+      const response = await fetch(`/api/data-catalog/columns?${params.toString()}`);
+
       if (!response.ok) {
         throw new Error(`Failed to fetch columns: ${response.statusText}`);
       }
-      
+
       const data: DataDictionaryResponse = await response.json();
       setColumns(data.columns);
       setTableCount(data.table_count);
-      setColumnCount(data.column_count);
+      setTotalCount(data.column_count);
+      setHasMore(data.has_more);
+      setOffset(data.offset);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       setError(message);
       toast({
         title: t('common:error'),
         description: message,
-        variant: 'destructive'
+        variant: 'destructive',
       });
     } finally {
       setIsLoading(false);
     }
-  }, [t, toast]);
+  }, [buildFilterParams, pageSize, t, toast]);
 
-  // Search columns
-  const searchColumns = useCallback(async (query: string) => {
+  // Search columns (paginated)
+  const searchColumns = useCallback(async (query: string, currentOffset: number) => {
     if (!query.trim()) {
-      fetchColumns(selectedTable !== 'all' ? selectedTable : undefined);
+      fetchColumns(0);
       return;
     }
-    
+
     setIsSearching(true);
-    
+
     try {
-      const params = new URLSearchParams({ q: query });
-      if (selectedTable && selectedTable !== 'all') {
-        params.append('table', selectedTable);
-      }
-      
+      const params = buildFilterParams();
+      params.set('q', query);
+      params.set('offset', String(currentOffset));
+      params.set('limit', String(pageSize));
+
       const response = await fetch(`/api/data-catalog/columns/search?${params.toString()}`);
       if (!response.ok) throw new Error('Search failed');
-      
-      const data = await response.json();
+
+      const data: ColumnSearchResponse = await response.json();
       setColumns(data.columns);
-      setColumnCount(data.total_count);
+      setTotalCount(data.total_count);
+      setHasMore(data.has_more);
+      setOffset(data.offset);
     } catch (err) {
       console.error('Search error:', err);
     } finally {
       setIsSearching(false);
+      setIsLoading(false);
     }
-  }, [selectedTable, fetchColumns]);
+  }, [buildFilterParams, fetchColumns, pageSize]);
 
-  // Initial load - also trigger search if URL param was provided
+  // Initial load
   useEffect(() => {
-    fetchTableList();
+    fetchHierarchy();
     if (initialSearch) {
-      // If we have a search from URL, trigger the search
-      searchColumns(initialSearch);
+      searchColumns(initialSearch, 0);
     } else {
-      fetchColumns();
+      fetchColumns(0);
     }
-  }, [fetchTableList, fetchColumns, initialSearch, searchColumns]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Handle table filter change
+  // Re-fetch when filters change
   useEffect(() => {
-    if (selectedTable === 'all') {
-      fetchColumns();
+    setOffset(0);
+    if (searchQuery.trim()) {
+      searchColumns(searchQuery, 0);
     } else {
-      fetchColumns(selectedTable);
+      fetchColumns(0);
     }
-  }, [selectedTable, fetchColumns]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedAssetType, selectedSystem, selectedCatalog, selectedSchema, pageSize]);
 
   // Debounced search
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (searchQuery) {
-        searchColumns(searchQuery);
+      setOffset(0);
+      if (searchQuery.trim()) {
+        searchColumns(searchQuery, 0);
+      } else {
+        fetchColumns(0);
       }
     }, 300);
-    
+
     return () => clearTimeout(timer);
-  }, [searchQuery, searchColumns]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery]);
+
+  // Pagination handlers
+  const handleNextPage = () => {
+    const newOffset = offset + pageSize;
+    if (searchQuery.trim()) {
+      searchColumns(searchQuery, newOffset);
+    } else {
+      fetchColumns(newOffset);
+    }
+  };
+
+  const handlePrevPage = () => {
+    const newOffset = Math.max(0, offset - pageSize);
+    if (searchQuery.trim()) {
+      searchColumns(searchQuery, newOffset);
+    } else {
+      fetchColumns(newOffset);
+    }
+  };
 
   // Sort handler
   const handleSort = (field: SortField) => {
-    setSortConfig(prev => ({
+    setSortConfig((prev) => ({
       field,
-      direction: prev.field === field && prev.direction === 'asc' ? 'desc' : 'asc'
+      direction: prev.field === field && prev.direction === 'asc' ? 'desc' : 'asc',
     }));
   };
 
-  // Sorted columns
+  // Sorted columns (client-side within page)
   const sortedColumns = useMemo(() => {
     const sorted = [...columns];
     sorted.sort((a, b) => {
-      let aVal: string = '';
-      let bVal: string = '';
-      
+      let aVal = '';
+      let bVal = '';
+
       switch (sortConfig.field) {
         case 'column_label':
           aVal = a.column_label || a.column_name;
@@ -255,27 +299,42 @@ const DataCatalog: React.FC = () => {
           bVal = b.column_type;
           break;
       }
-      
+
       const comparison = aVal.localeCompare(bVal);
       return sortConfig.direction === 'asc' ? comparison : -comparison;
     });
     return sorted;
   }, [columns, sortConfig]);
 
+  // Clear all filters
+  const clearFilters = () => {
+    setSelectedAssetType('all');
+    setSelectedSystem('all');
+    setSelectedCatalog('all');
+    setSelectedSchema('all');
+    setSearchQuery('');
+  };
+
+  const hasActiveFilters =
+    selectedAssetType !== 'all' ||
+    selectedSystem !== 'all' ||
+    selectedCatalog !== 'all' ||
+    selectedSchema !== 'all';
+
   // Navigate to table details or contract details
   const handleRowClick = (entry: ColumnDictionaryEntry) => {
     if (entry.table_type === 'CONTRACT' && entry.contract_id) {
-      // Navigate to Data Contract details page
       navigate(`/data-contracts/${entry.contract_id}`);
+    } else if (entry.asset_id) {
+      navigate(`/assets/${entry.asset_id}`);
     } else {
-      // Navigate to Data Catalog table details for actual UC tables
       navigate(`/data-catalog/${encodeURIComponent(entry.table_full_name)}`);
     }
   };
 
-  // Render sort header
+  // Render helpers
   const SortHeader: React.FC<{ field: SortField; children: React.ReactNode }> = ({ field, children }) => (
-    <TableHead 
+    <TableHead
       className="cursor-pointer hover:bg-muted/50 select-none"
       onClick={() => handleSort(field)}
     >
@@ -286,17 +345,31 @@ const DataCatalog: React.FC = () => {
     </TableHead>
   );
 
-  // Get display label for column
   const getDisplayLabel = (entry: ColumnDictionaryEntry): string => {
     return entry.column_label || entry.column_name;
   };
 
-  // Truncate description
   const truncateDescription = (desc: string | null, maxLength: number = 100): string => {
     if (!desc) return '—';
     if (desc.length <= maxLength) return desc;
     return desc.substring(0, maxLength) + '...';
   };
+
+  const getSourceBadge = (source: string) => {
+    switch (source) {
+      case 'both':
+        return <Badge variant="default" className="text-[10px] px-1.5 py-0">Both</Badge>;
+      case 'asset':
+        return <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Asset</Badge>;
+      case 'contract':
+        return <Badge variant="outline" className="text-[10px] px-1.5 py-0">Contract</Badge>;
+      default:
+        return null;
+    }
+  };
+
+  const currentPage = Math.floor(offset / pageSize) + 1;
+  const totalPages = Math.ceil(totalCount / pageSize);
 
   return (
     <div className="flex flex-col h-full p-6 gap-6">
@@ -306,7 +379,7 @@ const DataCatalog: React.FC = () => {
           <BookOpen className="h-8 w-8 text-primary" />
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">
-              {t('data-catalog:title', 'Data Dictionary')} 
+              {t('data-catalog:title', 'Data Catalog')}
               {!isLoading && <span className="text-muted-foreground ml-2">({tableCount} Tables)</span>}
             </h1>
             <p className="text-sm text-muted-foreground">
@@ -314,14 +387,13 @@ const DataCatalog: React.FC = () => {
             </p>
           </div>
         </div>
-        
+
         <Button
           variant="outline"
           size="sm"
           onClick={() => {
-            setSearchQuery('');
-            setSelectedTable('all');
-            fetchColumns();
+            clearFilters();
+            fetchColumns(0);
           }}
           disabled={isLoading}
         >
@@ -330,45 +402,79 @@ const DataCatalog: React.FC = () => {
         </Button>
       </div>
 
-      {/* Filters */}
-      <div className="flex items-center gap-4">
-        {/* Table Filter Dropdown */}
-        <Select value={selectedTable} onValueChange={setSelectedTable}>
-          <SelectTrigger className="w-[300px]">
-            <div className="flex items-center gap-2">
-              <Database className="h-4 w-4 text-muted-foreground" />
-              <SelectValue>
-                {selectedTable === 'all' 
-                  ? `All Tables (${columnCount} Columns)` 
-                  : tables.find(t => t.full_name === selectedTable)?.name || selectedTable}
-              </SelectValue>
-            </div>
+      {/* Faceted Filters */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {/* Asset Type */}
+        <Select value={selectedAssetType} onValueChange={setSelectedAssetType}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="Asset Type" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">
-              <div className="flex items-center justify-between w-full gap-4">
-                <span>All Tables</span>
-                <Badge variant="secondary" className="ml-auto">{columnCount}</Badge>
-              </div>
-            </SelectItem>
-            {tables.map((table) => (
-              <SelectItem key={table.full_name} value={table.full_name}>
-                <div className="flex items-center justify-between w-full gap-4">
-                  <span className="truncate max-w-[200px]" title={table.full_name}>
-                    {table.name}
-                  </span>
-                  <Badge variant="secondary" className="ml-auto">{table.column_count}</Badge>
-                </div>
-              </SelectItem>
+            <SelectItem value="all">All Types</SelectItem>
+            {hierarchyFilters?.asset_types.map((type) => (
+              <SelectItem key={type} value={type}>{type}</SelectItem>
             ))}
           </SelectContent>
         </Select>
 
+        {/* System */}
+        {hierarchyFilters && hierarchyFilters.systems.length > 0 && (
+          <Select value={selectedSystem} onValueChange={setSelectedSystem}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="System" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Systems</SelectItem>
+              {hierarchyFilters.systems.map((s) => (
+                <SelectItem key={s} value={s}>{s}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        {/* Catalog */}
+        {hierarchyFilters && hierarchyFilters.catalogs.length > 0 && (
+          <Select value={selectedCatalog} onValueChange={setSelectedCatalog}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Catalog" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Catalogs</SelectItem>
+              {hierarchyFilters.catalogs.map((c) => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        {/* Schema */}
+        {hierarchyFilters && hierarchyFilters.schemas.length > 0 && (
+          <Select value={selectedSchema} onValueChange={setSelectedSchema}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Schema" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Schemas</SelectItem>
+              {hierarchyFilters.schemas.map((s) => (
+                <SelectItem key={s} value={s}>{s}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        {/* Clear filters */}
+        {hasActiveFilters && (
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            <X className="h-4 w-4 mr-1" />
+            Clear
+          </Button>
+        )}
+
         {/* Search */}
-        <div className="relative flex-1 max-w-md">
+        <div className="relative flex-1 max-w-md ml-auto">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder={t('data-catalog:searchPlaceholder', 'Search columns...')}
+            placeholder={t('data-catalog:searchPlaceholder', 'Search columns, tables, terms...')}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-9"
@@ -403,7 +509,7 @@ const DataCatalog: React.FC = () => {
               <TableIcon className="h-12 w-12 mb-4 opacity-50" />
               <p className="text-lg mb-2">{t('data-catalog:noResults', 'No columns found')}</p>
               <p className="text-sm">
-                {searchQuery 
+                {searchQuery
                   ? t('data-catalog:tryDifferentSearch', 'Try a different search term')
                   : t('data-catalog:noTablesAccessible', 'No tables accessible in Unity Catalog')}
               </p>
@@ -416,7 +522,7 @@ const DataCatalog: React.FC = () => {
                     <SortHeader field="column_label">
                       {t('data-catalog:columns.label', 'Label')}
                     </SortHeader>
-                    <TableHead className="min-w-[300px]">
+                    <TableHead className="min-w-[250px]">
                       {t('data-catalog:columns.description', 'Description')}
                     </TableHead>
                     <SortHeader field="column_name">
@@ -425,18 +531,19 @@ const DataCatalog: React.FC = () => {
                     <SortHeader field="column_type">
                       {t('data-catalog:columns.type', 'Type')}
                     </SortHeader>
-                    <TableHead className="min-w-[150px]">
+                    <TableHead className="min-w-[120px]">
                       {t('data-catalog:columns.businessTerms', 'Business Terms')}
                     </TableHead>
                     <SortHeader field="table_name">
                       {t('data-catalog:columns.tableName', 'Table Name')}
                     </SortHeader>
-                    <TableHead className="w-[50px]"></TableHead>
+                    <TableHead className="w-[70px]">Source</TableHead>
+                    <TableHead className="w-[40px]"></TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {sortedColumns.map((entry, idx) => (
-                    <TableRow 
+                    <TableRow
                       key={`${entry.table_full_name}-${entry.column_name}-${idx}`}
                       className="cursor-pointer hover:bg-muted/50"
                       onClick={() => handleRowClick(entry)}
@@ -460,7 +567,7 @@ const DataCatalog: React.FC = () => {
                       <TableCell>
                         {entry.business_terms && entry.business_terms.length > 0 ? (
                           <div className="flex flex-wrap gap-1">
-                            {entry.business_terms.map((term, termIdx) => (
+                            {entry.business_terms.slice(0, 2).map((term, termIdx) => (
                               <Badge
                                 key={`${term.iri}-${termIdx}`}
                                 variant="secondary"
@@ -475,6 +582,11 @@ const DataCatalog: React.FC = () => {
                                 {term.label || term.iri.split('#').pop()?.split('/').pop() || 'Term'}
                               </Badge>
                             ))}
+                            {entry.business_terms.length > 2 && (
+                              <Badge variant="secondary" className="text-xs">
+                                +{entry.business_terms.length - 2}
+                              </Badge>
+                            )}
                           </div>
                         ) : (
                           <span className="text-muted-foreground">—</span>
@@ -484,6 +596,9 @@ const DataCatalog: React.FC = () => {
                         <span className="text-sm" title={entry.table_full_name}>
                           {entry.table_name}
                         </span>
+                      </TableCell>
+                      <TableCell>
+                        {getSourceBadge(entry.source)}
                       </TableCell>
                       <TableCell>
                         <Eye className="h-4 w-4 text-muted-foreground" />
@@ -497,11 +612,53 @@ const DataCatalog: React.FC = () => {
         </CardContent>
       </Card>
 
-      {/* Footer stats */}
-      {!isLoading && !error && (
-        <div className="text-sm text-muted-foreground">
-          {t('data-catalog:showingColumns', 'Showing {{count}} columns', { count: sortedColumns.length })}
-          {searchQuery && ` ${t('data-catalog:matchingSearch', 'matching')} "${searchQuery}"`}
+      {/* Pagination Footer */}
+      {!isLoading && !error && totalCount > 0 && (
+        <div className="flex items-center justify-between text-sm">
+          <div className="text-muted-foreground">
+            Showing {offset + 1}–{Math.min(offset + pageSize, totalCount)} of {totalCount.toLocaleString()} columns
+            {searchQuery && ` matching "${searchQuery}"`}
+          </div>
+
+          <div className="flex items-center gap-4">
+            {/* Page size selector */}
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">Per page:</span>
+              <Select value={String(pageSize)} onValueChange={(v) => setPageSize(Number(v))}>
+                <SelectTrigger className="w-[70px] h-8">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="25">25</SelectItem>
+                  <SelectItem value="50">50</SelectItem>
+                  <SelectItem value="100">100</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Page navigation */}
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePrevPage}
+                disabled={offset === 0}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-muted-foreground">
+                Page {currentPage} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleNextPage}
+                disabled={!hasMore}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
         </div>
       )}
     </div>
@@ -509,4 +666,3 @@ const DataCatalog: React.FC = () => {
 };
 
 export default DataCatalog;
-

--- a/src/frontend/src/views/data-catalog.tsx
+++ b/src/frontend/src/views/data-catalog.tsx
@@ -21,7 +21,6 @@ import {
   Table as TableIcon,
   Eye,
   ArrowUpDown,
-  Database,
   RefreshCw,
   Tag,
   ChevronLeft,


### PR DESCRIPTION
## Summary

Resolves #333

Complete overhaul of the Data Catalog (column dictionary) feature:

- **Merged data sources**: Columns from both Data Contracts and the Asset DB (Table/View/Dataset entities with `hasColumn` children) are now surfaced, deduplicated by `(table_full_name, column_name)`.
- **Server-side pagination**: `offset`/`limit` params on `/columns` and `/columns/search` (default 50 per page), with `total_count` and `has_more` in responses.
- **Faceted hierarchy filters**: New filter dropdowns for Asset Type, System, Catalog, Schema — values served via `GET /api/data-catalog/hierarchy`.
- **Expanded search**: Full-field search across column name, description, business terms (label + IRI), parent table, contract name, system name, catalog, schema. Removed the previous 5000-record search cap.
- **Source provenance**: Each column entry carries a `source` field (`contract` | `asset` | `both`) rendered as a badge in the UI.
- **Navigation**: Clicking a row now navigates to the correct detail page (Asset or Contract) depending on provenance.

### Files Changed

| File | Change |
|------|--------|
| `src/backend/src/models/data_catalog.py` | Pagination metadata, source field, `HierarchyFilters` model |
| `src/backend/src/controller/data_catalog_manager.py` | Asset extraction, merge/dedup logic, full-field search, hierarchy filters |
| `src/backend/src/routes/data_catalog_routes.py` | New query params, `/hierarchy` endpoint |
| `src/frontend/src/types/data-catalog.ts` | Updated TS interfaces |
| `src/frontend/src/views/data-catalog.tsx` | Filter bar, pagination controls, source badges, smart navigation |

## Test plan

- [ ] Load Data Catalog page — verify columns from both Contracts and Assets appear
- [ ] Confirm pagination: next/prev buttons, page size selector, total count accuracy
- [ ] Filter by Asset Type, System, Catalog, Schema — verify results narrow correctly
- [ ] Search for a business term — confirm it appears in results
- [ ] Search for a table name — confirm matching columns appear
- [ ] Click a row sourced from Asset → navigates to `/assets/:id`
- [ ] Click a row sourced from Contract → navigates to `/data-contracts/:id`
- [ ] Verify "Clear filters" resets all dropdowns and reloads full set


## Follow-ups

- [#409](https://github.com/databrickslabs/ontos/issues/409) — Push data-catalog pagination/filters into SQL (perf). Acknowledged in review; deferred from this PR.
