### PR TITLE
fix(e2e): unblock demo data load and cleanup on fresh DBs

### DIFF
--- a/src/backend/src/db_models/business_roles.py
+++ b/src/backend/src/db_models/business_roles.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Column, String, Text, Boolean, TIMESTAMP
+from sqlalchemy import Column, String, Text, Boolean, TIMESTAMP, text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.sql import func
 
@@ -16,7 +16,7 @@ class BusinessRoleDb(Base):
     category = Column(String, nullable=True, index=True)  # governance, technical, business, operational
     is_system = Column(Boolean, nullable=False, default=False)  # Built-in vs user-defined
     status = Column(String, nullable=False, default="active", index=True)  # active, deprecated
-    is_approver = Column(Boolean, nullable=False, default=False, index=True)  # Show in workflow approver dropdown
+    is_approver = Column(Boolean, nullable=False, default=False, server_default=text("false"), index=True)  # Show in workflow approver dropdown
 
     created_by = Column(String, nullable=True)
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)

--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -675,10 +675,14 @@ async def clear_demo_data(
         
         deleted_counts = {}
         for stmt in delete_statements:
+            # Use a SAVEPOINT per statement so a failure (e.g. a legacy table
+            # that no longer exists post-migration) doesn't abort the whole
+            # transaction and cascade-fail every subsequent DELETE.
             try:
-                result = db.execute(text(stmt))
-                table_name = stmt.split("FROM ")[1].split(" ")[0]
-                deleted_counts[table_name] = result.rowcount
+                with db.begin_nested():
+                    result = db.execute(text(stmt))
+                    table_name = stmt.split("FROM ")[1].split(" ")[0]
+                    deleted_counts[table_name] = result.rowcount
             except Exception as e:
                 logger.warning(f"Delete statement warning: {e}")
         


### PR DESCRIPTION
## Summary

E2E tests have been failing on `main` because the demo data seed and cleanup paths were broken on fresh databases.

- **`business_roles.is_approver`** — added `server_default=text("false")` so `create_all` (used in E2E + LOCAL when `APP_DB_DROP_ON_START=true`) produces the same DB-side default as the alembic migration `aa9_add_is_approver_to_business_roles`. Without it, the seed `INSERT INTO business_roles (...)` in `demo_data.sql` (which omits `is_approver`) hit a `NotNullViolation`, aborting the entire seed transaction and cascading FK failures into `business_owners`.
- **`settings clear-demo-data`** — wrapped each DELETE in `db.begin_nested()` (SAVEPOINT) so a failure on a legacy table that was dropped post-migration (e.g. `dataset_subscriptions`, dropped in `c1_drop_legacy_dataset_tables`) only rolls back its own savepoint instead of aborting the whole transaction and cascading "current transaction is aborted" errors through every subsequent DELETE.

Root cause was visible in the latest E2E run logs:
```
ERROR - Failed to load demo data from SQL: (psycopg2.errors.NotNullViolation)
null value in column "is_approver" of relation "business_roles" violates not-null constraint
```

## Test plan

- [ ] CI: `Test Coverage / E2E Tests` job passes on push to main after merge (job is gated on `push && refs/heads/main`, so the run on this PR will not include E2E)
- [ ] Local: `APP_DEMO_MODE=true APP_DB_DROP_ON_START=true` startup loads demo data without NotNullViolation
- [ ] Local: calling clear-demo-data on a migrated DB completes successfully and doesn't leave the txn in an aborted state

This pull request and its description were written by Isaac.