### PR TITLE
feat(concepts): full-page browser/detail, links, neighbourhood, robust ontology save

### DIFF
--- a/src/backend/src/controller/ontology_handlers/base_handler.py
+++ b/src/backend/src/controller/ontology_handlers/base_handler.py
@@ -25,6 +25,7 @@ from src.models.industry_ontology import (
     MaturityLevel,
 )
 from src.common.logging import get_logger
+from src.owl.owl_parser import clean_truncated_turtle
 
 logger = get_logger(__name__)
 
@@ -311,14 +312,18 @@ class OntologyHandler(ABC):
         }
         fmt = format_map.get(fmt, fmt)
         
+        cleaned_content = clean_truncated_turtle(content) if fmt in ('turtle', 'n3') else content
         try:
-            g.parse(data=content, format=fmt)
+            g.parse(data=cleaned_content, format=fmt)
         except Exception as e:
             # Try alternative formats
             for alt_fmt in ['turtle', 'xml', 'json-ld', 'nt']:
                 if alt_fmt != fmt:
                     try:
-                        g.parse(data=content, format=alt_fmt)
+                        alt_content = (
+                            clean_truncated_turtle(content) if alt_fmt in ('turtle', 'n3') else content
+                        )
+                        g.parse(data=alt_content, format=alt_fmt)
                         logger.debug(f"Parsed as {alt_fmt} after {fmt} failed")
                         break
                     except Exception:

--- a/src/backend/src/controller/semantic_links_manager.py
+++ b/src/backend/src/controller/semantic_links_manager.py
@@ -212,6 +212,9 @@ class SemanticLinksManager:
                 manager = None
             if manager is not None:
                 manager.add_entity_semantic_link_to_graph(payload.entity_type, payload.entity_id, payload.iri, created_by=created_by)
+                # The new triple changes which entities resolve to a concept,
+                # so any cached concept/property/stat snapshot is now stale.
+                manager._invalidate_cache()
             else:
                 # As a safe fallback, perform a lightweight rebuild using a temp instance
                 from src.controller.semantic_models_manager import SemanticModelsManager
@@ -247,6 +250,9 @@ class SemanticLinksManager:
                 manager = None
             if removed and manager is not None:
                 manager.remove_entity_semantic_link_from_graph(removed.entity_type, removed.entity_id, removed.iri)
+                # Mirror of the add path: the removed triple invalidates
+                # cached concepts/properties/stats and the inferred-link cache.
+                manager._invalidate_cache()
             else:
                 from src.controller.semantic_models_manager import SemanticModelsManager
                 SemanticModelsManager(db=self._db).on_models_changed()

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -41,6 +41,7 @@ from src.utils.semantic_model_title_candidates import (
     extract_title_candidates,
 )
 from src.utils.rdf_serialization_display import serialization_label_for_stored_model
+from src.owl.owl_parser import clean_truncated_turtle
 
 
 logger = get_logger(__name__)
@@ -165,7 +166,12 @@ class SemanticModelsManager:
                 else:
                     # Default based on format field
                     fmt = 'turtle' if data.format in ('skos', 'rdfs') else 'xml'
-                temp_graph.parse(data=data.content_text, format=fmt)
+                content_for_parse = (
+                    clean_truncated_turtle(data.content_text)
+                    if fmt == 'turtle'
+                    else data.content_text
+                )
+                temp_graph.parse(data=content_for_parse, format=fmt)
                 
                 if len(temp_graph) == 0:
                     raise ValueError("Content parsed but contains no triples")
@@ -266,7 +272,10 @@ class SemanticModelsManager:
             # Import new triples
             temp_graph = Graph()
             fmt = 'turtle' if db_obj.format == 'skos' else 'xml'
-            temp_graph.parse(data=content_text, format=fmt)
+            content_for_parse = (
+                clean_truncated_turtle(content_text) if fmt == 'turtle' else content_text
+            )
+            temp_graph.parse(data=content_for_parse, format=fmt)
             self._import_graph_to_db(
                 graph=temp_graph,
                 context_name=context_name,
@@ -425,7 +434,9 @@ class SemanticModelsManager:
         else:
             # Default to turtle for modern ontologies
             parse_format = 'turtle'
-        
+
+        if parse_format == 'turtle':
+            content_text = clean_truncated_turtle(content_text)
         self._graph.parse(data=content_text, format=parse_format)
 
     def _parse_into_graph_context(self, content_text: str, fmt: str, context: Graph) -> None:
@@ -448,7 +459,9 @@ class SemanticModelsManager:
         else:
             # Default to turtle for modern ontologies
             parse_format = 'turtle'
-        
+
+        if parse_format == 'turtle':
+            content_text = clean_truncated_turtle(content_text)
         context.parse(data=content_text, format=parse_format)
 
     # --- RDF Triple Persistence Methods ---
@@ -867,7 +880,23 @@ class SemanticModelsManager:
         """
         logger.info("Starting to rebuild graph from database and dynamic sources")
         self._graph = ConjunctiveGraph()
-        
+
+        # Defensively null every cached snapshot BEFORE we start mutating
+        # state. If any subsequent step raises, callers must not see stale
+        # data — they should see "no cache yet" and fall back to recompute.
+        self._cache.clear()
+        self._cached_concepts = None
+        self._cached_taxonomies = None
+        self._cached_stats = None
+
+        # The singleton manager keeps a long-lived SQLAlchemy session; expire
+        # any identity-map entries so it picks up triples that other request-
+        # scoped sessions have just committed.
+        try:
+            self._db.expire_all()
+        except Exception as e:
+            logger.warning(f"Failed to expire DB session during rebuild: {e}")
+
         # Step 1: Sync bundled taxonomy files to database (idempotent)
         # This ensures any new/missing files are imported
         try:
@@ -1162,10 +1191,18 @@ class SemanticModelsManager:
             logger.error(f"Failed to rebuild RDF graph: {e}")
 
     def _invalidate_cache(self) -> None:
-        """Clear all cache entries (in-memory and persistent file cache)."""
+        """Clear all cache entries (in-memory + persistent file cache).
+
+        Resets every cache pointer so subsequent reads recompute from the
+        DB-backed graph. Critical for keeping the Concepts UI consistent
+        after collection/concept/link mutations.
+        """
         self._cache.clear()
-        
-        # Also delete persistent cache files so they get rebuilt on next read
+
+        self._cached_concepts = None
+        self._cached_taxonomies = None
+        self._cached_stats = None
+
         cache_dir = self._data_dir / "cache"
         if cache_dir.exists():
             for cache_file in ["concepts_all.json", "taxonomies.json", "stats.json"]:
@@ -1176,8 +1213,37 @@ class SemanticModelsManager:
                         logger.debug(f"Deleted persistent cache file: {cache_file}")
                     except Exception as e:
                         logger.warning(f"Failed to delete cache file {cache_file}: {e}")
-        
+
         logger.info("Semantic models cache invalidated (in-memory and persistent)")
+
+    @staticmethod
+    def _extract_source_context(context_name: str) -> Optional[str]:
+        """Map a named-graph IRI (`context_name`) to the human-friendly
+        source bucket label used by `concepts-grouped` and the collection
+        counters.
+
+        Keep this as the single source of truth: every URN prefix the app
+        understands MUST be handled here, otherwise concepts get dropped
+        into the catch-all "Unassigned" bucket and their owning collection
+        appears empty (Bug 4).
+        """
+        if not context_name:
+            return None
+        prefix_map = (
+            ("urn:taxonomy:", None),
+            ("urn:semantic-model:", None),
+            ("urn:schema:", None),
+            ("urn:glossary:", None),
+            ("urn:ontology:", None),
+        )
+        for prefix, _ in prefix_map:
+            if context_name.startswith(prefix):
+                return context_name[len(prefix):]
+        if context_name.startswith("urn:demo"):
+            return "Demo Data"
+        if context_name.startswith("urn:app-entities"):
+            return "Application Entities"
+        return None
 
     def _get_cached(self, key: str) -> Optional[Any]:
         """Get cached value if still valid"""
@@ -1963,20 +2029,7 @@ class SemanticModelsManager:
                         ]):
                             parent_concepts.append(parent_type_str)
 
-                    # Extract source context name
-                    source_context = None
-                    if context_name.startswith("urn:taxonomy:"):
-                        source_context = context_name.replace("urn:taxonomy:", "")
-                    elif context_name.startswith("urn:semantic-model:"):
-                        source_context = context_name.replace("urn:semantic-model:", "")
-                    elif context_name.startswith("urn:schema:"):
-                        source_context = context_name.replace("urn:schema:", "")
-                    elif context_name.startswith("urn:glossary:"):
-                        source_context = context_name.replace("urn:glossary:", "")
-                    elif context_name.startswith("urn:demo"):
-                        source_context = "Demo Data"
-                    elif context_name.startswith("urn:app-entities"):
-                        source_context = "Application Entities"
+                    source_context = self._extract_source_context(context_name)
 
                     # For properties, extract domain/range
                     domain_val = None
@@ -2110,21 +2163,8 @@ class SemanticModelsManager:
             for child in context.subjects(RDF.type, concept_uri):
                 child_concepts.append(str(child))
             
-            # Extract source context
-            source_context = None
-            if context_name.startswith("urn:taxonomy:"):
-                source_context = context_name.replace("urn:taxonomy:", "")
-            elif context_name.startswith("urn:semantic-model:"):
-                source_context = context_name.replace("urn:semantic-model:", "")
-            elif context_name.startswith("urn:schema:"):
-                source_context = context_name.replace("urn:schema:", "")
-            elif context_name.startswith("urn:glossary:"):
-                source_context = context_name.replace("urn:glossary:", "")
-            elif context_name.startswith("urn:demo"):
-                source_context = "Demo Data"
-            elif context_name.startswith("urn:app-entities"):
-                source_context = "Application Entities"
-            
+            source_context = self._extract_source_context(context_name)
+
             concept = OntologyConcept(
                 iri=concept_iri,
                 label=label,
@@ -2340,23 +2380,7 @@ class SemanticModelsManager:
                 continue
             context_name = str(context_id)
 
-            # Extract source context name (same logic as concepts)
-            source_context = None
-            if context_name.startswith("urn:taxonomy:"):
-                source_context = context_name.replace("urn:taxonomy:", "")
-            elif context_name.startswith("urn:semantic-model:"):
-                source_context = context_name.replace("urn:semantic-model:", "")
-            elif context_name.startswith("urn:schema:"):
-                source_context = context_name.replace("urn:schema:", "")
-            elif context_name.startswith("urn:glossary:"):
-                source_context = context_name.replace("urn:glossary:", "")
-            elif context_name.startswith("urn:demo"):
-                source_context = "Demo Data"
-            elif context_name.startswith("urn:app-entities"):
-                source_context = "Application Entities"
-
-            if not source_context:
-                source_context = "Unassigned"
+            source_context = self._extract_source_context(context_name) or "Unassigned"
 
             # Query properties in this context
             try:
@@ -3585,10 +3609,18 @@ class SemanticModelsManager:
         if not collection.get("is_editable"):
             raise ValueError(f"Collection is not editable: {collection_iri}")
         
-        # Parse the content
+        # Parse the content. LLM-generated Turtle is often truncated mid-statement,
+        # which crashes rdflib's notation3 parser with an IndexError. Apply the
+        # shared cleanup heuristic before parsing and translate parse failures
+        # into ValueError so the route returns a 400 instead of a 500.
         temp_graph = Graph()
         rdf_format = "turtle" if format.lower() in ("ttl", "turtle") else "xml"
-        temp_graph.parse(data=content, format=rdf_format)
+        if rdf_format == "turtle":
+            content = clean_truncated_turtle(content)
+        try:
+            temp_graph.parse(data=content, format=rdf_format)
+        except Exception as e:
+            raise ValueError(f"Invalid {rdf_format} content: {e}")
         
         # Import to database
         count = self._import_graph_to_db(
@@ -3894,8 +3926,4 @@ class SemanticModelsManager:
             elif isinstance(obj, str) and (obj.startswith("urn:") or obj.startswith("http")):
                 return obj
         return None
-
-    def _invalidate_cache(self):
-        """Invalidate all cached results."""
-        self._cache.clear()
 

--- a/src/backend/src/owl/owl_parser.py
+++ b/src/backend/src/owl/owl_parser.py
@@ -18,6 +18,54 @@ logger = get_logger(__name__)
 ONTOBRICKS_NS = Namespace("http://ontobricks.com/schema#")
 
 
+def clean_truncated_turtle(content: str) -> str:
+    """Defensively trim incomplete trailing statements from Turtle/N3 content.
+
+    LLM-generated Turtle is often cut off mid-statement (token-limit truncation).
+    Feeding such content to rdflib's notation3 parser produces obscure crashes
+    (e.g. ``IndexError: string index out of range`` deep inside ``path()``).
+    This helper trims trailing lines that do not end a statement (``.``/``]``)
+    so the remainder parses cleanly. It is a no-op for content that already
+    ends in ``.``, ``]``, or ``>`` (covering Turtle, blank-node-list, and
+    RDF/XML closing tags), so it is safe to call on well-formed input.
+
+    Args:
+        content: Raw RDF text (typically Turtle).
+
+    Returns:
+        The original content if it looks complete, otherwise the longest prefix
+        whose last non-blank, non-comment line ends a Turtle statement.
+    """
+    if not content:
+        return content
+    content_stripped = content.strip()
+    if not content_stripped:
+        return content
+    if (
+        content_stripped.endswith(".")
+        or content_stripped.endswith("]")
+        or content_stripped.endswith(">")
+    ):
+        return content
+
+    lines = content_stripped.split("\n")
+    while lines and not (
+        lines[-1].strip().endswith(".")
+        or lines[-1].strip().endswith("]")
+        or lines[-1].strip() == ""
+        or lines[-1].strip().startswith("#")
+    ):
+        lines.pop()
+
+    if not lines:
+        return content
+
+    cleaned = "\n".join(lines)
+    if cleaned != content:
+        logger.warning("Content appeared truncated, removed incomplete statements")
+    return cleaned
+
+
 class OntologyParser:
     """Parse OWL ontologies to extract classes and properties."""
 
@@ -29,24 +77,7 @@ class OntologyParser:
         """
         self.graph = Graph()
 
-        # Check for truncated content (common with LLM generation)
-        content_stripped = owl_content.strip()
-        if content_stripped and not (
-            content_stripped.endswith(".")
-            or content_stripped.endswith("]")
-            or content_stripped.endswith(">")
-        ):
-            lines = content_stripped.split("\n")
-            while lines and not (
-                lines[-1].strip().endswith(".")
-                or lines[-1].strip().endswith("]")
-                or lines[-1].strip() == ""
-                or lines[-1].strip().startswith("#")
-            ):
-                lines.pop()
-            if lines:
-                owl_content = "\n".join(lines)
-                logger.warning("Content appeared truncated, removed incomplete statements")
+        owl_content = clean_truncated_turtle(owl_content)
 
         # Try turtle first, then XML
         turtle_error = None

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -18,6 +18,7 @@ from src.common.dependencies import CurrentUserDep, AuditManagerDep, DBSessionDe
 from src.common.authorization import PermissionChecker
 from src.common.features import FeatureAccessLevel
 from src.common.file_security import sanitize_filename
+from src.owl.owl_parser import clean_truncated_turtle
 from rdflib import ConjunctiveGraph, RDF
 
 # Configure logging
@@ -203,7 +204,7 @@ async def upload_semantic_model(
         try:
             temp_graph = ConjunctiveGraph()
             if format_type == "skos":
-                temp_graph.parse(data=content_text, format="turtle")
+                temp_graph.parse(data=clean_truncated_turtle(content_text), format="turtle")
             else:
                 temp_graph.parse(data=content_text, format="xml")
             

--- a/src/backend/src/tests/integration/test_knowledge_routes.py
+++ b/src/backend/src/tests/integration/test_knowledge_routes.py
@@ -1,0 +1,540 @@
+"""Integration tests for the Concepts feature: /api/knowledge/*, related
+endpoints under /api/semantic-models/*, /api/ontology/save-to-collection, and
+/api/semantic-links/.
+
+These tests exercise the cache-freshness, prefix-handling, and
+broadcast-after-rebuild behaviours that broke in production. They are
+written TDD-style and target the bugs documented in
+docs/research/concepts-bugs/repro-summary.md.
+
+A per-test SemanticModelsManager is instantiated against the in-memory
+SQLite db_session and registered on app.state so the route dependencies
+resolve correctly. We use a temp data_dir so persistent JSON cache files
+don't bleed between tests.
+"""
+import os
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.app import app
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.controller.ontology_schema_manager import OntologySchemaManager
+from src.common.app_state import set_app_state_manager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semantic_models_manager(db_session: Session, tmp_path: Path):
+    """Build a SemanticModelsManager backed by the test session + tmp data dir.
+
+    The manager is published on `app.state.semantic_models_manager` and via
+    the `app_state` registry so both the FastAPI dependency and the
+    `SemanticLinksManager` fallback locator can find it.
+    """
+    data_dir = tmp_path / "sm_data"
+    (data_dir / "cache").mkdir(parents=True, exist_ok=True)
+    (data_dir / "taxonomies").mkdir(parents=True, exist_ok=True)
+
+    manager = SemanticModelsManager(db=db_session, data_dir=data_dir)
+
+    app.state.semantic_models_manager = manager
+    set_app_state_manager("semantic_models_manager", manager)
+
+    # OntologySchemaManager is touched by /refresh-graph; provide a benign stub.
+    class _NoopOSM:
+        def sync_asset_types(self, *_args, **_kwargs):
+            return {"created": 0, "updated": 0}
+
+    app.state.ontology_schema_manager = _NoopOSM()
+
+    # Audit manager is required by semantic-links routes; a no-op stub is enough.
+    class _NoopAudit:
+        def log_action(self, *_args, **_kwargs):
+            return None
+        def log_event(self, *_args, **_kwargs):
+            return None
+
+    app.state.audit_manager = _NoopAudit()
+
+    yield manager
+
+    for attr in ("semantic_models_manager", "ontology_schema_manager", "audit_manager"):
+        if hasattr(app.state, attr):
+            delattr(app.state, attr)
+
+
+@pytest.fixture
+def make_collection(client: TestClient, semantic_models_manager):
+    """Factory that creates a fresh, uniquely-named collection and returns it."""
+
+    def _make(label_prefix: str = "Test Coll", collection_type: str = "glossary",
+              description: str = "made by test"):
+        label = f"{label_prefix} {uuid.uuid4().hex[:8]}"
+        payload = {
+            "label": label,
+            "collection_type": collection_type,
+            "scope_level": "enterprise",
+            "description": description,
+        }
+        r = client.post("/api/knowledge/collections", json=payload)
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Collections CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeCollections:
+    def test_list_collections_returns_envelope(self, client: TestClient, semantic_models_manager):
+        r = client.get("/api/knowledge/collections")
+        assert r.status_code == 200
+        body = r.json()
+        assert "collections" in body
+        assert isinstance(body["collections"], list)
+
+    def test_create_glossary_collection(self, client: TestClient, semantic_models_manager):
+        payload = {
+            "label": "Created Glossary",
+            "collection_type": "glossary",
+            "scope_level": "enterprise",
+            "description": "for unit test",
+        }
+        r = client.post("/api/knowledge/collections", json=payload)
+        assert r.status_code == 200, r.text
+        c = r.json()
+        assert c["iri"] == "urn:glossary:created-glossary"
+        assert c["label"] == "Created Glossary"
+        assert c["collection_type"] == "glossary"
+        assert c["is_editable"] is True
+        assert c["concept_count"] == 0
+
+    def test_create_taxonomy_and_ontology_collections(self, client: TestClient, semantic_models_manager):
+        for ctype, prefix in (("taxonomy", "urn:taxonomy:"),
+                              ("ontology", "urn:ontology:")):
+            r = client.post("/api/knowledge/collections", json={
+                "label": f"{ctype} test",
+                "collection_type": ctype,
+            })
+            assert r.status_code == 200
+            assert r.json()["iri"].startswith(prefix)
+
+    def test_get_collection_by_iri(self, client: TestClient, make_collection):
+        created = make_collection("Single Get")
+        r = client.get(f"/api/knowledge/collections/{created['iri']}")
+        assert r.status_code == 200
+        assert r.json()["iri"] == created["iri"]
+
+    def test_create_duplicate_collection_returns_400(self, client: TestClient, make_collection):
+        first = make_collection("Dup Test")
+        # Re-post with the SAME label → same generated IRI → must conflict.
+        r = client.post("/api/knowledge/collections", json={
+            "label": first["label"],
+            "collection_type": first["collection_type"],
+        })
+        assert r.status_code == 400, r.text
+
+    def test_update_collection_label_and_description(self, client: TestClient, make_collection):
+        c = make_collection("Original Label")
+        r = client.patch(f"/api/knowledge/collections/{c['iri']}", json={
+            "label": "Renamed Label",
+            "description": "updated",
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["label"] == "Renamed Label"
+        assert body["description"] == "updated"
+
+    def test_delete_collection(self, client: TestClient, make_collection):
+        c = make_collection("Delete Me")
+        r = client.delete(f"/api/knowledge/collections/{c['iri']}")
+        assert r.status_code == 200
+        assert r.json()["success"] is True
+        # Subsequent GET should 404.
+        r2 = client.get(f"/api/knowledge/collections/{c['iri']}")
+        assert r2.status_code == 404
+
+    def test_collection_appears_in_hierarchy_listing(self, client: TestClient, make_collection):
+        c = make_collection("Hierarchy Test")
+        r = client.get("/api/knowledge/collections?hierarchical=true")
+        assert r.status_code == 200
+        irirs = [coll["iri"] for coll in r.json()["collections"]]
+        assert c["iri"] in irirs
+
+
+# ---------------------------------------------------------------------------
+# Concept CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeConcepts:
+    def test_create_concept_in_collection(self, client: TestClient, make_collection):
+        c = make_collection("Concept Container")
+        r = client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"],
+            "label": "First Concept",
+            "definition": "A first test concept",
+            "concept_type": "concept",
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["iri"] == f"{c['iri']}/first-concept"
+        assert body["label"] == "First Concept"
+        assert body["status"] == "draft"
+
+    def test_get_concept_returns_full_payload(self, client: TestClient, make_collection):
+        c = make_collection("Get Concept Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Beta",
+        }).raise_for_status()
+        r = client.get(f"/api/knowledge/concepts/{c['iri']}/beta")
+        assert r.status_code == 200
+        assert r.json()["label"] == "Beta"
+
+    def test_update_concept_label_and_synonyms(self, client: TestClient, make_collection):
+        c = make_collection("Patch Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "OldName",
+        }).raise_for_status()
+        iri = f"{c['iri']}/oldname"
+        r = client.patch(f"/api/knowledge/concepts/{iri}", json={
+            "label": "NewName",
+            "synonyms": ["alias-a", "alias-b"],
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["label"] == "NewName"
+        assert sorted(body["synonyms"]) == ["alias-a", "alias-b"]
+
+    def test_delete_draft_concept(self, client: TestClient, make_collection):
+        c = make_collection("Delete Concept Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Doomed",
+        }).raise_for_status()
+        iri = f"{c['iri']}/doomed"
+        r = client.delete(f"/api/knowledge/concepts/{iri}")
+        assert r.status_code == 200
+        assert client.get(f"/api/knowledge/concepts/{iri}").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 + 2 — cache freshness for collections + concepts
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionConceptCountFreshness:
+    """After create-collection + create-concept, the count and the
+    `concepts-grouped` payload must reflect the new data WITHOUT requiring
+    an app restart or an explicit /refresh-graph call.
+    """
+
+    def test_collection_concept_count_updates_after_concept_create(
+        self, client: TestClient, make_collection
+    ):
+        c = make_collection("Count Coll")
+        # Initial count = 0
+        coll = client.get(f"/api/knowledge/collections/{c['iri']}").json()
+        assert coll["concept_count"] == 0
+
+        # Add one concept
+        r = client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Email",
+        })
+        assert r.status_code == 200, r.text
+
+        # Count must now be 1 — without rebuild
+        coll = client.get(f"/api/knowledge/collections/{c['iri']}").json()
+        assert coll["concept_count"] == 1, (
+            f"Expected concept_count=1 immediately after creation, got {coll['concept_count']}. "
+            "Likely cause: stale self._cached_concepts in SemanticModelsManager."
+        )
+
+    def test_concepts_grouped_includes_new_concept(
+        self, client: TestClient, make_collection
+    ):
+        c = make_collection("Grouped Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Phone",
+        }).raise_for_status()
+
+        r = client.get("/api/semantic-models/concepts-grouped")
+        assert r.status_code == 200
+        groups = r.json()["grouped_concepts"]
+
+        # Source key for urn:glossary:<slug> must be the slug.
+        slug = c["iri"].rsplit(":", 1)[-1]
+        assert slug in groups, (
+            f"Expected source-context group '{slug}' in concepts-grouped, "
+            f"got keys={list(groups.keys())}. Cache likely stale."
+        )
+        labels = [item.get("label") for item in groups[slug]]
+        assert "Phone" in labels
+
+
+# ---------------------------------------------------------------------------
+# Bug 4 — ontology generator save-to-collection
+# ---------------------------------------------------------------------------
+
+
+_TINY_TURTLE = """@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix ex: <http://example.org/onto/> .
+
+ex:Person a owl:Class ; rdfs:label "Person" .
+ex:Animal a owl:Class ; rdfs:label "Animal" .
+"""
+
+
+class TestOntologyGeneratorSave:
+    def test_save_to_collection_creates_listed_collection_with_concepts(
+        self, client: TestClient, semantic_models_manager
+    ):
+        r = client.post("/api/ontology/save-to-collection", json={
+            "collection_name": "Generator Test",
+            "collection_description": "from test",
+            "owl_content": _TINY_TURTLE,
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        assert body["collection_iri"] == "urn:ontology:generator-test"
+        assert body["triples_imported"] >= 4
+
+        # The new collection must show in the list with the concept count.
+        listing = client.get("/api/knowledge/collections").json()["collections"]
+        match = next((c for c in listing if c["iri"] == "urn:ontology:generator-test"), None)
+        assert match is not None
+        assert match["concept_count"] >= 2, (
+            f"Generated ontology collection should report >=2 concepts, got {match['concept_count']}. "
+            "Likely cause: source_context not stripped for urn:ontology: prefix."
+        )
+
+        # And the concepts should appear under the right source key.
+        groups = client.get("/api/semantic-models/concepts-grouped").json()["grouped_concepts"]
+        assert "generator-test" in groups, (
+            f"Expected 'generator-test' key in concepts-grouped, got {list(groups.keys())}. "
+            "Concepts likely fell into the 'Unassigned' bucket."
+        )
+        assert "Unassigned" not in groups or all(
+            c.get("source_context") != "Unassigned" for c in groups.get("Unassigned", [])
+            if "generator-test" in (c.get("iri") or "")
+        )
+
+    def test_save_to_collection_recovers_from_truncated_turtle(
+        self, client: TestClient, semantic_models_manager
+    ):
+        """Regression: LLM-generated Turtle is often cut off mid-statement.
+
+        Previously this raised ``IndexError: string index out of range`` deep
+        inside rdflib's notation3 ``path()`` and surfaced as a 500. The route
+        must now apply the truncation cleanup heuristic and import only the
+        complete prefix of the payload.
+        """
+        truncated_payload = (
+            _TINY_TURTLE
+            + "ex:Vehicle a owl:Class ;\n"
+            + "    rdfs:label \"Vehic"
+        )
+        r = client.post("/api/ontology/save-to-collection", json={
+            "collection_name": "Truncated Onto",
+            "owl_content": truncated_payload,
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        # Person + Animal definitely import; the Vehicle fragment is dropped.
+        assert body["triples_imported"] >= 4
+
+        groups = client.get("/api/semantic-models/concepts-grouped").json()["grouped_concepts"]
+        assert "truncated-onto" in groups
+        labels = {c.get("label") for c in groups["truncated-onto"]}
+        assert "Person" in labels
+        assert "Animal" in labels
+        assert "Vehic" not in labels  # truncated fragment must not leak through
+
+    def test_save_to_collection_returns_400_for_unparseable_content(
+        self, client: TestClient, semantic_models_manager
+    ):
+        """Garbage that cannot be salvaged should be a clean 400, not a 500."""
+        r = client.post("/api/ontology/save-to-collection", json={
+            "collection_name": "Garbage Onto",
+            "owl_content": "not turtle at all <<< >>> {{{",
+        })
+        assert r.status_code == 400, r.text
+        assert "invalid" in r.json().get("detail", "").lower() or "turtle" in r.json().get("detail", "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — semantic links to concepts
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticLinksAgainstConcepts:
+    def test_create_link_persists_and_is_listable(
+        self, client: TestClient, make_collection
+    ):
+        c = make_collection("Link Source Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Customer",
+        }).raise_for_status()
+        concept_iri = f"{c['iri']}/customer"
+
+        entity_id = f"prod-{uuid.uuid4().hex[:8]}"
+        r = client.post("/api/semantic-links/", json={
+            "entity_id": entity_id,
+            "entity_type": "data_product",
+            "iri": concept_iri,
+            "label": "Customer",
+        })
+        assert r.status_code == 200, r.text
+        link_id = r.json()["id"]
+
+        # Lookup by entity
+        by_entity = client.get(
+            f"/api/semantic-links/entity/data_product/{entity_id}"
+        ).json()
+        assert any(item["id"] == link_id for item in by_entity)
+
+        # Lookup by IRI
+        by_iri = client.get(f"/api/semantic-links/iri/{concept_iri}").json()
+        assert any(item["id"] == link_id for item in by_iri)
+
+    def test_delete_link_round_trip(
+        self, client: TestClient, make_collection, db_session: Session
+    ):
+        from src.controller.semantic_links_manager import SemanticLinksManager
+
+        c = make_collection("Link Delete Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Order",
+        }).raise_for_status()
+        concept_iri = f"{c['iri']}/order"
+
+        entity_id = f"prod-{uuid.uuid4().hex[:8]}"
+        link = client.post("/api/semantic-links/", json={
+            "entity_id": entity_id,
+            "entity_type": "data_product",
+            "iri": concept_iri,
+        }).json()
+
+        # NOTE: deleting via the HTTP route hits a pre-existing PG_UUID/SQLite
+        # incompatibility in CRUDBase.remove (unrelated to this feature). We
+        # call the manager directly with a UUID-typed id so this test exercises
+        # the right code path on SQLite.
+        manager = SemanticLinksManager(db_session, semantic_models_manager=None)
+        ok = manager.remove(uuid.UUID(link["id"]), removed_by="tester")
+        assert ok is True
+
+        rest = client.get(
+            f"/api/semantic-links/entity/data_product/{entity_id}"
+        ).json()
+        assert all(item["id"] != link["id"] for item in rest)
+
+    def test_link_create_invalidates_concept_cache(
+        self, client: TestClient, make_collection, semantic_models_manager
+    ):
+        """After a semantic link is created, the manager's cached concepts
+        must be re-read on the next call so any IRI-based queries reflect
+        the link in the in-memory graph."""
+        c = make_collection("Link Cache Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Address",
+        }).raise_for_status()
+        concept_iri = f"{c['iri']}/address"
+
+        # Warm the cache
+        client.get("/api/semantic-models/concepts-grouped").raise_for_status()
+        cached_before = semantic_models_manager._cached_concepts
+
+        client.post("/api/semantic-links/", json={
+            "entity_id": "prod-cache-1",
+            "entity_type": "data_product",
+            "iri": concept_iri,
+        }).raise_for_status()
+
+        # The mutation must have invalidated (or refreshed) the cache.
+        assert semantic_models_manager._cached_concepts is None or (
+            semantic_models_manager._cached_concepts is not cached_before
+        ), "Semantic-link mutation must invalidate the concepts cache."
+
+
+# ---------------------------------------------------------------------------
+# Bug 5 — Rebuild Graph end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildGraph:
+    def test_rebuild_graph_endpoint_returns_success(
+        self, client: TestClient, semantic_models_manager
+    ):
+        r = client.post("/api/semantic-models/refresh-graph")
+        assert r.status_code == 200, r.text
+        assert "message" in r.json()
+
+    def test_rebuild_graph_makes_new_concepts_visible(
+        self, client: TestClient, make_collection, semantic_models_manager
+    ):
+        """End-to-end: even without the in-line cache fix, a Rebuild Graph
+        call MUST leave the API returning the latest counts."""
+        c = make_collection("Rebuild Coll")
+        client.post("/api/knowledge/concepts", json={
+            "collection_iri": c["iri"], "label": "Rebuilt",
+        }).raise_for_status()
+
+        # Force rebuild
+        r = client.post("/api/semantic-models/refresh-graph")
+        assert r.status_code == 200
+
+        coll = client.get(f"/api/knowledge/collections/{c['iri']}").json()
+        assert coll["concept_count"] == 1
+
+        groups = client.get("/api/semantic-models/concepts-grouped").json()["grouped_concepts"]
+        slug = c["iri"].rsplit(":", 1)[-1]
+        assert slug in groups
+
+    def test_rebuild_graph_resolves_ontology_collection_source_context(
+        self, client: TestClient, semantic_models_manager
+    ):
+        """Generator-created ontology collections must group concepts under
+        the collection slug (not 'Unassigned') after a rebuild."""
+        client.post("/api/ontology/save-to-collection", json={
+            "collection_name": "Rebuild Onto",
+            "owl_content": _TINY_TURTLE,
+        }).raise_for_status()
+
+        client.post("/api/semantic-models/refresh-graph").raise_for_status()
+
+        groups = client.get("/api/semantic-models/concepts-grouped").json()["grouped_concepts"]
+        assert "rebuild-onto" in groups, (
+            f"After rebuild, ontology collection concepts must group under their slug. "
+            f"Got keys={list(groups.keys())}."
+        )
+
+    def test_rebuild_graph_clears_in_memory_caches_atomically(
+        self, semantic_models_manager
+    ):
+        """Defensive contract: a rebuild must never leave a stale
+        in-memory cache pointer alive on partial failure."""
+        # Pre-load a sentinel value so we can detect whether rebuild reset it.
+        semantic_models_manager._cached_concepts = ["SENTINEL"]
+        semantic_models_manager._cached_taxonomies = ["SENTINEL"]
+        semantic_models_manager._cached_stats = "SENTINEL"
+
+        semantic_models_manager.rebuild_graph_from_enabled()
+
+        assert semantic_models_manager._cached_concepts != ["SENTINEL"]
+        assert semantic_models_manager._cached_taxonomies != ["SENTINEL"]
+        assert semantic_models_manager._cached_stats != "SENTINEL"

--- a/src/backend/src/tests/unit/test_clean_truncated_turtle.py
+++ b/src/backend/src/tests/unit/test_clean_truncated_turtle.py
@@ -1,0 +1,120 @@
+"""Tests for the truncated-Turtle cleanup helper.
+
+LLM-generated Turtle is frequently cut off mid-statement (token-limit
+truncation). Feeding such content to rdflib's notation3 parser raises an
+``IndexError: string index out of range`` deep in ``path()``. The helper
+trims the trailing incomplete fragment so the remainder parses cleanly.
+"""
+import pytest
+from rdflib import Graph
+
+from src.owl.owl_parser import clean_truncated_turtle
+
+
+WELL_FORMED_TURTLE = """@prefix : <http://test.org/ontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:Customer a owl:Class ;
+    rdfs:label "Customer" .
+
+:Order a owl:Class ;
+    rdfs:label "Order" .
+"""
+
+
+def test_well_formed_turtle_is_unchanged():
+    assert clean_truncated_turtle(WELL_FORMED_TURTLE) == WELL_FORMED_TURTLE
+
+
+def test_empty_string_is_unchanged():
+    assert clean_truncated_turtle("") == ""
+    assert clean_truncated_turtle("   \n\n  ") == "   \n\n  "
+
+
+def test_content_ending_with_bracket_is_unchanged():
+    """Blank-node-list and collection terminators are valid endings."""
+    content = WELL_FORMED_TURTLE + ":Foo a owl:Class ;\n    rdfs:subClassOf [ a owl:Restriction ]"
+    # Note: ends with "]" -> treated as complete statement (will fail parse but cleanup is no-op).
+    assert clean_truncated_turtle(content) == content
+
+
+def test_content_ending_with_angle_bracket_is_unchanged():
+    """RDF/XML closing tags end in ``>``; cleanup must not touch them."""
+    content = "<?xml version=\"1.0\"?><rdf:RDF></rdf:RDF>"
+    assert clean_truncated_turtle(content) == content
+
+
+def test_truncated_trailing_dangling_triple_is_trimmed():
+    truncated = WELL_FORMED_TURTLE + ":Partial a owl:Class ;\n    rdfs:label \"Par"
+    cleaned = clean_truncated_turtle(truncated)
+    assert cleaned != truncated
+    assert ":Order" in cleaned
+    assert ":Partial" not in cleaned
+    Graph().parse(data=cleaned, format="turtle")
+
+
+def test_truncated_path_operator_is_trimmed():
+    """Reproduces the exact crash mode that produced the ontology-generator bug.
+
+    A trailing ``!`` or ``^`` Turtle path operator with no following token
+    causes rdflib's ``path()`` to read past the end of the buffer.
+    """
+    truncated = WELL_FORMED_TURTLE + ":Foo a owl:Class ;\n    rdfs:subClassOf :Bar !"
+    cleaned = clean_truncated_turtle(truncated)
+    assert ":Foo" not in cleaned
+    Graph().parse(data=cleaned, format="turtle")
+
+
+def test_truncated_then_only_comments_keeps_complete_part():
+    truncated = (
+        WELL_FORMED_TURTLE
+        + "# trailing comment\n"
+        + ":Half a owl:Class ;\n    rdfs:label \"Hal"
+    )
+    cleaned = clean_truncated_turtle(truncated)
+    assert ":Order" in cleaned
+    assert ":Half" not in cleaned
+    Graph().parse(data=cleaned, format="turtle")
+
+
+def test_cleanup_logs_when_it_trims(caplog):
+    truncated = WELL_FORMED_TURTLE + ":Partial a owl:Class ;\n    rdfs:label \"Par"
+    with caplog.at_level("WARNING"):
+        clean_truncated_turtle(truncated)
+    assert any("truncated" in rec.message.lower() for rec in caplog.records)
+
+
+def test_cleanup_does_not_log_when_input_complete(caplog):
+    with caplog.at_level("WARNING"):
+        clean_truncated_turtle(WELL_FORMED_TURTLE)
+    assert not any("truncated" in rec.message.lower() for rec in caplog.records)
+
+
+def test_truncated_real_world_llm_payload_parses_after_cleanup():
+    """Mirrors the failing payload shape from the ontology generator route.
+
+    The notation3 parser previously raised ``IndexError`` on a payload like
+    this; cleanup must trim and the result must parse without exception.
+    """
+    payload = (
+        "@prefix : <http://example.org/onto#> .\n"
+        "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n"
+        "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+        "\n"
+        ":Forecast a owl:Class ;\n"
+        "    rdfs:label \"Forecast\" ;\n"
+        "    rdfs:comment \"A weather forecast\" .\n"
+        "\n"
+        ":hasLocation a owl:ObjectProperty ;\n"
+        "    rdfs:domain :Forecast ;\n"
+        "    rdfs:range :Locat"
+    )
+    with pytest.raises(Exception):
+        Graph().parse(data=payload, format="turtle")
+
+    cleaned = clean_truncated_turtle(payload)
+    g = Graph()
+    g.parse(data=cleaned, format="turtle")
+    labels = list(g.objects(predicate=None))
+    assert any("Forecast" in str(o) for o in labels)

--- a/src/frontend/src/app.tsx
+++ b/src/frontend/src/app.tsx
@@ -19,6 +19,7 @@ import DataProductDetails from './views/data-product-details';
 import DataContracts from './views/data-contracts';
 import DataContractDetails from './views/data-contract-details';
 import BusinessTermsView from './views/business-terms';
+import ConceptDetailView from './views/concept-detail';
 import Compliance from './views/compliance';
 import CompliancePolicyDetails from './views/compliance-policy-details';
 import ComplianceRunDetails from './views/compliance-run-details';
@@ -184,6 +185,7 @@ export default function App() {
                 <Route index element={<Navigate to="/concepts/browser" replace />} />
                 <Route path="collections" element={<CollectionsView />} />
                 <Route path="browser" element={<BusinessTermsView />} />
+                <Route path="browser/:iri" element={<ConceptDetailView />} />
                 <Route path="search" element={<OntologySearchView />} />
                 <Route path="graph" element={<OntologyHomeView />} />
                 <Route path="hierarchy" element={<HierarchyBrowserView />} />

--- a/src/frontend/src/components/knowledge/concepts-tab.tsx
+++ b/src/frontend/src/components/knowledge/concepts-tab.tsx
@@ -1,9 +1,8 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Search,
   Plus,
@@ -12,10 +11,7 @@ import {
   Layers,
   BookOpen,
   Zap,
-  Pencil,
-  Trash2,
   User,
-  ExternalLink,
   FolderTree,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -24,46 +20,54 @@ import type {
   KnowledgeCollection,
   GroupedConcepts,
 } from '@/types/ontology';
-import { NodeLinksPanel } from '@/components/knowledge/node-links-panel';
-import EntityMetadataPanel from '@/components/metadata/entity-metadata-panel';
-import { OwnershipPanel } from '@/components/common/ownership-panel';
-import { resolveLabel, resolveComment } from '@/lib/ontology-utils';
+import { resolveLabel } from '@/lib/ontology-utils';
 import { systemRdfNamespaceDisplayLabel } from '@/lib/system-rdf-namespace-labels';
+import { useGlossaryPreferencesStore } from '@/stores/glossary-preferences-store';
 
 interface ConceptsTabProps {
   collections: KnowledgeCollection[];
   groupedConcepts: GroupedConcepts;
   filteredConcepts: OntologyConcept[];
-  selectedConcept: OntologyConcept | null;
+  selectedConcept?: OntologyConcept | null;
   onSelectConcept: (concept: OntologyConcept) => void;
   onCreateConcept: () => void;
-  onEditConcept: (concept: OntologyConcept) => void;
-  onDeleteConcept: (concept: OntologyConcept) => void;
-  onRefresh: () => Promise<void>;
-  canEdit: boolean;
   // Display options (from unified filter panel)
   groupBySource: boolean;
   showProperties: boolean;
   groupByDomain: boolean;
   selectedLanguage: string;
+  canEdit: boolean;
 }
 
 const typeIcons: Record<string, React.ReactNode> = {
-  concept: <Layers className="h-4 w-4 text-emerald-500" />,
-  class: <BookOpen className="h-4 w-4 text-blue-500" />,
-  property: <Zap className="h-4 w-4 text-purple-500" />,
-  individual: <User className="h-4 w-4 text-violet-500" />,
-  term: <Layers className="h-4 w-4 text-emerald-500" />,
+  concept: <Layers className="h-4 w-4 text-emerald-500 shrink-0" />,
+  class: <BookOpen className="h-4 w-4 text-blue-500 shrink-0" />,
+  property: <Zap className="h-4 w-4 text-purple-500 shrink-0" />,
+  individual: <User className="h-4 w-4 text-violet-500 shrink-0" />,
+  term: <Layers className="h-4 w-4 text-emerald-500 shrink-0" />,
 };
 
 const typeColors: Record<string, string> = {
-  concept: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-400',
-  class: 'bg-blue-500/20 text-blue-700 dark:text-blue-400',
-  property: 'bg-purple-500/20 text-purple-700 dark:text-purple-400',
-  individual: 'bg-violet-500/20 text-violet-700 dark:text-violet-400',
-  term: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-400',
+  concept: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+  class: 'bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30',
+  property: 'bg-purple-500/15 text-purple-700 dark:text-purple-400 border-purple-500/30',
+  individual: 'bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/30',
+  term: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
 };
 
+const STATUS_VARIANTS: Record<string, string> = {
+  draft: 'bg-muted text-muted-foreground border-muted-foreground/20',
+  pending: 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30',
+  in_review: 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30',
+  under_review: 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30',
+  active: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+  approved: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+  published: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+  certified: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+  deprecated: 'bg-orange-500/15 text-orange-700 dark:text-orange-400 border-orange-500/30',
+  archived: 'bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/30',
+  retired: 'bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/30',
+};
 
 export const ConceptsTab: React.FC<ConceptsTabProps> = ({
   collections,
@@ -72,42 +76,51 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
   selectedConcept,
   onSelectConcept,
   onCreateConcept,
-  onEditConcept,
-  onDeleteConcept,
-  onRefresh,
-  canEdit,
-  // Display options (from unified filter panel)
   groupBySource,
   showProperties: _showProperties,
   groupByDomain,
   selectedLanguage,
+  canEdit,
 }) => {
   const { t } = useTranslation(['semantic-models', 'common']);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set(['root']));
-  
+  const expandedGroups = useGlossaryPreferencesStore((s) => s.expandedConceptGroups);
+  const toggleConceptGroup = useGlossaryPreferencesStore((s) => s.toggleConceptGroup);
+  const setExpandedConceptGroups = useGlossaryPreferencesStore((s) => s.setExpandedConceptGroups);
+  const conceptListScrollTop = useGlossaryPreferencesStore((s) => s.conceptListScrollTop);
+  const setConceptListScrollTop = useGlossaryPreferencesStore((s) => s.setConceptListScrollTop);
+  const searchQuery = useGlossaryPreferencesStore((s) => s.conceptListSearch);
+  const setSearchQuery = useGlossaryPreferencesStore((s) => s.setConceptListSearch);
+
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+  // Restore scroll position once after mount, then again whenever the data
+  // size changes substantially. Saving happens on scroll.
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    el.scrollTop = conceptListScrollTop;
+    // Only restore on mount; subsequent changes are user-driven.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Build tree data structure from concepts
   const treeData = useMemo(() => {
     const conceptMap = new Map<string, OntologyConcept>();
     const hierarchy = new Map<string, string[]>();
     const sourceContexts = new Set<string>();
 
-    // Filter to classes, concepts, and properties
     const baseConcepts = filteredConcepts.filter(concept => {
       const conceptType = concept.concept_type;
       return conceptType === 'class' || conceptType === 'concept' || conceptType === 'property';
     });
-    
-    // Build concept map and hierarchy
+
     baseConcepts.forEach(concept => {
       conceptMap.set(concept.iri, concept);
-      
-      // Track source contexts
+
       if (concept.source_context) {
         sourceContexts.add(concept.source_context);
       }
 
-      // Build parent-child relationships
       concept.parent_concepts.forEach(parentIri => {
         if (!hierarchy.has(parentIri)) {
           hierarchy.set(parentIri, []);
@@ -117,121 +130,119 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
           parentChildren.push(concept.iri);
         }
       });
-      
-      // Ensure concept is in the map
+
       if (!hierarchy.has(concept.iri)) {
         hierarchy.set(concept.iri, []);
       }
     });
-    
+
     return { conceptMap, hierarchy, sourceContexts: Array.from(sourceContexts).sort() };
   }, [filteredConcepts]);
-  
-  // Get root concepts (no parents in our dataset)
+
   const rootConcepts = useMemo(() => {
     if (groupBySource) {
       return treeData.sourceContexts;
     }
-    
+
     return Array.from(treeData.conceptMap.values())
       .filter(concept => {
-        // When groupByDomain is enabled, properties with domains are shown under their domain concept
         if (groupByDomain && concept.concept_type === 'property' && concept.domain) {
           return false;
         }
-        return concept.parent_concepts.length === 0 || 
+        return concept.parent_concepts.length === 0 ||
                !concept.parent_concepts.some(parentIri => treeData.conceptMap.has(parentIri));
       })
       .map(concept => concept.iri);
   }, [treeData, groupBySource, groupByDomain]);
-  
-  // Get children of a node
+
   const getChildren = useCallback((itemId: string): string[] => {
     if (groupBySource && treeData.sourceContexts.includes(itemId)) {
-      // Return root concepts from that source
       return Array.from(treeData.conceptMap.values())
         .filter(concept => {
           const matchesSource = concept.source_context === itemId;
           if (groupByDomain && concept.concept_type === 'property' && concept.domain) {
             return false;
           }
-          const isRootLevel = concept.parent_concepts.length === 0 || 
+          const isRootLevel = concept.parent_concepts.length === 0 ||
                  !concept.parent_concepts.some(parentIri => treeData.conceptMap.has(parentIri));
           return matchesSource && isRootLevel;
         })
         .map(concept => concept.iri);
     }
-    
+
     if (groupByDomain) {
       const regularChildren = treeData.hierarchy.get(itemId) || [];
-      // Add properties that have this concept as domain
       const propertiesWithThisDomain = Array.from(treeData.conceptMap.values())
         .filter(concept => concept.concept_type === 'property' && concept.domain === itemId)
         .map(concept => concept.iri);
       return [...new Set([...regularChildren, ...propertiesWithThisDomain])];
     }
-    
+
     return treeData.hierarchy.get(itemId) || [];
   }, [treeData, groupBySource, groupByDomain]);
-  
-  // Check if node is a folder
+
   const isFolder = useCallback((itemId: string): boolean => {
     if (groupBySource && treeData.sourceContexts.includes(itemId)) {
       return true;
     }
-    
+
     const concept = treeData.conceptMap.get(itemId);
     if (!concept) return false;
-    
+
     if (groupByDomain) {
       const hasPropertiesWithThisDomain = Array.from(treeData.conceptMap.values()).some(
         c => c.concept_type === 'property' && c.domain === concept.iri
       );
       if (hasPropertiesWithThisDomain) return true;
     }
-    
+
     const children = treeData.hierarchy.get(itemId) || [];
     return children.length > 0 || (concept.child_concepts && concept.child_concepts.length > 0);
   }, [treeData, groupBySource, groupByDomain]);
-  
-  // Toggle group expansion
-  const toggleGroup = useCallback((group: string) => {
-    setExpandedGroups(prev => {
-      const next = new Set(prev);
-      if (next.has(group)) {
-        next.delete(group);
-      } else {
-        next.add(group);
+
+  // When switching grouping modes, expand the new top-level groups so users
+  // see something meaningful instead of a collapsed flat list.
+  useEffect(() => {
+    if (groupBySource && treeData.sourceContexts.length > 0) {
+      const next = new Set(expandedGroups);
+      treeData.sourceContexts.forEach((s) => next.add(s));
+      if (next.size !== expandedGroups.length) {
+        setExpandedConceptGroups(Array.from(next));
       }
-      return next;
-    });
-  }, []);
-  
-  // Get collection by context
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupBySource, treeData.sourceContexts.join('|')]);
+
   const getCollection = useCallback((context?: string) => {
     if (!context) return null;
-    return collections.find(c => 
+    return collections.find(c =>
       c.iri === context || c.iri.endsWith(`:${context}`)
     );
   }, [collections]);
-  
-  // Check if concept is editable
-  const isConceptEditable = useCallback((concept: OntologyConcept): boolean => {
-    const collection = getCollection(concept.source_context);
-    const isDraftStatus = !concept.status || concept.status === 'draft';
-    return !!(canEdit && collection?.is_editable && isDraftStatus);
-  }, [canEdit, getCollection]);
 
-  // Render a tree item recursively
-  const renderTreeItem = (itemId: string, level: number = 0) => {
+  const handleSelect = useCallback((concept: OntologyConcept) => {
+    // Save current scroll position so we can restore it on the way back.
+    if (scrollContainerRef.current) {
+      setConceptListScrollTop(scrollContainerRef.current.scrollTop);
+    }
+    onSelectConcept(concept);
+  }, [onSelectConcept, setConceptListScrollTop]);
+
+  const conceptLabel = useCallback(
+    (concept: OntologyConcept) => resolveLabel(concept, selectedLanguage),
+    [selectedLanguage],
+  );
+
+  // Render a single tree row with rich content (icon + label + type + collection
+  // + status pill + property hints).
+  const renderTreeItem = (itemId: string, level: number = 0): React.ReactNode => {
     const isSourceGroup = groupBySource && treeData.sourceContexts.includes(itemId);
     const concept = treeData.conceptMap.get(itemId);
-    const isExpanded = expandedGroups.has(itemId) || (searchQuery.length > 0);
+    const isExpanded = expandedGroups.includes(itemId) || (searchQuery.length > 0);
     const hasChildren = isFolder(itemId);
     const children = getChildren(itemId);
     const isSelected = selectedConcept?.iri === itemId;
-    
-    // For source groups, check if any child matches search
+
     if (isSourceGroup && searchQuery) {
       const hasMatchingChildren = children.some(childId => {
         const child = treeData.conceptMap.get(childId);
@@ -243,15 +254,13 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
       });
       if (!hasMatchingChildren) return null;
     }
-    
-    // For concepts, check if matches search
+
     if (!isSourceGroup && searchQuery && concept) {
       const query = searchQuery.toLowerCase();
       const matchesSelf = concept.label?.toLowerCase().includes(query) ||
                           concept.comment?.toLowerCase().includes(query) ||
                           concept.iri.toLowerCase().includes(query);
-      
-      // Check if any descendant matches
+
       const hasMatchingDescendants = (): boolean => {
         const stack = [...children];
         while (stack.length > 0) {
@@ -268,48 +277,67 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
         }
         return false;
       };
-      
+
       if (!matchesSelf && !hasMatchingDescendants()) {
         return null;
       }
     }
-    
+
     const getConceptIcon = () => {
       if (isSourceGroup) {
         return <FolderTree className="h-4 w-4 shrink-0 text-orange-500" />;
       }
-      return typeIcons[concept?.concept_type || 'concept'] || <Layers className="h-4 w-4" />;
+      return typeIcons[concept?.concept_type || 'concept'] || <Layers className="h-4 w-4 shrink-0" />;
     };
-    
+
     const displayName = isSourceGroup
       ? systemRdfNamespaceDisplayLabel(itemId, t)
-      : (concept ? resolveLabel(concept, selectedLanguage) : itemId);
-    
+      : (concept ? conceptLabel(concept) : itemId);
+
+    const collection = concept?.source_context ? getCollection(concept.source_context) : null;
+    const collectionLabel = collection?.label
+      || (concept?.source_context ? systemRdfNamespaceDisplayLabel(concept.source_context, t) : null);
+
     return (
       <div key={itemId}>
         <div
+          role={isSourceGroup ? 'button' : 'link'}
+          tabIndex={0}
+          data-testid={isSourceGroup ? `concept-group-${itemId}` : `concept-row-${itemId}`}
           className={cn(
-            "flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer w-full text-left",
+            "flex items-center gap-2 px-2 py-1 rounded-md cursor-pointer w-full text-left",
             "hover:bg-accent hover:text-accent-foreground transition-colors",
             isSelected && !isSourceGroup && "bg-primary/10 text-primary",
-            isSourceGroup && "font-semibold bg-muted/50"
+            isSourceGroup && "font-semibold bg-muted/40",
           )}
           style={{ paddingLeft: `${level * 12 + 8}px` }}
           onClick={() => {
             if (!isSourceGroup && concept) {
-              onSelectConcept(concept);
+              handleSelect(concept);
             } else if (hasChildren) {
-              toggleGroup(itemId);
+              toggleConceptGroup(itemId);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              if (!isSourceGroup && concept) {
+                handleSelect(concept);
+              } else if (hasChildren) {
+                toggleConceptGroup(itemId);
+              }
             }
           }}
         >
-          <div className="flex items-center w-5 justify-center">
+          <div className="flex items-center w-5 justify-center shrink-0">
             {hasChildren && (
               <button
+                type="button"
+                aria-label={isExpanded ? 'Collapse' : 'Expand'}
                 className="p-0.5 hover:bg-muted rounded"
                 onClick={(e) => {
                   e.stopPropagation();
-                  toggleGroup(itemId);
+                  toggleConceptGroup(itemId);
                 }}
               >
                 {isExpanded ? (
@@ -320,20 +348,62 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
               </button>
             )}
           </div>
-          <div className="flex items-center gap-2 min-w-0 flex-1">
-            {getConceptIcon()}
-            <span className="truncate text-sm font-medium" title={displayName}>
-              {displayName}
-            </span>
-          </div>
+
+          {getConceptIcon()}
+
+          <span className="truncate text-sm font-medium" title={displayName}>
+            {displayName}
+          </span>
+
+          {/* Right-side metadata: type, collection, status, property hints */}
+          {!isSourceGroup && concept && (
+            <div className="ml-auto flex items-center gap-2 shrink-0 pl-2">
+              {concept.concept_type === 'property' && (concept.domain || concept.range) && (
+                <span
+                  className="hidden md:inline-flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground font-mono truncate max-w-[260px]"
+                  title={`${concept.domain || '?'} → ${concept.range || '?'}`}
+                >
+                  {(concept.domain ? concept.domain.split(/[/#]/).pop() : '?')}
+                  <span className="opacity-60">→</span>
+                  {(concept.range ? concept.range.split(/[/#]/).pop() : '?')}
+                </span>
+              )}
+              {collectionLabel && (
+                <Badge
+                  variant="outline"
+                  className="hidden lg:inline-flex text-[10px] font-normal max-w-[200px] truncate border-muted-foreground/20"
+                  title={collectionLabel}
+                >
+                  {collectionLabel}
+                </Badge>
+              )}
+              <Badge
+                variant="outline"
+                className={cn('text-[10px] font-medium', typeColors[concept.concept_type] || '')}
+              >
+                {t(`semantic-models:types.${concept.concept_type}`)}
+              </Badge>
+              {concept.status && (
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    'hidden sm:inline-flex text-[10px] font-medium',
+                    STATUS_VARIANTS[concept.status] || '',
+                  )}
+                >
+                  {t(`semantic-models:status.${concept.status}`, concept.status)}
+                </Badge>
+              )}
+            </div>
+          )}
+
           {isSourceGroup && (
-            <Badge variant="secondary" className="text-xs">
+            <Badge variant="secondary" className="text-xs ml-auto">
               {children.length}
             </Badge>
           )}
         </div>
-        
-        {/* Render children */}
+
         {hasChildren && isExpanded && (
           <div className="ml-2">
             {children.map(childId => renderTreeItem(childId, level + 1))}
@@ -342,271 +412,54 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
       </div>
     );
   };
-  
-  // Helper to get concept label by IRI with language resolution
-  const getConceptLabel = (iri: string): string => {
-    const concept = filteredConcepts.find(c => c.iri === iri);
-    if (concept) return resolveLabel(concept, selectedLanguage);
-    return iri.split(/[/#]/).pop() || iri;
-  };
-  
+
   return (
-    <div className="grid grid-cols-12 gap-4">
-      {/* Left Panel - Concept Tree */}
-      <div className="col-span-4 border rounded-lg flex flex-col bg-card overflow-hidden max-h-[calc(100vh-280px)]">
-        {/* Search */}
-        <div className="p-4 border-b">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder={t('common:placeholders.searchConceptsAndTerms')}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
-            />
-          </div>
+    <div className="border rounded-lg flex flex-col bg-card overflow-hidden max-h-[calc(100vh-260px)]">
+      <div className="p-2 border-b flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder={t('common:placeholders.searchConceptsAndTerms')}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
         </div>
-        
-        {/* Concept Tree */}
-        <div className="flex-1 min-h-0 overflow-auto">
-          <div className="p-2 min-w-max">
-            {rootConcepts.map(id => renderTreeItem(id, 0))}
-            
-            {rootConcepts.length === 0 && (
-              <div className="text-center text-muted-foreground py-8">
-                <Layers className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                <p>{t('semantic-models:messages.noConceptsFound')}</p>
-              </div>
-            )}
-          </div>
-        </div>
-        
-        {/* Create button */}
         {canEdit && (
-          <div className="p-3 border-t">
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={onCreateConcept}
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              {t('semantic-models:actions.createConcept')}
-            </Button>
-          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onCreateConcept}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            {t('semantic-models:actions.createConcept')}
+          </Button>
         )}
       </div>
-      
-      {/* Right Panel - Concept Detail */}
-      <div className="col-span-8 border rounded-lg bg-card">
-        {selectedConcept ? (
-          <ScrollArea className="h-full">
-            <div className="p-6 space-y-6">
-              {/* Header */}
-              <div className="flex items-start justify-between">
-                <div className="space-y-2">
-                  <div className="flex items-center gap-3">
-                    {typeIcons[selectedConcept.concept_type]}
-                    <h2 className="text-2xl font-bold">
-                      {resolveLabel(selectedConcept, selectedLanguage)}
-                    </h2>
-                    <Badge className={typeColors[selectedConcept.concept_type]}>
-                      {t(`semantic-models:types.${selectedConcept.concept_type}`)}
-                    </Badge>
-                    {selectedConcept.status && (
-                      <Badge variant="outline">{t(`semantic-models:status.${selectedConcept.status}`)}</Badge>
-                    )}
-                  </div>
-                  
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <code className="px-2 py-0.5 bg-muted rounded text-xs">
-                      {selectedConcept.iri}
-                    </code>
-                    <Button variant="ghost" size="icon" className="h-6 w-6">
-                      <ExternalLink className="h-3 w-3" />
-                    </Button>
-                  </div>
-                </div>
-                
-                {isConceptEditable(selectedConcept) && (
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => onEditConcept(selectedConcept)}
-                    >
-                      <Pencil className="h-4 w-4 mr-1" />
-                      {t('common:actions.edit')}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="text-destructive hover:text-destructive"
-                      onClick={() => onDeleteConcept(selectedConcept)}
-                    >
-                      <Trash2 className="h-4 w-4 mr-1" />
-                      {t('common:actions.delete')}
-                    </Button>
-                  </div>
-                )}
-              </div>
-              
-              {/* Definition */}
-              {(selectedConcept.comments || selectedConcept.comment) && (
-                <div className="bg-muted/30 rounded-lg p-4">
-                  <h3 className="text-sm font-medium mb-2">{t('semantic-models:fields.definition')}</h3>
-                  <p className="text-sm">{resolveComment(selectedConcept, selectedLanguage)}</p>
-                </div>
-              )}
-              
-              {/* Property-specific: Domain & Range */}
-              {selectedConcept.concept_type === 'property' && (
-                <div className="grid grid-cols-2 gap-4">
-                  {selectedConcept.domain && (
-                    <div className="bg-muted/30 rounded-lg p-4">
-                      <h3 className="text-sm font-medium mb-2">{t('semantic-models:fields.domain')}</h3>
-                      <Badge 
-                        variant="secondary" 
-                        className="cursor-pointer"
-                        onClick={() => {
-                          const domain = filteredConcepts.find(c => c.iri === selectedConcept.domain);
-                          if (domain) onSelectConcept(domain);
-                        }}
-                      >
-                        {getConceptLabel(selectedConcept.domain)}
-                      </Badge>
-                    </div>
-                  )}
-                  {selectedConcept.range && (
-                    <div className="bg-muted/30 rounded-lg p-4">
-                      <h3 className="text-sm font-medium mb-2">{t('semantic-models:fields.range')}</h3>
-                      <Badge 
-                        variant="secondary"
-                        className="cursor-pointer"
-                        onClick={() => {
-                          const range = filteredConcepts.find(c => c.iri === selectedConcept.range);
-                          if (range) onSelectConcept(range);
-                        }}
-                      >
-                        {getConceptLabel(selectedConcept.range)}
-                      </Badge>
-                    </div>
-                  )}
-                </div>
-              )}
-              
-              {/* Parent & Child concepts */}
-              {selectedConcept.parent_concepts.length > 0 && (
-                <div>
-                  <h3 className="text-sm font-medium mb-2">{t('semantic-models:fields.parentConcepts')}</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {selectedConcept.parent_concepts.map(parentIri => (
-                      <Badge 
-                        key={parentIri} 
-                        variant="secondary" 
-                        className="cursor-pointer hover:bg-secondary/80"
-                        onClick={() => {
-                          const parent = filteredConcepts.find(c => c.iri === parentIri);
-                          if (parent) onSelectConcept(parent);
-                        }}
-                      >
-                        {getConceptLabel(parentIri)}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-              
-              {selectedConcept.child_concepts.length > 0 && (
-                <div>
-                  <h3 className="text-sm font-medium mb-2">{t('semantic-models:fields.childConcepts')}</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {selectedConcept.child_concepts.map(childIri => (
-                      <Badge 
-                        key={childIri} 
-                        variant="outline" 
-                        className="cursor-pointer hover:bg-accent/80"
-                        onClick={() => {
-                          const child = filteredConcepts.find(c => c.iri === childIri);
-                          if (child) onSelectConcept(child);
-                        }}
-                      >
-                        {getConceptLabel(childIri)}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-              
-              {/* Synonyms & Examples */}
-              {(selectedConcept.synonyms?.length > 0 || selectedConcept.examples?.length > 0) && (
-                <div className="grid grid-cols-2 gap-4">
-                  {selectedConcept.synonyms?.length > 0 && (
-                    <div>
-                      <h3 className="text-sm font-medium mb-2">{t('semantic-models:fields.synonyms')}</h3>
-                      <div className="flex flex-wrap gap-1">
-                        {selectedConcept.synonyms.map(syn => (
-                          <Badge key={syn} variant="outline" className="text-xs">{syn}</Badge>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  {selectedConcept.examples?.length > 0 && (
-                    <div>
-                      <h3 className="text-sm font-medium mb-2">{t('semantic-models:fields.examples')}</h3>
-                      <div className="flex flex-wrap gap-1">
-                        {selectedConcept.examples.map(ex => (
-                          <Badge key={ex} variant="outline" className="text-xs">{ex}</Badge>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-              
-              {/* Links Panel */}
-              <NodeLinksPanel
-                concept={selectedConcept}
-                allConcepts={filteredConcepts}
-                collections={collections}
-                onSelectConcept={onSelectConcept}
-                onRefresh={onRefresh}
-                canEdit={isConceptEditable(selectedConcept)}
-                selectedLanguage={selectedLanguage}
-              />
-              
-              {/* Ownership Panel */}
-              <OwnershipPanel
-                objectType="business_term"
-                objectId={selectedConcept.iri}
-                canAssign={isConceptEditable(selectedConcept)}
-              />
 
-              {/* Source Info */}
-              <div className="text-sm text-muted-foreground border-t pt-4">
-                <p>
-                  {t('semantic-models:fields.source')}:{' '}
-                  {selectedConcept.source_context
-                    ? systemRdfNamespaceDisplayLabel(selectedConcept.source_context, t)
-                    : '—'}
-                </p>
-                {selectedConcept.created_at && (
-                  <p>Created: {new Date(selectedConcept.created_at).toLocaleDateString()}</p>
-                )}
-              </div>
-              
-              {/* Metadata Panel */}
-              <EntityMetadataPanel 
-                entityType="concept" 
-                entityId={selectedConcept.iri} 
-              />
+      <div
+        ref={scrollContainerRef}
+        className="flex-1 min-h-0 overflow-auto"
+        onScroll={(e) => {
+          const target = e.currentTarget;
+          // Throttle via rAF; this is simple and good enough for a tree.
+          if (target) {
+            window.requestAnimationFrame(() => {
+              setConceptListScrollTop(target.scrollTop);
+            });
+          }
+        }}
+      >
+        <div className="p-2 min-w-max">
+          {rootConcepts.map(id => renderTreeItem(id, 0))}
+
+          {rootConcepts.length === 0 && (
+            <div className="text-center text-muted-foreground py-12">
+              <Layers className="h-8 w-8 mx-auto mb-2 opacity-50" />
+              <p>{t('semantic-models:messages.noConceptsFound')}</p>
             </div>
-          </ScrollArea>
-        ) : (
-          <div className="h-full flex flex-col items-center justify-center text-muted-foreground">
-            <Layers className="h-12 w-12 mb-4 opacity-50" />
-            <p>{t('semantic-models:messages.selectConcept')}</p>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/frontend/src/components/knowledge/node-links-panel.tsx
+++ b/src/frontend/src/components/knowledge/node-links-panel.tsx
@@ -28,6 +28,9 @@ interface NodeLinksPanelProps {
   onRefresh: () => Promise<void>;
   canEdit: boolean;
   selectedLanguage?: string;
+  // When set, the outgoing/incoming lists scroll internally past this row
+  // count instead of growing the page. ~36px per row, so 10 ≈ 360px.
+  maxVisibleRows?: number;
 }
 
 interface LinkInfo {
@@ -59,7 +62,13 @@ export const NodeLinksPanel: React.FC<NodeLinksPanelProps> = ({
   onRefresh,
   canEdit,
   selectedLanguage = 'en',
+  maxVisibleRows,
 }) => {
+  // Approx row height for the list rows below (py-1.5 + gap + text-sm ≈ 36px).
+  const ROW_HEIGHT_PX = 36;
+  const listMaxHeight = maxVisibleRows
+    ? { maxHeight: ROW_HEIGHT_PX * maxVisibleRows }
+    : undefined;
   const { t } = useTranslation(['semantic-models', 'common']);
   const { toast } = useToast();
   const [outgoingOpen, setOutgoingOpen] = useState(true);
@@ -390,7 +399,10 @@ export const NodeLinksPanel: React.FC<NodeLinksPanelProps> = ({
           </CollapsibleTrigger>
           
           <CollapsibleContent>
-            <div className="border-t px-2 py-1">
+            <div
+              className={`border-t px-2 py-1 ${maxVisibleRows ? 'overflow-y-auto' : ''}`}
+              style={listMaxHeight}
+            >
               {outgoingLinks.length === 0 ? (
                 <p className="text-sm text-muted-foreground py-2 px-2">
                   {t('semantic-models:links.noOutgoing')}
@@ -439,7 +451,10 @@ export const NodeLinksPanel: React.FC<NodeLinksPanelProps> = ({
           </CollapsibleTrigger>
           
           <CollapsibleContent>
-            <div className="border-t px-2 py-1">
+            <div
+              className={`border-t px-2 py-1 ${maxVisibleRows ? 'overflow-y-auto' : ''}`}
+              style={listMaxHeight}
+            >
               {incomingLinks.length === 0 ? (
                 <p className="text-sm text-muted-foreground py-2 px-2">
                   {t('semantic-models:links.noIncoming')}

--- a/src/frontend/src/components/semantic/concept-neighborhood-graph.test.tsx
+++ b/src/frontend/src/components/semantic/concept-neighborhood-graph.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { OntologyConcept } from '@/types/ontology'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockGet = vi.fn()
+
+vi.mock('@/hooks/use-api', () => ({
+  useApi: () => ({
+    get: mockGet,
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      if (options && typeof options === 'object' && 'defaultValue' in options) {
+        return options.defaultValue as string
+      }
+      return key
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+// Stub reactflow to surface node/edge inputs for assertion without exercising
+// the real renderer (which has heavy DOM/measurement requirements in jsdom).
+vi.mock('reactflow', () => {
+  const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
+  const MarkerType = { ArrowClosed: 'arrowclosed' }
+  const Handle = (_props: any) => null
+  const ReactFlowProvider = ({ children }: any) => children
+  const useReactFlow = () => ({ fitView: vi.fn() })
+  const ReactFlow = ({ nodes = [], edges = [], nodeTypes = {} }: any) => {
+    const renderNode = (n: any) => {
+      const NodeComp = nodeTypes[n.type]
+      return (
+        <div key={n.id} data-testid={`rf-node-${n.id}`}>
+          {NodeComp ? <NodeComp data={n.data} /> : null}
+        </div>
+      )
+    }
+    return (
+      <div data-testid="rf-canvas">
+        <div data-testid="rf-nodes" data-count={nodes.length}>
+          {nodes.map(renderNode)}
+        </div>
+        <div data-testid="rf-edges" data-count={edges.length}>
+          {edges.map((e: any) => (
+            <div key={e.id} data-testid={`rf-edge-${e.id}`} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+  return {
+    __esModule: true,
+    default: ReactFlow,
+    Position,
+    MarkerType,
+    Handle,
+    ReactFlowProvider,
+    useReactFlow,
+  }
+})
+
+// Re-import after mocks are registered
+import ConceptNeighborhoodGraph from './concept-neighborhood-graph'
+
+// ---- Fixtures -------------------------------------------------------------
+
+const concept: OntologyConcept = {
+  iri: 'https://example.org/onto#Customer',
+  label: 'Customer',
+  concept_type: 'class',
+  parent_concepts: [],
+  child_concepts: [],
+  properties: [],
+  tagged_assets: [],
+  synonyms: [],
+  examples: [],
+}
+
+const neighborsResponse = [
+  // 1 parent via subClassOf
+  {
+    direction: 'outgoing',
+    predicate: 'http://www.w3.org/2000/01/rdf-schema#subClassOf',
+    display: 'https://example.org/onto#Party',
+    displayType: 'resource',
+    stepIri: 'https://example.org/onto#Party',
+    stepIsResource: true,
+  },
+  // 3 children via incoming subClassOf
+  {
+    direction: 'incoming',
+    predicate: 'http://www.w3.org/2000/01/rdf-schema#subClassOf',
+    display: 'https://example.org/onto#PremiumCustomer',
+    displayType: 'resource',
+    stepIri: 'https://example.org/onto#PremiumCustomer',
+    stepIsResource: true,
+  },
+  {
+    direction: 'incoming',
+    predicate: 'http://www.w3.org/2000/01/rdf-schema#subClassOf',
+    display: 'https://example.org/onto#RetailCustomer',
+    displayType: 'resource',
+    stepIri: 'https://example.org/onto#RetailCustomer',
+    stepIsResource: true,
+  },
+  {
+    direction: 'incoming',
+    predicate: 'http://www.w3.org/2000/01/rdf-schema#subClassOf',
+    display: 'https://example.org/onto#WholesaleCustomer',
+    displayType: 'resource',
+    stepIri: 'https://example.org/onto#WholesaleCustomer',
+    stepIsResource: true,
+  },
+  // unrelated outgoing predicate (should be ignored)
+  {
+    direction: 'outgoing',
+    predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+    display: 'http://www.w3.org/2002/07/owl#Class',
+    displayType: 'resource',
+    stepIri: 'http://www.w3.org/2002/07/owl#Class',
+    stepIsResource: true,
+  },
+]
+
+describe('ConceptNeighborhoodGraph', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/semantic-models/neighbors')) {
+        return { data: neighborsResponse }
+      }
+      return { data: [] }
+    })
+  })
+
+  it('renders 5 nodes (1 parent + current + 3 children) and 4 edges', async () => {
+    render(<ConceptNeighborhoodGraph concept={concept} onNavigate={() => {}} />)
+
+    await waitFor(() => {
+      const nodesContainer = screen.getByTestId('rf-nodes')
+      expect(nodesContainer.getAttribute('data-count')).toBe('5')
+    })
+
+    const edgesContainer = screen.getByTestId('rf-edges')
+    expect(edgesContainer.getAttribute('data-count')).toBe('4')
+
+    expect(
+      screen.getByTestId('rf-node-parent-https://example.org/onto#Party'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('rf-node-current')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('rf-node-child-https://example.org/onto#PremiumCustomer'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('rf-node-child-https://example.org/onto#RetailCustomer'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('rf-node-child-https://example.org/onto#WholesaleCustomer'),
+    ).toBeInTheDocument()
+  })
+
+  it('fires onNavigate with the child IRI when a child node is clicked', async () => {
+    const onNavigate = vi.fn()
+    render(<ConceptNeighborhoodGraph concept={concept} onNavigate={onNavigate} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('rf-node-child-https://example.org/onto#PremiumCustomer'),
+      ).toBeInTheDocument()
+    })
+
+    const child = screen.getByText('PremiumCustomer')
+    const user = userEvent.setup()
+    await user.click(child)
+
+    expect(onNavigate).toHaveBeenCalledWith('https://example.org/onto#PremiumCustomer')
+  })
+
+  it('renders empty state when there are no related concepts', async () => {
+    mockGet.mockImplementation(async () => ({ data: [] }))
+    render(<ConceptNeighborhoodGraph concept={concept} onNavigate={() => {}} />)
+    expect(await screen.findByText('No related concepts.')).toBeInTheDocument()
+    expect(screen.queryByTestId('rf-canvas')).not.toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/components/semantic/concept-neighborhood-graph.tsx
+++ b/src/frontend/src/components/semantic/concept-neighborhood-graph.tsx
@@ -1,0 +1,458 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import ReactFlow, {
+  Edge,
+  Handle,
+  MarkerType,
+  Node,
+  Position,
+  ReactFlowProvider,
+  useReactFlow,
+} from 'reactflow'
+import 'reactflow/dist/style.css'
+import { Card } from '@/components/ui/card'
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useApi } from '@/hooks/use-api'
+import { OntologyConcept } from '@/types/ontology'
+
+interface NeighborItem {
+  direction: 'outgoing' | 'incoming' | 'predicate'
+  predicate: string
+  display: string
+  displayType: 'resource' | 'property' | 'literal'
+  stepIri?: string | null
+  stepIsResource?: boolean
+}
+
+interface ConceptNeighborhoodGraphProps {
+  concept: OntologyConcept
+  onNavigate: (iri: string) => void
+}
+
+const PARENT_PREDICATE_FRAGMENTS = [
+  'subClassOf',
+  'broader',
+  'subPropertyOf',
+]
+
+const CHILD_PREDICATE_FRAGMENTS = [
+  'subClassOf',
+  'narrower',
+  'subPropertyOf',
+]
+
+const matchesPredicate = (predicate: string, fragments: string[]): boolean => {
+  const lower = predicate.toLowerCase()
+  return fragments.some((f) => lower.endsWith(f.toLowerCase()))
+}
+
+const localName = (iri: string): string => {
+  if (!iri) return ''
+  const fragment = iri.split('#').pop()
+  if (fragment && fragment !== iri) return fragment
+  const path = iri.split('/').pop()
+  return path || iri
+}
+
+interface MiniNodeData {
+  label: string
+  iri: string
+  isCurrent?: boolean
+  isPlaceholder?: boolean
+  onClick?: (iri: string) => void
+  typeBadge?: string
+}
+
+const NODE_WIDTH = 170
+const NODE_HEIGHT = 56
+const HORIZONTAL_SPACING = 24
+const VERTICAL_LEVEL_SPACING = 50
+const FIXED_PADDING = 16
+
+function MiniNode({ data }: { data: MiniNodeData }) {
+  // The default `bg-card` + `text-card-foreground` combo always pairs
+  // correctly in both light and dark themes. The "current" node only tints
+  // the background (bg-primary/10) so we keep the regular foreground colour
+  // there too -- using `text-primary-foreground` would render invisibly on
+  // such a faintly-tinted background. Placeholders use `text-foreground`
+  // muted via opacity so they read in both modes.
+  return (
+    <Card
+      onClick={() => {
+        if (data.isPlaceholder) return
+        if (data.iri && data.onClick) data.onClick(data.iri)
+      }}
+      title={data.iri || data.label}
+      className={cn(
+        'p-2 flex flex-col items-center justify-center text-center text-xs shadow-sm hover:shadow-md transition-shadow',
+        'bg-card text-card-foreground',
+        data.isPlaceholder &&
+          'cursor-default bg-muted/60 text-muted-foreground border-dashed',
+        !data.isPlaceholder && !data.isCurrent && 'cursor-pointer',
+        data.isCurrent &&
+          'cursor-default bg-primary/10 border-primary text-foreground ring-1 ring-primary/40',
+      )}
+      style={{ width: NODE_WIDTH, height: NODE_HEIGHT }}
+    >
+      <Handle type="target" position={Position.Top} id="t-top" style={{ background: 'transparent', border: 'none' }} />
+      <Handle type="source" position={Position.Bottom} id="s-bottom" style={{ background: 'transparent', border: 'none' }} />
+      <div
+        className={cn(
+          'font-medium truncate w-full',
+          data.isPlaceholder && 'opacity-80',
+        )}
+      >
+        {data.label}
+      </div>
+      {data.typeBadge && (
+        <div
+          className={cn(
+            'text-[10px] uppercase tracking-wide',
+            data.isCurrent ? 'text-primary' : 'text-muted-foreground',
+          )}
+        >
+          {data.typeBadge}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+const nodeTypes = { mini: MiniNode }
+
+interface NeighborItemForLayout {
+  iri: string
+  label: string
+  typeBadge: string
+}
+
+interface LayoutInput {
+  current: NeighborItemForLayout
+  parents: NeighborItemForLayout[]
+  children: NeighborItemForLayout[]
+  parentOverflow: number
+  childOverflow: number
+}
+
+function buildNodesAndEdges(
+  layout: LayoutInput,
+  onNavigate: (iri: string) => void,
+  parentMoreLabel: string,
+  childMoreLabel: string,
+): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = []
+  const edges: Edge[] = []
+
+  const parentRowCount = layout.parents.length + (layout.parentOverflow > 0 ? 1 : 0)
+  const childRowCount = layout.children.length + (layout.childOverflow > 0 ? 1 : 0)
+
+  const rowWidth = (count: number) =>
+    count > 0 ? count * NODE_WIDTH + Math.max(0, count - 1) * HORIZONTAL_SPACING : NODE_WIDTH
+
+  const parentWidth = rowWidth(parentRowCount)
+  const childWidth = rowWidth(childRowCount)
+  const maxWidth = Math.max(parentWidth, childWidth, NODE_WIDTH)
+
+  const centralX = (maxWidth - NODE_WIDTH) / 2 + FIXED_PADDING
+  const parentRowStartX = (maxWidth - parentWidth) / 2 + FIXED_PADDING
+  const childRowStartX = (maxWidth - childWidth) / 2 + FIXED_PADDING
+
+  let yCursor = FIXED_PADDING
+
+  // Parents (top row)
+  if (parentRowCount > 0) {
+    const parentY = yCursor
+    layout.parents.forEach((parent, idx) => {
+      const x = parentRowStartX + idx * (NODE_WIDTH + HORIZONTAL_SPACING)
+      nodes.push({
+        id: `parent-${parent.iri}`,
+        type: 'mini',
+        position: { x, y: parentY },
+        data: {
+          label: parent.label,
+          iri: parent.iri,
+          typeBadge: parent.typeBadge,
+          onClick: onNavigate,
+        },
+      })
+      edges.push({
+        id: `e-parent-${parent.iri}`,
+        source: `parent-${parent.iri}`,
+        target: 'current',
+        sourceHandle: 's-bottom',
+        targetHandle: 't-top',
+      })
+    })
+    if (layout.parentOverflow > 0) {
+      const overflowX =
+        parentRowStartX + layout.parents.length * (NODE_WIDTH + HORIZONTAL_SPACING)
+      nodes.push({
+        id: 'parent-overflow',
+        type: 'mini',
+        position: { x: overflowX, y: parentY },
+        data: {
+          label: parentMoreLabel.replace('{{count}}', String(layout.parentOverflow)),
+          iri: '',
+          isPlaceholder: true,
+        },
+      })
+    }
+    yCursor += NODE_HEIGHT + VERTICAL_LEVEL_SPACING
+  }
+
+  // Current (centre)
+  const currentY = yCursor
+  nodes.push({
+    id: 'current',
+    type: 'mini',
+    position: { x: centralX, y: currentY },
+    data: {
+      label: layout.current.label,
+      iri: layout.current.iri,
+      isCurrent: true,
+      typeBadge: layout.current.typeBadge,
+    },
+  })
+  yCursor += NODE_HEIGHT + VERTICAL_LEVEL_SPACING
+
+  // Children (bottom row)
+  if (childRowCount > 0) {
+    const childY = yCursor
+    layout.children.forEach((child, idx) => {
+      const x = childRowStartX + idx * (NODE_WIDTH + HORIZONTAL_SPACING)
+      nodes.push({
+        id: `child-${child.iri}`,
+        type: 'mini',
+        position: { x, y: childY },
+        data: {
+          label: child.label,
+          iri: child.iri,
+          typeBadge: child.typeBadge,
+          onClick: onNavigate,
+        },
+      })
+      edges.push({
+        id: `e-child-${child.iri}`,
+        source: 'current',
+        target: `child-${child.iri}`,
+        sourceHandle: 's-bottom',
+        targetHandle: 't-top',
+      })
+    })
+    if (layout.childOverflow > 0) {
+      const overflowX =
+        childRowStartX + layout.children.length * (NODE_WIDTH + HORIZONTAL_SPACING)
+      nodes.push({
+        id: 'child-overflow',
+        type: 'mini',
+        position: { x: overflowX, y: childY },
+        data: {
+          label: childMoreLabel.replace('{{count}}', String(layout.childOverflow)),
+          iri: '',
+          isPlaceholder: true,
+        },
+      })
+    }
+  }
+
+  return { nodes, edges }
+}
+
+const MAX_PER_SIDE = 8
+
+function ConceptNeighborhoodGraphInner({
+  concept,
+  onNavigate,
+}: ConceptNeighborhoodGraphProps) {
+  const { get } = useApi()
+  const { t } = useTranslation(['semantic-models'])
+  const { fitView } = useReactFlow()
+  const [neighbors, setNeighbors] = useState<NeighborItem[] | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      if (!concept?.iri) {
+        setNeighbors([])
+        return
+      }
+      setIsLoading(true)
+      try {
+        const url = `/api/semantic-models/neighbors?iri=${encodeURIComponent(
+          concept.iri,
+        )}&limit=200`
+        const res = await get<NeighborItem[]>(url)
+        if (cancelled) return
+        setNeighbors(res.data || [])
+      } catch (error) {
+        console.error('ConceptNeighborhoodGraph: failed to load neighbors', error)
+        if (!cancelled) setNeighbors([])
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [concept?.iri, get])
+
+  const layout = useMemo<LayoutInput | null>(() => {
+    if (!neighbors) return null
+
+    const typeBadgeFor = (c: OntologyConcept): string =>
+      c.concept_type === 'property'
+        ? t('semantic-models:types.property', { defaultValue: 'Property' })
+        : t('semantic-models:types.class', { defaultValue: 'Class' })
+
+    const parentsAll: NeighborItemForLayout[] = []
+    const childrenAll: NeighborItemForLayout[] = []
+    const seenParents = new Set<string>()
+    const seenChildren = new Set<string>()
+
+    for (const n of neighbors) {
+      if (!n.stepIri || !n.stepIsResource) continue
+      if (n.direction === 'outgoing' && matchesPredicate(n.predicate, PARENT_PREDICATE_FRAGMENTS)) {
+        if (n.stepIri === concept.iri) continue
+        if (seenParents.has(n.stepIri)) continue
+        seenParents.add(n.stepIri)
+        parentsAll.push({
+          iri: n.stepIri,
+          label: localName(n.display) || n.display,
+          typeBadge: t('semantic-models:types.class', { defaultValue: 'Class' }),
+        })
+      } else if (
+        n.direction === 'incoming' &&
+        matchesPredicate(n.predicate, CHILD_PREDICATE_FRAGMENTS)
+      ) {
+        if (n.stepIri === concept.iri) continue
+        if (seenChildren.has(n.stepIri)) continue
+        seenChildren.add(n.stepIri)
+        childrenAll.push({
+          iri: n.stepIri,
+          label: localName(n.display) || n.display,
+          typeBadge: t('semantic-models:types.class', { defaultValue: 'Class' }),
+        })
+      }
+    }
+
+    const parents = parentsAll.slice(0, MAX_PER_SIDE)
+    const children = childrenAll.slice(0, MAX_PER_SIDE)
+    return {
+      current: {
+        iri: concept.iri,
+        label: concept.label || localName(concept.iri) || concept.iri,
+        typeBadge: typeBadgeFor(concept),
+      },
+      parents,
+      children,
+      parentOverflow: parentsAll.length - parents.length,
+      childOverflow: childrenAll.length - children.length,
+    }
+  }, [neighbors, concept, t])
+
+  const parentMoreLabel = t('semantic-models:neighborhood.moreParents', {
+    count: layout?.parentOverflow ?? 0,
+    defaultValue: '+{{count}} more',
+  })
+  const childMoreLabel = t('semantic-models:neighborhood.moreChildren', {
+    count: layout?.childOverflow ?? 0,
+    defaultValue: '+{{count}} more',
+  })
+
+  const { nodes, edges } = useMemo(() => {
+    if (!layout) return { nodes: [], edges: [] }
+    return buildNodesAndEdges(layout, onNavigate, parentMoreLabel, childMoreLabel)
+  }, [layout, onNavigate, parentMoreLabel, childMoreLabel])
+
+  useEffect(() => {
+    if (nodes.length === 0) return
+    const timer = setTimeout(() => {
+      fitView({ padding: 0.1, duration: 200 })
+    }, 50)
+    return () => clearTimeout(timer)
+  }, [nodes, fitView])
+
+  if (isLoading && !layout) {
+    return (
+      <div className="flex items-center justify-center text-sm text-muted-foreground py-3 gap-2">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        {t('semantic-models:neighborhood.loading', {
+          defaultValue: 'Loading neighbourhood...',
+        })}
+      </div>
+    )
+  }
+
+  if (
+    layout &&
+    layout.parents.length === 0 &&
+    layout.children.length === 0 &&
+    layout.parentOverflow === 0 &&
+    layout.childOverflow === 0
+  ) {
+    return (
+      <p className="text-sm text-muted-foreground py-2 px-2">
+        {t('semantic-models:neighborhood.empty', {
+          defaultValue: 'No related concepts.',
+        })}
+      </p>
+    )
+  }
+
+  const isDarkMode =
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark')
+
+  const defaultEdgeOptions = {
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 14,
+      height: 14,
+      color: isDarkMode ? '#94a3b8' : '#64748b',
+    },
+    style: {
+      stroke: isDarkMode ? '#94a3b8' : '#64748b',
+      strokeWidth: 1.5,
+    },
+  }
+
+  return (
+    <div
+      className="bg-muted/30"
+      style={{ height: GRAPH_HEIGHT }}
+      data-testid="concept-neighborhood-graph"
+    >
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        defaultEdgeOptions={defaultEdgeOptions}
+        fitView
+        fitViewOptions={{ padding: 0.1 }}
+        proOptions={{ hideAttribution: true }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        zoomOnScroll={false}
+        panOnDrag={false}
+        selectNodesOnDrag={false}
+        minZoom={0.2}
+        maxZoom={1.5}
+      />
+    </div>
+  )
+}
+
+const GRAPH_HEIGHT = 320
+
+export default function ConceptNeighborhoodGraph(
+  props: ConceptNeighborhoodGraphProps,
+) {
+  return (
+    <ReactFlowProvider>
+      <ConceptNeighborhoodGraphInner {...props} />
+    </ReactFlowProvider>
+  )
+}

--- a/src/frontend/src/components/semantic/concept-relations-panel.test.tsx
+++ b/src/frontend/src/components/semantic/concept-relations-panel.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockGet = vi.fn()
+vi.mock('@/hooks/use-api', () => ({
+  useApi: () => ({
+    get: mockGet,
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      if (options && typeof options === 'object' && 'defaultValue' in options) {
+        return options.defaultValue as string
+      }
+      return key
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+import ConceptRelationsPanel from './concept-relations-panel'
+
+const sampleNeighbors = [
+  // Outgoing -- should appear
+  {
+    direction: 'outgoing',
+    predicate: 'http://www.w3.org/2000/01/rdf-schema#subClassOf',
+    display: 'http://example.org/onto#WeatherObservation',
+    displayType: 'resource',
+    stepIri: 'http://example.org/onto#WeatherObservation',
+    stepIsResource: true,
+  },
+  {
+    direction: 'outgoing',
+    predicate: 'http://www.w3.org/2002/07/owl#equivalentClass',
+    display: 'http://other.org/onto#Measurement',
+    displayType: 'resource',
+    stepIri: 'http://other.org/onto#Measurement',
+    stepIsResource: true,
+  },
+  // Incoming -- should appear
+  {
+    direction: 'incoming',
+    predicate: 'http://www.w3.org/2000/01/rdf-schema#subClassOf',
+    display: 'http://example.org/onto#TemperatureMeasurement',
+    displayType: 'resource',
+    stepIri: 'http://example.org/onto#TemperatureMeasurement',
+    stepIsResource: true,
+  },
+  // Hidden noise predicates
+  {
+    direction: 'outgoing',
+    predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+    display: 'http://www.w3.org/2002/07/owl#Class',
+    displayType: 'resource',
+    stepIri: 'http://www.w3.org/2002/07/owl#Class',
+    stepIsResource: true,
+  },
+  {
+    direction: 'outgoing',
+    predicate: 'http://www.w3.org/2000/01/rdf-schema#label',
+    display: 'Atmospheric Measurement',
+    displayType: 'literal',
+    stepIri: null,
+    stepIsResource: false,
+  },
+  // Predicate-direction items: also dropped to avoid double-counting
+  {
+    direction: 'predicate',
+    predicate: 'http://example.org/onto#AtmosphericMeasurement',
+    display: 'http://example.org/onto#someSubject',
+    displayType: 'resource',
+    stepIri: 'http://example.org/onto#someSubject',
+    stepIsResource: true,
+  },
+]
+
+describe('ConceptRelationsPanel', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockGet.mockResolvedValue({ data: sampleNeighbors })
+  })
+
+  const renderPanel = (overrides: Partial<React.ComponentProps<typeof ConceptRelationsPanel>> = {}) => {
+    const props: React.ComponentProps<typeof ConceptRelationsPanel> = {
+      conceptIri: 'http://example.org/onto#AtmosphericMeasurement',
+      onNavigate: vi.fn(),
+      ...overrides,
+    }
+    return { ...render(<ConceptRelationsPanel {...props} />), props }
+  }
+
+  it('renders only meaningful relations (drops rdf:type, label, predicate-direction)', async () => {
+    renderPanel()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('concept-relations-list')).toBeInTheDocument()
+    })
+
+    // Three meaningful relations: 2 outgoing + 1 incoming
+    expect(
+      screen.getByTestId('relation-outgoing-subClassOf-WeatherObservation'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('relation-outgoing-equivalentClass-Measurement'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('relation-incoming-subClassOf-TemperatureMeasurement'),
+    ).toBeInTheDocument()
+
+    // Filtered ones are absent
+    expect(screen.queryByText(/owl#Class/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Atmospheric Measurement')).not.toBeInTheDocument()
+  })
+
+  it('shows total count and outgoing/incoming breakdown in the header', async () => {
+    renderPanel()
+    await waitFor(() => {
+      expect(screen.getByTestId('concept-relations-list')).toBeInTheDocument()
+    })
+    // Total is 3 (the visible ones); outgoing 2, incoming 1
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('navigates when clicking on a resource target', async () => {
+    const onNavigate = vi.fn()
+    renderPanel({ onNavigate })
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('relation-outgoing-equivalentClass-Measurement'),
+      ).toBeInTheDocument()
+    })
+    const user = userEvent.setup()
+    const row = screen.getByTestId('relation-outgoing-equivalentClass-Measurement')
+    const link = row.querySelector('button')!
+    await user.click(link)
+    expect(onNavigate).toHaveBeenCalledWith('http://other.org/onto#Measurement')
+  })
+
+  it('renders an empty state when no neighbours exist', async () => {
+    mockGet.mockResolvedValue({ data: [] })
+    renderPanel()
+    await waitFor(() => {
+      expect(screen.getByText(/No relations found\./i)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/frontend/src/components/semantic/concept-relations-panel.tsx
+++ b/src/frontend/src/components/semantic/concept-relations-panel.tsx
@@ -1,0 +1,311 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChevronDown,
+  ChevronRight,
+  Link as LinkIcon,
+  Loader2,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { useApi } from '@/hooks/use-api'
+
+interface NeighborItem {
+  direction: 'outgoing' | 'incoming' | 'predicate'
+  predicate: string
+  display: string
+  displayType: 'resource' | 'property' | 'literal'
+  stepIri?: string | null
+  stepIsResource?: boolean
+}
+
+interface ConceptRelationsPanelProps {
+  conceptIri: string
+  onNavigate: (iri: string) => void
+  // When set, the relations list scrolls internally past this row count
+  // instead of growing the page (rows are ~32px high).
+  maxVisibleRows?: number
+  // Optional cap on how many neighbours to fetch from the backend.
+  fetchLimit?: number
+}
+
+// Predicates whose values are already surfaced elsewhere on the page
+// (title, type pill, definition, synonyms, examples). Hiding them keeps
+// the relations panel focused on actual semantic relationships.
+const PREDICATES_TO_HIDE = new Set<string>([
+  'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+  'http://www.w3.org/2000/01/rdf-schema#label',
+  'http://www.w3.org/2000/01/rdf-schema#comment',
+  'http://www.w3.org/2004/02/skos/core#prefLabel',
+  'http://www.w3.org/2004/02/skos/core#altLabel',
+  'http://www.w3.org/2004/02/skos/core#hiddenLabel',
+  'http://www.w3.org/2004/02/skos/core#definition',
+  'http://www.w3.org/2004/02/skos/core#example',
+  'http://www.w3.org/2004/02/skos/core#notation',
+])
+
+// Friendly colour scheme by relationship family. Falls back to neutral.
+const PREDICATE_COLORS: Array<[RegExp, string]> = [
+  [/subClassOf$|broader$|broaderTransitive$|subPropertyOf$|broadMatch$/i,
+    'bg-indigo-500/10 text-indigo-600 border-indigo-500/30'],
+  [/narrower$|narrowerTransitive$|narrowMatch$/i,
+    'bg-green-500/10 text-green-600 border-green-500/30'],
+  [/related$|relatedMatch$|seeAlso$/i,
+    'bg-orange-500/10 text-orange-600 border-orange-500/30'],
+  [/domain$/i, 'bg-violet-500/10 text-violet-600 border-violet-500/30'],
+  [/range$/i, 'bg-pink-500/10 text-pink-600 border-pink-500/30'],
+  [/sameAs$|equivalentClass$|equivalentProperty$|exactMatch$|closeMatch$/i,
+    'bg-cyan-500/10 text-cyan-600 border-cyan-500/30'],
+  [/disjointWith$|complementOf$/i,
+    'bg-red-500/10 text-red-600 border-red-500/30'],
+  [/inverseOf$/i, 'bg-amber-500/10 text-amber-600 border-amber-500/30'],
+  [/isDefinedBy$/i, 'bg-slate-500/10 text-slate-600 border-slate-500/30'],
+]
+
+const localName = (iri: string): string => {
+  if (!iri) return ''
+  const fragment = iri.split('#').pop()
+  if (fragment && fragment !== iri) return fragment
+  const path = iri.split('/').pop()
+  return path || iri
+}
+
+const colourFor = (predicate: string): string => {
+  for (const [re, cls] of PREDICATE_COLORS) {
+    if (re.test(predicate)) return cls
+  }
+  return ''
+}
+
+interface NormalizedRelation {
+  key: string
+  direction: 'outgoing' | 'incoming'
+  predicate: string
+  predicateShort: string
+  targetLabel: string
+  targetIri?: string | null
+  isResource: boolean
+}
+
+export default function ConceptRelationsPanel({
+  conceptIri,
+  onNavigate,
+  maxVisibleRows,
+  fetchLimit = 500,
+}: ConceptRelationsPanelProps) {
+  const { get } = useApi()
+  const { t } = useTranslation(['semantic-models', 'common'])
+
+  const [neighbors, setNeighbors] = useState<NeighborItem[] | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [open, setOpen] = useState(true)
+
+  const ROW_HEIGHT_PX = 32
+  const listMaxHeight = maxVisibleRows
+    ? { maxHeight: ROW_HEIGHT_PX * maxVisibleRows }
+    : undefined
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      if (!conceptIri) {
+        setNeighbors([])
+        return
+      }
+      setIsLoading(true)
+      try {
+        const url = `/api/semantic-models/neighbors?iri=${encodeURIComponent(
+          conceptIri,
+        )}&limit=${fetchLimit}`
+        const res = await get<NeighborItem[]>(url)
+        if (cancelled) return
+        setNeighbors(res.data || [])
+      } catch (err) {
+        console.error('ConceptRelationsPanel: failed to load neighbors', err)
+        if (!cancelled) setNeighbors([])
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [conceptIri, fetchLimit, get])
+
+  // Normalise + dedupe + sort. Outgoing first, then incoming, then by
+  // predicate local name for stable scanning.
+  const relations = useMemo<NormalizedRelation[]>(() => {
+    if (!neighbors) return []
+    const seen = new Set<string>()
+    const out: NormalizedRelation[] = []
+    for (const n of neighbors) {
+      // Predicate-direction items only appear when the IRI itself IS used as
+      // a predicate. They are already covered by the inverse triples on the
+      // other side, so we ignore them here to avoid double-counting.
+      if (n.direction === 'predicate') continue
+      if (PREDICATES_TO_HIDE.has(n.predicate)) continue
+      // A literal whose predicate we hid still shouldn't appear; literals
+      // we keep are domain-specific annotations (e.g. dc:identifier).
+
+      const targetIri = n.stepIri || (n.displayType !== 'literal' ? n.display : null)
+      const targetLabel =
+        n.displayType === 'literal'
+          ? n.display
+          : localName(n.display) || n.display
+
+      const key = `${n.direction}|${n.predicate}|${n.display}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push({
+        key,
+        direction: n.direction,
+        predicate: n.predicate,
+        predicateShort: localName(n.predicate) || n.predicate,
+        targetLabel,
+        targetIri,
+        isResource: !!n.stepIsResource,
+      })
+    }
+    out.sort((a, b) => {
+      if (a.direction !== b.direction) {
+        return a.direction === 'outgoing' ? -1 : 1
+      }
+      if (a.predicateShort !== b.predicateShort) {
+        return a.predicateShort.localeCompare(b.predicateShort)
+      }
+      return a.targetLabel.localeCompare(b.targetLabel)
+    })
+    return out
+  }, [neighbors])
+
+  const counts = useMemo(() => {
+    let outgoing = 0
+    let incoming = 0
+    for (const r of relations) {
+      if (r.direction === 'outgoing') outgoing += 1
+      else incoming += 1
+    }
+    return { outgoing, incoming, total: relations.length }
+  }, [relations])
+
+  const renderRow = useCallback(
+    (r: NormalizedRelation) => {
+      const colour = colourFor(r.predicate)
+      const DirIcon = r.direction === 'outgoing' ? ArrowRight : ArrowLeft
+      const dirTooltip =
+        r.direction === 'outgoing'
+          ? t('semantic-models:relations.outgoingTooltip', {
+              defaultValue: 'This concept → target',
+            })
+          : t('semantic-models:relations.incomingTooltip', {
+              defaultValue: 'Source → this concept',
+            })
+      return (
+        <div
+          key={r.key}
+          data-testid={`relation-${r.direction}-${r.predicateShort}-${r.targetLabel}`}
+          className="flex items-center gap-2 py-1 px-2 rounded hover:bg-muted/50"
+        >
+          <Badge
+            variant="outline"
+            className={`text-[10px] font-mono ${colour}`}
+            title={r.predicate}
+          >
+            {r.predicateShort}
+          </Badge>
+          <DirIcon
+            className="h-3 w-3 text-muted-foreground shrink-0"
+            aria-label={dirTooltip}
+          />
+          {r.isResource && r.targetIri ? (
+            <button
+              type="button"
+              className="text-sm text-primary hover:underline text-left truncate"
+              onClick={() => onNavigate(r.targetIri!)}
+              title={r.targetIri}
+            >
+              {r.targetLabel}
+            </button>
+          ) : (
+            <span
+              className="text-sm text-muted-foreground truncate"
+              title={r.targetLabel}
+            >
+              {r.targetLabel}
+            </span>
+          )}
+        </div>
+      )
+    },
+    [onNavigate, t],
+  )
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="border rounded-lg">
+        <CollapsibleTrigger className="flex items-center justify-between w-full p-3 hover:bg-muted/50">
+          <div className="flex items-center gap-2">
+            {open ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            <LinkIcon className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium text-sm">
+              {t('semantic-models:relations.title', {
+                defaultValue: 'Relations',
+              })}
+            </span>
+            <Badge variant="secondary" className="text-xs">
+              {counts.total}
+            </Badge>
+            {counts.total > 0 && (
+              <span className="text-[11px] text-muted-foreground inline-flex items-center gap-2 ml-1">
+                <span className="inline-flex items-center gap-1">
+                  <ArrowRight className="h-3 w-3" />
+                  {counts.outgoing}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <ArrowLeft className="h-3 w-3" />
+                  {counts.incoming}
+                </span>
+              </span>
+            )}
+          </div>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div
+            className={`border-t px-2 py-1 ${maxVisibleRows ? 'overflow-y-auto' : ''}`}
+            style={listMaxHeight}
+            data-testid="concept-relations-list"
+          >
+            {isLoading && relations.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground py-2 px-2">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                {t('semantic-models:relations.loading', {
+                  defaultValue: 'Loading relations...',
+                })}
+              </div>
+            ) : relations.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-2 px-2">
+                {t('semantic-models:relations.empty', {
+                  defaultValue: 'No relations found.',
+                })}
+              </p>
+            ) : (
+              relations.map(renderRow)
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  )
+}

--- a/src/frontend/src/components/semantic/linked-objects-panel.test.tsx
+++ b/src/frontend/src/components/semantic/linked-objects-panel.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+
+vi.mock('@/hooks/use-api', () => ({
+  useApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    put: vi.fn(),
+    delete: vi.fn(),
+  }),
+}))
+
+const toastSpy = vi.fn()
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastSpy }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      if (options && typeof options === 'object' && 'defaultValue' in options) {
+        return options.defaultValue as string
+      }
+      return key
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+const bumpRefreshNonce = vi.fn()
+vi.mock('@/stores/knowledge-graph-store', () => ({
+  useKnowledgeGraphStore: (selector: any) =>
+    selector({ refreshNonce: 0, lastReason: null, bumpRefreshNonce }),
+}))
+
+// Avoid pulling the heavy UC asset dialog into the test render
+vi.mock('@/components/data-contracts/uc-asset-lookup-dialog', () => ({
+  default: () => null,
+}))
+
+// Re-export after mocks are registered
+import LinkedObjectsPanel from './linked-objects-panel'
+
+// ---- Helpers --------------------------------------------------------------
+
+function renderPanel(props: Partial<React.ComponentProps<typeof LinkedObjectsPanel>> = {}) {
+  const merged: React.ComponentProps<typeof LinkedObjectsPanel> = {
+    conceptIri: 'https://example.org/onto#Customer',
+    conceptLabel: 'Customer',
+    canAssign: true,
+    onChanged: vi.fn(),
+    ...props,
+  }
+  return render(
+    <BrowserRouter>
+      <TooltipProvider>
+        <LinkedObjectsPanel {...merged} />
+      </TooltipProvider>
+    </BrowserRouter>,
+  )
+}
+
+const sampleLinks = [
+  {
+    id: 'link-1',
+    entity_id: 'product-a',
+    entity_type: 'data_product',
+    iri: 'https://example.org/onto#Customer',
+  },
+  {
+    id: 'link-2',
+    entity_id: 'main.sales.orders',
+    entity_type: 'uc_table',
+    iri: 'https://example.org/onto#Customer',
+  },
+]
+
+describe('LinkedObjectsPanel', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    bumpRefreshNonce.mockReset()
+    toastSpy.mockReset()
+    // default mocks: links + entity enrichment
+    mockGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/semantic-links/iri/')) {
+        return { data: sampleLinks }
+      }
+      if (url.startsWith('/api/data-products/')) {
+        return { data: { id: 'product-a', name: 'Product A' } }
+      }
+      return { data: [] }
+    })
+  })
+
+  it('renders linked rows once fetched', async () => {
+    renderPanel()
+    await waitFor(() => {
+      expect(screen.getByTestId('linked-objects-list')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('linked-object-link-1')).toBeInTheDocument()
+    expect(screen.getByTestId('linked-object-link-2')).toBeInTheDocument()
+    expect(screen.getByText(/Product A/)).toBeInTheDocument()
+    expect(screen.getByText(/main\.sales\.orders/)).toBeInTheDocument()
+  })
+
+  it('hides assign button and remove buttons when read-only', async () => {
+    renderPanel({ canAssign: false })
+    await waitFor(() => {
+      expect(screen.getByTestId('linked-objects-list')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('linked-objects-assign-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('linked-object-remove-link-1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('linked-object-remove-link-2')).not.toBeInTheDocument()
+  })
+
+  it('shows assign button when canAssign is true', async () => {
+    renderPanel({ canAssign: true })
+    await waitFor(() => {
+      expect(screen.getByTestId('linked-objects-assign-button')).toBeInTheDocument()
+    })
+  })
+
+  it('fires DELETE and bumps refresh store when removing a link', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => '',
+    })
+    global.fetch = fetchSpy as unknown as typeof fetch
+
+    const onChanged = vi.fn()
+    renderPanel({ onChanged })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('linked-object-remove-link-1')).toBeInTheDocument()
+    })
+
+    const user = userEvent.setup()
+    const removeBtn = screen.getByTestId('linked-object-remove-link-1')
+    await user.click(removeBtn)
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/semantic-links/link-1',
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
+    expect(bumpRefreshNonce).toHaveBeenCalledWith('semantic-link-mutated')
+    expect(onChanged).toHaveBeenCalled()
+  })
+
+  it('renders empty state when no links exist', async () => {
+    mockGet.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/semantic-links/iri/')) {
+        return { data: [] }
+      }
+      return { data: [] }
+    })
+    renderPanel()
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No entities linked to this concept/i),
+      ).toBeInTheDocument()
+    })
+    // No link rows should be rendered, even though the content container
+    // (which holds the empty-state copy) is always present in the new shell.
+    expect(screen.queryByTestId(/^linked-object-link-/)).not.toBeInTheDocument()
+  })
+
+  it('always shows the title row', async () => {
+    renderPanel({ canAssign: false })
+    const heading = await screen.findByText('Linked Entities')
+    expect(heading).toBeInTheDocument()
+    // Sanity: heading is in the same panel, not a stray match
+    expect(within(heading.parentElement as HTMLElement).getByText('Linked Entities'))
+      .toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/components/semantic/linked-objects-panel.tsx
+++ b/src/frontend/src/components/semantic/linked-objects-panel.tsx
@@ -1,0 +1,608 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  ChevronDown,
+  ChevronRight,
+  Columns2,
+  Database,
+  FileText,
+  Folder,
+  FolderOpen,
+  Globe,
+  Link2,
+  Loader2,
+  Package,
+  Plus,
+  Shapes,
+  Table,
+  X,
+} from 'lucide-react'
+import { useApi } from '@/hooks/use-api'
+import { useToast } from '@/hooks/use-toast'
+import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store'
+
+interface SemanticLink {
+  id: string
+  entity_id: string
+  entity_type: string
+  iri: string
+  label?: string
+}
+
+interface EnrichedSemanticLink extends SemanticLink {
+  entity_name?: string
+}
+
+interface LinkedObjectsPanelProps {
+  conceptIri: string
+  conceptLabel: string
+  canAssign: boolean
+  onChanged?: () => void
+  // When set, the linked-objects list scrolls internally past this row
+  // count instead of growing the page (rows are ~32px high).
+  maxVisibleRows?: number
+}
+
+const ENTITY_ICONS: Record<string, typeof FileText> = {
+  data_contract: FileText,
+  data_product: Package,
+  asset: Database,
+  data_domain: Globe,
+  uc_catalog: Folder,
+  uc_schema: FolderOpen,
+  uc_table: Table,
+  uc_column: Columns2,
+  data_contract_schema: Shapes,
+  data_contract_property: Columns2,
+}
+
+// Same colour vocabulary as NodeLinksPanel relationshipColors so the badges
+// look at home next to the ontology relations panel above.
+const ENTITY_TYPE_COLORS: Record<string, string> = {
+  data_product: 'bg-emerald-500/10 text-emerald-600 border-emerald-500/30',
+  data_contract: 'bg-blue-500/10 text-blue-600 border-blue-500/30',
+  asset: 'bg-rose-500/10 text-rose-600 border-rose-500/30',
+  data_domain: 'bg-cyan-500/10 text-cyan-600 border-cyan-500/30',
+  uc_catalog: 'bg-amber-500/10 text-amber-600 border-amber-500/30',
+  uc_schema: 'bg-amber-500/10 text-amber-600 border-amber-500/30',
+  uc_table: 'bg-orange-500/10 text-orange-600 border-orange-500/30',
+  uc_column: 'bg-orange-500/10 text-orange-600 border-orange-500/30',
+  data_contract_schema: 'bg-violet-500/10 text-violet-600 border-violet-500/30',
+  data_contract_property: 'bg-purple-500/10 text-purple-600 border-purple-500/30',
+}
+
+const iconFor = (entityType: string) => ENTITY_ICONS[entityType] ?? FileText
+
+const formatEntityType = (entityType: string) =>
+  entityType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+
+export default function LinkedObjectsPanel({
+  conceptIri,
+  conceptLabel,
+  canAssign,
+  onChanged,
+  maxVisibleRows,
+}: LinkedObjectsPanelProps) {
+  const ROW_HEIGHT_PX = 32
+  const listMaxHeight = maxVisibleRows
+    ? { maxHeight: ROW_HEIGHT_PX * maxVisibleRows }
+    : undefined
+  const { get, post } = useApi()
+  const { toast } = useToast()
+  const navigate = useNavigate()
+  const { t } = useTranslation(['search', 'common', 'semantic-models'])
+  const bumpKnowledgeGraphRefresh = useKnowledgeGraphStore((s) => s.bumpRefreshNonce)
+
+  const [links, setLinks] = useState<EnrichedSemanticLink[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [open, setOpen] = useState(true)
+
+  // Assign dialog state
+  const [assignDialogOpen, setAssignDialogOpen] = useState(false)
+  const [selectedEntityType, setSelectedEntityType] = useState('')
+  const [selectedEntityId, setSelectedEntityId] = useState('')
+  const [availableEntities, setAvailableEntities] = useState<any[]>([])
+
+  const enrichLinks = useCallback(
+    async (raw: SemanticLink[]): Promise<EnrichedSemanticLink[]> => {
+      const enriched: EnrichedSemanticLink[] = []
+      for (const link of raw) {
+        try {
+          let endpoint = ''
+          let entityName: string | undefined = link.entity_id
+
+          switch (link.entity_type) {
+            case 'data_product':
+              endpoint = `/api/data-products/${link.entity_id}`
+              break
+            case 'data_contract':
+              endpoint = `/api/data-contracts/${link.entity_id}`
+              break
+            case 'asset':
+              endpoint = `/api/assets/${link.entity_id}`
+              break
+            case 'data_domain':
+              endpoint = `/api/data-domains/${link.entity_id}`
+              break
+            case 'data_contract_schema': {
+              const [contractId, schemaName] = String(link.entity_id).split('#')
+              if (contractId) {
+                const contractRes = await get<any>(`/api/data-contracts/${contractId}`)
+                const title =
+                  contractRes.data?.name || contractRes.data?.info?.title || contractId
+                entityName = `${title}#${schemaName || ''}`.trim()
+              }
+              enriched.push({ ...link, entity_name: entityName })
+              continue
+            }
+            case 'data_contract_property': {
+              const [contractId, schemaName, propertyName] = String(link.entity_id).split('#')
+              if (contractId) {
+                const contractRes = await get<any>(`/api/data-contracts/${contractId}`)
+                const title =
+                  contractRes.data?.name || contractRes.data?.info?.title || contractId
+                entityName = `${title}#${schemaName || ''}.${propertyName || ''}`.trim()
+              }
+              enriched.push({ ...link, entity_name: entityName })
+              continue
+            }
+            case 'uc_catalog':
+            case 'uc_schema':
+            case 'uc_table':
+            case 'uc_column':
+              // entity_id is already the human-readable full name
+              enriched.push({ ...link, entity_name: link.entity_id })
+              continue
+            default:
+              enriched.push({ ...link, entity_name: link.entity_id })
+              continue
+          }
+
+          if (endpoint) {
+            const entityRes = await get<any>(endpoint)
+            if (entityRes.data && !entityRes.error) {
+              entityName =
+                entityRes.data.name ||
+                entityRes.data.info?.title ||
+                entityRes.data.title ||
+                link.entity_id
+            }
+          }
+          enriched.push({ ...link, entity_name: entityName })
+        } catch (error) {
+          console.error('LinkedObjectsPanel: failed to enrich link', link, error)
+          enriched.push({ ...link, entity_name: link.entity_id })
+        }
+      }
+      return enriched
+    },
+    [get]
+  )
+
+  const fetchLinks = useCallback(async () => {
+    if (!conceptIri) {
+      setLinks([])
+      return
+    }
+    setIsLoading(true)
+    try {
+      const res = await get<SemanticLink[]>(
+        `/api/semantic-links/iri/${encodeURIComponent(conceptIri)}`
+      )
+      const raw = res.data || []
+      const enriched = await enrichLinks(raw)
+      setLinks(enriched)
+    } catch (error) {
+      console.error('LinkedObjectsPanel: failed to load links', error)
+      setLinks([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [conceptIri, get, enrichLinks])
+
+  useEffect(() => {
+    fetchLinks()
+  }, [fetchLinks])
+
+  const loadEntitiesForType = useCallback(
+    async (entityType: string) => {
+      try {
+        if (entityType === 'asset') {
+          // /api/assets returns a PaginatedAssetSummary { items, total, ... }
+          const res = await get<{ items: any[] }>('/api/assets?limit=500')
+          setAvailableEntities(res.data?.items || [])
+          return
+        }
+
+        let endpoint = ''
+        switch (entityType) {
+          case 'data_product':
+            endpoint = '/api/data-products'
+            break
+          case 'data_contract':
+            endpoint = '/api/data-contracts'
+            break
+          default:
+            setAvailableEntities([])
+            return
+        }
+        const res = await get<any[]>(endpoint)
+        setAvailableEntities(res.data || [])
+      } catch (error) {
+        console.error('LinkedObjectsPanel: failed to load entities for', entityType, error)
+        setAvailableEntities([])
+      }
+    },
+    [get]
+  )
+
+  const handleEntityTypeChange = (entityType: string) => {
+    setSelectedEntityType(entityType)
+    setSelectedEntityId('')
+    loadEntitiesForType(entityType)
+  }
+
+  const getEntityTypeLabel = (entityType: string): string => {
+    switch (entityType) {
+      case 'data_product':
+        return t('search:concepts.assignDialog.dataProduct')
+      case 'data_contract':
+        return t('search:concepts.assignDialog.dataContract')
+      case 'asset':
+        return t('search:concepts.assignDialog.asset', { defaultValue: 'Asset' })
+      case 'data_domain':
+        return t('search:concepts.assignDialog.dataDomain')
+      case 'uc_catalog':
+        return t('search:concepts.assignDialog.ucCatalog')
+      case 'uc_schema':
+        return t('search:concepts.assignDialog.ucSchema')
+      case 'uc_table':
+        return t('search:concepts.assignDialog.ucTable')
+      default:
+        return formatEntityType(entityType)
+    }
+  }
+
+  const navigateToEntity = (link: EnrichedSemanticLink) => {
+    switch (link.entity_type) {
+      case 'data_product':
+        navigate(`/data-products/${link.entity_id}`)
+        return
+      case 'data_contract':
+        navigate(`/data-contracts/${link.entity_id}`)
+        return
+      case 'asset':
+        navigate(`/assets/${link.entity_id}`)
+        return
+      case 'data_domain':
+        navigate(`/settings/data-domains/${link.entity_id}`)
+        return
+      case 'uc_catalog':
+      case 'uc_schema':
+      case 'uc_table':
+      case 'uc_column': {
+        navigate('/catalog-commander')
+        const ucLabel =
+          link.entity_type === 'uc_catalog'
+            ? t('search:concepts.linkedUCCatalog')
+            : link.entity_type === 'uc_schema'
+              ? t('search:concepts.linkedUCSchema')
+              : link.entity_type === 'uc_column'
+                ? t('search:concepts.linkedUCColumn')
+                : t('search:concepts.linkedUCTable')
+        toast({ title: ucLabel, description: link.entity_name || link.entity_id })
+        return
+      }
+      default:
+        toast({
+          title: t('common:toast.error'),
+          description: t('search:concepts.messages.navigationError', {
+            entityType: link.entity_type,
+          }),
+          variant: 'destructive',
+        })
+    }
+  }
+
+  const completeAssignment = async (
+    entityType: string,
+    _entityId: string,
+    successDescriptionId: string
+  ) => {
+    bumpKnowledgeGraphRefresh('semantic-link-mutated')
+    onChanged?.()
+    await fetchLinks()
+    toast({
+      title: t('common:toast.success'),
+      description: t('search:concepts.messages.linkedSuccess', {
+        label: conceptLabel,
+        entityType: getEntityTypeLabel(entityType),
+        entityId: successDescriptionId,
+      }),
+    })
+  }
+
+  const handleAssignToObject = async () => {
+    if (!conceptIri || !selectedEntityType || !selectedEntityId) {
+      toast({
+        title: t('common:toast.error'),
+        description: t('search:concepts.messages.assignError'),
+        variant: 'destructive',
+      })
+      return
+    }
+    try {
+      const res = await post('/api/semantic-links/', {
+        entity_id: selectedEntityId,
+        entity_type: selectedEntityType,
+        iri: conceptIri,
+      })
+      if (res.error) throw new Error(res.error)
+
+      setAssignDialogOpen(false)
+      const finishedType = selectedEntityType
+      const finishedId = selectedEntityId
+      setSelectedEntityType('')
+      setSelectedEntityId('')
+      await completeAssignment(finishedType, finishedId, finishedId)
+    } catch (error: any) {
+      toast({
+        title: t('common:toast.error'),
+        description: error?.message || t('search:concepts.messages.assignFailed'),
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const handleRemoveLink = async (link: EnrichedSemanticLink) => {
+    try {
+      const res = await fetch(`/api/semantic-links/${link.id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(text || `HTTP ${res.status}`)
+      }
+      bumpKnowledgeGraphRefresh('semantic-link-mutated')
+      onChanged?.()
+      await fetchLinks()
+      toast({
+        title: t('common:toast.success'),
+        description: t('semantic-models:linkedObjects.removed', {
+          label: link.entity_name || link.entity_id,
+          defaultValue: 'Removed link to "{{label}}".',
+        }),
+      })
+    } catch (error: any) {
+      toast({
+        title: t('common:toast.error'),
+        description:
+          error?.message ||
+          t('semantic-models:linkedObjects.removeFailed', {
+            defaultValue: 'Failed to remove link.',
+          }),
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const renderLinkRow = (link: EnrichedSemanticLink) => {
+    const Icon = iconFor(link.entity_type)
+    const typeLabel = getEntityTypeLabel(link.entity_type)
+    const colour = ENTITY_TYPE_COLORS[link.entity_type] || ''
+    return (
+      <div
+        key={link.id}
+        data-testid={`linked-object-${link.id}`}
+        className="flex items-center gap-2 py-1.5 px-2 rounded hover:bg-muted/50 group"
+      >
+        <Badge variant="outline" className={`text-xs ${colour}`}>
+          {typeLabel}
+        </Badge>
+        <Icon className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+        <button
+          type="button"
+          className="text-sm text-primary hover:underline text-left truncate"
+          onClick={() => navigateToEntity(link)}
+          title={`${typeLabel}: ${link.entity_name || link.entity_id} • ${link.iri}`}
+        >
+          {link.entity_name || link.entity_id}
+        </button>
+        {canAssign && (
+          <Button
+            variant="ghost"
+            size="icon"
+            data-testid={`linked-object-remove-${link.id}`}
+            aria-label={t('semantic-models:linkedObjects.removeAria', {
+              defaultValue: 'Remove linked entity',
+            })}
+            className="h-6 w-6 opacity-0 group-hover:opacity-100 flex-shrink-0 ml-auto"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              handleRemoveLink(link)
+            }}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="border rounded-lg">
+        <CollapsibleTrigger className="flex items-center justify-between w-full p-3 hover:bg-muted/50">
+          <div className="flex items-center gap-2">
+            {open ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            <Link2 className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium text-sm">
+              {t('semantic-models:linkedObjects.title', {
+                defaultValue: 'Linked Entities',
+              })}
+            </span>
+            <Badge variant="secondary" className="text-xs">
+              {links.length}
+            </Badge>
+          </div>
+
+          {canAssign && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7"
+              data-testid="linked-objects-assign-button"
+              onClick={(e) => {
+                e.stopPropagation()
+                setAssignDialogOpen(true)
+              }}
+            >
+              <Plus className="h-3 w-3 mr-1" />
+              {t('common:actions.add')}
+            </Button>
+          )}
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div
+            className={`border-t px-2 py-1 ${maxVisibleRows ? 'overflow-y-auto' : ''}`}
+            style={listMaxHeight}
+            data-testid="linked-objects-list"
+          >
+            {isLoading && links.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground py-2 px-2">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                {t('semantic-models:linkedObjects.loading', {
+                  defaultValue: 'Loading linked entities...',
+                })}
+              </div>
+            ) : links.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-2 px-2">
+                {t('semantic-models:linkedObjects.empty', {
+                  defaultValue: 'No entities linked to this concept.',
+                })}
+              </p>
+            ) : (
+              links.map(renderLinkRow)
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+
+      {/* Assign dialog */}
+      <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t('search:concepts.assignDialog.title')}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="text-sm">
+              <p className="font-medium">{conceptLabel}</p>
+              <p className="text-muted-foreground font-mono text-xs break-all">{conceptIri}</p>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                {t('search:concepts.assignDialog.entityType')}
+              </label>
+              <Select value={selectedEntityType} onValueChange={handleEntityTypeChange}>
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={t('search:concepts.assignDialog.selectEntityType')}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="data_product">
+                    {t('search:concepts.assignDialog.dataProduct')}
+                  </SelectItem>
+                  <SelectItem value="data_contract">
+                    {t('search:concepts.assignDialog.dataContract')}
+                  </SelectItem>
+                  <SelectItem value="asset">
+                    {t('search:concepts.assignDialog.asset', { defaultValue: 'Asset' })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {selectedEntityType && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  {getEntityTypeLabel(selectedEntityType)}
+                </label>
+                <Select value={selectedEntityId} onValueChange={setSelectedEntityId}>
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={t('search:concepts.assignDialog.selectEntity', {
+                        entityType: getEntityTypeLabel(selectedEntityType),
+                      })}
+                    />
+                  </SelectTrigger>
+                  <SelectContent className="max-h-72 overflow-y-auto">
+                    {availableEntities.map((entity) => {
+                      const label =
+                        entity.name || entity.info?.title || entity.title || entity.id
+                      const subLabel =
+                        selectedEntityType === 'asset' && entity.asset_type_name
+                          ? entity.asset_type_name
+                          : null
+                      return (
+                        <SelectItem key={entity.id} value={entity.id}>
+                          <span className="flex items-center gap-2">
+                            <span>{label}</span>
+                            {subLabel && (
+                              <span className="text-xs text-muted-foreground">
+                                · {subLabel}
+                              </span>
+                            )}
+                          </span>
+                        </SelectItem>
+                      )
+                    })}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <div className="flex justify-end space-x-2 pt-4">
+              <Button variant="outline" onClick={() => setAssignDialogOpen(false)}>
+                {t('common:actions.cancel')}
+              </Button>
+              <Button
+                onClick={handleAssignToObject}
+                disabled={!selectedEntityType || !selectedEntityId}
+                data-testid="linked-objects-assign-confirm"
+              >
+                {t('common:actions.assign')}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </Collapsible>
+  )
+}

--- a/src/frontend/src/components/settings/semantic-models-settings.tsx
+++ b/src/frontend/src/components/settings/semantic-models-settings.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/components/ui/dialog';
 import OntologyLibraryDialog from '@/components/settings/ontology-library-dialog';
 import { usePermissions } from '@/stores/permissions-store';
+import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
@@ -75,6 +76,7 @@ export default function SemanticModelsSettings() {
   const canWriteSemantic = !permissionsLoading && hasPermission('semantic-models', FeatureAccessLevel.READ_WRITE);
   const { get, post, delete: deleteApi } = useApi();
   const { toast } = useToast();
+  const bumpKnowledgeGraphRefresh = useKnowledgeGraphStore((s) => s.bumpRefreshNonce);
   const [items, setItems] = useState<SemanticModel[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [uploadingId, setUploadingId] = useState<string | null>(null);
@@ -136,6 +138,8 @@ export default function SemanticModelsSettings() {
       } else {
         toast({ title: 'Success', description: res.data?.message ?? 'Knowledge graph refreshed successfully' });
         await fetchItems();
+        // Notify other Concepts/Graph views that cached data is now stale.
+        bumpKnowledgeGraphRefresh('rebuild-graph');
       }
     } catch (e: any) {
       toast({ title: 'Error', description: e.message ?? 'Failed to refresh knowledge graph', variant: 'destructive' });

--- a/src/frontend/src/i18n/locales/de/search.json
+++ b/src/frontend/src/i18n/locales/de/search.json
@@ -87,6 +87,7 @@
       "selectEntityType": "Entitätstyp auswählen...",
       "dataProduct": "Datenprodukt",
       "dataContract": "Datenvertrag",
+      "asset": "Asset",
       "dataDomain": "Datendomäne",
       "dataset": "Datensatz",
       "ucCatalog": "UC-Katalog",

--- a/src/frontend/src/i18n/locales/de/semantic-models.json
+++ b/src/frontend/src/i18n/locales/de/semantic-models.json
@@ -8,6 +8,29 @@
   "newTerm": "Neuer Begriff",
   "searchPlaceholder": "Begriffe suchen...",
   "loading": "Semantische Modelle werden geladen...",
+  "linkedObjects": {
+    "title": "Verknüpfte Entitäten",
+    "assign": "Entität zuweisen",
+    "loading": "Verknüpfte Entitäten werden geladen...",
+    "empty": "Keine Entitäten mit diesem Konzept verknüpft.",
+    "removed": "Verknüpfung zu \"{{label}}\" entfernt.",
+    "removeFailed": "Verknüpfung konnte nicht entfernt werden.",
+    "removeAria": "Verknüpfte Entität entfernen"
+  },
+  "relations": {
+    "title": "Beziehungen",
+    "loading": "Beziehungen werden geladen...",
+    "empty": "Keine Beziehungen gefunden.",
+    "outgoingTooltip": "Dieses Konzept → Ziel",
+    "incomingTooltip": "Quelle → dieses Konzept"
+  },
+  "neighborhood": {
+    "title": "Konzeptumgebung",
+    "loading": "Umgebung wird geladen...",
+    "empty": "Keine verwandten Konzepte.",
+    "moreParents": "+{{count}} weitere",
+    "moreChildren": "+{{count}} weitere"
+  },
   "filters": {
     "allGlossaries": "Alle Glossare",
     "allStatus": "Alle Status",
@@ -43,10 +66,10 @@
     "retired": "Stillgelegt"
   },
   "details": {
-    "backToList": "Zurück zu Begriffen",
+    "backToList": "Zurück zu Konzepten",
     "edit": "Bearbeiten",
     "delete": "Löschen",
-    "notFound": "Begriff nicht gefunden",
+    "notFound": "Konzept nicht gefunden",
     "loading": "Wird geladen...",
     "linkedAssets": "Verknüpfte Assets",
     "synonyms": "Synonyme",

--- a/src/frontend/src/i18n/locales/en/search.json
+++ b/src/frontend/src/i18n/locales/en/search.json
@@ -92,6 +92,7 @@
       "selectEntityType": "Select entity type...",
       "dataProduct": "Data Product",
       "dataContract": "Data Contract",
+      "asset": "Asset",
       "dataDomain": "Data Domain",
       "dataset": "Dataset",
       "ucCatalog": "UC Catalog",

--- a/src/frontend/src/i18n/locales/en/semantic-models.json
+++ b/src/frontend/src/i18n/locales/en/semantic-models.json
@@ -20,6 +20,29 @@
     "individual": "Individual",
     "term": "Term"
   },
+  "linkedObjects": {
+    "title": "Linked Entities",
+    "assign": "Assign Entity",
+    "loading": "Loading linked entities...",
+    "empty": "No entities linked to this concept.",
+    "removed": "Removed link to \"{{label}}\".",
+    "removeFailed": "Failed to remove link.",
+    "removeAria": "Remove linked entity"
+  },
+  "neighborhood": {
+    "title": "Concept Neighbourhood",
+    "loading": "Loading neighbourhood...",
+    "empty": "No related concepts.",
+    "moreParents": "+{{count}} more",
+    "moreChildren": "+{{count}} more"
+  },
+  "relations": {
+    "title": "Relations",
+    "loading": "Loading relations...",
+    "empty": "No relations found.",
+    "outgoingTooltip": "This concept → target",
+    "incomingTooltip": "Source → this concept"
+  },
   "filters": {
     "allGlossaries": "All Glossaries",
     "allStatus": "All Status",
@@ -91,10 +114,10 @@
     "retired": "Retired"
   },
   "details": {
-    "backToList": "Back to Terms",
+    "backToList": "Back to Concepts",
     "edit": "Edit",
     "delete": "Delete",
-    "notFound": "Term not found",
+    "notFound": "Concept not found",
     "loading": "Loading...",
     "linkedAssets": "Linked Assets",
     "synonyms": "Synonyms",

--- a/src/frontend/src/i18n/locales/es/search.json
+++ b/src/frontend/src/i18n/locales/es/search.json
@@ -82,6 +82,7 @@
       "selectEntityType": "Seleccionar tipo de entidad...",
       "dataProduct": "Producto de Datos",
       "dataContract": "Contrato de Datos",
+      "asset": "Activo",
       "dataDomain": "Dominio de Datos",
       "selectEntity": "Seleccionar {{entityType}}..."
     },

--- a/src/frontend/src/i18n/locales/es/semantic-models.json
+++ b/src/frontend/src/i18n/locales/es/semantic-models.json
@@ -8,6 +8,29 @@
   "newTerm": "Nuevo Término",
   "searchPlaceholder": "Buscar términos...",
   "loading": "Cargando modelos semánticos...",
+  "linkedObjects": {
+    "title": "Entidades vinculadas",
+    "assign": "Asignar entidad",
+    "loading": "Cargando entidades vinculadas...",
+    "empty": "Ninguna entidad vinculada a este concepto.",
+    "removed": "Se eliminó el vínculo con \"{{label}}\".",
+    "removeFailed": "No se pudo eliminar el vínculo.",
+    "removeAria": "Eliminar entidad vinculada"
+  },
+  "relations": {
+    "title": "Relaciones",
+    "loading": "Cargando relaciones...",
+    "empty": "No se encontraron relaciones.",
+    "outgoingTooltip": "Este concepto → destino",
+    "incomingTooltip": "Origen → este concepto"
+  },
+  "neighborhood": {
+    "title": "Vecindario del concepto",
+    "loading": "Cargando vecindario...",
+    "empty": "Sin conceptos relacionados.",
+    "moreParents": "+{{count}} más",
+    "moreChildren": "+{{count}} más"
+  },
   "filters": {
     "allGlossaries": "Todos los Glosarios",
     "allStatus": "Todos los Estados",
@@ -43,10 +66,10 @@
     "retired": "Retirado"
   },
   "details": {
-    "backToList": "Volver a Términos",
+    "backToList": "Volver a Conceptos",
     "edit": "Editar",
     "delete": "Eliminar",
-    "notFound": "Término no encontrado",
+    "notFound": "Concepto no encontrado",
     "loading": "Cargando...",
     "linkedAssets": "Activos Vinculados",
     "synonyms": "Sinónimos",

--- a/src/frontend/src/i18n/locales/fr/search.json
+++ b/src/frontend/src/i18n/locales/fr/search.json
@@ -82,6 +82,7 @@
       "selectEntityType": "Sélectionner le type d'entité...",
       "dataProduct": "Produit de Données",
       "dataContract": "Contrat de Données",
+      "asset": "Actif",
       "dataDomain": "Domaine de Données",
       "selectEntity": "Sélectionner {{entityType}}..."
     },

--- a/src/frontend/src/i18n/locales/fr/semantic-models.json
+++ b/src/frontend/src/i18n/locales/fr/semantic-models.json
@@ -8,6 +8,29 @@
   "newTerm": "Nouveau Terme",
   "searchPlaceholder": "Rechercher des termes...",
   "loading": "Chargement des modèles sémantiques...",
+  "linkedObjects": {
+    "title": "Entités liées",
+    "assign": "Associer une entité",
+    "loading": "Chargement des entités liées...",
+    "empty": "Aucune entité liée à ce concept.",
+    "removed": "Lien vers \"{{label}}\" supprimé.",
+    "removeFailed": "Impossible de supprimer le lien.",
+    "removeAria": "Supprimer l'entité liée"
+  },
+  "relations": {
+    "title": "Relations",
+    "loading": "Chargement des relations...",
+    "empty": "Aucune relation trouvée.",
+    "outgoingTooltip": "Ce concept → cible",
+    "incomingTooltip": "Source → ce concept"
+  },
+  "neighborhood": {
+    "title": "Voisinage du concept",
+    "loading": "Chargement du voisinage...",
+    "empty": "Aucun concept lié.",
+    "moreParents": "+{{count}} de plus",
+    "moreChildren": "+{{count}} de plus"
+  },
   "filters": {
     "allGlossaries": "Tous les Glossaires",
     "allStatus": "Tous les Statuts",
@@ -43,10 +66,10 @@
     "retired": "Retiré"
   },
   "details": {
-    "backToList": "Retour aux Termes",
+    "backToList": "Retour aux Concepts",
     "edit": "Modifier",
     "delete": "Supprimer",
-    "notFound": "Terme non trouvé",
+    "notFound": "Concept non trouvé",
     "loading": "Chargement...",
     "linkedAssets": "Actifs Liés",
     "synonyms": "Synonymes",

--- a/src/frontend/src/i18n/locales/it/search.json
+++ b/src/frontend/src/i18n/locales/it/search.json
@@ -82,6 +82,7 @@
       "selectEntityType": "Seleziona tipo di entità...",
       "dataProduct": "Prodotto Dati",
       "dataContract": "Contratto Dati",
+      "asset": "Risorsa",
       "dataDomain": "Dominio Dati",
       "selectEntity": "Seleziona {{entityType}}..."
     },

--- a/src/frontend/src/i18n/locales/it/semantic-models.json
+++ b/src/frontend/src/i18n/locales/it/semantic-models.json
@@ -8,6 +8,29 @@
   "newTerm": "Nuovo Termine",
   "searchPlaceholder": "Cerca termini...",
   "loading": "Caricamento modelli semantici...",
+  "linkedObjects": {
+    "title": "Entità collegate",
+    "assign": "Assegna entità",
+    "loading": "Caricamento entità collegate...",
+    "empty": "Nessuna entità collegata a questo concetto.",
+    "removed": "Collegamento a \"{{label}}\" rimosso.",
+    "removeFailed": "Impossibile rimuovere il collegamento.",
+    "removeAria": "Rimuovi entità collegata"
+  },
+  "relations": {
+    "title": "Relazioni",
+    "loading": "Caricamento relazioni...",
+    "empty": "Nessuna relazione trovata.",
+    "outgoingTooltip": "Questo concetto → destinazione",
+    "incomingTooltip": "Origine → questo concetto"
+  },
+  "neighborhood": {
+    "title": "Vicinato del concetto",
+    "loading": "Caricamento del vicinato...",
+    "empty": "Nessun concetto correlato.",
+    "moreParents": "+{{count}} altri",
+    "moreChildren": "+{{count}} altri"
+  },
   "filters": {
     "allGlossaries": "Tutti i Glossari",
     "allStatus": "Tutti gli Stati",
@@ -43,10 +66,10 @@
     "retired": "Ritirato"
   },
   "details": {
-    "backToList": "Torna ai Termini",
+    "backToList": "Torna ai Concetti",
     "edit": "Modifica",
     "delete": "Elimina",
-    "notFound": "Termine non trovato",
+    "notFound": "Concetto non trovato",
     "loading": "Caricamento...",
     "linkedAssets": "Asset Collegati",
     "synonyms": "Sinonimi",

--- a/src/frontend/src/i18n/locales/ja/search.json
+++ b/src/frontend/src/i18n/locales/ja/search.json
@@ -82,6 +82,7 @@
       "selectEntityType": "エンティティタイプを選択...",
       "dataProduct": "データ製品",
       "dataContract": "データ契約",
+      "asset": "アセット",
       "dataDomain": "データドメイン",
       "selectEntity": "{{entityType}}を選択..."
     },

--- a/src/frontend/src/i18n/locales/ja/semantic-models.json
+++ b/src/frontend/src/i18n/locales/ja/semantic-models.json
@@ -8,6 +8,29 @@
   "newTerm": "新規用語",
   "searchPlaceholder": "用語を検索...",
   "loading": "セマンティックモデルを読み込み中...",
+  "linkedObjects": {
+    "title": "関連エンティティ",
+    "assign": "エンティティを割り当てる",
+    "loading": "関連エンティティを読み込み中...",
+    "empty": "このコンセプトに関連付けられたエンティティはありません。",
+    "removed": "「{{label}}」へのリンクを削除しました。",
+    "removeFailed": "リンクを削除できませんでした。",
+    "removeAria": "関連エンティティを削除"
+  },
+  "relations": {
+    "title": "関係",
+    "loading": "関係を読み込み中...",
+    "empty": "関係が見つかりません。",
+    "outgoingTooltip": "このコンセプト → 対象",
+    "incomingTooltip": "ソース → このコンセプト"
+  },
+  "neighborhood": {
+    "title": "コンセプトの近傍",
+    "loading": "近傍を読み込み中...",
+    "empty": "関連するコンセプトはありません。",
+    "moreParents": "他 {{count}} 件",
+    "moreChildren": "他 {{count}} 件"
+  },
   "filters": {
     "allGlossaries": "すべての用語集",
     "allStatus": "すべてのステータス",
@@ -43,10 +66,10 @@
     "retired": "廃止"
   },
   "details": {
-    "backToList": "用語一覧に戻る",
+    "backToList": "コンセプト一覧に戻る",
     "edit": "編集",
     "delete": "削除",
-    "notFound": "用語が見つかりません",
+    "notFound": "コンセプトが見つかりません",
     "loading": "読み込み中...",
     "linkedAssets": "リンクされたアセット",
     "synonyms": "同義語",

--- a/src/frontend/src/i18n/locales/nl/search.json
+++ b/src/frontend/src/i18n/locales/nl/search.json
@@ -82,6 +82,7 @@
       "selectEntityType": "Selecteer entity type...",
       "dataProduct": "Dataproduct",
       "dataContract": "Datacontract",
+      "asset": "Asset",
       "dataDomain": "Datadomein",
       "selectEntity": "Selecteer {{entityType}}..."
     },

--- a/src/frontend/src/i18n/locales/nl/semantic-models.json
+++ b/src/frontend/src/i18n/locales/nl/semantic-models.json
@@ -8,6 +8,29 @@
   "newTerm": "Nieuwe Term",
   "searchPlaceholder": "Zoek termen...",
   "loading": "Semantische modellen laden...",
+  "linkedObjects": {
+    "title": "Gekoppelde entiteiten",
+    "assign": "Entiteit koppelen",
+    "loading": "Gekoppelde entiteiten laden...",
+    "empty": "Geen entiteiten gekoppeld aan dit concept.",
+    "removed": "Koppeling naar \"{{label}}\" verwijderd.",
+    "removeFailed": "Kan koppeling niet verwijderen.",
+    "removeAria": "Gekoppelde entiteit verwijderen"
+  },
+  "relations": {
+    "title": "Relaties",
+    "loading": "Relaties laden...",
+    "empty": "Geen relaties gevonden.",
+    "outgoingTooltip": "Dit concept → doel",
+    "incomingTooltip": "Bron → dit concept"
+  },
+  "neighborhood": {
+    "title": "Concept-omgeving",
+    "loading": "Omgeving laden...",
+    "empty": "Geen gerelateerde concepten.",
+    "moreParents": "+{{count}} meer",
+    "moreChildren": "+{{count}} meer"
+  },
   "filters": {
     "allGlossaries": "Alle Glossaries",
     "allStatus": "Alle Status",
@@ -45,10 +68,10 @@
     "retired": "Buiten Gebruik"
   },
   "details": {
-    "backToList": "Terug naar Termen",
+    "backToList": "Terug naar Concepten",
     "edit": "Bewerken",
     "delete": "Verwijderen",
-    "notFound": "Term niet gevonden",
+    "notFound": "Concept niet gevonden",
     "loading": "Laden...",
     "linkedAssets": "Gekoppelde Assets",
     "synonyms": "Synoniemen",

--- a/src/frontend/src/stores/glossary-preferences-store.ts
+++ b/src/frontend/src/stores/glossary-preferences-store.ts
@@ -16,6 +16,13 @@ interface GlossaryPreferencesState {
   
   // UI state
   isFilterExpanded: boolean;
+
+  // Concepts list-view UI state. Persisted so the user's tree exploration
+  // survives navigation into a concept detail page and back, plus full
+  // page reloads.
+  expandedConceptGroups: string[];
+  conceptListScrollTop: number;
+  conceptListSearch: string;
   
   // Actions
   toggleSource: (source: string) => void;
@@ -26,6 +33,10 @@ interface GlossaryPreferencesState {
   setGroupByDomain: (enabled: boolean) => void;
   isSourceVisible: (source: string) => boolean;
   setFilterExpanded: (expanded: boolean) => void;
+  setExpandedConceptGroups: (groups: string[]) => void;
+  toggleConceptGroup: (group: string) => void;
+  setConceptListScrollTop: (scrollTop: number) => void;
+  setConceptListSearch: (search: string) => void;
 }
 
 export const useGlossaryPreferencesStore = create<GlossaryPreferencesState>()(
@@ -36,6 +47,9 @@ export const useGlossaryPreferencesStore = create<GlossaryPreferencesState>()(
       showProperties: false,
       groupByDomain: false,
       isFilterExpanded: true,
+      expandedConceptGroups: ['root'],
+      conceptListScrollTop: 0,
+      conceptListSearch: '',
 
       toggleSource: (source: string) => {
         set((state) => {
@@ -83,6 +97,32 @@ export const useGlossaryPreferencesStore = create<GlossaryPreferencesState>()(
       setFilterExpanded: (expanded: boolean) => {
         set({ isFilterExpanded: expanded });
       },
+
+      setExpandedConceptGroups: (groups: string[]) => {
+        set({ expandedConceptGroups: groups });
+      },
+
+      toggleConceptGroup: (group: string) => {
+        set((state) => {
+          const isExpanded = state.expandedConceptGroups.includes(group);
+          if (isExpanded) {
+            return {
+              expandedConceptGroups: state.expandedConceptGroups.filter((g) => g !== group),
+            };
+          }
+          return {
+            expandedConceptGroups: [...state.expandedConceptGroups, group],
+          };
+        });
+      },
+
+      setConceptListScrollTop: (scrollTop: number) => {
+        set({ conceptListScrollTop: scrollTop });
+      },
+
+      setConceptListSearch: (search: string) => {
+        set({ conceptListSearch: search });
+      },
     }),
     {
       name: 'glossary-preferences-storage',
@@ -93,6 +133,12 @@ export const useGlossaryPreferencesStore = create<GlossaryPreferencesState>()(
         showProperties: state.showProperties,
         groupByDomain: state.groupByDomain,
         isFilterExpanded: state.isFilterExpanded,
+        expandedConceptGroups: state.expandedConceptGroups,
+        // Scroll position is intentionally NOT persisted across reloads --
+        // it is only kept across in-app navigation while the store stays
+        // in memory. Persisting it would scroll users to stale offsets
+        // after a refresh when the underlying data changed.
+        conceptListSearch: state.conceptListSearch,
       }),
     }
   )
@@ -108,4 +154,3 @@ export const useGlossaryPreferencesActions = () =>
     setShowProperties: state.setShowProperties,
     setGroupByDomain: state.setGroupByDomain,
   }));
-

--- a/src/frontend/src/stores/knowledge-graph-store.ts
+++ b/src/frontend/src/stores/knowledge-graph-store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+/**
+ * Lightweight cross-view broadcast channel for the Concepts feature.
+ *
+ * Any view (Concepts, Graph, Settings/RDF Sources, Ontology Generator,
+ * Semantic Links manager, …) that mutates collections, concepts, semantic
+ * links, or rebuilds the knowledge graph should call `bumpRefreshNonce()`.
+ * Views that show derived data (collection lists, concept groupings,
+ * filter chips, etc.) can subscribe to `refreshNonce` in a `useEffect`
+ * dependency array to refetch automatically.
+ */
+interface KnowledgeGraphState {
+  refreshNonce: number;
+  lastReason: string | null;
+  bumpRefreshNonce: (reason?: string) => void;
+}
+
+export const useKnowledgeGraphStore = create<KnowledgeGraphState>((set) => ({
+  refreshNonce: 0,
+  lastReason: null,
+  bumpRefreshNonce: (reason?: string) =>
+    set((state) => ({
+      refreshNonce: state.refreshNonce + 1,
+      lastReason: reason ?? null,
+    })),
+}));

--- a/src/frontend/src/views/business-terms.test.tsx
+++ b/src/frontend/src/views/business-terms.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// We isolate the redirect logic from the heavy children -- ConceptsTab,
+// dialogs, the filter panel, and the API. The redirect is the only behaviour
+// under test here, so we render the smallest realistic shell.
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      if (options && typeof options === 'object' && 'defaultValue' in options) {
+        return options.defaultValue as string;
+      }
+      return key;
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/stores/permissions-store', () => ({
+  usePermissions: () => ({
+    hasPermission: () => true,
+    fetchPermissions: vi.fn(),
+    fetchAvailableRoles: vi.fn(),
+  }),
+}));
+
+vi.mock('@/stores/breadcrumb-store', () => ({
+  default: () => () => undefined,
+}));
+
+vi.mock('@/stores/knowledge-graph-store', () => ({
+  useKnowledgeGraphStore: (selector: any) =>
+    selector({
+      refreshNonce: 0,
+      lastReason: null,
+      bumpRefreshNonce: vi.fn(),
+    }),
+}));
+
+vi.mock('@/stores/glossary-preferences-store', () => ({
+  useGlossaryPreferencesStore: () => ({
+    hiddenSources: [],
+    groupBySource: false,
+    showProperties: false,
+    groupByDomain: false,
+    isFilterExpanded: false,
+    expandedConceptGroups: [],
+    conceptListScrollTop: 0,
+    conceptListSearch: '',
+    toggleSource: vi.fn(),
+    selectAllSources: vi.fn(),
+    selectNoneSources: vi.fn(),
+    setGroupBySource: vi.fn(),
+    setShowProperties: vi.fn(),
+    setGroupByDomain: vi.fn(),
+    setFilterExpanded: vi.fn(),
+    setExpandedConceptGroups: vi.fn(),
+    toggleConceptGroup: vi.fn(),
+    setConceptListScrollTop: vi.fn(),
+    setConceptListSearch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/knowledge', () => ({
+  ConceptsTab: () => null,
+  CollectionEditorDialog: () => null,
+  ConceptEditorDialog: () => null,
+  GlossaryFilterPanel: () => null,
+  ImportConceptsDialog: () => null,
+}));
+
+// Stub out the global fetch so initial data loads resolve to empty. The
+// redirect happens before these matter, but we do not want unhandled
+// promises spamming the test console.
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    text: async () => '',
+  })) as unknown as typeof fetch;
+});
+
+import BusinessTermsView from './business-terms';
+
+function renderAt(initialEntry: string) {
+  let observed = { pathname: '', search: '' };
+  function Probe() {
+    const location = useLocation();
+    observed = { pathname: location.pathname, search: location.search };
+    return null;
+  }
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/concepts/browser" element={<><BusinessTermsView /><Probe /></>} />
+        <Route
+          path="/concepts/browser/:iri"
+          element={<><div data-testid="detail-route" /><Probe /></>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return () => observed;
+}
+
+describe('BusinessTermsView legacy ?concept= redirect', () => {
+  it('redirects ?concept=IRI to /concepts/browser/:iri', async () => {
+    const iri = 'https://example.org/onto#Customer';
+    const observe = renderAt(`/concepts/browser?concept=${encodeURIComponent(iri)}`);
+
+    await waitFor(() => {
+      expect(observe().pathname).toBe(`/concepts/browser/${encodeURIComponent(iri)}`);
+    });
+  });
+
+  it('does not redirect when no ?concept= is present', async () => {
+    const observe = renderAt('/concepts/browser');
+    // Give react a tick to settle effects.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(observe().pathname).toBe('/concepts/browser');
+  });
+});

--- a/src/frontend/src/views/business-terms.tsx
+++ b/src/frontend/src/views/business-terms.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import i18n from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
@@ -25,6 +25,7 @@ import type {
 } from '@/types/ontology';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { useGlossaryPreferencesStore } from '@/stores/glossary-preferences-store';
+import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/feature-access-levels';
 import { useToast } from '@/hooks/use-toast';
@@ -38,9 +39,11 @@ import {
 
 export default function BusinessTermsView() {
   const { t } = useTranslation(['semantic-models', 'common']);
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const { toast } = useToast();
   const { hasPermission } = usePermissions();
+  const bumpKnowledgeGraphRefresh = useKnowledgeGraphStore((s) => s.bumpRefreshNonce);
 
   const canWrite = hasPermission('semantic-models', FeatureAccessLevel.READ_WRITE);
 
@@ -49,14 +52,12 @@ export default function BusinessTermsView() {
   const [collections, setCollections] = useState<KnowledgeCollection[]>([]);
   const [groupedConcepts, setGroupedConcepts] = useState<GroupedConcepts>({});
   const [groupedProperties, setGroupedProperties] = useState<Record<string, OntologyConcept[]>>({});
-  const [selectedConcept, setSelectedConcept] = useState<OntologyConcept | null>(null);
   const [stats, setStats] = useState<TaxonomyStats | null>(null);
 
   // Dialog state
   const [collectionEditorOpen, setCollectionEditorOpen] = useState(false);
   const [editingCollection, setEditingCollection] = useState<KnowledgeCollection | null>(null);
   const [conceptEditorOpen, setConceptEditorOpen] = useState(false);
-  const [editingConcept, setEditingConcept] = useState<OntologyConcept | null>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
 
   // Language selection - defaults to UI language
@@ -77,6 +78,19 @@ export default function BusinessTermsView() {
     setGroupByDomain,
     setFilterExpanded,
   } = useGlossaryPreferencesStore();
+
+  // Backwards-compat: the old single-page view tracked the selected concept
+  // via ?concept=IRI. New layout uses /concepts/browser/:iri, so any old
+  // deep link gets redirected once at mount.
+  useEffect(() => {
+    const conceptIri = searchParams.get('concept');
+    if (!conceptIri) return;
+    const decoded = (() => {
+      try { return decodeURIComponent(conceptIri); } catch { return conceptIri; }
+    })();
+    navigate(`/concepts/browser/${encodeURIComponent(decoded)}`, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Extract unique source contexts
   const availableSources = useMemo(() => {
@@ -127,9 +141,9 @@ export default function BusinessTermsView() {
 
   useEffect(() => {
     setStaticSegments([
-      { label: t('semantic-models:title'), path: '/ontology' },
-      { label: t('semantic-models:tabs.concepts'), path: '/semantic-models' },
+      { label: t('semantic-models:title'), path: '/concepts/browser' },
     ]);
+    return () => { setStaticSegments([]); };
   }, [setStaticSegments, t]);
 
   // Fetch data
@@ -167,14 +181,12 @@ export default function BusinessTermsView() {
   useEffect(() => {
     const sourceParam = searchParams.get('source');
     if (sourceParam && availableSources.length > 0) {
-      // Show only the specified source, hide all others
       const sourcesToHide = availableSources.filter(s => s !== sourceParam);
       sourcesToHide.forEach(source => {
         if (!hiddenSources.includes(source)) {
           toggleSource(source);
         }
       });
-      // Ensure the target source is visible
       if (hiddenSources.includes(sourceParam)) {
         toggleSource(sourceParam);
       }
@@ -215,42 +227,30 @@ export default function BusinessTermsView() {
     fetchData();
   }, [fetchData]);
 
-  // Handle concept from URL
+  // Refetch when any other view (Settings/RDF Sources rebuild, ontology
+  // generator save, etc.) bumps the global knowledge-graph nonce.
+  const knowledgeGraphRefreshNonce = useKnowledgeGraphStore((s) => s.refreshNonce);
   useEffect(() => {
-    const conceptIri = searchParams.get('concept');
-    if (conceptIri && filteredConcepts.length > 0) {
-      const decoded = decodeURIComponent(conceptIri);
-      const found = filteredConcepts.find((c) => c.iri === decoded);
-      if (found) setSelectedConcept(found);
+    if (knowledgeGraphRefreshNonce > 0) {
+      fetchData();
     }
-  }, [searchParams, filteredConcepts]);
+  }, [knowledgeGraphRefreshNonce, fetchData]);
 
-  // Concept selection handler
-  const handleSelectConcept = (concept: OntologyConcept) => {
-    setSelectedConcept(concept);
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set('concept', encodeURIComponent(concept.iri));
-    setSearchParams(newParams, { replace: true });
-  };
+  // Concept selection handler — navigates to dedicated detail page.
+  const handleSelectConcept = useCallback((concept: OntologyConcept) => {
+    navigate(`/concepts/browser/${encodeURIComponent(concept.iri)}`);
+  }, [navigate]);
 
-  // Concept CRUD handlers
+  // Concept CRUD handlers (creation flow only; edit/delete now live on the
+  // detail page itself).
   const handleCreateConcept = () => {
-    setEditingConcept(null);
-    setConceptEditorOpen(true);
-  };
-
-  const handleEditConcept = (concept: OntologyConcept) => {
-    setEditingConcept(concept);
     setConceptEditorOpen(true);
   };
 
   const handleSaveConcept = async (data: any, isNew: boolean) => {
     try {
-      const url = isNew
-        ? '/api/knowledge/concepts'
-        : `/api/knowledge/concepts/${encodeURIComponent(editingConcept!.iri)}`;
-      const method = isNew ? 'POST' : 'PATCH';
-
+      const url = '/api/knowledge/concepts';
+      const method = 'POST';
       const response = await fetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
@@ -271,6 +271,7 @@ export default function BusinessTermsView() {
 
       setConceptEditorOpen(false);
       await fetchData();
+      bumpKnowledgeGraphRefresh(isNew ? 'concept-create' : 'concept-update');
     } catch (error: any) {
       toast({
         title: t('common:toast.error'),
@@ -278,34 +279,6 @@ export default function BusinessTermsView() {
         variant: 'destructive',
       });
       throw error;
-    }
-  };
-
-  const handleDeleteConcept = async (concept: OntologyConcept) => {
-    try {
-      const response = await fetch(
-        `/api/knowledge/concepts/${encodeURIComponent(concept.iri)}`,
-        { method: 'DELETE' }
-      );
-
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.detail || 'Failed to delete concept');
-      }
-
-      toast({
-        title: t('common:toast.success'),
-        description: t('semantic-models:messages.conceptDeleted'),
-      });
-
-      if (selectedConcept?.iri === concept.iri) setSelectedConcept(null);
-      await fetchData();
-    } catch (error: any) {
-      toast({
-        title: t('common:toast.error'),
-        description: error.message,
-        variant: 'destructive',
-      });
     }
   };
 
@@ -342,6 +315,7 @@ export default function BusinessTermsView() {
 
       setCollectionEditorOpen(false);
       await fetchData();
+      bumpKnowledgeGraphRefresh(isNew ? 'collection-create' : 'collection-update');
     } catch (error: any) {
       toast({
         title: t('common:toast.error'),
@@ -414,7 +388,7 @@ export default function BusinessTermsView() {
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
       ) : (
-        <div className="flex-1 flex flex-col">
+        <div className="flex-1 flex flex-col gap-4">
           {/* Filter Panel */}
           <GlossaryFilterPanel
             filteredConcepts={filteredConcepts}
@@ -436,17 +410,14 @@ export default function BusinessTermsView() {
             onSetFilterExpanded={setFilterExpanded}
           />
 
-          {/* Concepts Tree + Detail */}
+          {/* Concepts list — full-width tree, navigates to detail page on row click */}
           <ConceptsTab
             collections={collections}
             groupedConcepts={groupedConcepts}
             filteredConcepts={filteredConcepts}
-            selectedConcept={selectedConcept}
+            selectedConcept={null}
             onSelectConcept={handleSelectConcept}
             onCreateConcept={handleCreateConcept}
-            onEditConcept={handleEditConcept}
-            onDeleteConcept={handleDeleteConcept}
-            onRefresh={fetchData}
             canEdit={canWrite}
             groupBySource={groupBySource}
             showProperties={showProperties}
@@ -465,11 +436,11 @@ export default function BusinessTermsView() {
         onSave={handleSaveCollection}
       />
 
-      {/* Concept Editor Dialog */}
+      {/* Concept Editor Dialog (create-only from this view) */}
       <ConceptEditorDialog
         open={conceptEditorOpen}
         onOpenChange={setConceptEditorOpen}
-        concept={editingConcept}
+        concept={null}
         collection={selectedCollection || editableCollections[0]}
         collections={editableCollections}
         onSave={handleSaveConcept}

--- a/src/frontend/src/views/concept-detail.tsx
+++ b/src/frontend/src/views/concept-detail.tsx
@@ -1,0 +1,531 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import i18n from 'i18next';
+import {
+  ArrowLeft,
+  AlertCircle,
+  ExternalLink,
+  Loader2,
+  Pencil,
+  Trash2,
+  Layers,
+  BookOpen,
+  Zap,
+  User,
+  Network,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type {
+  KnowledgeCollection,
+  OntologyConcept,
+} from '@/types/ontology';
+import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import { useToast } from '@/hooks/use-toast';
+import { useApi } from '@/hooks/use-api';
+import { usePermissions } from '@/stores/permissions-store';
+import { FeatureAccessLevel } from '@/types/feature-access-levels';
+import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
+import { resolveLabel, resolveComment } from '@/lib/ontology-utils';
+import { systemRdfNamespaceDisplayLabel } from '@/lib/system-rdf-namespace-labels';
+import ConceptRelationsPanel from '@/components/semantic/concept-relations-panel';
+import LinkedObjectsPanel from '@/components/semantic/linked-objects-panel';
+import ConceptNeighborhoodGraph from '@/components/semantic/concept-neighborhood-graph';
+import { ConceptEditorDialog } from '@/components/knowledge/concept-editor-dialog';
+import { OwnershipPanel } from '@/components/common/ownership-panel';
+import EntityMetadataPanel from '@/components/metadata/entity-metadata-panel';
+
+const typeIcons: Record<string, React.ReactNode> = {
+  concept: <Layers className="h-5 w-5 text-emerald-500 shrink-0" />,
+  class: <BookOpen className="h-5 w-5 text-blue-500 shrink-0" />,
+  property: <Zap className="h-5 w-5 text-purple-500 shrink-0" />,
+  individual: <User className="h-5 w-5 text-violet-500 shrink-0" />,
+  term: <Layers className="h-5 w-5 text-emerald-500 shrink-0" />,
+};
+
+const typeColors: Record<string, string> = {
+  concept: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+  class: 'bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30',
+  property: 'bg-purple-500/15 text-purple-700 dark:text-purple-400 border-purple-500/30',
+  individual: 'bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/30',
+  term: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+};
+
+// Bound list-like sections to ~10 rows of vertical real-estate via internal
+// scrolling, so the page stays compact regardless of how many relations or
+// linked objects a concept has.
+const MAX_VISIBLE_ROWS = 10;
+
+export default function ConceptDetailView() {
+  const { iri: rawIri } = useParams<{ iri: string }>();
+  const navigate = useNavigate();
+  const { t } = useTranslation(['semantic-models', 'common']);
+  const { get } = useApi();
+  const { toast } = useToast();
+  const { hasPermission } = usePermissions();
+  const bumpKnowledgeGraphRefresh = useKnowledgeGraphStore((s) => s.bumpRefreshNonce);
+
+  const setStaticSegments = useBreadcrumbStore((s) => s.setStaticSegments);
+  const setDynamicTitle = useBreadcrumbStore((s) => s.setDynamicTitle);
+
+  // The :iri segment is URL-encoded; double-decoding is harmless because
+  // valid IRIs do not contain literal '%' characters in their canonical form.
+  const conceptIri = useMemo(() => {
+    if (!rawIri) return '';
+    try {
+      return decodeURIComponent(rawIri);
+    } catch {
+      return rawIri;
+    }
+  }, [rawIri]);
+
+  const canWrite = hasPermission('semantic-models', FeatureAccessLevel.READ_WRITE);
+
+  const [concept, setConcept] = useState<OntologyConcept | null>(null);
+  const [collections, setCollections] = useState<KnowledgeCollection[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [neighbourhoodOpen, setNeighbourhoodOpen] = useState(true);
+  const selectedLanguage = i18n.language?.split('-')[0] || 'en';
+
+  // Fetch the focused concept by IRI. This is intentionally separated from
+  // the (lazier) neighbourhood load so the header renders ASAP.
+  const fetchConcept = useCallback(async () => {
+    if (!conceptIri) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await get<{ concept?: OntologyConcept }>(
+        `/api/semantic-models/concepts/${encodeURIComponent(conceptIri)}`,
+      );
+      if (res.error || !res.data?.concept) {
+        setError(res.error || 'Concept not found');
+        setConcept(null);
+        return;
+      }
+      setConcept(res.data.concept);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load concept');
+      setConcept(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [conceptIri, get]);
+
+  // Collections are needed for source-context lookup (editability check) and
+  // for the create/edit concept dialog. The relations panel itself loads
+  // its data straight from the neighbours API and does not need a global
+  // concept list.
+  const fetchSupporting = useCallback(async () => {
+    try {
+      const res = await get<{ collections?: KnowledgeCollection[] }>(
+        '/api/knowledge/collections?hierarchical=true',
+      );
+      if (res.data?.collections) {
+        setCollections(res.data.collections);
+      }
+    } catch (err) {
+      console.error('ConceptDetailView: failed to load collections', err);
+    }
+  }, [get]);
+
+  useEffect(() => {
+    fetchConcept();
+  }, [fetchConcept]);
+
+  useEffect(() => {
+    fetchSupporting();
+  }, [fetchSupporting]);
+
+  // Keep breadcrumbs in sync with the concept the URL is pointing at.
+  useEffect(() => {
+    setStaticSegments([
+      { label: t('semantic-models:title', 'Concepts'), path: '/concepts/browser' },
+    ]);
+    if (concept) {
+      setDynamicTitle(resolveLabel(concept, selectedLanguage));
+    } else {
+      setDynamicTitle(null);
+    }
+    return () => {
+      setStaticSegments([]);
+      setDynamicTitle(null);
+    };
+  }, [concept, setStaticSegments, setDynamicTitle, selectedLanguage, t]);
+
+  const collection = useMemo(() => {
+    if (!concept?.source_context) return null;
+    return (
+      collections.find(
+        (c) => c.iri === concept.source_context || c.iri.endsWith(`:${concept.source_context}`),
+      ) || null
+    );
+  }, [collections, concept]);
+
+  // Whether the concept *itself* can be modified (label, definition, status,
+  // relations within the concept document). Restricted to draft concepts in
+  // an editable collection, since imported ontologies (databricks-ontology,
+  // SKOS, etc.) are read-only by design.
+  const isEditable = useMemo(() => {
+    if (!concept) return false;
+    const isDraftStatus = !concept.status || concept.status === 'draft';
+    return !!(canWrite && collection?.is_editable && isDraftStatus);
+  }, [canWrite, collection, concept]);
+
+  // Linking Ontos entities to a concept and assigning ownership are stored
+  // *on our side* (semantic_links / ownership tables), not in the source
+  // ontology. So they only require write permission on semantic-models --
+  // they should work even for concepts that come from a read-only ontology.
+  const canLinkEntities = canWrite;
+
+  // Navigation between concepts (from in-graph clicks, link clicks, etc.)
+  // updates the URL in place, which re-mounts the data effects via the new
+  // :iri param. We use replace=false so browser-back works as expected.
+  const handleNavigateToConcept = useCallback(
+    (iri: string) => {
+      if (!iri) return;
+      navigate(`/concepts/browser/${encodeURIComponent(iri)}`);
+    },
+    [navigate],
+  );
+
+  const handleSaveConcept = async (data: any, isNew: boolean) => {
+    if (!concept) return;
+    try {
+      const url = isNew
+        ? '/api/knowledge/concepts'
+        : `/api/knowledge/concepts/${encodeURIComponent(concept.iri)}`;
+      const method = isNew ? 'POST' : 'PATCH';
+      const response = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({} as any));
+        throw new Error(err?.detail || 'Failed to save concept');
+      }
+      toast({
+        title: t('common:toast.success'),
+        description: t('semantic-models:messages.conceptUpdated'),
+      });
+      setEditorOpen(false);
+      bumpKnowledgeGraphRefresh('concept-update');
+      await fetchConcept();
+      await fetchSupporting();
+    } catch (err: any) {
+      toast({
+        title: t('common:toast.error'),
+        description: err?.message,
+        variant: 'destructive',
+      });
+      throw err;
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!concept) return;
+    try {
+      const response = await fetch(
+        `/api/knowledge/concepts/${encodeURIComponent(concept.iri)}`,
+        { method: 'DELETE' },
+      );
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({} as any));
+        throw new Error(err?.detail || 'Failed to delete concept');
+      }
+      toast({
+        title: t('common:toast.success'),
+        description: t('semantic-models:messages.conceptDeleted'),
+      });
+      bumpKnowledgeGraphRefresh('concept-delete');
+      navigate('/concepts/browser', { replace: true });
+    } catch (err: any) {
+      toast({
+        title: t('common:toast.error'),
+        description: err?.message,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  // Loading skeleton mirrors the asset-detail skeleton style for visual
+  // consistency.
+  if (isLoading && !concept) {
+    return (
+      <div className="py-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <Button variant="outline" size="sm" onClick={() => navigate(-1)}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {t('semantic-models:details.backToList', 'Back to Concepts')}
+          </Button>
+        </div>
+        <Skeleton className="h-9 w-2/3" />
+        <Skeleton className="h-3 w-1/2" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !concept) {
+    return (
+      <div className="py-6 space-y-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate('/concepts/browser')}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {t('semantic-models:details.backToList', 'Back to Concepts')}
+        </Button>
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>{t('common:toast.error')}</AlertTitle>
+          <AlertDescription>
+            {error || t('semantic-models:details.notFound', 'Concept not found')}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const conceptTitle = resolveLabel(concept, selectedLanguage);
+  const conceptDefinition = resolveComment(concept, selectedLanguage);
+  const hasSynonymsOrExamples =
+    (concept.synonyms?.length ?? 0) > 0 || (concept.examples?.length ?? 0) > 0;
+  const isProperty = concept.concept_type === 'property';
+  const hasDomainRange = isProperty && (concept.domain || concept.range);
+
+  return (
+    <div className="py-4 space-y-3">
+      {/* Top action row: back + edit/delete (matches asset-detail). */}
+      <div className="flex items-center justify-between">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate('/concepts/browser')}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {t('semantic-models:details.backToList', 'Back to Concepts')}
+        </Button>
+        {isEditable && (
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={() => setEditorOpen(true)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              {t('common:actions.edit')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={handleDelete}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              {t('common:actions.delete')}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Title + meta block (no extra card; mirrors asset-detail). */}
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          {typeIcons[concept.concept_type] || typeIcons.concept}
+          <h1 className="text-2xl font-bold truncate" title={conceptTitle}>
+            {conceptTitle}
+          </h1>
+          <Badge
+            variant="outline"
+            className={typeColors[concept.concept_type] || ''}
+          >
+            {t(`semantic-models:types.${concept.concept_type}`)}
+          </Badge>
+          {concept.status && (
+            <Badge variant="outline">
+              {t(`semantic-models:status.${concept.status}`, concept.status)}
+            </Badge>
+          )}
+          {concept.source_context && (
+            <span className="text-xs text-muted-foreground ml-1">
+              · {systemRdfNamespaceDisplayLabel(concept.source_context, t)}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground min-w-0">
+          <code
+            className="px-1.5 py-0.5 bg-muted rounded font-mono truncate"
+            title={concept.iri}
+          >
+            {concept.iri}
+          </code>
+          <a
+            href={concept.iri}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center text-muted-foreground hover:text-foreground shrink-0"
+            aria-label="Open IRI"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      </div>
+
+      {/* Definition + property domain/range collapsed into a single compact
+          card so short definitions don't get an entire page section to
+          themselves. */}
+      {(conceptDefinition || hasDomainRange) && (
+        <section className="rounded-lg border bg-muted/20 p-3 space-y-2">
+          {conceptDefinition && (
+            <p className="text-sm whitespace-pre-line">{conceptDefinition}</p>
+          )}
+          {hasDomainRange && (
+            <div className="flex flex-wrap items-center gap-2 text-xs pt-1">
+              {concept.domain && (
+                <span className="inline-flex items-center gap-1">
+                  <span className="text-muted-foreground uppercase tracking-wide">
+                    {t('semantic-models:fields.domain')}:
+                  </span>
+                  <Badge
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => handleNavigateToConcept(concept.domain!)}
+                  >
+                    {concept.domain.split(/[/#]/).pop() || concept.domain}
+                  </Badge>
+                </span>
+              )}
+              {concept.range && (
+                <span className="inline-flex items-center gap-1">
+                  <span className="text-muted-foreground uppercase tracking-wide">
+                    {t('semantic-models:fields.range')}:
+                  </span>
+                  <Badge
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => handleNavigateToConcept(concept.range!)}
+                  >
+                    {concept.range.split(/[/#]/).pop() || concept.range}
+                  </Badge>
+                </span>
+              )}
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Synonyms + examples on a single dense row. */}
+      {hasSynonymsOrExamples && (
+        <section className="flex flex-wrap items-start gap-x-6 gap-y-2 rounded-lg border bg-card p-3 text-xs">
+          {concept.synonyms?.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="font-semibold uppercase tracking-wide text-muted-foreground mr-1">
+                {t('semantic-models:fields.synonyms')}:
+              </span>
+              {concept.synonyms.map((s) => (
+                <Badge key={s} variant="outline" className="text-[10px]">
+                  {s}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {concept.examples?.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="font-semibold uppercase tracking-wide text-muted-foreground mr-1">
+                {t('semantic-models:fields.examples')}:
+              </span>
+              {concept.examples.map((e) => (
+                <Badge key={e} variant="outline" className="text-[10px]">
+                  {e}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      <ConceptRelationsPanel
+        conceptIri={concept.iri}
+        onNavigate={handleNavigateToConcept}
+        maxVisibleRows={MAX_VISIBLE_ROWS}
+      />
+
+      <LinkedObjectsPanel
+        conceptIri={concept.iri}
+        conceptLabel={conceptTitle}
+        canAssign={canLinkEntities}
+        onChanged={fetchConcept}
+        maxVisibleRows={MAX_VISIBLE_ROWS}
+      />
+
+      {/* Inline neighbourhood graph at full width. Clicking any node updates
+          the :iri route in place so the user can keep walking the graph. */}
+      <Collapsible open={neighbourhoodOpen} onOpenChange={setNeighbourhoodOpen}>
+        <div className="border rounded-lg">
+          <CollapsibleTrigger className="flex items-center justify-between w-full p-3 hover:bg-muted/50">
+            <div className="flex items-center gap-2">
+              {neighbourhoodOpen ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              <Network className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium text-sm">
+                {t('semantic-models:neighborhood.title', {
+                  defaultValue: 'Concept Neighbourhood',
+                })}
+              </span>
+            </div>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="border-t">
+              <ConceptNeighborhoodGraph
+                concept={concept}
+                onNavigate={handleNavigateToConcept}
+              />
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+
+      <OwnershipPanel
+        objectType="business_term"
+        objectId={concept.iri}
+        canAssign={canLinkEntities}
+      />
+
+      <EntityMetadataPanel entityType="concept" entityId={concept.iri} />
+
+      {concept.created_at && (
+        <p className="text-xs text-muted-foreground">
+          Created: {new Date(concept.created_at).toLocaleDateString()}
+        </p>
+      )}
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" /> Refreshing...
+        </div>
+      )}
+
+      <ConceptEditorDialog
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        concept={concept}
+        collection={collection ?? undefined}
+        collections={collections.filter((c) => c.is_editable)}
+        onSave={handleSaveConcept}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/views/ontology-generator.tsx
+++ b/src/frontend/src/views/ontology-generator.tsx
@@ -29,6 +29,7 @@ import {
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
 import type { Connection } from '@/types/connections';
 import SchemaBrowser from '@/components/schema-importer/schema-browser';
 
@@ -78,6 +79,7 @@ export default function OntologyGeneratorView() {
   const { toast } = useToast();
   const setStaticSegments = useBreadcrumbStore((s) => s.setStaticSegments);
   const setDynamicTitle = useBreadcrumbStore((s) => s.setDynamicTitle);
+  const bumpKnowledgeGraphRefresh = useKnowledgeGraphStore((s) => s.bumpRefreshNonce);
 
   const [connections, setConnections] = useState<Connection[]>([]);
   const [isLoadingConnections, setIsLoadingConnections] = useState(true);
@@ -227,6 +229,9 @@ export default function OntologyGeneratorView() {
         setIsSaveDialogOpen(false);
         setCollectionName('');
         setCollectionDescription('');
+        // Refresh any open Concepts/Graph views so the new collection
+        // appears without requiring a manual reload.
+        bumpKnowledgeGraphRefresh('ontology-save');
       } else {
         toast({
           title: 'Save failed',

--- a/src/frontend/src/views/ontology-home.tsx
+++ b/src/frontend/src/views/ontology-home.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@/types/ontology';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { useGlossaryPreferencesStore } from '@/stores/glossary-preferences-store';
+import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
 import {
   GraphTab,
   GlossaryFilterPanel,
@@ -151,6 +152,15 @@ export default function OntologyHomeView() {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Refetch when other views (Settings rebuild, ontology generator save,
+  // collection/concept edits) bump the global knowledge-graph nonce.
+  const knowledgeGraphRefreshNonce = useKnowledgeGraphStore((s) => s.refreshNonce);
+  useEffect(() => {
+    if (knowledgeGraphRefreshNonce > 0) {
+      fetchData();
+    }
+  }, [knowledgeGraphRefreshNonce, fetchData]);
 
   // Navigate to concept in Business Terms view on node click
   const handleNodeClick = useCallback((concept: OntologyConcept) => {


### PR DESCRIPTION
## Summary

Rebuilds the Concepts experience around a full-page master/detail flow and hardens the backend so LLM-generated ontologies always import cleanly.

### Concepts UX
- **New Concept detail page** at `/concepts/browser/:iri` with a sticky header (back, title/type/IRI, edit/delete), single dense column matching other detail views. Legacy `?concept=IRI` URLs auto-redirect.
- **List view** is now full-width with richer rows (type icon, badge, status pill, collection chip, property hints) and persisted UI state (expanded groups, scroll position, search) via `glossary-preferences-store`.
- **LinkedObjectsPanel**: collapsible card matching `NodeLinksPanel` style. Assign dialog now restricted to **Data Product**, **Data Contract**, and **Asset** — no raw UC objects. Asset list pulls from `/api/assets` (paginated) and is bounded + scrollable. Existing UC links keep rendering for back-compat but can no longer be created from this UI.
- **ConceptRelationsPanel** replaces `NodeLinksPanel` on detail; consumes `/api/semantic-models/neighbors` so the full set of incoming/outgoing triples renders, with directional icons and colour-coded predicate badges.
- **ConceptNeighborhoodGraph**: ReactFlow mini-graph (parents → current → children) with click-to-navigate and theme-correct colours for light/dark.
- **Cache-coherence store** (`knowledge-graph-store`): bumped on Settings → Rebuild Graph and on every semantic-link mutation so dependent panels refetch without a hard reload.
- **i18n**: `linkedObjects` / `neighborhood` / `relations` keys plus the new `Asset` label across `de/en/es/fr/it/ja/nl`.

### Backend hardening
- `clean_truncated_turtle` helper in `owl/owl_parser.py` salvages truncated LLM Turtle; applied in `SemanticModelsManager`, the base ontology handler, and the upload route. `rdflib.parse()` failures now surface as HTTP 400 instead of 500.
- `SemanticLinksManager` invalidates the manager cache on create/delete so the UI sees fresh state immediately.

## Test plan

- [x] Unit: `tests/unit/test_clean_truncated_turtle.py` (10 cases)
- [x] Integration: `tests/integration/test_knowledge_routes.py` covers truncated-Turtle recovery and unparseable rejection
- [x] Component: `linked-objects-panel.test.tsx` (6), `concept-relations-panel.test.tsx`, `concept-neighborhood-graph.test.tsx`, `business-terms.test.tsx` (redirect)
- [ ] Manual: assign Data Product / Data Contract / Asset to a concept; verify navigation and removal
- [ ] Manual: open a concept with many neighbours; confirm the relations and linked-entities lists scroll past the cap and the neighbourhood graph remains readable in light + dark modes
- [ ] Manual: re-import an LLM ontology that previously truncated; confirm save succeeds and Settings → Rebuild Graph refreshes the tree