### PR TITLE
fix(settings): make clear_demo_data resilient to dropped legacy tables

### DIFF
--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -588,11 +588,6 @@ async def clear_demo_data(
             # Entity relationships (0f6%) — hasColumn
             "DELETE FROM entity_relationships WHERE id::text LIKE '0f6%'",
             
-            # Legacy: dataset subscriptions/custom properties (if old tables still exist)
-            "DELETE FROM dataset_subscriptions WHERE id::text LIKE '022%'",
-            "DELETE FROM dataset_subscriptions WHERE id::text LIKE '0260%'",
-            "DELETE FROM dataset_custom_properties WHERE id::text LIKE '024%'",
-            
             # Physical assets (025%) — migrated from dataset_instances
             "DELETE FROM assets WHERE id::text LIKE '025%'",
             
@@ -605,10 +600,9 @@ async def clear_demo_data(
             "DELETE FROM assets WHERE id::text LIKE '0f8%'",
             # Delivery Channel assets (0f9%)
             "DELETE FROM assets WHERE id::text LIKE '0f9%'",
-            
-            # Legacy: dataset instances (025) and datasets (021) (if old tables still exist)
-            "DELETE FROM dataset_instances WHERE id::text LIKE '025%'",
-            "DELETE FROM datasets WHERE id::text LIKE '021%'",
+            # Note: legacy dataset_subscriptions / dataset_custom_properties /
+            # dataset_instances / datasets tables were dropped by migration
+            # c1_drop_legacy_dataset_tables.py — no DELETEs needed.
             
             # Data contract servers (srv pattern for server IDs)
             "DELETE FROM data_contract_servers WHERE id::text LIKE 'srv%'",
@@ -673,14 +667,20 @@ async def clear_demo_data(
             "DELETE FROM data_domains WHERE id::text LIKE '000%'",
         ]
         
-        deleted_counts = {}
+        # Wrap each statement in a SAVEPOINT so that a single failing
+        # DELETE (e.g. against a table dropped by a later migration) does
+        # not poison the surrounding transaction and silently abort all
+        # subsequent deletes. Accumulate rowcounts per table since several
+        # patterns target the same table (e.g. entity_relationships).
+        deleted_counts: Dict[str, int] = {}
         for stmt in delete_statements:
+            table_name = stmt.split("FROM ")[1].split(" ")[0]
             try:
-                result = db.execute(text(stmt))
-                table_name = stmt.split("FROM ")[1].split(" ")[0]
-                deleted_counts[table_name] = result.rowcount
+                with db.begin_nested():
+                    result = db.execute(text(stmt))
+                deleted_counts[table_name] = deleted_counts.get(table_name, 0) + (result.rowcount or 0)
             except Exception as e:
-                logger.warning(f"Delete statement warning: {e}")
+                logger.warning(f"Delete statement warning ({table_name}): {e}")
         
         db.commit()
         


### PR DESCRIPTION
## Summary

The `DELETE /api/settings/demo-data` endpoint silently leaves most demo data behind (Data Products, Data Contracts, Data Domains, Reviews, MDM, Compliance, Notifications, Metadata, …). Reported result for a fully-loaded demo:

```
{
  \"status\": \"success\",
  \"message\": \"Demo data cleared. Deleted 184 records.\",
  \"deleted_counts\": {
    \"suggested_quality_checks\": 10,
    \"data_profiling_runs\": 3,
    \"comments\": 33,
    \"workflow_steps\": 27,
    \"process_workflows\": 3,
    \"entity_tag_associations\": 41,
    \"tag_namespace_permissions\": 16,
    \"tags\": 23,
    \"tag_namespaces\": 5,
    \"rdf_triples\": 0,
    \"entity_subscriptions\": 7,
    \"entity_relationships\": 16
  }
}
```

…and stops there. The remaining ~30 DELETE statements never run.

## Root cause

`clear_demo_data` ran each `DELETE` directly on the session transaction. The list still contained statements against the **legacy `dataset_subscriptions` / `dataset_custom_properties` / `dataset_instances` / `datasets` tables**, which were dropped by migration `c1_drop_legacy_dataset_tables.py`. When Postgres raised `relation \"dataset_subscriptions\" does not exist`, the entire transaction entered an aborted state. The surrounding `try/except` swallowed that error, but every subsequent `db.execute()` then failed with `InFailedSqlTransaction` — also swallowed silently — so the cleanup stopped exactly at the poison pill.

The deleted_counts dict was also lossy: multiple patterns targeting the same table (e.g. four `entity_relationships` variants) overwrote each other rather than summing.

## Fix

1. Wrap each statement in a `SAVEPOINT` via `db.begin_nested()`, mirroring what `load_demo_data` already does. A single bad statement now rolls back its own savepoint and the outer transaction stays healthy.
2. Accumulate rowcounts per table (`+=`) instead of overwriting.
3. Drop the obsolete legacy `dataset_*` DELETEs (those tables no longer exist).

## Test plan

- [ ] Load demo data: `POST /api/settings/demo-data/load`
- [ ] Verify Data Products / Data Contracts / Data Domains visible in UI
- [ ] Clear demo data: `DELETE /api/settings/demo-data`
- [ ] Confirm response now reports deletes for `data_products`, `data_contracts`, `data_domains`, `assets`, `compliance_*`, `notifications`, `data_asset_review_requests`, `metadata_*`, `mdm_*`, etc.
- [ ] Verify UI now shows zero Data Products / Contracts / Domains after the call
- [ ] Re-run the load → clear cycle to confirm idempotency