### PR TITLE
ci(coverage): collect backend/src/tests/unit/ and ratchet gate to 30%

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -103,9 +103,11 @@ jobs:
           DATABRICKS_VOLUME: test_volume
           APP_AUDIT_LOG_DIR: /tmp/audit_logs
         run: |
-          # Gate set to current baseline (~8%) to prevent regressions.
-          # Ratchet up as coverage improves toward the 80% goal.
-          hatch -e dev run coverage report --fail-under=8
+          # Gate set to current baseline (~33.7%) minus a small buffer.
+          # Coverage jumped because pytest now collects backend/src/tests/unit/
+          # in addition to backend/tests/. Ratchet up toward the 80% goal as
+          # quarantined modules in tests/unit/conftest.py are fixed.
+          hatch -e dev run coverage report --fail-under=30
 
   frontend-tests:
     name: Frontend Tests

--- a/src/backend/src/tests/unit/conftest.py
+++ b/src/backend/src/tests/unit/conftest.py
@@ -1,0 +1,25 @@
+# Skip unit-test modules that are broken pending fixes.
+#
+# These tests were silently excluded from CI for a long time (testpaths only
+# pointed at backend/tests), so they bit-rotted relative to current schemas
+# and managers. We now collect the rest of backend/src/tests/unit/ so coverage
+# reflects reality; the broken modules below are quarantined here so the
+# coverage gate can ratchet up. Fix-and-remove one entry at a time.
+#
+# TODO(coverage): unquarantine each module after rewriting its fixtures.
+collect_ignore = [
+    "test_audit_manager.py",
+    "test_comments_manager.py",
+    "test_costs_manager.py",
+    "test_data_products_manager.py",
+    "test_llm_client.py",
+    "test_metadata_manager.py",
+    "test_notifications_manager.py",
+    "test_search_manager.py",
+    "test_security_features_manager.py",
+    "test_semantic_links_manager.py",
+    "test_settings_manager.py",
+    "test_users_manager.py",
+    "test_workflow_executor_scripts.py",
+    "test_workflow_notification_channels.py",
+]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -74,13 +74,17 @@ pythonpath = [
   "backend",
   "backend/src"
 ]
-testpaths = ["backend/tests"]
+# NOTE: backend/src/tests/unit/ holds the bulk of the unit tests. The legacy
+# backend/tests/ dir is kept for the few suites that haven't migrated yet.
+# importlib mode lets us collect both trees without test-module name collisions.
+testpaths = ["backend/src/tests/unit", "backend/tests"]
 addopts = [
     "--cov=backend/src",
     "--cov-report=html",
     "--cov-report=term-missing",
     "--cov-report=xml",
-    "-v"
+    "--import-mode=importlib",
+    "-v",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
- `testpaths` only pointed at `backend/tests/`, so the bulk of the unit suite under `backend/src/tests/unit/` (60+ files) was silently excluded from CI. Wiring it in lifts backend coverage from **8.72% → 33.74%** with zero new tests.
- Switched pytest to `--import-mode=importlib` to avoid module-name collisions between the two test trees (e.g., duplicate `test_file_security.py`).
- Quarantined 14 bit-rotted unit modules via a new `backend/src/tests/unit/conftest.py` (mostly `UserInfo` Pydantic schema drift, where tests pre-date the `user`/`ip` required fields). Each entry is a paydown TODO to unquarantine one at a time.
- Bumped backend coverage gate **8 → 30** with a small buffer below the new 33.74% floor.

## Test plan
- [ ] `backend-tests` job in CI passes with `--fail-under=30`
- [ ] Coverage report shows ~33% (was ~8%)
- [ ] No previously-passing tests regress
- [ ] Local: 872 passed, 1 skipped, 0 failed in 5:35 ✅

## Follow-ups (not in this PR)
1. Unquarantine `unit/conftest.py` modules one at a time. Biggest wins:
   - `test_notifications_manager.py` (11 fails)
   - `test_metadata_manager.py` (9)
   - `test_comments_manager.py` (9)
   - `test_search_manager.py` (9 — fix the shared `UserInfo` fixture once)
2. Frontend coverage gate (`lines: 3, functions: 25`) deserves its own ratchet pass.
3. Wire `backend/src/tests/integration/` into CI behind the postgres service that already exists in the e2e job.

This pull request and its description were written by Isaac.