### PR TITLE
fix(data-products): null-safety in change-impact analyzer for products without team/description/support

### DIFF
--- a/src/backend/src/tests/unit/test_product_change_analyzer.py
+++ b/src/backend/src/tests/unit/test_product_change_analyzer.py
@@ -1,0 +1,148 @@
+"""
+Unit tests for ProductChangeAnalyzer null-safety.
+
+Regression coverage for a customer 500 where a data product with no team
+(`owner_team_id IS NULL`, no `data_product_teams` row) crashed the analyzer
+on `old_product.get('team', {}).get('members', [])`. The chained-`.get()`
+default only fires for missing keys; when the key is present but the value
+is None (the common API serialization case), the default is skipped and
+`.get(...)` blows up on NoneType.
+"""
+from typing import Dict
+
+import pytest
+
+from src.utils.product_change_analyzer import (
+    ChangeType,
+    ProductChangeAnalyzer,
+)
+
+
+def _empty_product(version: str = "1.0.0") -> Dict:
+    """Product with all top-level optional collections explicitly set to None.
+
+    Mirrors the response-builder output for a data product whose team,
+    description, support, and ports are all unpopulated.
+    """
+    return {
+        "id": f"product-{version}",
+        "name": "test-product",
+        "version": version,
+        "team": None,
+        "description": None,
+        "support": None,
+        "inputPorts": None,
+        "outputPorts": None,
+        "managementPorts": None,
+    }
+
+
+class TestProductChangeAnalyzerNullSafety:
+    """Regression tests: analyzer must not crash on None-valued fields."""
+
+    def test_analyze_with_all_none_fields_does_not_raise(self):
+        """Smoke test: analyzer survives a product with every optional field None."""
+        analyzer = ProductChangeAnalyzer()
+        old_product = _empty_product("1.0.0")
+        new_product = _empty_product("1.0.0")
+
+        # Should not raise AttributeError on NoneType.
+        result = analyzer.analyze(old_product, new_product)
+
+        assert result.change_type == ChangeType.NONE
+        assert result.version_bump == "none"
+        assert result.port_changes == []
+        assert result.team_changes == []
+        assert result.support_changes == []
+        assert result.breaking_changes == []
+        assert result.new_features == []
+        assert result.fixes == []
+        assert "No significant changes" in result.summary
+
+    def test_analyze_team_none_to_populated(self):
+        """Adding a team to a product that previously had none is a feature, not a crash."""
+        analyzer = ProductChangeAnalyzer()
+        old_product = _empty_product()
+        new_product = {
+            **_empty_product(),
+            "team": {
+                "members": [
+                    {"name": "alice", "email": "alice@example.com", "role": "owner"},
+                ]
+            },
+        }
+
+        result = analyzer.analyze(old_product, new_product)
+
+        assert result.change_type == ChangeType.FEATURE
+        assert any("alice" in entry for entry in result.new_features)
+
+    def test_analyze_team_present_but_members_none(self):
+        """`team` present but `members` is None — second-level None must not crash."""
+        analyzer = ProductChangeAnalyzer()
+        product = {
+            **_empty_product(),
+            "team": {"members": None},
+        }
+
+        # Both sides identical → no changes, no crash.
+        result = analyzer.analyze(product, product)
+
+        assert result.change_type == ChangeType.NONE
+        assert result.team_changes == []
+
+    def test_analyze_port_lists_none(self):
+        """Adding output ports to a product whose port lists were None is a feature."""
+        analyzer = ProductChangeAnalyzer()
+        old_product = _empty_product()
+        new_product = {
+            **_empty_product(),
+            "outputPorts": [
+                {"name": "main", "contractId": "c1", "version": "1.0.0"},
+            ],
+        }
+
+        result = analyzer.analyze(old_product, new_product)
+
+        assert result.change_type == ChangeType.FEATURE
+        assert any("main" in feat for feat in result.new_features)
+
+    def test_analyze_support_none(self):
+        """Support list is None on both sides — no crash, no changes."""
+        analyzer = ProductChangeAnalyzer()
+        product = _empty_product()
+
+        result = analyzer.analyze(product, product)
+
+        assert result.support_changes == []
+        assert result.change_type == ChangeType.NONE
+
+    def test_analyze_description_none(self):
+        """Description None on both sides — no crash, no patch-level fix recorded."""
+        analyzer = ProductChangeAnalyzer()
+        product = _empty_product()
+
+        result = analyzer.analyze(product, product)
+
+        assert all("description" not in fix.lower() for fix in result.fixes)
+        assert result.change_type == ChangeType.NONE
+
+    def test_member_with_none_role_does_not_crash(self):
+        """A team member with role=None must not blow up role.lower()."""
+        analyzer = ProductChangeAnalyzer()
+        old_product = {
+            **_empty_product(),
+            "team": {
+                "members": [
+                    {"name": "bob", "email": "bob@example.com", "role": None},
+                ]
+            },
+        }
+        # Remove bob in the new version.
+        new_product = _empty_product()
+
+        result = analyzer.analyze(old_product, new_product)
+
+        # bob without a critical role → patch-level fix, not breaking.
+        assert result.change_type == ChangeType.FIX
+        assert any("bob" in entry for entry in result.fixes)

--- a/src/backend/src/utils/product_change_analyzer.py
+++ b/src/backend/src/utils/product_change_analyzer.py
@@ -92,38 +92,43 @@ class ProductChangeAnalyzer:
         self._reset()
 
         # Analyze port changes (most critical for products)
+        # NOTE on `(x.get('k') or default)`: chained `.get('k', default).get(...)`
+        # only falls back to `default` when the key is MISSING. When the key is
+        # present but the value is None (common when the API serializes optional
+        # nullable relationships), the fallback is skipped and `.get(...)` crashes
+        # on NoneType. The `or` form covers both missing-key and None-value.
         self._analyze_port_changes(
-            old_product.get('inputPorts', []),
-            new_product.get('inputPorts', []),
+            old_product.get('inputPorts') or [],
+            new_product.get('inputPorts') or [],
             'input'
         )
         self._analyze_port_changes(
-            old_product.get('outputPorts', []),
-            new_product.get('outputPorts', []),
+            old_product.get('outputPorts') or [],
+            new_product.get('outputPorts') or [],
             'output'
         )
         self._analyze_port_changes(
-            old_product.get('managementPorts', []),
-            new_product.get('managementPorts', []),
+            old_product.get('managementPorts') or [],
+            new_product.get('managementPorts') or [],
             'management'
         )
 
         # Analyze team changes
         self._analyze_team_changes(
-            old_product.get('team', {}).get('members', []),
-            new_product.get('team', {}).get('members', [])
+            (old_product.get('team') or {}).get('members') or [],
+            (new_product.get('team') or {}).get('members') or []
         )
 
         # Analyze support channel changes
         self._analyze_support_changes(
-            old_product.get('support', []),
-            new_product.get('support', [])
+            old_product.get('support') or [],
+            new_product.get('support') or []
         )
 
         # Analyze description changes (minor/patch)
         self._analyze_description_changes(
-            old_product.get('description', {}),
-            new_product.get('description', {})
+            old_product.get('description') or {},
+            new_product.get('description') or {}
         )
 
         # Determine change type and version bump
@@ -155,8 +160,10 @@ class ProductChangeAnalyzer:
 
     def _analyze_port_changes(self, old_ports: List[Dict], new_ports: List[Dict], port_type: str):
         """Analyze changes in ports (input/output/management)"""
-        old_port_map = {p.get('name'): p for p in old_ports}
-        new_port_map = {p.get('name'): p for p in new_ports}
+        # Filter out None entries defensively; serialized port lists from
+        # partially-populated products can contain holes.
+        old_port_map = {p.get('name'): p for p in (old_ports or []) if p}
+        new_port_map = {p.get('name'): p for p in (new_ports or []) if p}
 
         old_names = set(old_port_map.keys())
         new_names = set(new_port_map.keys())
@@ -265,8 +272,16 @@ class ProductChangeAnalyzer:
 
     def _analyze_team_changes(self, old_members: List[Dict], new_members: List[Dict]):
         """Analyze changes in team members"""
-        old_member_map = {m.get('name', m.get('email', '')): m for m in old_members}
-        new_member_map = {m.get('name', m.get('email', '')): m for m in new_members}
+        # `m.get('name', m.get('email', ''))` keys on name, falling back to email.
+        # `or ''` guards against a stored member with name=None / email=None.
+        old_member_map = {
+            (m.get('name') or m.get('email') or ''): m
+            for m in (old_members or []) if m
+        }
+        new_member_map = {
+            (m.get('name') or m.get('email') or ''): m
+            for m in (new_members or []) if m
+        }
 
         old_keys = set(old_member_map.keys())
         new_keys = set(new_member_map.keys())
@@ -274,8 +289,8 @@ class ProductChangeAnalyzer:
         # Removed members
         for removed_key in old_keys - new_keys:
             old_member = old_member_map[removed_key]
-            role = old_member.get('role', 'unknown')
-            
+            role = old_member.get('role') or 'unknown'
+
             # Removing owner or critical roles could be breaking
             if role.lower() in ('owner', 'productOwner', 'product_owner'):
                 self.breaking_changes.append(f"Removed team member with critical role: {removed_key} ({role})")
@@ -291,7 +306,7 @@ class ProductChangeAnalyzer:
         # Added members (always a feature)
         for added_key in new_keys - old_keys:
             new_member = new_member_map[added_key]
-            role = new_member.get('role', 'unknown')
+            role = new_member.get('role') or 'unknown'
             self.new_features.append(f"Added team member: {added_key} ({role})")
             self.team_changes.append({
                 'type': 'added',
@@ -301,8 +316,14 @@ class ProductChangeAnalyzer:
 
     def _analyze_support_changes(self, old_support: List[Dict], new_support: List[Dict]):
         """Analyze changes in support channels"""
-        old_channel_map = {s.get('channel', s.get('type', '')): s for s in old_support}
-        new_channel_map = {s.get('channel', s.get('type', '')): s for s in new_support}
+        old_channel_map = {
+            (s.get('channel') or s.get('type') or ''): s
+            for s in (old_support or []) if s
+        }
+        new_channel_map = {
+            (s.get('channel') or s.get('type') or ''): s
+            for s in (new_support or []) if s
+        }
 
         old_channels = set(old_channel_map.keys())
         new_channels = set(new_channel_map.keys())


### PR DESCRIPTION
## Summary

Found while debugging a customer 500 on `PUT /api/data-products/{id}` (adding an output port). **Not a regression from #318** — latent null-safety bug exposed by a permitted-but-undertested state: a data product with `owner_team_id IS NULL` and no row in `data_product_teams`. The response builder serializes that as `team: None`, and the change-impact analyzer crashes on `old_product.get('team', {}).get('members', [])`.

### The Python footgun

`dict.get('k', default)` only falls back to `default` when the key is **missing**. When the key is **present but the value is None**, the default is skipped and the chained `.get(...)` raises `AttributeError: 'NoneType' object has no attribute 'get'`. Confirmed in DB inspection of the affected deployment with team-less products — schema permits it (`owner_team_id` is nullable), the API returns the product fine, only the analyzer trips.

## Call sites fixed

In `src/backend/src/utils/product_change_analyzer.py`:

- `analyze()`: `team`, `description`, `support`, `inputPorts`, `outputPorts`, `managementPorts` — switched every `x.get('k', default)` (where the value can legitimately be `None`) to `x.get('k') or default`. The two-level `team → members` access uses `(x.get('team') or {}).get('members') or []`.
- `_analyze_port_changes()`: filter out `None` entries when building the port name → port map.
- `_analyze_team_changes()`: same defensive filter for member list, plus `or ''` on the name/email key fallback so a member with both fields `None` doesn't blow up the dict comprehension.
- `_analyze_support_changes()`: same defensive filter for support channel list.
- `role.lower()` calls now use `role = member.get('role') or 'unknown'` so a stored `role=None` doesn't crash.

## Regression test

New `src/backend/src/tests/unit/test_product_change_analyzer.py` covers:

1. All top-level optional fields = `None` (smoke test — analyzer returns a clean empty-change result, no raise).
2. `team: None` → populated team (analyzer recognizes a feature-level addition).
3. `team` present but `members: None` (second-level None path).
4. `outputPorts: None` → populated ports (feature-level).
5. `support: None` on both sides.
6. `description: None` on both sides.
7. Team member with `role=None` (covers `role.lower()` crash path).

All 7 cases pass; existing tests untouched.

## Ship plan

Small, isolated, no schema or API changes. Pure null-safety hardening in one utility module + a new unit test file.