### PR TITLE
docs: add coverage and CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Ontos
 
+[![Test Coverage](https://github.com/databrickslabs/ontos/actions/workflows/test-coverage.yml/badge.svg?branch=main)](https://github.com/databrickslabs/ontos/actions/workflows/test-coverage.yml)
+[![codecov](https://codecov.io/gh/databrickslabs/ontos/branch/main/graph/badge.svg)](https://codecov.io/gh/databrickslabs/ontos)
+[![backend coverage](https://codecov.io/gh/databrickslabs/ontos/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/databrickslabs/ontos?flags[0]=backend)
+[![frontend coverage](https://codecov.io/gh/databrickslabs/ontos/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/databrickslabs/ontos?flags[0]=frontend)
+
 A comprehensive data governance and management platform built for Databricks Unity Catalog.
 
 ![Home](docs/images/home.png)


### PR DESCRIPTION
## Summary
- Adds 4 badges to the top of the README: Test Coverage workflow status, overall Codecov, backend-flag coverage, frontend-flag coverage.
- Surfaces existing Codecov uploads already configured in `.github/workflows/test-coverage.yml` (no CI changes needed).

## Test plan
- [ ] Confirm Codecov is activated for `databrickslabs/ontos` so badges populate (public repo, no token required for OSS uploads).
- [ ] Verify badges render on the rendered README after merge to `main`.

This pull request and its description were written by Isaac.