### PR TITLE
fix(data-products): default request-type to 'access' via configurable prop

### DIFF
--- a/src/frontend/src/components/data-products/request-product-action-dialog.test.tsx
+++ b/src/frontend/src/components/data-products/request-product-action-dialog.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for RequestProductActionDialog component
+ *
+ * Focused on the initial-request-type behavior. The dialog uses Radix Select
+ * elements which hang in jsdom when interacted with, so these tests only assert
+ * static text rendered by the dialog header — which is driven directly by the
+ * initial request-type state.
+ */
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '@/test/utils';
+import RequestProductActionDialog from './request-product-action-dialog';
+
+// Mock hooks that hit external services
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() })
+}));
+
+vi.mock('@/hooks/use-api', () => ({
+  useApi: () => ({
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: null })
+  })
+}));
+
+vi.mock('@/stores/notifications-store', () => ({
+  useNotificationsStore: (selector: any) =>
+    selector({ refreshNotifications: vi.fn() })
+}));
+
+describe('RequestProductActionDialog default request type', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults to 'access' when defaultRequestType is not provided", () => {
+    renderWithProviders(
+      <RequestProductActionDialog
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        productId="prod-1"
+        productName="Test Product"
+        productStatus="draft"
+      />
+    );
+
+    // Header title is driven by the active request type. 'access' renders
+    // 'Request Access to Product'; 'status_change' would render
+    // 'Request Status Change' / 'Change Status'.
+    expect(
+      screen.getByRole('heading', { name: /Request Access to Product/ })
+    ).toBeInTheDocument();
+  });
+
+  it("uses 'status_change' when defaultRequestType='status_change' is passed", () => {
+    renderWithProviders(
+      <RequestProductActionDialog
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        productId="prod-1"
+        productName="Test Product"
+        productStatus="draft"
+        defaultRequestType="status_change"
+      />
+    );
+
+    // The dialog title (h2) reflects the active request type. Scope the
+    // assertion to the heading role so we don't match identical text in the
+    // request-type Select dropdown options.
+    expect(
+      screen.getByRole('heading', { name: /Request Status Change/ })
+    ).toBeInTheDocument();
+  });
+
+  it("uses 'status_change' direct-change title when canDirectStatusChange is true", () => {
+    renderWithProviders(
+      <RequestProductActionDialog
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        productId="prod-1"
+        productName="Test Product"
+        productStatus="draft"
+        defaultRequestType="status_change"
+        canDirectStatusChange={true}
+      />
+    );
+
+    // With direct-change permission the title flips to 'Change Status'.
+    expect(
+      screen.getByRole('heading', { name: /Change Status/ })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/data-products/request-product-action-dialog.tsx
+++ b/src/frontend/src/components/data-products/request-product-action-dialog.tsx
@@ -29,6 +29,10 @@ interface RequestProductActionDialogProps {
   onSuccess?: () => void;
   /** If true, status changes are applied directly without approval workflow */
   canDirectStatusChange?: boolean;
+  /** Initial request type to select when the dialog opens. Defaults to 'access',
+   * since access requests are the most common entry point. Call sites that open
+   * the dialog from a status-change-specific affordance should pass 'status_change'. */
+  defaultRequestType?: RequestType;
 }
 
 // ODPS lifecycle transitions
@@ -74,13 +78,14 @@ export default function RequestProductActionDialog({
   productName,
   productStatus,
   onSuccess,
-  canDirectStatusChange = false
+  canDirectStatusChange = false,
+  defaultRequestType = 'access'
 }: RequestProductActionDialogProps) {
   const { post, get } = useApi();
   const { toast } = useToast();
   const refreshNotifications = useNotificationsStore((state) => state.refreshNotifications);
-  
-  const [requestType, setRequestType] = useState<RequestType>('status_change');
+
+  const [requestType, setRequestType] = useState<RequestType>(defaultRequestType);
   const [message, setMessage] = useState('');
   const [justification, setJustification] = useState('');
   const [targetStatus, setTargetStatus] = useState('');
@@ -100,7 +105,7 @@ export default function RequestProductActionDialog({
   // Reset form when dialog opens/closes
   useEffect(() => {
     if (isOpen) {
-      setRequestType('status_change');
+      setRequestType(defaultRequestType);
       setMessage('');
       setJustification('');
       setTargetStatus('');
@@ -109,7 +114,7 @@ export default function RequestProductActionDialog({
       setCertificationLevel(null);
       setPublicationScope('organization');
     }
-  }, [isOpen]);
+  }, [isOpen, defaultRequestType]);
 
   const getRequestTypeConfig = (type: RequestType) => {
     switch (type) {


### PR DESCRIPTION
## Summary

P1 fix from a customer feedback batch. `RequestProductActionDialog` defaulted `requestType` to `'status_change'` — a rarely-used path. The most common entry point (access requests) had to flip the dropdown manually on every open.

## Approach

Rather than hardcoding `'access'` as the new default and risking regressions in publish/certify entry points, this PR adds a configurable `defaultRequestType` prop with a sensible global default of `'access'`. Call sites can override when their context calls for a different starting type.

## Changes

- **`request-product-action-dialog.tsx`** — new `defaultRequestType?: RequestType` prop, defaults to `'access'`. Wired through the `useState` initializer and the open-reset `useEffect` (added to deps array).
- **`request-product-action-dialog.test.tsx`** (new) — three regression cases:
  - No prop → renders the access-request title
  - `defaultRequestType="status_change"` → renders `Request Status Change`
  - `defaultRequestType="status_change"` + `canDirectStatusChange` → renders `Change Status`

## Call sites

Only one consumer in the codebase: `data-product-details.tsx:2154`, a generic "Request..." button with no status-change-specific intent. Left without an explicit prop so it picks up the new `'access'` default — which matches the user expectation in the customer feedback.

## Verification

- Frontend tests: 400 pass / 6 pre-existing skips (matches main)
- Typecheck: clean (`yarn tsc --noEmit`)
- No backend / API / schema changes

Small, isolated, low-risk.
