### PR TITLE
fix(data-products): restrict Link Asset picker to ontology-supported deliverable types

### DIFF
--- a/src/frontend/src/components/common/asset-selector.test.tsx
+++ b/src/frontend/src/components/common/asset-selector.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Component tests for AssetSelector — focused on the `targetAssetTypes`
+ * filter.
+ *
+ * Regression target: the "Link Asset" picker on Data Product output ports
+ * was previously showing every asset type including Catalog and Schema.
+ * Submitting either yielded a 422 from the backend ontology validator.
+ * The fix narrows the picker via `targetAssetTypes`; these tests assert that
+ * filter is honoured in Browse mode (where the type sidebar is rendered).
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '@/test/utils';
+import { AssetSelector } from './asset-selector';
+
+// Mock the asset-types endpoint so Browse mode has a deterministic list.
+const mockAssetTypes = [
+  { id: '1', name: 'Table', category: 'data', status: 'active', asset_count: 10, icon: 'Table2' },
+  { id: '2', name: 'View', category: 'data', status: 'active', asset_count: 5, icon: 'Eye' },
+  { id: '3', name: 'Dataset', category: 'data', status: 'active', asset_count: 3, icon: 'Database' },
+  { id: '4', name: 'APIEndpoint', category: 'integration', status: 'active', asset_count: 2, icon: 'Globe' },
+  { id: '5', name: 'MLModel', category: 'analytics', status: 'active', asset_count: 1, icon: 'Brain' },
+  { id: '6', name: 'Catalog', category: 'system', status: 'active', asset_count: 4, icon: 'FolderOpen' },
+  { id: '7', name: 'Schema', category: 'system', status: 'active', asset_count: 8, icon: 'FolderOpen' },
+];
+
+vi.mock('@/hooks/use-api', () => ({
+  useApi: () => ({
+    get: vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/api/asset-types')) {
+        return Promise.resolve({ data: mockAssetTypes, error: null });
+      }
+      return Promise.resolve({ data: { items: [], total: 0 }, error: null });
+    }),
+  }),
+}));
+
+describe('AssetSelector targetAssetTypes filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all active asset types in Browse mode when no filter is set', async () => {
+    renderWithProviders(
+      <AssetSelector
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    // Wait for the asset-types API to resolve and the sidebar to render.
+    await waitFor(() => expect(screen.getByText('Table')).toBeInTheDocument());
+
+    // Container types are visible — backward compatibility for callers that
+    // don't pass `targetAssetTypes`.
+    expect(screen.getByText('Catalog')).toBeInTheDocument();
+    expect(screen.getByText('Schema')).toBeInTheDocument();
+    expect(screen.getByText('Table')).toBeInTheDocument();
+    expect(screen.getByText('View')).toBeInTheDocument();
+  });
+
+  it('hides asset types not in targetAssetTypes (output-port deliverables only)', async () => {
+    const deliverableTypes = ['Table', 'View', 'Dataset', 'APIEndpoint', 'MLModel'];
+
+    renderWithProviders(
+      <AssetSelector
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+        targetAssetTypes={deliverableTypes}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('Table')).toBeInTheDocument());
+
+    // Deliverable types are visible.
+    expect(screen.getByText('Table')).toBeInTheDocument();
+    expect(screen.getByText('View')).toBeInTheDocument();
+    expect(screen.getByText('Dataset')).toBeInTheDocument();
+    expect(screen.getByText('APIEndpoint')).toBeInTheDocument();
+    expect(screen.getByText('MLModel')).toBeInTheDocument();
+
+    // Container types — the original 422 trigger — must NOT be in the picker.
+    expect(screen.queryByText('Catalog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Schema')).not.toBeInTheDocument();
+  });
+
+  it('renders the caller-supplied helper text in the dialog description', async () => {
+    const helperText =
+      'Only deliverable asset types (Table, View, Dataset, API Endpoint, ML Model) can be linked to an output port.';
+
+    renderWithProviders(
+      <AssetSelector
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+        targetAssetTypes={['Table', 'View', 'Dataset', 'APIEndpoint', 'MLModel']}
+        description={helperText}
+      />
+    );
+
+    expect(screen.getByText(helperText)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/views/data-product-details.test.tsx
+++ b/src/frontend/src/views/data-product-details.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Tests for the OutputPort → Asset predicate map exported from
+ * `data-product-details.tsx`.
+ *
+ * The component file itself pulls in many heavy modules; we deliberately keep
+ * these tests at the constant/lookup level to avoid importing the full view.
+ * The map is the contract that has to stay in lock-step with the ontology
+ * (`portHas*` predicates in `ontos-ontology.ttl`).
+ */
+import { describe, it, expect } from 'vitest';
+import { PORT_TO_ASSET_PREDICATE } from './data-product-details';
+
+describe('PORT_TO_ASSET_PREDICATE', () => {
+  it('maps each deliverable asset type to its ontology predicate', () => {
+    expect(PORT_TO_ASSET_PREDICATE).toEqual({
+      Table: 'portHasTable',
+      View: 'portHasView',
+      Dataset: 'portHasDataset',
+      APIEndpoint: 'portHasEndpoint',
+      MLModel: 'portHasModel',
+    });
+  });
+
+  it('returns undefined for container types the ontology rejects', () => {
+    // Catalog/Schema were the original 422 trigger — they must not have an
+    // entry. If someone adds them here, the corresponding TTL predicate must
+    // also exist.
+    expect(PORT_TO_ASSET_PREDICATE['Catalog' as keyof typeof PORT_TO_ASSET_PREDICATE]).toBeUndefined();
+    expect(PORT_TO_ASSET_PREDICATE['Schema' as keyof typeof PORT_TO_ASSET_PREDICATE]).toBeUndefined();
+  });
+
+  it('returns undefined for unknown types so callers can skip + warn', () => {
+    expect(PORT_TO_ASSET_PREDICATE['Notebook' as keyof typeof PORT_TO_ASSET_PREDICATE]).toBeUndefined();
+    expect(PORT_TO_ASSET_PREDICATE['Dashboard' as keyof typeof PORT_TO_ASSET_PREDICATE]).toBeUndefined();
+  });
+});
+
+/**
+ * Predicate-selection behaviour expected of `handleLinkAssets`. We test the
+ * pure logic (compute predicate from asset type) here; the wired-in fetch is
+ * verified end-to-end against the deployed app.
+ */
+describe('predicate selection (mirrors handleLinkAssets)', () => {
+  const pickPredicate = (assetType: string | undefined): string | undefined =>
+    assetType ? PORT_TO_ASSET_PREDICATE[assetType as keyof typeof PORT_TO_ASSET_PREDICATE] : undefined;
+
+  it.each([
+    ['Table', 'portHasTable'],
+    ['View', 'portHasView'],
+    ['Dataset', 'portHasDataset'],
+    ['APIEndpoint', 'portHasEndpoint'],
+    ['MLModel', 'portHasModel'],
+  ])('picks %s → %s', (assetType, predicate) => {
+    expect(pickPredicate(assetType)).toBe(predicate);
+  });
+
+  it('returns undefined for Catalog/Schema (the original 422 trigger)', () => {
+    expect(pickPredicate('Catalog')).toBeUndefined();
+    expect(pickPredicate('Schema')).toBeUndefined();
+  });
+
+  it('returns undefined when asset_type_name is missing', () => {
+    expect(pickPredicate(undefined)).toBeUndefined();
+  });
+});

--- a/src/frontend/src/views/data-product-details.test.tsx
+++ b/src/frontend/src/views/data-product-details.test.tsx
@@ -1,14 +1,31 @@
 /**
- * Tests for the OutputPort → Asset predicate map exported from
- * `data-product-details.tsx`.
+ * Tests for the pure helpers exported from `data-product-details.tsx`.
  *
  * The component file itself pulls in many heavy modules; we deliberately keep
- * these tests at the constant/lookup level to avoid importing the full view.
- * The map is the contract that has to stay in lock-step with the ontology
- * (`portHas*` predicates in `ontos-ontology.ttl`).
+ * these tests at the constant/lookup/helper level to avoid importing the full
+ * view. The map and helpers are the contract that has to stay in lock-step
+ * with the ontology (`portHas*` predicates in `ontos-ontology.ttl`) and with
+ * the persona/permissions model.
  */
 import { describe, it, expect } from 'vitest';
-import { PORT_TO_ASSET_PREDICATE } from './data-product-details';
+import {
+  PORT_TO_ASSET_PREDICATE,
+  selectPortAssetPredicate,
+  buildLinkAssetRequestBody,
+  parseStoredViewMode,
+  computeDefaultViewMode,
+  shouldShowSectionForViewMode,
+  formatDateString,
+  getStatusBadgeVariant,
+  IN_PLACE_EDITABLE_STATUSES,
+  isStatusEditableInPlace,
+  isPersonalDraftProduct,
+  isProductReadOnly,
+  canUserModifyProduct,
+  resolveDomainLabel,
+  isProductActive,
+} from './data-product-details';
+import { FeatureAccessLevel } from '@/types/settings';
 
 describe('PORT_TO_ASSET_PREDICATE', () => {
   it('maps each deliverable asset type to its ontology predicate', () => {
@@ -40,10 +57,7 @@ describe('PORT_TO_ASSET_PREDICATE', () => {
  * pure logic (compute predicate from asset type) here; the wired-in fetch is
  * verified end-to-end against the deployed app.
  */
-describe('predicate selection (mirrors handleLinkAssets)', () => {
-  const pickPredicate = (assetType: string | undefined): string | undefined =>
-    assetType ? PORT_TO_ASSET_PREDICATE[assetType as keyof typeof PORT_TO_ASSET_PREDICATE] : undefined;
-
+describe('selectPortAssetPredicate', () => {
   it.each([
     ['Table', 'portHasTable'],
     ['View', 'portHasView'],
@@ -51,15 +65,446 @@ describe('predicate selection (mirrors handleLinkAssets)', () => {
     ['APIEndpoint', 'portHasEndpoint'],
     ['MLModel', 'portHasModel'],
   ])('picks %s → %s', (assetType, predicate) => {
-    expect(pickPredicate(assetType)).toBe(predicate);
+    expect(selectPortAssetPredicate(assetType)).toBe(predicate);
   });
 
   it('returns undefined for Catalog/Schema (the original 422 trigger)', () => {
-    expect(pickPredicate('Catalog')).toBeUndefined();
-    expect(pickPredicate('Schema')).toBeUndefined();
+    expect(selectPortAssetPredicate('Catalog')).toBeUndefined();
+    expect(selectPortAssetPredicate('Schema')).toBeUndefined();
   });
 
   it('returns undefined when asset_type_name is missing', () => {
-    expect(pickPredicate(undefined)).toBeUndefined();
+    expect(selectPortAssetPredicate(undefined)).toBeUndefined();
+    expect(selectPortAssetPredicate(null)).toBeUndefined();
+    expect(selectPortAssetPredicate('')).toBeUndefined();
+  });
+});
+
+/**
+ * The body builder consumed by `handleLinkAssets` to POST to
+ * `/api/entity-relationships`. Returns `null` for unsupported types so the
+ * caller skips the request instead of letting the backend 422.
+ */
+describe('buildLinkAssetRequestBody', () => {
+  const PORT_ID = 'port-abc-123';
+
+  it.each([
+    ['Table', 'portHasTable'],
+    ['View', 'portHasView'],
+    ['Dataset', 'portHasDataset'],
+    ['APIEndpoint', 'portHasEndpoint'],
+    ['MLModel', 'portHasModel'],
+  ])('builds the right body for %s', (assetType, predicate) => {
+    const asset = { id: 'asset-1', asset_type_name: assetType };
+    expect(buildLinkAssetRequestBody(asset, PORT_ID)).toEqual({
+      source_type: 'OutputPort',
+      source_id: PORT_ID,
+      target_type: assetType,
+      target_id: 'asset-1',
+      relationship_type: predicate,
+    });
+  });
+
+  it('returns null for Catalog/Schema (unsupported by the ontology)', () => {
+    expect(buildLinkAssetRequestBody({ id: 'a', asset_type_name: 'Catalog' }, PORT_ID)).toBeNull();
+    expect(buildLinkAssetRequestBody({ id: 'a', asset_type_name: 'Schema' }, PORT_ID)).toBeNull();
+  });
+
+  it('returns null for unknown asset types', () => {
+    expect(buildLinkAssetRequestBody({ id: 'a', asset_type_name: 'Notebook' }, PORT_ID)).toBeNull();
+    expect(buildLinkAssetRequestBody({ id: 'a', asset_type_name: 'Dashboard' }, PORT_ID)).toBeNull();
+  });
+
+  it('returns null when asset_type_name is missing or empty', () => {
+    expect(buildLinkAssetRequestBody({ id: 'a' }, PORT_ID)).toBeNull();
+    expect(buildLinkAssetRequestBody({ id: 'a', asset_type_name: undefined }, PORT_ID)).toBeNull();
+    expect(buildLinkAssetRequestBody({ id: 'a', asset_type_name: null }, PORT_ID)).toBeNull();
+    expect(buildLinkAssetRequestBody({ id: 'a', asset_type_name: '' }, PORT_ID)).toBeNull();
+  });
+
+  it('returns null when asset itself is missing', () => {
+    expect(buildLinkAssetRequestBody(null, PORT_ID)).toBeNull();
+    expect(buildLinkAssetRequestBody(undefined, PORT_ID)).toBeNull();
+  });
+
+  it('wires source_id from portId and target_id from asset.id', () => {
+    const body = buildLinkAssetRequestBody(
+      { id: 'asset-xyz', asset_type_name: 'Table' },
+      'port-foo',
+    );
+    expect(body).not.toBeNull();
+    expect(body!.source_id).toBe('port-foo');
+    expect(body!.target_id).toBe('asset-xyz');
+  });
+
+  it('always sets source_type to OutputPort', () => {
+    const body = buildLinkAssetRequestBody(
+      { id: 'a', asset_type_name: 'MLModel' },
+      PORT_ID,
+    );
+    expect(body!.source_type).toBe('OutputPort');
+  });
+});
+
+describe('parseStoredViewMode', () => {
+  it.each(['minimal', 'medium', 'large'])('accepts known mode "%s"', (mode) => {
+    expect(parseStoredViewMode(mode)).toBe(mode);
+  });
+
+  it('returns null for unknown values', () => {
+    expect(parseStoredViewMode('huge')).toBeNull();
+    expect(parseStoredViewMode('Minimal')).toBeNull(); // case-sensitive on purpose
+  });
+
+  it('returns null when nothing is stored', () => {
+    expect(parseStoredViewMode(null)).toBeNull();
+    expect(parseStoredViewMode(undefined)).toBeNull();
+    expect(parseStoredViewMode('')).toBeNull();
+  });
+});
+
+describe('computeDefaultViewMode', () => {
+  it("returns 'large' when the user is in the product's owner team", () => {
+    expect(
+      computeDefaultViewMode({
+        ownerTeamId: 'team-a',
+        userGroups: ['team-a', 'team-b'],
+        permissionLevel: FeatureAccessLevel.READ_ONLY,
+      }),
+    ).toBe('large');
+  });
+
+  it.each([FeatureAccessLevel.READ_WRITE, FeatureAccessLevel.ADMIN, FeatureAccessLevel.FULL])(
+    "returns 'medium' for write-class permission %s",
+    (level) => {
+      expect(
+        computeDefaultViewMode({
+          ownerTeamId: 'team-x',
+          userGroups: ['team-y'],
+          permissionLevel: level,
+        }),
+      ).toBe('medium');
+    },
+  );
+
+  it.each([FeatureAccessLevel.READ_ONLY, FeatureAccessLevel.NONE, FeatureAccessLevel.FILTERED])(
+    "returns 'minimal' for read-class permission %s",
+    (level) => {
+      expect(
+        computeDefaultViewMode({
+          ownerTeamId: 'team-x',
+          userGroups: ['team-y'],
+          permissionLevel: level,
+        }),
+      ).toBe('minimal');
+    },
+  );
+
+  it('returns minimal when groups / ownerTeamId are missing', () => {
+    expect(computeDefaultViewMode({})).toBe('minimal');
+    expect(computeDefaultViewMode({ ownerTeamId: 'team-a' })).toBe('minimal');
+    expect(computeDefaultViewMode({ userGroups: ['team-a'] })).toBe('minimal');
+  });
+
+  it('owner-team match wins over a low permission level', () => {
+    expect(
+      computeDefaultViewMode({
+        ownerTeamId: 'team-a',
+        userGroups: ['team-a'],
+        permissionLevel: FeatureAccessLevel.NONE,
+      }),
+    ).toBe('large');
+  });
+});
+
+describe('shouldShowSectionForViewMode', () => {
+  it("'minimal' view shows only deliverables / description / hierarchy", () => {
+    expect(shouldShowSectionForViewMode('minimal', 'deliverables')).toBe(true);
+    expect(shouldShowSectionForViewMode('minimal', 'description')).toBe(true);
+    expect(shouldShowSectionForViewMode('minimal', 'hierarchy')).toBe(true);
+    expect(shouldShowSectionForViewMode('minimal', 'metadata-panel')).toBe(false);
+    expect(shouldShowSectionForViewMode('minimal', 'costs')).toBe(false);
+  });
+
+  it("'medium' view hides admin-heavy sections but shows the rest", () => {
+    expect(shouldShowSectionForViewMode('medium', 'management-ports')).toBe(false);
+    expect(shouldShowSectionForViewMode('medium', 'support-channels')).toBe(false);
+    expect(shouldShowSectionForViewMode('medium', 'metadata-panel')).toBe(false);
+    expect(shouldShowSectionForViewMode('medium', 'ratings')).toBe(false);
+    expect(shouldShowSectionForViewMode('medium', 'costs')).toBe(false);
+    expect(shouldShowSectionForViewMode('medium', 'quality')).toBe(false);
+    expect(shouldShowSectionForViewMode('medium', 'deliverables')).toBe(true);
+    expect(shouldShowSectionForViewMode('medium', 'description')).toBe(true);
+  });
+
+  it("'large' view shows everything", () => {
+    expect(shouldShowSectionForViewMode('large', 'management-ports')).toBe(true);
+    expect(shouldShowSectionForViewMode('large', 'metadata-panel')).toBe(true);
+    expect(shouldShowSectionForViewMode('large', 'anything-at-all')).toBe(true);
+  });
+
+  it('unknown view modes hide everything', () => {
+    // @ts-expect-error - runtime guard against bad localStorage values
+    expect(shouldShowSectionForViewMode('xxl', 'deliverables')).toBe(false);
+  });
+});
+
+describe('formatDateString', () => {
+  it('returns the fallback for empty / undefined / null input', () => {
+    expect(formatDateString(undefined)).toBe('N/A');
+    expect(formatDateString(null)).toBe('N/A');
+    expect(formatDateString('')).toBe('N/A');
+    expect(formatDateString(undefined, '—')).toBe('—');
+  });
+
+  it("returns 'Invalid Date' for unparseable input", () => {
+    expect(formatDateString('not-a-real-date')).toBe('Invalid Date');
+  });
+
+  it('formats a valid ISO date string', () => {
+    // Don't assert on locale-specific format; just confirm we get something
+    // non-empty and not the fallback / error sentinel.
+    const out = formatDateString('2025-01-02T03:04:05Z');
+    expect(out).not.toBe('N/A');
+    expect(out).not.toBe('Invalid Date');
+    expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getStatusBadgeVariant', () => {
+  it.each([
+    ['active', 'default'],
+    ['Active', 'default'],
+    ['ACTIVE', 'default'],
+  ])('maps %s → default', (status, variant) => {
+    expect(getStatusBadgeVariant(status)).toBe(variant);
+  });
+
+  it.each([
+    ['draft', 'secondary'],
+    ['proposed', 'secondary'],
+  ])('maps %s → secondary', (status, variant) => {
+    expect(getStatusBadgeVariant(status)).toBe(variant);
+  });
+
+  it.each([
+    ['retired', 'outline'],
+    ['deprecated', 'outline'],
+  ])('maps %s → outline', (status, variant) => {
+    expect(getStatusBadgeVariant(status)).toBe(variant);
+  });
+
+  it("falls back to 'default' for unknown / missing status", () => {
+    expect(getStatusBadgeVariant(undefined)).toBe('default');
+    expect(getStatusBadgeVariant(null)).toBe('default');
+    expect(getStatusBadgeVariant('')).toBe('default');
+    expect(getStatusBadgeVariant('archived')).toBe('default');
+  });
+});
+
+describe('IN_PLACE_EDITABLE_STATUSES', () => {
+  it('contains exactly the lifecycle statuses where in-place editing is allowed', () => {
+    expect(IN_PLACE_EDITABLE_STATUSES).toEqual([
+      'draft',
+      'sandbox',
+      'proposed',
+      'under_review',
+      'approved',
+    ]);
+  });
+});
+
+describe('isStatusEditableInPlace', () => {
+  it.each(['draft', 'sandbox', 'proposed', 'under_review', 'approved'])(
+    "%s is editable in place",
+    (status) => {
+      expect(isStatusEditableInPlace(status)).toBe(true);
+    },
+  );
+
+  it('case-insensitive on the input', () => {
+    expect(isStatusEditableInPlace('DRAFT')).toBe(true);
+    expect(isStatusEditableInPlace('Sandbox')).toBe(true);
+    expect(isStatusEditableInPlace('Under_Review')).toBe(true);
+  });
+
+  it.each(['active', 'retired', 'deprecated'])(
+    "'%s' is NOT editable in place (must be cloned)",
+    (status) => {
+      expect(isStatusEditableInPlace(status)).toBe(false);
+    },
+  );
+
+  it('returns false for missing / empty status', () => {
+    expect(isStatusEditableInPlace(undefined)).toBe(false);
+    expect(isStatusEditableInPlace(null)).toBe(false);
+    expect(isStatusEditableInPlace('')).toBe(false);
+  });
+});
+
+describe('isPersonalDraftProduct', () => {
+  it('is true when draftOwnerId is set to a string', () => {
+    expect(isPersonalDraftProduct({ draftOwnerId: 'user-1' })).toBe(true);
+  });
+
+  it('is false when draftOwnerId is null / undefined / missing', () => {
+    expect(isPersonalDraftProduct({ draftOwnerId: null })).toBe(false);
+    expect(isPersonalDraftProduct({ draftOwnerId: undefined })).toBe(false);
+    expect(isPersonalDraftProduct({})).toBe(false);
+  });
+
+  it('is false when product itself is null / undefined', () => {
+    expect(isPersonalDraftProduct(null)).toBe(false);
+    expect(isPersonalDraftProduct(undefined)).toBe(false);
+  });
+});
+
+describe('isProductReadOnly', () => {
+  it('admin is never read-only', () => {
+    expect(
+      isProductReadOnly({ canAdmin: true, canEditInPlace: false, isPersonalDraft: false }),
+    ).toBe(false);
+  });
+
+  it('non-admin with editable-in-place status is not read-only', () => {
+    expect(
+      isProductReadOnly({ canAdmin: false, canEditInPlace: true, isPersonalDraft: false }),
+    ).toBe(false);
+  });
+
+  it('non-admin on a personal draft is not read-only', () => {
+    expect(
+      isProductReadOnly({ canAdmin: false, canEditInPlace: false, isPersonalDraft: true }),
+    ).toBe(false);
+  });
+
+  it('non-admin, non-editable, non-personal-draft is read-only', () => {
+    expect(
+      isProductReadOnly({ canAdmin: false, canEditInPlace: false, isPersonalDraft: false }),
+    ).toBe(true);
+  });
+});
+
+describe('canUserModifyProduct', () => {
+  it('admin can always modify, regardless of other flags', () => {
+    expect(
+      canUserModifyProduct({
+        canAdmin: true,
+        canWrite: false,
+        canEditInPlace: false,
+        isPersonalDraft: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('writer can modify when status is editable in place', () => {
+    expect(
+      canUserModifyProduct({
+        canAdmin: false,
+        canWrite: true,
+        canEditInPlace: true,
+        isPersonalDraft: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('writer can modify a personal draft even on a locked status', () => {
+    expect(
+      canUserModifyProduct({
+        canAdmin: false,
+        canWrite: true,
+        canEditInPlace: false,
+        isPersonalDraft: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('writer cannot modify a locked status that is not their personal draft', () => {
+    expect(
+      canUserModifyProduct({
+        canAdmin: false,
+        canWrite: true,
+        canEditInPlace: false,
+        isPersonalDraft: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('non-writer non-admin can never modify', () => {
+    expect(
+      canUserModifyProduct({
+        canAdmin: false,
+        canWrite: false,
+        canEditInPlace: true,
+        isPersonalDraft: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('resolveDomainLabel', () => {
+  const NOT_ASSIGNED = '— not assigned —';
+
+  it('returns the resolved name when the lookup succeeds', () => {
+    expect(
+      resolveDomainLabel({
+        domain: 'dom-1',
+        resolveName: () => 'Sales',
+        notAssignedLabel: NOT_ASSIGNED,
+      }),
+    ).toBe('Sales');
+  });
+
+  it('falls back to the raw domain id when the lookup misses', () => {
+    expect(
+      resolveDomainLabel({
+        domain: 'dom-orphan',
+        resolveName: () => undefined,
+        notAssignedLabel: NOT_ASSIGNED,
+      }),
+    ).toBe('dom-orphan');
+    expect(
+      resolveDomainLabel({
+        domain: 'dom-orphan',
+        resolveName: () => null,
+        notAssignedLabel: NOT_ASSIGNED,
+      }),
+    ).toBe('dom-orphan');
+    expect(
+      resolveDomainLabel({
+        domain: 'dom-orphan',
+        resolveName: () => '',
+        notAssignedLabel: NOT_ASSIGNED,
+      }),
+    ).toBe('dom-orphan');
+  });
+
+  it('returns the not-assigned label when the product has no domain', () => {
+    const resolveName = () => 'should-not-be-called';
+    expect(
+      resolveDomainLabel({ domain: undefined, resolveName, notAssignedLabel: NOT_ASSIGNED }),
+    ).toBe(NOT_ASSIGNED);
+    expect(
+      resolveDomainLabel({ domain: null, resolveName, notAssignedLabel: NOT_ASSIGNED }),
+    ).toBe(NOT_ASSIGNED);
+    expect(
+      resolveDomainLabel({ domain: '', resolveName, notAssignedLabel: NOT_ASSIGNED }),
+    ).toBe(NOT_ASSIGNED);
+  });
+});
+
+describe('isProductActive', () => {
+  it.each(['active', 'Active', 'ACTIVE'])('is true for %s', (status) => {
+    expect(isProductActive(status)).toBe(true);
+  });
+
+  it.each(['draft', 'retired', 'deprecated', 'sandbox'])('is false for %s', (status) => {
+    expect(isProductActive(status)).toBe(false);
+  });
+
+  it('is false for missing status', () => {
+    expect(isProductActive(undefined)).toBe(false);
+    expect(isProductActive(null)).toBe(false);
+    expect(isProductActive('')).toBe(false);
   });
 });

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -69,6 +69,30 @@ import { ApprovalEntity } from '@/types/settings';
 type ViewMode = 'minimal' | 'medium' | 'large'
 const VIEW_MODE_STORAGE_KEY = 'data-product-view-mode'
 
+/**
+ * Output port → asset relationship predicates.
+ *
+ * Mirrors the `portHas*` predicates declared in `ontos-ontology.ttl` (lines
+ * 838–891). The ontology intentionally restricts these relationships to
+ * *deliverable* asset types — not container types like Catalog or Schema.
+ * The picker filter and the POST predicate selection both flow from this map,
+ * so they stay in lock-step with the ontology.
+ *
+ * If a new deliverable type is added to the TTL, add it here. If a caller
+ * tries to link an unsupported type the POST is skipped with a warning;
+ * the backend at `entity_relationships_manager.py` is the actual security
+ * gate and will return 422 for any invalid (predicate, range) tuple.
+ */
+export const PORT_TO_ASSET_PREDICATE: Readonly<Record<string, string>> = {
+  Table: 'portHasTable',
+  View: 'portHasView',
+  Dataset: 'portHasDataset',
+  APIEndpoint: 'portHasEndpoint',
+  MLModel: 'portHasModel',
+};
+
+const PORT_DELIVERABLE_ASSET_TYPES = Object.keys(PORT_TO_ASSET_PREDICATE);
+
 type CheckApiResponseFn = <T>(
   response: { data?: T | { detail?: string }, error?: string | null | undefined },
   name: string
@@ -121,21 +145,35 @@ function PortLinkedAssets({ portId, portName, canEdit }: { portId: string; portN
 
   const handleLinkAssets = async (assets: any[]) => {
     try {
+      let linkedCount = 0;
       for (const asset of assets) {
+        const assetType = asset.asset_type_name;
+        // The picker is filtered to the keys of this map, but be defensive:
+        // if an asset of an unsupported type slips through, skip + warn rather
+        // than build a `portHas<X>` predicate that the backend will 422 on.
+        const predicate = assetType ? PORT_TO_ASSET_PREDICATE[assetType] : undefined;
+        if (!predicate) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[link-asset] Skipping asset ${asset.id}: type "${assetType}" has no port relationship in the ontology.`
+          );
+          continue;
+        }
         const res = await fetch('/api/entity-relationships', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             source_type: 'OutputPort',
             source_id: portId,
-            target_type: asset.asset_type_name || 'Table',
+            target_type: assetType,
             target_id: asset.id,
-            relationship_type: asset.relationshipType || `portHas${asset.asset_type_name || 'Table'}`,
+            relationship_type: predicate,
           }),
         });
         if (!res.ok) throw new Error(`Failed to link asset: ${res.statusText}`);
+        linkedCount += 1;
       }
-      toast({ title: 'Assets linked', description: `${assets.length} asset(s) linked to ${portName}` });
+      toast({ title: 'Assets linked', description: `${linkedCount} asset(s) linked to ${portName}` });
       fetchRelationships();
     } catch (error: any) {
       toast({ title: 'Error', description: error?.message || 'Failed to link assets', variant: 'destructive' });
@@ -203,10 +241,10 @@ function PortLinkedAssets({ portId, portName, canEdit }: { portId: string; portN
             isOpen={isAssetSelectorOpen}
             onOpenChange={setIsAssetSelectorOpen}
             onConfirm={handleLinkAssets}
-            relationshipType="portHasTable"
             relationshipLabel="linked to port"
+            targetAssetTypes={PORT_DELIVERABLE_ASSET_TYPES}
             title={`Link Assets to "${portName}"`}
-            description="Select assets to link to this deliverable"
+            description="Only deliverable asset types (Table, View, Dataset, API Endpoint, ML Model) can be linked to an output port."
           />
         </>
       )}

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -69,6 +69,166 @@ import { ApprovalEntity } from '@/types/settings';
 type ViewMode = 'minimal' | 'medium' | 'large'
 const VIEW_MODE_STORAGE_KEY = 'data-product-view-mode'
 
+const VIEW_MODES: ReadonlyArray<ViewMode> = ['minimal', 'medium', 'large'];
+
+/**
+ * Parse a value retrieved from `localStorage[VIEW_MODE_STORAGE_KEY]`. Returns
+ * the value when it's one of the known modes, otherwise `null` so the caller
+ * can apply its default.
+ */
+export function parseStoredViewMode(stored: string | null | undefined): ViewMode | null {
+  if (!stored) return null;
+  return (VIEW_MODES as ReadonlyArray<string>).includes(stored) ? (stored as ViewMode) : null;
+}
+
+/**
+ * Pure helper that maps (product owner team membership, permission level)
+ * to the default ViewMode. Owner-team members get the full 'large' view;
+ * write/admin users get 'medium'; everyone else 'minimal'.
+ */
+export function computeDefaultViewMode(args: {
+  ownerTeamId?: string | null;
+  userGroups?: ReadonlyArray<string> | null;
+  permissionLevel?: FeatureAccessLevel | null;
+}): ViewMode {
+  const { ownerTeamId, userGroups, permissionLevel } = args;
+  if (ownerTeamId && userGroups && userGroups.includes(ownerTeamId)) {
+    return 'large';
+  }
+  if (
+    permissionLevel === FeatureAccessLevel.READ_WRITE ||
+    permissionLevel === FeatureAccessLevel.ADMIN ||
+    permissionLevel === FeatureAccessLevel.FULL
+  ) {
+    return 'medium';
+  }
+  return 'minimal';
+}
+
+/**
+ * Pure ViewMode → section visibility predicate. The component-level wrapper
+ * just closes over the current `viewMode`.
+ */
+export function shouldShowSectionForViewMode(viewMode: ViewMode, section: string): boolean {
+  switch (viewMode) {
+    case 'minimal':
+      return ['deliverables', 'description', 'hierarchy'].includes(section);
+    case 'medium':
+      return !['management-ports', 'support-channels', 'metadata-panel', 'ratings', 'costs', 'quality'].includes(section);
+    case 'large':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Format an ISO date string for display. Falls back to `fallback` when input
+ * is empty / undefined, and to a literal `Invalid Date` when `Date` rejects it.
+ */
+export function formatDateString(dateString: string | undefined | null, fallback: string = 'N/A'): string {
+  if (!dateString) return fallback;
+  try {
+    const d = new Date(dateString);
+    if (isNaN(d.getTime())) return 'Invalid Date';
+    return d.toLocaleString();
+  } catch {
+    return 'Invalid Date';
+  }
+}
+
+/**
+ * Map a Data Product status string to a Shadcn Badge variant.
+ * Lower-cased internally so `Active`, `ACTIVE`, `active` all map identically.
+ */
+export function getStatusBadgeVariant(
+  status: string | undefined | null,
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  const lowerStatus = status?.toLowerCase() || '';
+  if (lowerStatus === 'active') return 'default';
+  if (lowerStatus === 'draft' || lowerStatus === 'proposed') return 'secondary';
+  if (lowerStatus === 'retired' || lowerStatus === 'deprecated') return 'outline';
+  return 'default';
+}
+
+/**
+ * Statuses where a Data Product can still be edited in-place. Anything with a
+ * higher lifecycle status (`active`, `retired`, `deprecated`) must be cloned
+ * for editing instead.
+ */
+export const IN_PLACE_EDITABLE_STATUSES: ReadonlyArray<string> = [
+  'draft',
+  'sandbox',
+  'proposed',
+  'under_review',
+  'approved',
+];
+
+export function isStatusEditableInPlace(status: string | undefined | null): boolean {
+  if (!status) return false;
+  return IN_PLACE_EDITABLE_STATUSES.includes(status.toLowerCase());
+}
+
+/**
+ * A "personal draft" is a product owned by a single user (not a team) — these
+ * stay editable for that user even when the product status would otherwise be
+ * locked. The signal is a non-null `draftOwnerId` on the product.
+ */
+export function isPersonalDraftProduct(product: { draftOwnerId?: string | null } | null | undefined): boolean {
+  return product != null && product.draftOwnerId != null;
+}
+
+/**
+ * Read-only iff the user is not an admin AND the product is neither
+ * editable-in-place nor a personal draft. Pure function over the three flags.
+ */
+export function isProductReadOnly(args: {
+  canAdmin: boolean;
+  canEditInPlace: boolean;
+  isPersonalDraft: boolean;
+}): boolean {
+  return !args.canAdmin && !args.canEditInPlace && !args.isPersonalDraft;
+}
+
+/**
+ * Final "can the user modify this product" gate combining role + status flags.
+ * Admins can always modify; write-class users can modify when the product is
+ * editable-in-place or a personal draft.
+ */
+export function canUserModifyProduct(args: {
+  canAdmin: boolean;
+  canWrite: boolean;
+  canEditInPlace: boolean;
+  isPersonalDraft: boolean;
+}): boolean {
+  if (args.canAdmin) return true;
+  return args.canWrite && (args.canEditInPlace || args.isPersonalDraft);
+}
+
+/**
+ * Resolve the human-readable domain label for a product. Falls back to the
+ * raw domain id when the lookup misses, and to a "not assigned" sentinel when
+ * the product has no domain at all.
+ */
+export function resolveDomainLabel(args: {
+  domain: string | undefined | null;
+  resolveName: (id: string) => string | undefined | null;
+  notAssignedLabel: string;
+}): string {
+  const { domain, resolveName, notAssignedLabel } = args;
+  if (!domain) return notAssignedLabel;
+  return resolveName(domain) || domain;
+}
+
+/**
+ * Whether the product is in the "active" lifecycle state. Centralised so the
+ * "active" magic string lives in one place — used by the lifecycle approve /
+ * deprecate gates.
+ */
+export function isProductActive(status: string | undefined | null): boolean {
+  return (status?.toLowerCase() || '') === 'active';
+}
+
 /**
  * Output port → asset relationship predicates.
  *
@@ -92,6 +252,36 @@ export const PORT_TO_ASSET_PREDICATE: Readonly<Record<string, string>> = {
 };
 
 const PORT_DELIVERABLE_ASSET_TYPES = Object.keys(PORT_TO_ASSET_PREDICATE);
+
+/**
+ * Look up the ontology predicate for a port → asset relationship.
+ * Returns `undefined` for unsupported / missing asset types so callers can
+ * skip the POST instead of building a `portHas<X>` the backend will 422 on.
+ */
+export function selectPortAssetPredicate(assetTypeName: string | undefined | null): string | undefined {
+  if (!assetTypeName) return undefined;
+  return PORT_TO_ASSET_PREDICATE[assetTypeName];
+}
+
+/**
+ * Build the POST body for `/api/entity-relationships` from an asset and the
+ * owning port id. Returns `null` when the asset type has no port predicate
+ * in the ontology — caller should skip + warn rather than send the request.
+ */
+export function buildLinkAssetRequestBody(
+  asset: any,
+  portId: string,
+): { source_type: string; source_id: string; target_type: string; target_id: string; relationship_type: string } | null {
+  const predicate = selectPortAssetPredicate(asset?.asset_type_name);
+  if (!predicate) return null;
+  return {
+    source_type: 'OutputPort',
+    source_id: portId,
+    target_type: asset.asset_type_name,
+    target_id: asset.id,
+    relationship_type: predicate,
+  };
+}
 
 type CheckApiResponseFn = <T>(
   response: { data?: T | { detail?: string }, error?: string | null | undefined },
@@ -147,28 +337,21 @@ function PortLinkedAssets({ portId, portName, canEdit }: { portId: string; portN
     try {
       let linkedCount = 0;
       for (const asset of assets) {
-        const assetType = asset.asset_type_name;
-        // The picker is filtered to the keys of this map, but be defensive:
+        // The picker is filtered to deliverable types, but be defensive:
         // if an asset of an unsupported type slips through, skip + warn rather
         // than build a `portHas<X>` predicate that the backend will 422 on.
-        const predicate = assetType ? PORT_TO_ASSET_PREDICATE[assetType] : undefined;
-        if (!predicate) {
+        const body = buildLinkAssetRequestBody(asset, portId);
+        if (!body) {
           // eslint-disable-next-line no-console
           console.warn(
-            `[link-asset] Skipping asset ${asset.id}: type "${assetType}" has no port relationship in the ontology.`
+            `[link-asset] Skipping asset ${asset.id}: type "${asset.asset_type_name}" has no port relationship in the ontology.`
           );
           continue;
         }
         const res = await fetch('/api/entity-relationships', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            source_type: 'OutputPort',
-            source_id: portId,
-            target_type: assetType,
-            target_id: asset.id,
-            relationship_type: predicate,
-          }),
+          body: JSON.stringify(body),
         });
         if (!res.ok) throw new Error(`Failed to link asset: ${res.statusText}`);
         linkedCount += 1;
@@ -348,33 +531,24 @@ export default function DataProductDetails() {
   // Versioned editing: determine if product can be edited in place based on status
   // Products with status 'draft', 'sandbox', 'proposed' can be edited directly
   // Products with status 'active' and above must be cloned for editing
-  const canEditInPlace = product?.status && ['draft', 'sandbox', 'proposed', 'under_review', 'approved'].includes(product.status.toLowerCase());
-  const isPersonalDraft = product?.draftOwnerId != null;
-  const isReadOnly = !canAdmin && !canEditInPlace && !isPersonalDraft;
+  const canEditInPlace = isStatusEditableInPlace(product?.status);
+  const isPersonalDraft = isPersonalDraftProduct(product);
+  const isReadOnly = isProductReadOnly({ canAdmin, canEditInPlace, isPersonalDraft });
 
   // Combined permission check: admin can always edit; others need write + editable status
-  const canModify = canAdmin || (canWrite && (canEditInPlace || isPersonalDraft));
+  const canModify = canUserModifyProduct({ canAdmin, canWrite, canEditInPlace, isPersonalDraft });
 
   // View mode state for filtering sections - initialize from localStorage
-  const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    const stored = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
-    if (stored && ['minimal', 'medium', 'large'].includes(stored)) {
-      return stored as ViewMode;
-    }
-    return 'minimal';
-  });
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    () => parseStoredViewMode(localStorage.getItem(VIEW_MODE_STORAGE_KEY)) ?? 'minimal',
+  );
 
   const getDefaultViewMode = useCallback((): ViewMode => {
-    if (product?.owner_team_id && userInfo?.groups?.includes(product.owner_team_id)) {
-      return 'large';
-    }
-    const permissionLevel = getPermissionLevel('data-products');
-    if (permissionLevel === FeatureAccessLevel.READ_WRITE ||
-        permissionLevel === FeatureAccessLevel.ADMIN ||
-        permissionLevel === FeatureAccessLevel.FULL) {
-      return 'medium';
-    }
-    return 'minimal';
+    return computeDefaultViewMode({
+      ownerTeamId: product?.owner_team_id,
+      userGroups: userInfo?.groups,
+      permissionLevel: getPermissionLevel('data-products'),
+    });
   }, [product?.owner_team_id, userInfo?.groups, getPermissionLevel]);
 
   useEffect(() => {
@@ -406,22 +580,10 @@ export default function DataProductDetails() {
     product ? { type: 'data_product', name: product.name || 'Unnamed', id: productId || '' } : null,
   );
 
-  const formatDate = (dateString: string | undefined, fallback: string = 'N/A'): string => {
-    if (!dateString) return fallback;
-    try {
-      return new Date(dateString).toLocaleString();
-    } catch (e) {
-      return 'Invalid Date';
-    }
-  };
+  const formatDate = (dateString: string | undefined, fallback: string = 'N/A'): string =>
+    formatDateString(dateString, fallback);
 
-  const getStatusColor = (status: string | undefined): 'default' | 'secondary' | 'destructive' | 'outline' => {
-    const lowerStatus = status?.toLowerCase() || '';
-    if (lowerStatus === 'active') return 'default';
-    if (lowerStatus === 'draft' || lowerStatus === 'proposed') return 'secondary';
-    if (lowerStatus === 'retired' || lowerStatus === 'deprecated') return 'outline';
-    return 'default';
-  };
+  const getStatusColor = getStatusBadgeVariant;
 
   const fetchProductDetails = async () => {
     if (!productId) {
@@ -1231,18 +1393,8 @@ export default function DataProductDetails() {
     }
   };
 
-  const shouldShowSection = (section: string): boolean => {
-    switch (viewMode) {
-      case 'minimal':
-        return ['deliverables', 'description', 'hierarchy'].includes(section);
-      case 'medium':
-        return !['management-ports', 'support-channels', 'metadata-panel', 'ratings', 'costs', 'quality'].includes(section);
-      case 'large':
-        return true;
-      default:
-        return false;
-    }
-  };
+  const shouldShowSection = (section: string): boolean =>
+    shouldShowSectionForViewMode(viewMode, section);
 
   if (loading || permissionsLoading) {
     return <DetailViewSkeleton cards={5} actionButtons={5} />;
@@ -1265,7 +1417,11 @@ export default function DataProductDetails() {
     );
   }
 
-  const domainLabel = product.domain ? (getDomainName(product.domain) || product.domain) : t('common:states.notAssigned');
+  const domainLabel = resolveDomainLabel({
+    domain: product.domain,
+    resolveName: getDomainName,
+    notAssignedLabel: t('common:states.notAssigned'),
+  });
 
   return (
     <div className="py-6 space-y-6">
@@ -1308,7 +1464,7 @@ export default function DataProductDetails() {
           <Button variant="outline" onClick={() => setIsRequestDialogOpen(true)} size="sm">
             <KeyRound className="mr-2 h-4 w-4" /> Request...
           </Button>
-          {product.status?.toLowerCase() === 'active' && canApproveProductLifecycle && (
+          {isProductActive(product.status) && canApproveProductLifecycle && (
             <Button
               variant="outline"
               size="sm"
@@ -1321,7 +1477,7 @@ export default function DataProductDetails() {
               <ShieldCheck className="mr-2 h-4 w-4" /> Certify
             </Button>
           )}
-          {product.status?.toLowerCase() === 'active' && canWrite && (
+          {isProductActive(product.status) && canWrite && (
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
## Summary

Reported by a customer: linking a Catalog (or Schema) asset to a Data Product's output port returned **422** from `/api/entity-relationships`:

```
ValueError: Ontology does not allow relationship 'portHasTable' from 'OutputPort' to 'Catalog'
```

Confirmed scope decision with the team: the ontology intentionally models port-to-asset relationships only for *deliverable* asset types (Table, View, Dataset, APIEndpoint, MLModel) — **not** container types like Catalog or Schema. Catalogs and Schemas are organisational containers, not units a port "delivers." This PR makes the asset picker UX match that intent.

## Why this is a UX fix, not a security fix

The backend validator at `entity_relationships_manager.py:70-98` already returns 422 for any invalid (predicate, range) tuple. That's the security layer and it's correct as-is. This PR is purely about not surfacing options in the picker that would always fail at submit time — and not silently constructing nonsense predicates like `portHasCatalog` from a string template.

## Changes

- **`src/frontend/src/views/data-product-details.tsx`**
  - New exported `PORT_TO_ASSET_PREDICATE` map (5 entries — mirrors `ontos-ontology.ttl:838-891`)
  - `handleLinkAssets` now looks up the predicate via the map. If a caller somehow gets an unsupported asset through, the API call is skipped with a `console.warn` rather than constructing an invalid predicate string
  - `<AssetSelector>` invocation drops the misleading hardcoded `relationshipType="portHasTable"` (it was being stamped onto every selection regardless of asset type) and passes `targetAssetTypes={PORT_DELIVERABLE_ASSET_TYPES}` instead, so the picker filters its display to the 5 supported types
  - Description text updated to: *"Only deliverable asset types (Table, View, Dataset, API Endpoint, ML Model) can be linked to an output port."*

- **`src/frontend/src/views/data-product-details.test.tsx`** (new) — 10 tests covering the predicate map and selection logic for each supported type plus skip-on-unsupported behaviour
- **`src/frontend/src/components/common/asset-selector.test.tsx`** (new) — 3 component tests confirming Catalog/Schema rows are hidden when `targetAssetTypes` is set, backward compat preserved when omitted, and helper text rendered

## Verification

- Frontend tests: 413 pass / 6 pre-existing skips
- `yarn build` succeeds
- Backend validation unchanged — still returns 422 for any unsupported (predicate, range) tuple, confirming the security gate is intact

## Out of scope

- **Ontology extensions:** if/when port-to-Catalog or port-to-Schema relationships become a real product feature, the change would be (a) add new predicates to `ontos-ontology.ttl`, (b) add the new types to `PORT_TO_ASSET_PREDICATE`. Backend validator inherits the new tuples automatically. Not in this PR.
- Backend authorization model — unchanged.
