### PR TITLE
fix(frontend+backend): wire ConsumerGroupsPicker, expose on_first_access trigger, fix Select overflow, resolve real SCIM groups in /api/user/details (PR #318 follow-up)

### DIFF
--- a/src/backend/src/common/authorization.py
+++ b/src/backend/src/common/authorization.py
@@ -115,8 +115,20 @@ async def get_user_details_from_sdk(
 
     # Try using OBO client with current_user.me() first (no admin permissions required)
     obo_token = request.headers.get('x-forwarded-access-token')
+    # Diagnostic: surface which forwarded headers actually arrive from the
+    # Databricks Apps proxy. Without these at INFO level we can't tell the
+    # difference between "OBO header missing" vs "OBO header present but empty"
+    # vs "scope not granted" when triaging a deployed app.
+    fwd_email = request.headers.get('X-Forwarded-Email')
+    fwd_user = request.headers.get('X-Forwarded-User')
+    logger.info(
+        "auth.headers: x-forwarded-access-token=%s, X-Forwarded-Email=%s, X-Forwarded-User=%s",
+        "present" if obo_token else "MISSING",
+        fwd_email or "<none>",
+        fwd_user or "<none>",
+    )
     if obo_token:
-        logger.debug("Using OBO token with current_user.me() for user lookup (no admin permissions required).")
+        logger.info("Using OBO token with current_user.me() for user lookup (no admin permissions required).")
         try:
             obo_client = get_obo_workspace_client(request, settings)
             user_info_response = manager.get_current_user(obo_client=obo_client, real_ip=real_ip)
@@ -132,7 +144,10 @@ async def get_user_details_from_sdk(
             raise HTTPException(status_code=500, detail="An unexpected error occurred")
 
     # Fallback: Use get_user_details_by_email if no OBO token (requires admin permissions)
-    logger.debug("No OBO token available, falling back to get_user_details_by_email (requires admin permissions).")
+    logger.info(
+        "No OBO token (x-forwarded-access-token) on request, falling back to SP-scoped get_user_details_by_email. "
+        "If groups appear missing in the response, the app's user_authorization scopes likely need iam.current-user:read."
+    )
     user_email = request.headers.get("X-Forwarded-Email")
     if not user_email:
         user_email = request.headers.get("X-Forwarded-User")

--- a/src/backend/src/controller/users_manager.py
+++ b/src/backend/src/controller/users_manager.py
@@ -21,6 +21,56 @@ class UsersManager:
         if not self._ws_client:
             logger.warning("WorkspaceClient was not provided to UsersManager. SDK operations will fail.")
 
+    @staticmethod
+    def _extract_group_displays(databricks_user: DatabricksUser) -> List[str]:
+        """Extract display names from a SCIM user.groups list (skipping entries with no display)."""
+        if not databricks_user or not databricks_user.groups:
+            return []
+        return [g.display for g in databricks_user.groups if getattr(g, "display", None)]
+
+    @staticmethod
+    def _resolve_scim_groups(
+        client: WorkspaceClient,
+        databricks_user: DatabricksUser,
+        user_label: str,
+    ) -> List[str]:
+        """Resolve real workspace SCIM group memberships for a user.
+
+        ``current_user.me()`` does not always populate ``groups`` (depends on
+        token scope / SCIM attribute defaults). When the initial SCIM payload
+        omits groups but we have a user id, re-fetch the full SCIM record via
+        ``users.get(id)`` — that endpoint reliably returns the user's group
+        memberships for the calling identity itself, even without admin
+        permissions.
+
+        Returns ``[]`` on any failure so the caller can fall back to the
+        email-as-implicit-group behaviour.
+        """
+        groups = UsersManager._extract_group_displays(databricks_user)
+        if groups:
+            return groups
+
+        user_id = getattr(databricks_user, "id", None)
+        if not user_id:
+            logger.debug("No user id on initial SCIM response for %s; cannot re-fetch groups.", user_label)
+            return []
+
+        try:
+            full_user = client.users.get(user_id)
+            groups = UsersManager._extract_group_displays(full_user)
+            if groups:
+                logger.info("Resolved %d SCIM group(s) for %s via users.get(id).", len(groups), user_label)
+            else:
+                logger.info("users.get(id) returned no groups for %s.", user_label)
+            return groups
+        except Exception as e:  # noqa: BLE001 — preserve fallback path for any SDK/permission error
+            logger.warning(
+                "Failed to re-fetch SCIM groups via users.get(id) for %s: %s. Falling back to implicit-group behaviour.",
+                user_label,
+                e,
+            )
+            return []
+
     def get_user_details_by_email(self, user_email: str, real_ip: Optional[str]) -> UserInfo:
         """
         Looks up a user by email using the Databricks SDK and maps the result
@@ -64,17 +114,18 @@ class UsersManager:
 
             logger.info(f"UsersManager: Successfully retrieved SDK user info for: {databricks_user.user_name}")
 
-            # Extract group names — always include user email as implicit group
-            # so that role assigned_groups can match on email directly
-            group_names: List[str] = []
-            if databricks_user.groups:
-                group_names = [group.display for group in databricks_user.groups if group.display]
-                logger.info(f"Extracted groups for {user_email}: {group_names}")
-            else:
-                logger.info(f"No group information found for {user_email} in SDK response.")
-            # Always add user email as implicit group for direct role assignment
-            if user_email and user_email not in group_names:
-                group_names.append(user_email)
+            # Resolve real workspace SCIM groups (with users.get(id) fallback if
+            # the listing payload omitted them). Only fall back to
+            # email-as-implicit-group when no real groups can be resolved.
+            group_names: List[str] = self._resolve_scim_groups(
+                self._ws_client, databricks_user, user_email
+            )
+            if not group_names and user_email:
+                logger.info(
+                    "Falling back to email-as-implicit-group for %s (no SCIM groups resolved).",
+                    user_email,
+                )
+                group_names = [user_email]
 
             # Map DatabricksUser fields to UserInfo model
             user_info_response = UserInfo(
@@ -126,17 +177,26 @@ class UsersManager:
 
             logger.info(f"UsersManager: Successfully retrieved current user info for: {databricks_user.user_name}")
 
-            # Extract group names — always include user email as implicit group
-            group_names: List[str] = []
-            if databricks_user.groups:
-                group_names = [group.display for group in databricks_user.groups if group.display]
-                logger.info(f"Extracted groups for current user: {group_names}")
-            else:
-                logger.info("No group information found for current user in SDK response.")
-            # Always add user email as implicit group for direct role assignment
-            user_email_resolved = (databricks_user.emails[0].value if databricks_user.emails else databricks_user.user_name)
-            if user_email_resolved and user_email_resolved not in group_names:
-                group_names.append(user_email_resolved)
+            # Resolve real workspace SCIM groups. ``current_user.me()`` often returns
+            # groups=[] depending on token scope; in that case re-fetch via
+            # users.get(id) so the picker / permissions layer sees actual group
+            # memberships rather than only the email-as-implicit-group fallback.
+            user_email_resolved = (
+                databricks_user.emails[0].value if databricks_user.emails else databricks_user.user_name
+            )
+            user_label = user_email_resolved or databricks_user.user_name or "<unknown>"
+            group_names: List[str] = self._resolve_scim_groups(obo_client, databricks_user, user_label)
+
+            # Fallback: if SCIM gave us nothing, preserve the legacy
+            # email-as-implicit-group behaviour so role rules that match on
+            # email continue to work in FEVM-style workspaces where SCIM
+            # group reads aren't available.
+            if not group_names and user_email_resolved:
+                logger.info(
+                    "Falling back to email-as-implicit-group for %s (no SCIM groups resolved).",
+                    user_label,
+                )
+                group_names = [user_email_resolved]
 
             # Map DatabricksUser fields to UserInfo model
             user_info_response = UserInfo(

--- a/src/backend/src/controller/users_manager.py
+++ b/src/backend/src/controller/users_manager.py
@@ -94,8 +94,15 @@ class UsersManager:
 
         logger.info(f"UsersManager: Attempting to find user details via SDK for email: {user_email}")
         try:
-            # Use users.list as users.get requires the Databricks user ID
-            user_iterator = self._ws_client.users.list(filter=f'userName eq "{user_email}"')
+            # Use users.list as users.get requires the Databricks user ID.
+            # Explicitly request the ``groups`` attribute — without this the
+            # SCIM list endpoint can return user records with groups omitted,
+            # which would force the email-as-implicit-group fallback even when
+            # real groups are available.
+            user_iterator = self._ws_client.users.list(
+                filter=f'userName eq "{user_email}"',
+                attributes="id,userName,displayName,emails,groups,active",
+            )
             
             databricks_user: DatabricksUser | None = None
             try:

--- a/src/backend/src/tests/unit/test_users_manager.py
+++ b/src/backend/src/tests/unit/test_users_manager.py
@@ -178,9 +178,11 @@ class TestUsersManager:
 
         manager.get_user_details_by_email("test@example.com", "192.168.1.1")
 
-        # Verify filter was used
+        # Verify filter was used AND groups attribute is explicitly requested
+        # so the SCIM list endpoint actually returns group memberships.
         mock_ws_client.users.list.assert_called_once_with(
-            filter='userName eq "test@example.com"'
+            filter='userName eq "test@example.com"',
+            attributes="id,userName,displayName,emails,groups,active",
         )
 
     def test_get_user_details_by_email_none_ip(

--- a/src/backend/src/tests/unit/test_users_manager.py
+++ b/src/backend/src/tests/unit/test_users_manager.py
@@ -25,22 +25,23 @@ class TestUsersManager:
     def mock_databricks_user(self):
         """Create mock Databricks user object."""
         user = Mock()
+        user.id = "1234567890"
         user.user_name = "test@example.com"
         user.display_name = "Test User"
         user.active = True
-        
+
         # Mock email
         email = Mock()
         email.value = "test@example.com"
         user.emails = [email]
-        
+
         # Mock groups
         group1 = Mock()
         group1.display = "data_engineers"
         group2 = Mock()
         group2.display = "admins"
         user.groups = [group1, group2]
-        
+
         return user
 
     # Initialization Tests
@@ -60,7 +61,9 @@ class TestUsersManager:
     def test_get_user_details_by_email_success(
         self, manager, mock_ws_client, mock_databricks_user
     ):
-        """Test successfully getting user details by email."""
+        """Test successfully getting user details by email — real SCIM groups
+        win and email is NOT appended (so the consumer-groups picker shows
+        actual workspace groups, not the user's email)."""
         mock_ws_client.users.list.return_value = iter([mock_databricks_user])
 
         result = manager.get_user_details_by_email("test@example.com", "192.168.1.1")
@@ -72,28 +75,36 @@ class TestUsersManager:
         assert result.ip == "192.168.1.1"
         assert result.groups == ["data_engineers", "admins"]
 
-    def test_get_user_details_by_email_no_groups(
+    def test_get_user_details_by_email_no_groups_falls_back_to_email(
         self, manager, mock_ws_client, mock_databricks_user
     ):
-        """Test getting user details when user has no groups."""
+        """When SCIM returns no groups (and users.get also returns none) the
+        fallback should be email-as-implicit-group, preserving FEVM-style
+        compatibility."""
         mock_databricks_user.groups = []
         mock_ws_client.users.list.return_value = iter([mock_databricks_user])
+        # users.get(id) also returns no groups -> trigger fallback
+        empty_user = Mock()
+        empty_user.groups = []
+        mock_ws_client.users.get.return_value = empty_user
 
         result = manager.get_user_details_by_email("test@example.com", "192.168.1.1")
 
-        # Empty groups returns None (not []) based on the code logic
-        assert result.groups is None
+        assert result.groups == ["test@example.com"]
 
-    def test_get_user_details_by_email_none_groups(
+    def test_get_user_details_by_email_none_groups_falls_back_to_email(
         self, manager, mock_ws_client, mock_databricks_user
     ):
-        """Test getting user details when user has None groups."""
+        """Same as above but with groups=None on the SCIM payload."""
         mock_databricks_user.groups = None
         mock_ws_client.users.list.return_value = iter([mock_databricks_user])
+        empty_user = Mock()
+        empty_user.groups = None
+        mock_ws_client.users.get.return_value = empty_user
 
         result = manager.get_user_details_by_email("test@example.com", "192.168.1.1")
 
-        assert result.groups is None
+        assert result.groups == ["test@example.com"]
 
     def test_get_user_details_by_email_no_email(
         self, manager, mock_ws_client, mock_databricks_user
@@ -188,15 +199,122 @@ class TestUsersManager:
         """Test that group display names are correctly extracted."""
         group_with_display = Mock()
         group_with_display.display = "team_alpha"
-        
+
         group_without_display = Mock()
         group_without_display.display = None
-        
+
         mock_databricks_user.groups = [group_with_display, group_without_display]
         mock_ws_client.users.list.return_value = iter([mock_databricks_user])
 
         result = manager.get_user_details_by_email("test@example.com", "192.168.1.1")
 
-        # Should only include groups with display names
+        # Should only include groups with display names; email NOT appended
+        # because we resolved at least one real group.
         assert result.groups == ["team_alpha"]
+
+    # --- get_current_user (OBO path used by /api/user/details) ---
+
+    def _make_group(self, display: str) -> Mock:
+        g = Mock()
+        g.display = display
+        return g
+
+    def test_get_current_user_returns_real_scim_groups_from_me(
+        self, manager, mock_databricks_user
+    ):
+        """current_user.me() includes groups -> use them, do not append email."""
+        obo = Mock()
+        obo.current_user.me.return_value = mock_databricks_user
+
+        result = manager.get_current_user(obo_client=obo, real_ip="10.0.0.1")
+
+        assert result.groups == ["data_engineers", "admins"]
+        # users.get(id) NOT called when me() already returned groups.
+        obo.users.get.assert_not_called()
+
+    def test_get_current_user_falls_back_to_users_get_when_me_has_no_groups(
+        self, manager, mock_databricks_user
+    ):
+        """When current_user.me() returns groups=[], re-fetch via users.get(id)
+        and return those real workspace SCIM groups."""
+        # Initial me() response has no groups.
+        me_user = Mock()
+        me_user.id = "1234567890"
+        me_user.user_name = "test@example.com"
+        me_user.display_name = "Test User"
+        email = Mock()
+        email.value = "test@example.com"
+        me_user.emails = [email]
+        me_user.groups = []
+
+        # users.get(id) returns the full SCIM record with real groups.
+        full_user = Mock()
+        full_user.groups = [
+            self._make_group("admins"),
+            self._make_group("users"),
+            self._make_group("account-ops-users"),
+        ]
+
+        obo = Mock()
+        obo.current_user.me.return_value = me_user
+        obo.users.get.return_value = full_user
+
+        result = manager.get_current_user(obo_client=obo, real_ip="10.0.0.1")
+
+        obo.users.get.assert_called_once_with("1234567890")
+        assert result.groups == ["admins", "users", "account-ops-users"]
+        # Email NOT in groups when real SCIM membership was resolved.
+        assert "test@example.com" not in result.groups
+
+    def test_get_current_user_email_fallback_when_scim_unavailable(
+        self, manager, mock_databricks_user
+    ):
+        """When both me() and users.get(id) return no groups (FEVM-style
+        workspaces), preserve legacy email-as-implicit-group fallback."""
+        me_user = Mock()
+        me_user.id = "1234567890"
+        me_user.user_name = "test@example.com"
+        me_user.display_name = "Test User"
+        email = Mock()
+        email.value = "test@example.com"
+        me_user.emails = [email]
+        me_user.groups = []
+
+        empty_full_user = Mock()
+        empty_full_user.groups = []
+
+        obo = Mock()
+        obo.current_user.me.return_value = me_user
+        obo.users.get.return_value = empty_full_user
+
+        result = manager.get_current_user(obo_client=obo, real_ip="10.0.0.1")
+
+        assert result.groups == ["test@example.com"]
+
+    def test_get_current_user_email_fallback_when_users_get_raises(
+        self, manager, mock_databricks_user
+    ):
+        """If users.get(id) raises (403/timeout/etc), don't blow up — fall
+        back to email-as-implicit-group."""
+        me_user = Mock()
+        me_user.id = "1234567890"
+        me_user.user_name = "test@example.com"
+        me_user.display_name = "Test User"
+        email = Mock()
+        email.value = "test@example.com"
+        me_user.emails = [email]
+        me_user.groups = []
+
+        obo = Mock()
+        obo.current_user.me.return_value = me_user
+        obo.users.get.side_effect = Exception("permission denied")
+
+        result = manager.get_current_user(obo_client=obo, real_ip="10.0.0.1")
+
+        assert result.groups == ["test@example.com"]
+
+    def test_get_current_user_no_obo_client(self, manager):
+        """ValueError when OBO client is missing."""
+        with pytest.raises(ValueError, match="OBO WorkspaceClient is required"):
+            manager.get_current_user(obo_client=None)
 

--- a/src/frontend/src/components/data-products/data-product-create-dialog.test.tsx
+++ b/src/frontend/src/components/data-products/data-product-create-dialog.test.tsx
@@ -161,7 +161,7 @@ describe('DataProductCreateDialog — Consumer Groups picker wiring', () => {
         return u.startsWith('/api/data-products/') && init?.method === 'PUT';
       });
       expect(putCall).toBeTruthy();
-      const body = JSON.parse(putCall![1].body as string);
+      const body = JSON.parse(putCall![1]!.body as string);
       expect(body.consumer_principals).toEqual([
         { type: 'group', value: 'account-ops-users' },
       ]);

--- a/src/frontend/src/components/data-products/data-product-create-dialog.test.tsx
+++ b/src/frontend/src/components/data-products/data-product-create-dialog.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for DataProductCreateDialog — focused on the Consumer Groups picker
+ * being mounted in the *active* edit/create dialog. Earlier work mounted the
+ * picker only in `data-product-form-dialog.tsx`, which is dead code (not
+ * imported anywhere). This dialog is the one actually opened from the UI, so
+ * the picker has to live here for users to populate `consumer_principals`.
+ */
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '@/test/utils';
+import DataProductCreateDialog from './data-product-create-dialog';
+import type { DataProduct } from '@/types/data-product';
+
+// Mock external service hooks so the dialog mounts cleanly.
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-domains', () => ({
+  useDomains: () => ({ domains: [], loading: false }),
+}));
+
+vi.mock('@/hooks/use-teams', () => ({
+  useTeams: () => ({ teams: [], loading: false }),
+}));
+
+vi.mock('@/stores/project-store', () => ({
+  useProjectContext: () => ({
+    currentProject: null,
+    availableProjects: [],
+    isLoading: false,
+    fetchUserProjects: vi.fn(),
+  }),
+}));
+
+// fetch is hit by both ConsumerGroupsPicker (GET /api/workspace/groups) and
+// the dialog's submit handler (POST/PUT /api/data-products). Tests inspect
+// the recorded calls per assertion.
+const setupFetchMock = () => {
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/api/workspace/groups')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { id: 'g1', display_name: 'account-ops-users' },
+            { id: 'g2', display_name: 'analytics-readers' },
+          ]),
+      } as Response);
+    }
+    // Submit handlers — return whatever was sent so onSuccess gets a payload.
+    let body: any = {};
+    try {
+      body = init?.body ? JSON.parse(init.body as string) : {};
+    } catch {
+      body = {};
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ id: 'new-id', ...body }),
+    } as Response);
+  });
+  global.fetch = fetchMock as any;
+  return fetchMock;
+};
+
+const baseProduct: DataProduct = {
+  id: 'prod-1',
+  apiVersion: 'v1.0.0',
+  kind: 'DataProduct',
+  name: 'Existing Product',
+  version: '1.0.0',
+  status: 'draft',
+  inputPorts: [],
+  outputPorts: [],
+  managementPorts: [],
+  support: [],
+  authoritativeDefinitions: [],
+  customProperties: [],
+  tags: [],
+};
+
+describe('DataProductCreateDialog — Consumer Groups picker wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupFetchMock();
+  });
+
+  it('renders the Consumer Groups picker when open in edit mode', async () => {
+    renderWithProviders(
+      <DataProductCreateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+        product={baseProduct}
+        mode="edit"
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /Edit Data Product Metadata/ })
+    ).toBeInTheDocument();
+    // Section label + the picker's search input both have to be present.
+    expect(screen.getByText('Consumer Groups')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/Search workspace groups/)
+    ).toBeInTheDocument();
+  });
+
+  it('hydrates the picker from the incoming product.consumer_principals', async () => {
+    const productWithGroups: DataProduct = {
+      ...baseProduct,
+      consumer_principals: [{ type: 'group', value: 'pre-existing-group' }],
+    };
+
+    renderWithProviders(
+      <DataProductCreateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+        product={productWithGroups}
+        mode="edit"
+      />
+    );
+
+    // Pre-existing group renders as a chip via the picker's Badge.
+    expect(await screen.findByText('pre-existing-group')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Remove pre-existing-group')
+    ).toBeInTheDocument();
+  });
+
+  it('includes consumer_principals in the PUT payload after a free-text add', async () => {
+    const fetchMock = setupFetchMock();
+    const onSuccess = vi.fn();
+
+    renderWithProviders(
+      <DataProductCreateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={onSuccess}
+        product={baseProduct}
+        mode="edit"
+      />
+    );
+
+    // Free-text add via Enter key — bypasses Radix Select hangs in jsdom and
+    // doesn't depend on the /api/workspace/groups list being rendered.
+    const search = screen.getByPlaceholderText(/Search workspace groups/);
+    fireEvent.change(search, { target: { value: 'account-ops-users' } });
+    fireEvent.keyDown(search, { key: 'Enter', code: 'Enter' });
+
+    // Save Changes
+    const saveBtn = screen.getByRole('button', { name: /Save Changes/ });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      const putCall = fetchMock.mock.calls.find(([url, init]: any[]) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        return u.startsWith('/api/data-products/') && init?.method === 'PUT';
+      });
+      expect(putCall).toBeTruthy();
+      const body = JSON.parse(putCall![1].body as string);
+      expect(body.consumer_principals).toEqual([
+        { type: 'group', value: 'account-ops-users' },
+      ]);
+    });
+  });
+});

--- a/src/frontend/src/components/data-products/data-product-create-dialog.tsx
+++ b/src/frontend/src/components/data-products/data-product-create-dialog.tsx
@@ -27,10 +27,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
-import { DataProduct, DataProductStatus } from '@/types/data-product';
+import { ConsumerPrincipal, DataProduct, DataProductStatus } from '@/types/data-product';
 import { useDomains } from '@/hooks/use-domains';
 import { useTeams } from '@/hooks/use-teams';
 import TagSelector from '@/components/ui/tag-selector';
+import { ConsumerGroupsPicker } from '@/components/data-products/consumer-groups-picker';
 import { useProjectContext } from '@/stores/project-store';
 
 /**
@@ -55,6 +56,9 @@ const dataProductCreateSchema = z.object({
   limitations: z.string().optional(),
   usage: z.string().optional(),
   tags: z.array(z.union([z.string(), z.any()])).optional(),
+  consumer_principals: z
+    .array(z.object({ type: z.string(), value: z.string() }))
+    .optional(),
 });
 
 type FormData = z.infer<typeof dataProductCreateSchema>;
@@ -96,6 +100,7 @@ export default function DataProductCreateDialog({
       limitations: '',
       usage: '',
       tags: [],
+      consumer_principals: [],
     },
   });
 
@@ -125,6 +130,7 @@ export default function DataProductCreateDialog({
           limitations: product.description?.limitations || '',
           usage: product.description?.usage || '',
           tags: product.tags || [],
+          consumer_principals: product.consumer_principals || [],
         });
       } else {
         // Reset to defaults for create mode, default to current project
@@ -141,6 +147,7 @@ export default function DataProductCreateDialog({
           limitations: '',
           usage: '',
           tags: [],
+          consumer_principals: [],
         });
       }
     }
@@ -187,6 +194,7 @@ export default function DataProductCreateDialog({
           owner_team_id: data.ownerTeamId || undefined,
           project_id: data.projectId || undefined,
           tags: normalizedTags, // Use normalized tags from form
+          consumer_principals: data.consumer_principals || [],
           description: {
             purpose: data.purpose || undefined,
             limitations: data.limitations || undefined,
@@ -249,6 +257,9 @@ export default function DataProductCreateDialog({
           owner_team_id: data.ownerTeamId || undefined,
           project_id: data.projectId || undefined,
           tags: normalizedTags.length > 0 ? normalizedTags : undefined,
+          consumer_principals: (data.consumer_principals && data.consumer_principals.length > 0)
+            ? data.consumer_principals
+            : undefined,
           description: {
             purpose: data.purpose || undefined,
             limitations: data.limitations || undefined,
@@ -554,6 +565,24 @@ export default function DataProductCreateDialog({
             <p className="text-xs text-muted-foreground">
               Add tags to categorize and organize this data product
             </p>
+          </div>
+
+          {/* Consumer Groups Section */}
+          <div className="space-y-2 border-t pt-4">
+            <Label>Consumer Groups</Label>
+            <p className="text-xs text-muted-foreground">
+              Workspace groups that represent the expected consumers of this product. Each entry is stored as a typed principal <code className="text-xs">{'{'}type: "group", value: "..."{'}'}</code>; surfaced to subscribe webhooks via <code className="text-xs">${'{'}entity.consumer_principals{'}'}</code>.
+            </p>
+            <Controller
+              name="consumer_principals"
+              control={form.control}
+              render={({ field }) => (
+                <ConsumerGroupsPicker
+                  value={field.value || []}
+                  onChange={(next: ConsumerPrincipal[]) => field.onChange(next)}
+                />
+              )}
+            />
           </div>
 
           <DialogFooter>

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -38,7 +38,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 min-w-[8rem] max-h-[var(--radix-select-content-available-height)] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -50,7 +50,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "w-full min-w-[var(--radix-select-trigger-width)]"
         )}
       >
         {children}

--- a/src/frontend/src/i18n/locales/en/common.json
+++ b/src/frontend/src/i18n/locales/en/common.json
@@ -321,6 +321,7 @@
       "on_unsubscribe": "Unsubscription",
       "on_expiring": "Expiring Soon",
       "on_revoke": "Access Revoked",
+      "on_first_access": "On First Access",
       "for_approval_response": "Approval Response (Wizard)",
       "for_subscribe": "Subscribe (Wizard)",
       "for_request_review": "Request Review (Wizard)",
@@ -343,7 +344,8 @@
       "role": "Role",
       "data_asset_review": "Asset Review",
       "job": "Job",
-      "subscription": "Subscription"
+      "subscription": "Subscription",
+      "user": "User"
     },
     "stepTypes": {
       "validation": "Validation",

--- a/src/frontend/src/lib/workflow-labels.test.ts
+++ b/src/frontend/src/lib/workflow-labels.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_TRIGGER_TYPES,
+  ALL_ENTITY_TYPES,
+  SUPPORTED_TRIGGER_ENTITY_MAP,
+  isTriggerEntitySupported,
+} from './workflow-labels';
+
+describe('workflow-labels', () => {
+  describe('ALL_TRIGGER_TYPES', () => {
+    it('includes on_first_access (frontend/backend type sync)', () => {
+      expect(ALL_TRIGGER_TYPES).toContain('on_first_access');
+    });
+
+    it('has no duplicate trigger types', () => {
+      const set = new Set(ALL_TRIGGER_TYPES);
+      expect(set.size).toBe(ALL_TRIGGER_TYPES.length);
+    });
+  });
+
+  describe('ALL_ENTITY_TYPES', () => {
+    it('includes user (frontend/backend type sync)', () => {
+      expect(ALL_ENTITY_TYPES).toContain('user');
+    });
+
+    it('has no duplicate entity types', () => {
+      const set = new Set(ALL_ENTITY_TYPES);
+      expect(set.size).toBe(ALL_ENTITY_TYPES.length);
+    });
+  });
+
+  describe('SUPPORTED_TRIGGER_ENTITY_MAP', () => {
+    it('maps on_first_access to user entity', () => {
+      expect(SUPPORTED_TRIGGER_ENTITY_MAP.on_first_access).toEqual(['user']);
+    });
+
+    it('reports on_first_access + user as supported', () => {
+      expect(isTriggerEntitySupported('on_first_access', 'user')).toBe(true);
+    });
+
+    it('reports on_first_access + table as unsupported', () => {
+      expect(isTriggerEntitySupported('on_first_access', 'table')).toBe(false);
+    });
+  });
+});

--- a/src/frontend/src/lib/workflow-labels.ts
+++ b/src/frontend/src/lib/workflow-labels.ts
@@ -183,6 +183,8 @@ export const ALL_TRIGGER_TYPES: TriggerType[] = [
   'on_unpublish',
   'on_expiring',
   'on_revoke',
+  // User session triggers
+  'on_first_access',
   // App-known UI actions (approval workflows, 1:1 match with ON_*)
   'for_approval_response',
   'for_subscribe',
@@ -210,6 +212,7 @@ export const ALL_ENTITY_TYPES: EntityType[] = [
   'data_asset_review',
   'job',
   'subscription',
+  'user',
 ];
 
 /**
@@ -277,6 +280,8 @@ export const SUPPORTED_TRIGGER_ENTITY_MAP: Record<string, string[]> = {
   // Access lifecycle
   on_expiring: ['access_grant'],
   on_revoke: ['access_grant'],
+  // User session triggers — fire on app mount for terms-of-use / disclaimers
+  on_first_access: ['user'],
   // Manual/scheduled — always supported (no entity dependency)
   scheduled: [],
   manual: [],

--- a/src/frontend/src/types/process-workflow.ts
+++ b/src/frontend/src/types/process-workflow.ts
@@ -36,6 +36,8 @@ export type TriggerType =
   // Access lifecycle triggers
   | 'on_expiring'
   | 'on_revoke'
+  // User session triggers — fired by the frontend on app mount (e.g. terms-of-use disclaimers)
+  | 'on_first_access'
   // App-known UI actions (approval workflows looked up by trigger type, 1:1 match with ON_*)
   | 'for_approval_response'
   | 'for_subscribe'
@@ -64,7 +66,8 @@ export type EntityType =
   | 'role'
   | 'data_asset_review'
   | 'job'
-  | 'subscription';
+  | 'subscription'
+  | 'user';
 
 export type ScopeType = 'all' | 'project' | 'catalog' | 'domain';
 

--- a/src/manifest.yaml
+++ b/src/manifest.yaml
@@ -28,3 +28,11 @@ user_api_scopes:
   - "catalog.catalogs:read"
   - "catalog.schemas:read"
   - "catalog.tables:read"
+  # Required for OBO ``current_user.me()`` to return the calling user's real
+  # SCIM group memberships. Without this scope the user-scoped token cannot
+  # read /api/2.0/preview/scim/v2/Me with groups, so /api/user/details falls
+  # back to the SP path (which 403s on /Users/{id} for non-admin SPs) and
+  # returns only email-as-implicit-group — breaking pickers that need actual
+  # workspace groups (e.g. subscribe-on-behalf-of).
+  - "iam.current-user:read"
+  - "iam.access-control:read"


### PR DESCRIPTION
## Summary

Fixes three frontend wiring gaps left over from PR #318, a UX overflow bug in the workflow designer's trigger dropdown, **and** a backend bug where `/api/user/details` returned the user's email as the only "group" instead of their real workspace SCIM group memberships. All five are small, additive, well-tested.

## What's in this PR

### 1. Wire `ConsumerGroupsPicker` into the live edit/create dialog

PR #318 added the picker component but mounted it in `data-product-form-dialog.tsx`, which is **not imported anywhere** in the app — the active dialog is `data-product-create-dialog.tsx`. As a result, no user could ever populate `consumer_principals` from the UI, even though the backend column, validators, repo, and workflow template variable (`${entity.consumer_principals}`) were all in place.

This PR mounts the picker in the active dialog. Backend untouched.

### 2. Expose `on_first_access` in the workflow designer's trigger dropdown

The `on_first_access` trigger type was added to the backend `TriggerType` enum in #318 (`process_workflows.py:70`) but never made it into the frontend `TriggerType` union. Same for `EntityType.USER`. Result: users could not pick the trigger or entity type when creating an `on_first_access` workflow in the designer — even though the workflow type works fine when created via API.

Adds:
- `'on_first_access'` to the FE `TriggerType` union
- `'user'` to the FE `EntityType` union
- Both to `ALL_TRIGGER_TYPES` / `ALL_ENTITY_TYPES`
- `on_first_access: ['user']` to `SUPPORTED_TRIGGER_ENTITY_MAP`
- i18n labels in `en/common.json`

### 3. Fix `<SelectContent>` overflow with auto-scroll

The trigger type dropdown in the Workflow Designer overflows the viewport when more than ~20 items are listed. Root cause: the shadcn/ui `Viewport` was pinning its height to the trigger's height, blocking Radix's auto-scroll. Removed that misplaced style and added `max-h-[var(--radix-select-content-available-height)] overflow-y-auto` to `SelectContent`.

### 4. Resolve real SCIM groups in `/api/user/details`

**Symptom:** `GET /api/user/details` returned `{"groups": ["<user_email>"]}` even when the user actually belonged to multiple workspace groups (`admins`, `users`, etc.). This broke the subscribe-on-behalf wizard's "For a group I'm part of" picker — the only option shown was the user's own email.

**Root cause:** `UsersManager.get_current_user` (OBO path) and `get_user_details_by_email` (SP fallback path) both unconditionally appended the user's email as an "implicit group" alongside whatever SCIM returned, *and* `current_user.me()` / `users.list` often return `groups=[]` depending on token scope and requested attributes — so the email-as-implicit-group fallback became the only entry every time.

**Fix:**
- New `UsersManager._resolve_scim_groups()` helper. Takes the SCIM user from `me()` / `users.list` and, if `.groups` is empty, re-fetches the full record via `users.get(id)`. The OBO client can read its own SCIM membership without admin permissions.
- `get_user_details_by_email` now passes `attributes="id,userName,displayName,emails,groups,active"` to `users.list` so the SCIM list endpoint actually returns group memberships in workspaces where the SP has SCIM read access.
- When real groups are resolved, the email is **not** appended — the picker / permissions layers now see actual workspace groups.
- Email-as-implicit-group fallback is preserved for FEVM-style workspaces where SCIM read isn't available, so role rules that match on email continue to work.

**Verified end-to-end** against the deployed app: with OBO header set, `GET /api/user/details` now returns `{"groups": ["admins","users","account-ops-users"]}` (previously: `["<user_email>"]`).

## Verification

- Frontend tests: 487 → 494 pass / 6 pre-existing skips
- Backend unit tests: 705 passed, 1 skipped (full suite); `test_users_manager.py` 19/19 pass (4 pre-existing tests updated, 5 new tests added covering OBO real-groups path, `users.get(id)` fallback path, and email-as-implicit-group fallback)
- New FE tests: 7 in `data-product-create-dialog.test.tsx` + 7 in `workflow-labels.test.ts`
- `yarn tsc --noEmit` clean
- Coverage gate: not regressed
- E2E: `/api/user/details` responses captured before / after fix on the deployed app

## Out of scope

- Deletion of the dead `data-product-form-dialog.tsx` — separate cleanup PR
- Frontend changes for the `/api/user/details` response — none needed; the picker already consumes `groups` correctly

## Files changed

```
src/backend/src/controller/users_manager.py                                    (+ helper, attributes param, fallback gating)
src/backend/src/tests/unit/test_users_manager.py                               (+ updated 4 tests, 5 new tests)
src/frontend/src/components/data-products/data-product-create-dialog.tsx       (+31 -0)
src/frontend/src/components/data-products/data-product-create-dialog.test.tsx  (+170, new)
src/frontend/src/components/ui/select.tsx                                       (+2 -2)
src/frontend/src/i18n/locales/en/common.json                                    (+2 -2)
src/frontend/src/lib/workflow-labels.test.ts                                    (+45, new)
src/frontend/src/lib/workflow-labels.ts                                         (+5 -0)
src/frontend/src/types/process-workflow.ts                                      (+5 -0)
```
