### PR TITLE
fix(data-products): wire ConsumerGroupsPicker into the live edit/create dialog

### DIFF
--- a/src/frontend/src/components/data-products/data-product-create-dialog.test.tsx
+++ b/src/frontend/src/components/data-products/data-product-create-dialog.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for DataProductCreateDialog — focused on the Consumer Groups picker
+ * being mounted in the *active* edit/create dialog. Earlier work mounted the
+ * picker only in `data-product-form-dialog.tsx`, which is dead code (not
+ * imported anywhere). This dialog is the one actually opened from the UI, so
+ * the picker has to live here for users to populate `consumer_principals`.
+ */
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '@/test/utils';
+import DataProductCreateDialog from './data-product-create-dialog';
+import type { DataProduct } from '@/types/data-product';
+
+// Mock external service hooks so the dialog mounts cleanly.
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-domains', () => ({
+  useDomains: () => ({ domains: [], loading: false }),
+}));
+
+vi.mock('@/hooks/use-teams', () => ({
+  useTeams: () => ({ teams: [], loading: false }),
+}));
+
+vi.mock('@/stores/project-store', () => ({
+  useProjectContext: () => ({
+    currentProject: null,
+    availableProjects: [],
+    isLoading: false,
+    fetchUserProjects: vi.fn(),
+  }),
+}));
+
+// fetch is hit by both ConsumerGroupsPicker (GET /api/workspace/groups) and
+// the dialog's submit handler (POST/PUT /api/data-products). Tests inspect
+// the recorded calls per assertion.
+const setupFetchMock = () => {
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/api/workspace/groups')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { id: 'g1', display_name: 'account-ops-users' },
+            { id: 'g2', display_name: 'analytics-readers' },
+          ]),
+      } as Response);
+    }
+    // Submit handlers — return whatever was sent so onSuccess gets a payload.
+    let body: any = {};
+    try {
+      body = init?.body ? JSON.parse(init.body as string) : {};
+    } catch {
+      body = {};
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ id: 'new-id', ...body }),
+    } as Response);
+  });
+  global.fetch = fetchMock as any;
+  return fetchMock;
+};
+
+const baseProduct: DataProduct = {
+  id: 'prod-1',
+  apiVersion: 'v1.0.0',
+  kind: 'DataProduct',
+  name: 'Existing Product',
+  version: '1.0.0',
+  status: 'draft',
+  inputPorts: [],
+  outputPorts: [],
+  managementPorts: [],
+  support: [],
+  authoritativeDefinitions: [],
+  customProperties: [],
+  tags: [],
+};
+
+describe('DataProductCreateDialog — Consumer Groups picker wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupFetchMock();
+  });
+
+  it('renders the Consumer Groups picker when open in edit mode', async () => {
+    renderWithProviders(
+      <DataProductCreateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+        product={baseProduct}
+        mode="edit"
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /Edit Data Product Metadata/ })
+    ).toBeInTheDocument();
+    // Section label + the picker's search input both have to be present.
+    expect(screen.getByText('Consumer Groups')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/Search workspace groups/)
+    ).toBeInTheDocument();
+  });
+
+  it('hydrates the picker from the incoming product.consumer_principals', async () => {
+    const productWithGroups: DataProduct = {
+      ...baseProduct,
+      consumer_principals: [{ type: 'group', value: 'pre-existing-group' }],
+    };
+
+    renderWithProviders(
+      <DataProductCreateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+        product={productWithGroups}
+        mode="edit"
+      />
+    );
+
+    // Pre-existing group renders as a chip via the picker's Badge.
+    expect(await screen.findByText('pre-existing-group')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Remove pre-existing-group')
+    ).toBeInTheDocument();
+  });
+
+  it('includes consumer_principals in the PUT payload after a free-text add', async () => {
+    const fetchMock = setupFetchMock();
+    const onSuccess = vi.fn();
+
+    renderWithProviders(
+      <DataProductCreateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={onSuccess}
+        product={baseProduct}
+        mode="edit"
+      />
+    );
+
+    // Free-text add via Enter key — bypasses Radix Select hangs in jsdom and
+    // doesn't depend on the /api/workspace/groups list being rendered.
+    const search = screen.getByPlaceholderText(/Search workspace groups/);
+    fireEvent.change(search, { target: { value: 'account-ops-users' } });
+    fireEvent.keyDown(search, { key: 'Enter', code: 'Enter' });
+
+    // Save Changes
+    const saveBtn = screen.getByRole('button', { name: /Save Changes/ });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      const putCall = fetchMock.mock.calls.find(([url, init]: any[]) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        return u.startsWith('/api/data-products/') && init?.method === 'PUT';
+      });
+      expect(putCall).toBeTruthy();
+      const body = JSON.parse(putCall![1].body as string);
+      expect(body.consumer_principals).toEqual([
+        { type: 'group', value: 'account-ops-users' },
+      ]);
+    });
+  });
+});

--- a/src/frontend/src/components/data-products/data-product-create-dialog.tsx
+++ b/src/frontend/src/components/data-products/data-product-create-dialog.tsx
@@ -27,10 +27,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
-import { DataProduct, DataProductStatus } from '@/types/data-product';
+import { ConsumerPrincipal, DataProduct, DataProductStatus } from '@/types/data-product';
 import { useDomains } from '@/hooks/use-domains';
 import { useTeams } from '@/hooks/use-teams';
 import TagSelector from '@/components/ui/tag-selector';
+import { ConsumerGroupsPicker } from '@/components/data-products/consumer-groups-picker';
 import { useProjectContext } from '@/stores/project-store';
 
 /**
@@ -55,6 +56,9 @@ const dataProductCreateSchema = z.object({
   limitations: z.string().optional(),
   usage: z.string().optional(),
   tags: z.array(z.union([z.string(), z.any()])).optional(),
+  consumer_principals: z
+    .array(z.object({ type: z.string(), value: z.string() }))
+    .optional(),
 });
 
 type FormData = z.infer<typeof dataProductCreateSchema>;
@@ -96,6 +100,7 @@ export default function DataProductCreateDialog({
       limitations: '',
       usage: '',
       tags: [],
+      consumer_principals: [],
     },
   });
 
@@ -125,6 +130,7 @@ export default function DataProductCreateDialog({
           limitations: product.description?.limitations || '',
           usage: product.description?.usage || '',
           tags: product.tags || [],
+          consumer_principals: product.consumer_principals || [],
         });
       } else {
         // Reset to defaults for create mode, default to current project
@@ -141,6 +147,7 @@ export default function DataProductCreateDialog({
           limitations: '',
           usage: '',
           tags: [],
+          consumer_principals: [],
         });
       }
     }
@@ -187,6 +194,7 @@ export default function DataProductCreateDialog({
           owner_team_id: data.ownerTeamId || undefined,
           project_id: data.projectId || undefined,
           tags: normalizedTags, // Use normalized tags from form
+          consumer_principals: data.consumer_principals || [],
           description: {
             purpose: data.purpose || undefined,
             limitations: data.limitations || undefined,
@@ -249,6 +257,9 @@ export default function DataProductCreateDialog({
           owner_team_id: data.ownerTeamId || undefined,
           project_id: data.projectId || undefined,
           tags: normalizedTags.length > 0 ? normalizedTags : undefined,
+          consumer_principals: (data.consumer_principals && data.consumer_principals.length > 0)
+            ? data.consumer_principals
+            : undefined,
           description: {
             purpose: data.purpose || undefined,
             limitations: data.limitations || undefined,
@@ -554,6 +565,24 @@ export default function DataProductCreateDialog({
             <p className="text-xs text-muted-foreground">
               Add tags to categorize and organize this data product
             </p>
+          </div>
+
+          {/* Consumer Groups Section */}
+          <div className="space-y-2 border-t pt-4">
+            <Label>Consumer Groups</Label>
+            <p className="text-xs text-muted-foreground">
+              Workspace groups that represent the expected consumers of this product. Each entry is stored as a typed principal <code className="text-xs">{'{'}type: "group", value: "..."{'}'}</code>; surfaced to subscribe webhooks via <code className="text-xs">${'{'}entity.consumer_principals{'}'}</code>.
+            </p>
+            <Controller
+              name="consumer_principals"
+              control={form.control}
+              render={({ field }) => (
+                <ConsumerGroupsPicker
+                  value={field.value || []}
+                  onChange={(next: ConsumerPrincipal[]) => field.onChange(next)}
+                />
+              )}
+            />
           </div>
 
           <DialogFooter>


### PR DESCRIPTION
## Summary

Fixes a wiring gap from #318. The `ConsumerGroupsPicker` was mounted in `data-product-form-dialog.tsx`, which is **not imported anywhere** — the active dialog opened from `data-product-details.tsx` and `data-products.tsx` is `data-product-create-dialog.tsx`. As a result, users had no way to populate `consumer_principals` from the UI even though the backend (column, Pydantic models, repository, `${entity.consumer_principals}` workflow template variable) was already in place.

This PR mounts the picker in the active dialog so the round-trip works end-to-end.

## Changes

- `data-product-create-dialog.tsx`
  - Add `consumer_principals` to the form schema and default values
  - Hydrate from `product.consumer_principals` in edit mode
  - Include in both `POST /api/data-products` (create) and `PUT /api/data-products/{id}` (edit) payloads
  - Add a **Consumer Groups** section between **Tags** and **Save Changes** with the same description copy as the dead form-dialog (typed-principal explainer + `${entity.consumer_principals}` reference)
- `data-product-create-dialog.test.tsx` (new)
  - Picker renders when dialog opens in edit mode
  - Initial values from the product prop hydrate as chips
  - Submit payload includes `consumer_principals` after a free-text add
- No backend changes required.

## Test results

- `yarn tsc --noEmit` — clean
- `yarn test --run --coverage` — **403 passed | 6 skipped (409)**, function coverage **75.92%** (gate: 25%)
- New file adds 3 component tests, all green

## E2E verification (deployed app)

Verified against a deployment:

1. Synced changed frontend files to the workspace and ran `databricks apps deploy` — succeeded, app `RUNNING`.
2. `GET /api/data-products/{id}` — `consumer_principals: []` (clean draft).
3. `PUT /api/data-products/{id}` with body containing `consumer_principals: [{type: "group", value: "<group-name>"}]` — accepted, response echoes the principal.
4. `GET /api/data-products/{id}` again — value persisted.
5. `GET` after re-fetch shows the same shape that the picker emits — confirms the wire format dialog → API → DB → API → dialog matches end-to-end.

The deployed `data-product-create-dialog.tsx` in the workspace shows 11 references to `ConsumerGroupsPicker` / `consumer_principals` (vs 0 on `main`), confirming the synced code is the live code path.

## Out of scope

Deletion of the dead `data-product-form-dialog.tsx` (whose own test file is `describe.skip`) is intentionally not included here to keep the diff focused on the wiring fix. Will be addressed in a follow-up.
