### PR TITLE
feat(knowledge-graph): interactive controls for layout density and labels

### DIFF
--- a/src/backend/src/common/workspace_client.py
+++ b/src/backend/src/common/workspace_client.py
@@ -272,8 +272,15 @@ def _verify_workspace_client(ws: WorkspaceClient, skip_cluster_check: bool = Fal
             ws.clusters.select_spark_version()
             logger.info("Workspace connectivity verified successfully")
         except Exception as e:
-            logger.error(f"Failed to verify workspace connectivity: {e}")
-            raise
+            # Some workspaces (e.g. gov/restricted) deny clusters API to app SPs even
+            # when basic auth is fine. Fall back to current_user.me() before giving up.
+            logger.warning(f"Cluster API check failed ({e}); falling back to current_user.me()")
+            try:
+                ws.current_user.me()
+                logger.info("Workspace connectivity verified successfully (fallback mode)")
+            except Exception as fallback_e:
+                logger.error(f"Failed to verify workspace connectivity: {fallback_e}")
+                raise
 
     return ws
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tabs": "^1.1.3",

--- a/src/frontend/src/components/semantic-models/knowledge-graph.tsx
+++ b/src/frontend/src/components/semantic-models/knowledge-graph.tsx
@@ -20,7 +20,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { ZoomIn, ZoomOut, Maximize, RotateCcw, Expand, Group, Ungroup, ChevronDown, Tag } from 'lucide-react';
+import { ZoomIn, ZoomOut, Maximize, RotateCcw, Expand, Group, Ungroup, ChevronDown, Tag, Workflow, CircleDot, MoveHorizontal } from 'lucide-react';
+import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
 import {
   Dialog,
@@ -244,7 +245,10 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showDomainBoxes, setShowDomainBoxes] = useState(true);
-  const [showLabels, setShowLabels] = useState(false);
+  const [showNodeLabels, setShowNodeLabels] = useState(false);
+  const [showEdgeLabels, setShowEdgeLabels] = useState(false);
+  const [nodeSize, setNodeSize] = useState(24);
+  const [spacing, setSpacing] = useState(80);
   
   // Handler for toggling domain boxes
   const handleToggleDomainBoxes = useCallback(() => {
@@ -434,6 +438,8 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
               id: `edge_${concept.iri}_${childIri}`,
               source: concept.iri,
               target: childIri,
+              // Generic hierarchy relation; future: derive from RDF predicate when typed edges land.
+              label: 'subClassOf',
             },
             classes: 'hierarchy-edge',
           });
@@ -473,20 +479,20 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
         selector: '.concept-node',
         style: {
           'shape': 'ellipse',
-          'width': 24,
-          'height': 24,
+          'width': nodeSize,
+          'height': nodeSize,
           'background-color': 'data(color)',
           'border-width': 2,
           'border-color': isDarkMode ? 'rgba(30,30,30,0.8)' : 'rgba(255,255,255,0.9)',
-          'label': showLabels ? 'data(label)' : '',
+          'label': showNodeLabels ? 'data(label)' : '',
         },
       },
       // Concept node hover
       {
         selector: '.concept-node.hover',
         style: {
-          'width': 32,
-          'height': 32,
+          'width': nodeSize * 1.33,
+          'height': nodeSize * 1.33,
           'border-width': 3,
           'label': 'data(label)',
           'font-size': 13,
@@ -498,8 +504,8 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
       {
         selector: '.concept-node:selected',
         style: {
-          'width': 40,
-          'height': 40,
+          'width': nodeSize * 1.67,
+          'height': nodeSize * 1.67,
           'border-width': 4,
           'border-color': '#FFD700',
           'label': 'data(label)',
@@ -512,22 +518,22 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
         selector: '.property-node',
         style: {
           'shape': 'diamond',
-          'width': 20,
-          'height': 20,
+          'width': nodeSize * 0.83,
+          'height': nodeSize * 0.83,
         },
       },
       {
         selector: '.property-node.hover',
         style: {
-          'width': 28,
-          'height': 28,
+          'width': nodeSize * 1.17,
+          'height': nodeSize * 1.17,
         },
       },
       {
         selector: '.property-node:selected',
         style: {
-          'width': 36,
-          'height': 36,
+          'width': nodeSize * 1.5,
+          'height': nodeSize * 1.5,
         },
       },
       // Domain compound nodes (no label to avoid redundancy with contained nodes)
@@ -555,6 +561,14 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
           'arrow-scale': 0.8,
           'curve-style': 'bezier',
           'opacity': 0.6,
+          'label': showEdgeLabels ? 'data(label)' : '',
+          'font-size': 9,
+          'font-family': 'Inter, -apple-system, BlinkMacSystemFont, sans-serif',
+          'color': textColor,
+          'text-outline-width': 1,
+          'text-outline-color': textOutlineColor,
+          'text-rotation': 'autorotate',
+          'text-background-opacity': 0,
         },
       },
       // Edge hover
@@ -568,7 +582,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
         },
       },
     ];
-  }, [isDarkMode, showLabels]);
+  }, [isDarkMode, showNodeLabels, showEdgeLabels, nodeSize]);
 
   // Layout configurations
   const getLayoutConfig = useCallback((layoutName: LayoutType, animate = true): LayoutOptions => {
@@ -579,21 +593,25 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
       animationDuration: animate ? 500 : 0,
     };
 
+    // Scale layout-level spacing knobs from the single user slider (default 80).
+    const spacingFactor = (spacing / 80) * 1.5;
+
     switch (layoutName) {
       case 'circle':
         return {
           name: 'circle',
           ...baseConfig,
           avoidOverlap: true,
-          spacingFactor: 1.5,
+          spacingFactor,
         };
       case 'cose':
         return {
           name: 'cose',
           ...baseConfig,
-          idealEdgeLength: () => 80,
+          idealEdgeLength: () => spacing,
           nodeOverlap: 20,
-          nodeRepulsion: () => 400000,
+          // Preserves 80 → 400000 ratio so default behavior matches pre-slider.
+          nodeRepulsion: () => spacing * 5000,
           edgeElasticity: () => 100,
           nestingFactor: 5,
           gravity: 80,
@@ -608,7 +626,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
           name: 'grid',
           ...baseConfig,
           avoidOverlap: true,
-          avoidOverlapPadding: 10,
+          avoidOverlapPadding: Math.max(4, spacing / 8),
           condense: false,
         };
       case 'breadthfirst':
@@ -616,7 +634,7 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
           name: 'breadthfirst',
           ...baseConfig,
           directed: true,
-          spacingFactor: 1.5,
+          spacingFactor,
           avoidOverlap: true,
           maximal: false,
         };
@@ -625,14 +643,14 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
           name: 'concentric',
           ...baseConfig,
           avoidOverlap: true,
-          minNodeSpacing: 20,
+          minNodeSpacing: Math.max(8, spacing / 4),
           concentric: (node: any) => node.degree(),
           levelWidth: () => 2,
         };
       default:
         return { name: 'circle', ...baseConfig };
     }
-  }, []);
+  }, [spacing]);
 
   // Wire up event handlers
   useEffect(() => {
@@ -771,24 +789,96 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
           
           <Button
             variant={showDomainBoxes ? "secondary" : "ghost"}
-            size="icon"
-            className="h-8 w-8"
+            size="sm"
+            className="h-8 gap-1.5"
             onClick={handleToggleDomainBoxes}
             title={showDomainBoxes ? "Hide domain groups" : "Show domain groups"}
           >
             {showDomainBoxes ? <Group className="h-4 w-4" /> : <Ungroup className="h-4 w-4" />}
+            <span>Groups</span>
           </Button>
 
           <Button
-            variant={showLabels ? "secondary" : "ghost"}
-            size="icon"
-            className="h-8 w-8"
-            onClick={() => setShowLabels(prev => !prev)}
-            title={showLabels ? "Hide labels" : "Show labels"}
+            variant={showNodeLabels ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() => setShowNodeLabels(prev => !prev)}
+            title={showNodeLabels ? "Hide node labels" : "Show node labels"}
           >
             <Tag className="h-4 w-4" />
+            <span>Node labels</span>
           </Button>
-          
+
+          <Button
+            variant={showEdgeLabels ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() => setShowEdgeLabels(prev => !prev)}
+            title={showEdgeLabels ? "Hide edge labels" : "Show edge labels"}
+          >
+            <Workflow className="h-4 w-4" />
+            <span>Edge labels</span>
+          </Button>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-8 gap-1.5" title="Node size">
+                <CircleDot className="h-4 w-4" />
+                <span>Size</span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-64 p-3" align="start">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm font-medium">Node size</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground tabular-nums w-6 text-right">{nodeSize}</span>
+                  <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => setNodeSize(24)}>
+                    Reset
+                  </Button>
+                </div>
+              </div>
+              <Slider
+                value={[nodeSize]}
+                onValueChange={(v) => setNodeSize(v[0])}
+                min={12}
+                max={48}
+                step={2}
+                aria-label="Node size"
+              />
+            </PopoverContent>
+          </Popover>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-8 gap-1.5" title="Node spacing">
+                <MoveHorizontal className="h-4 w-4" />
+                <span>Spacing</span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-64 p-3" align="start">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm font-medium">Spacing</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground tabular-nums w-8 text-right">{spacing}</span>
+                  <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => setSpacing(80)}>
+                    Reset
+                  </Button>
+                </div>
+              </div>
+              <Slider
+                value={[spacing]}
+                onValueChange={(v) => setSpacing(v[0])}
+                min={40}
+                max={240}
+                step={10}
+                aria-label="Node spacing"
+              />
+              <p className="text-[10px] text-muted-foreground mt-2">
+                Re-runs layout. Affects edge length and node repulsion.
+              </p>
+            </PopoverContent>
+          </Popover>
+
           <Badge variant="secondary" className="text-xs">
             {graphData.elements.filter(e => e.classes?.includes('concept-node')).length} concepts
           </Badge>
@@ -877,22 +967,91 @@ export const KnowledgeGraph: React.FC<KnowledgeGraphProps> = ({
                 </Select>
                 <Button
                   variant={showDomainBoxes ? "secondary" : "ghost"}
-                  size="icon"
-                  className="h-8 w-8"
+                  size="sm"
+                  className="h-8 gap-1.5"
                   onClick={handleToggleDomainBoxes}
                   title={showDomainBoxes ? "Hide domain groups" : "Show domain groups"}
                 >
                   {showDomainBoxes ? <Group className="h-4 w-4" /> : <Ungroup className="h-4 w-4" />}
+                  <span>Groups</span>
                 </Button>
                 <Button
-                  variant={showLabels ? "secondary" : "ghost"}
-                  size="icon"
-                  className="h-8 w-8"
-                  onClick={() => setShowLabels(prev => !prev)}
-                  title={showLabels ? "Hide labels" : "Show labels"}
+                  variant={showNodeLabels ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-8 gap-1.5"
+                  onClick={() => setShowNodeLabels(prev => !prev)}
+                  title={showNodeLabels ? "Hide node labels" : "Show node labels"}
                 >
                   <Tag className="h-4 w-4" />
+                  <span>Node labels</span>
                 </Button>
+                <Button
+                  variant={showEdgeLabels ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-8 gap-1.5"
+                  onClick={() => setShowEdgeLabels(prev => !prev)}
+                  title={showEdgeLabels ? "Hide edge labels" : "Show edge labels"}
+                >
+                  <Workflow className="h-4 w-4" />
+                  <span>Edge labels</span>
+                </Button>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-8 gap-1.5" title="Node size">
+                      <CircleDot className="h-4 w-4" />
+                      <span>Size</span>
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64 p-3" align="end">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-sm font-medium">Node size</span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground tabular-nums w-6 text-right">{nodeSize}</span>
+                        <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => setNodeSize(24)}>
+                          Reset
+                        </Button>
+                      </div>
+                    </div>
+                    <Slider
+                      value={[nodeSize]}
+                      onValueChange={(v) => setNodeSize(v[0])}
+                      min={12}
+                      max={48}
+                      step={2}
+                      aria-label="Node size"
+                    />
+                  </PopoverContent>
+                </Popover>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-8 gap-1.5" title="Node spacing">
+                      <MoveHorizontal className="h-4 w-4" />
+                      <span>Spacing</span>
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64 p-3" align="end">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-sm font-medium">Spacing</span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground tabular-nums w-8 text-right">{spacing}</span>
+                        <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => setSpacing(80)}>
+                          Reset
+                        </Button>
+                      </div>
+                    </div>
+                    <Slider
+                      value={[spacing]}
+                      onValueChange={(v) => setSpacing(v[0])}
+                      min={40}
+                      max={240}
+                      step={10}
+                      aria-label="Node spacing"
+                    />
+                    <p className="text-[10px] text-muted-foreground mt-2">
+                      Re-runs layout. Affects edge length and node repulsion.
+                    </p>
+                  </PopoverContent>
+                </Popover>
                 <Badge variant="secondary" className="text-xs">
                   {graphData.elements.filter(e => e.classes?.includes('concept-node')).length} concepts
                 </Badge>

--- a/src/frontend/src/components/ui/slider.tsx
+++ b/src/frontend/src/components/ui/slider.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1410,6 +1410,23 @@
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
 
+"@radix-ui/react-slider@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.3.6.tgz#409453110b8f34ca00972750b80cd792f0b23a8c"
+  integrity sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==
+  dependencies:
+    "@radix-ui/number" "1.1.1"
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-slot@1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"


### PR DESCRIPTION
## Summary

Adds five new toolbar controls to the Semantic Models knowledge graph so users can tune readability without leaving the canvas:

- **Node labels** toggle (now with visible text label)
- **Edge labels** toggle — renders `subClassOf` along hierarchy edges
- **Size** slider (12–48 px) — scales concept and property nodes live, no relayout
- **Spacing** slider (40–240) — drives `cose` `idealEdgeLength` + `nodeRepulsion`, plus `spacingFactor` for circle/breadthfirst/concentric
- **Groups** toggle (renamed from icon-only Group/Ungroup for clarity)

Both the main toolbar and the fullscreen header share state and expose the same controls.

<img src="https://raw.githubusercontent.com/databrickslabs/ontos/media/kg-controls.png" alt="Knowledge graph controls" />

### Other changes

- `_verify_workspace_client` falls back to `current_user.me()` when the clusters API is denied (restricted/gov workspaces), preventing unnecessary startup failures.
- Adds Shadcn `Slider` primitive (`@radix-ui/react-slider`).

## Test plan

- [ ] All five new controls appear in toolbar
- [ ] Toggle node/edge labels independently
- [ ] Size slider resizes live, no layout re-run
- [ ] Spacing slider re-runs layout on each layout type (Force-Directed, Circular, Hierarchical, Concentric, Grid)
- [ ] Fullscreen mirrors all controls and shares state
- [ ] Dark + light mode legibility for edge labels

Live demo: https://ontos-wy-1444828305810485.aws.databricksapps.com