### PR TITLE
fix(settings): restore skipped accumulator and demo-foundation DELETEs in clear_demo_data

### DIFF
--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -615,6 +615,17 @@ async def clear_demo_data(
             "DELETE FROM assets WHERE id::text LIKE '0f8%'",
             # Delivery Channel assets (0f9%)
             "DELETE FROM assets WHERE id::text LIKE '0f9%'",
+            # Business Owners — must be removed before business_roles because
+            # of the role_id FK. Retail uses the 0f6% prefix; the vertical
+            # packs (hls/fsi/mfg/auto) use 0fb%.
+            "DELETE FROM business_owners WHERE id::text LIKE '0f6%'",
+            "DELETE FROM business_owners WHERE id::text LIKE '0fb%'",
+            # Vertical-specific demo asset types (0f2%, is_system=false)
+            "DELETE FROM asset_types WHERE id::text LIKE '0f2%' AND is_system = false AND created_by = 'system@demo'",
+            # Demo-inserted business_roles and delivery_methods — scoped by
+            # created_by to avoid touching app-seeded reference rows.
+            "DELETE FROM business_roles WHERE id::text LIKE '0f0%' AND created_by = 'system@demo'",
+            "DELETE FROM delivery_methods WHERE id::text LIKE '0f4%' AND created_by = 'system@demo'",
             # Note: legacy dataset_subscriptions / dataset_custom_properties /
             # dataset_instances / datasets tables were dropped by migration
             # c1_drop_legacy_dataset_tables.py — no DELETEs needed.
@@ -688,14 +699,25 @@ async def clear_demo_data(
         # subsequent deletes. Accumulate rowcounts per table since several
         # patterns target the same table (e.g. entity_relationships).
         deleted_counts: Dict[str, int] = {}
+        skipped: List[Dict[str, str]] = []
         for stmt in delete_statements:
             table_name = stmt.split("FROM ")[1].split(" ")[0]
             try:
                 with db.begin_nested():
                     result = db.execute(text(stmt))
-                deleted_counts[table_name] = deleted_counts.get(table_name, 0) + (result.rowcount or 0)
+                rowcount = result.rowcount or 0
+                if rowcount > 0:
+                    deleted_counts[table_name] = deleted_counts.get(table_name, 0) + rowcount
             except Exception as e:
-                logger.warning(f"Delete statement warning ({table_name}): {e}")
+                err_short = str(e).splitlines()[0][:200]
+                logger.warning(
+                    f"Delete statement FAILED ({table_name}): {err_short} | stmt={stmt}"
+                )
+                skipped.append({
+                    "table": table_name,
+                    "statement": stmt,
+                    "error": err_short,
+                })
         
         db.commit()
 


### PR DESCRIPTION
## Summary

PR #342 refactored `clear_demo_data` to use `with db.begin_nested():` and drop the obsolete legacy `dataset_*` DELETEs, but inadvertently broke three things:

1. **NameError crash.** Removed the `skipped: List[Dict[str, str]] = []` initialization while leaving four references intact below the loop. Every call to `DELETE /api/settings/demo-data` now 500s with:

   ```
   NameError: name 'skipped' is not defined
   ```

   The deletes actually happen (committed before the NameError fires) but the client gets a misleading 500.

2. **Coverage regression.** Dropped five legitimate demo-foundation DELETEs from #331's standalone-presets work, so vertical packs (hls/fsi/mfg/auto) leave residue after clear:
   - `business_owners` `0f6%` (retail) / `0fb%` (verticals)
   - `asset_types` `0f2%` (demo-only, `is_system=false`)
   - `business_roles` `0f0%` (demo-only, `created_by='system@demo'`)
   - `delivery_methods` `0f4%` (demo-only, `created_by='system@demo'`)

3. **Silent-failure regression.** Removed the `skipped` array surfacing in the API response, so future regressions like this one became invisible to the consumer.

This PR restores all three behaviors while keeping #342's cleaner `with db.begin_nested():` style (the context manager auto-rolls the savepoint on exception, so no manual rollback is needed).

## Changes

- `src/backend/src/routes/settings_routes.py`:
  - Re-introduce `skipped: List[Dict[str, str]] = []` accumulator and structured failure capture in the DELETE loop.
  - Re-add the five missing demo-foundation DELETEs in correct FK order (owners before roles).
  - Response now includes `skipped` array and `status: "partial"` when any DELETE fails.

## Test plan

Verified locally via REST:

- [x] `DELETE /api/settings/demo-data` on empty DB returns 200 with empty deleted_counts and skipped (no NameError).
- [x] `POST /api/settings/demo-data/load?preset=hls` returns 200, 39 SQL statements executed.
- [x] `DELETE /api/settings/demo-data` after HLS load returns 200 with **233 records deleted across 38 tables**, including the five previously-missing foundation tables: `business_owners` 5, `asset_types` 3, `business_roles` 5, `delivery_methods` 4. `skipped: []`.

## Optional follow-up

Add a unit test that verifies the `clear_demo_data` response shape includes `skipped` and `deleted_counts` — would have caught #342's NameError pre-merge.