### PR TITLE
ci(codecov): fix flag path mapping so frontend coverage is reported

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,42 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: backend
+      paths:
+        - src/backend/
+    - name: frontend
+      paths:
+        - src/frontend/
+
+# Test runners emit paths relative to their working directory, not the repo
+# root, so Codecov can't resolve them against the file tree:
+#   - vitest runs from src/frontend  → "src/app.tsx"
+#   - pytest runs from src           → "backend/src/..."
+# Rewrite both back to repo-root paths.
+fixes:
+  - "src/::src/frontend/src/"
+  - "backend/::src/backend/"
+
+ignore:
+  - "**/node_modules/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "src/frontend/src/test/**"
+  - "src/frontend/src/components/ui/**"


### PR DESCRIPTION
## Summary
- Frontend coverage badge in the README was rendering blank because Codecov could not resolve vitest's `src/`-relative paths against the repo root (real frontend tree is `src/frontend/src/`).
- Add `codecov.yml` with path fixes, flag scoping, `node_modules` ignores, and informational PR status so coverage is reported correctly without blocking PRs while baseline ratchets toward the 80% goal in `vitest.config.ts`.

## Why
vitest and pytest emit lcov/xml paths relative to their own working directory, not the repo root. Backend (`backend/src/...`) happened to match via Codecov's suffix heuristic, but frontend (`src/app.tsx`) was too ambiguous and resolved to 0% coverage.

## What changed
- `fixes:` rewrite `src/` → `src/frontend/src/` and `backend/` → `src/backend/`
- `flag_management:` scope backend/frontend flags to their real source trees (defense in depth against cross-flag leakage)
- `ignore:` drop `node_modules` entries v8 coverage emits (these were 1343 of 1736 SF records in the frontend lcov)
- `coverage.status.*.informational: true` — stop posting failing PR checks while baseline catches up

## Validation
- Config validated against https://codecov.io/validate
- One file changed, +42 lines, no source/test changes

## Test plan
- [ ] Merge and verify the next Codecov upload shows non-zero `frontend` flag coverage
- [ ] Confirm the README frontend badge renders a real percentage
- [ ] Confirm PR Codecov check shows as informational (no failing status)

This pull request and its description were written by Isaac.