### PR TITLE
ci: add optional manual deploy workflow

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,94 @@
+name: Deploy to Test Workspace
+
+# Optional, manually-triggered deploy of Ontos to a Databricks workspace.
+# Run from the Actions tab → "Deploy to Test Workspace" → "Run workflow".
+#
+# Workspace selection is driven by GitHub Environments. Each Environment supplies:
+#   var    DATABRICKS_HOST   — workspace URL (e.g. https://...cloud.databricks.com)
+#   secret DATABRICKS_TOKEN  — PAT (or OAuth M2M token) for that workspace
+#
+# To add a new workspace: create a new Environment in repo Settings → Environments,
+# set the host/token, and add its name to the `environment` choice list below.
+#
+# Notes on what this workflow does NOT do:
+#   - Does not build the frontend. Databricks Apps detects package.json on the
+#     workspace side and runs `npm install` + `npm run build` at deploy time
+#     (see scripts/build_static.sh). The frontend-build job in test-coverage.yml
+#     already gates build correctness on every push/PR to main.
+#   - Does not install Python deps. `databricks bundle deploy` uploads source;
+#     the workspace builds the app from there.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment (selects workspace host + token)"
+        type: choice
+        options:
+          - ontos-test
+        default: ontos-test
+      target:
+        description: "Bundle target (from src/databricks.yaml)"
+        type: choice
+        options: [dev, prod]
+        default: dev
+      start_app:
+        description: "Start the app after deploy (databricks bundle run)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ inputs.environment }}-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 15
+
+    env:
+      DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+      BUNDLE_TARGET: ${{ inputs.target }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Verify auth
+        run: |
+          databricks current-user me \
+            | jq -r '"Authenticated as: \(.userName) on \(env.DATABRICKS_HOST)"'
+
+      - name: Validate bundle
+        working-directory: src
+        run: databricks bundle validate -t "$BUNDLE_TARGET"
+
+      - name: Deploy bundle
+        working-directory: src
+        run: databricks bundle deploy -t "$BUNDLE_TARGET"
+
+      - name: Start app
+        if: ${{ inputs.start_app }}
+        working-directory: src
+        run: databricks bundle run -t "$BUNDLE_TARGET" ontos
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Ontos deploy"
+            echo ""
+            echo "- **Environment:** ${{ inputs.environment }}"
+            echo "- **Workspace:**   ${DATABRICKS_HOST}"
+            echo "- **Target:**      ${BUNDLE_TARGET}"
+            echo "- **App started:** ${{ inputs.start_app }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-test.yml` — a `workflow_dispatch`-only GitHub Action for ad-hoc deploys of Ontos to a Databricks workspace.
- Workspace selection is driven by GitHub Environments, so adding a new target workspace later is just "create another Environment" — no workflow edit needed.
- Does not run on push or pull_request. Manual only.

## How workspace selection works
Each target workspace is a GitHub Environment that supplies:
- `var DATABRICKS_HOST` — workspace URL
- `secret DATABRICKS_TOKEN` — PAT or OAuth M2M token

To add another workspace later: create a new Environment in repo Settings → Environments, populate the host/token, then add its name to the workflow's `environment` choice input.

## Steps the workflow runs
1. Checkout
2. Install Databricks CLI (`databricks/setup-cli@main`)
3. Verify auth (`databricks current-user me`)
4. `databricks bundle validate -t <target>`
5. `databricks bundle deploy -t <target>`
6. Optional `databricks bundle run -t <target> ontos` (toggleable input)

## What's deliberately not here
- **No frontend build.** Databricks Apps detects `package.json` at deploy time and runs `npm install` + `npm run build` on the workspace side. The existing `frontend-build` job in `test-coverage.yml` already gates build correctness on every push/PR to `main`.
- **No Python deps install.** `databricks bundle deploy` uploads source; the workspace builds the runtime from there.
- **`ubuntu-latest` runner, not the protected runner group + JFrog mirrors.** Manual deploy doesn't install pip/npm packages, so the JFrog plumbing isn't needed. Happy to switch if there's a policy reason.

## Bootstrap (one-time, requires repo admin)
Before the first run:
1. Settings → Environments → New environment → `ontos-test`
2. Add variable `DATABRICKS_HOST` = `https://fevm-ontos-v1-test.cloud.databricks.com`
3. Add secret `DATABRICKS_TOKEN` = PAT for that workspace (or OAuth M2M token)

## Test plan
- [ ] Merge
- [ ] Create the `ontos-test` Environment per Bootstrap
- [ ] Actions tab → "Deploy to Test Workspace" → Run workflow → defaults (ontos-test / dev / start_app: true)
- [ ] Verify auth step prints expected user
- [ ] Verify bundle deploy completes and app starts in the workspace

This pull request and its description were written by Isaac.