### PR TITLE
ci: extract JFrog auth + Python/Node setup into composite actions

### DIFF
--- a/.github/actions/jfrog-auth/action.yml
+++ b/.github/actions/jfrog-auth/action.yml
@@ -1,0 +1,29 @@
+name: "Fetch JFrog OIDC token"
+description: >
+  Exchanges the GitHub Actions OIDC token for a JFrog access token and exports
+  JFROG_ACCESS_TOKEN to the workflow environment. Subsequent steps in the same
+  job can read it from $JFROG_ACCESS_TOKEN to configure pip/uv/npm against
+  databricks.jfrog.io.
+
+runs:
+  using: composite
+  steps:
+    - name: Get JFrog OIDC token
+      shell: bash
+      run: |
+        set -euo pipefail
+        ID_TOKEN=$(curl -sLS \
+          -H "User-Agent: actions/oidc-client" \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+        echo "::add-mask::${ID_TOKEN}"
+        ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+          "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+          -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+        echo "::add-mask::${ACCESS_TOKEN}"
+        if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+          echo "FAIL: Could not extract JFrog access token"
+          exit 1
+        fi
+        echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+        echo "JFrog OIDC token obtained successfully"

--- a/.github/actions/setup-node-jfrog/action.yml
+++ b/.github/actions/setup-node-jfrog/action.yml
@@ -1,0 +1,42 @@
+name: "Set up Node with JFrog npm + yarn.lock rewrite"
+description: >
+  Fetches a JFrog OIDC token, writes ~/.npmrc to authenticate against
+  databricks.jfrog.io npm, rewrites src/frontend/yarn.lock so yarn 1
+  --frozen-lockfile fetches tarballs through JFrog, then sets up Node.
+
+inputs:
+  node-version:
+    description: "Node version (e.g., '24')"
+    required: true
+  yarn-lock-path:
+    description: "Path to the yarn.lock that yarn cache + URL rewrite should target"
+    required: false
+    default: ./src/frontend/yarn.lock
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/jfrog-auth
+
+    - name: Configure npm via JFrog
+      shell: bash
+      run: |
+        set -euo pipefail
+        cat > ~/.npmrc << EOF
+        registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+        //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
+        always-auth=true
+        EOF
+        echo "npm configured to use JFrog registry"
+        # yarn 1 with --frozen-lockfile honors `resolved` URLs in yarn.lock,
+        # bypassing the configured registry. Rewrite them to JFrog so CI
+        # (which has no egress to registry.yarnpkg.com) can fetch tarballs.
+        sed -i 's|https://registry.yarnpkg.com/|https://databricks.jfrog.io/artifactory/api/npm/db-npm/|g' "${{ inputs.yarn-lock-path }}"
+        echo "yarn.lock registry URLs rewritten for JFrog"
+
+    - name: Set up Node
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+        cache-dependency-path: ${{ inputs.yarn-lock-path }}

--- a/.github/actions/setup-python-jfrog/action.yml
+++ b/.github/actions/setup-python-jfrog/action.yml
@@ -1,0 +1,44 @@
+name: "Set up Python with JFrog pip/uv"
+description: >
+  Fetches a JFrog OIDC token, sets up Python, and configures either pip or uv
+  to install packages from databricks.jfrog.io/artifactory/api/pypi/db-pypi.
+
+inputs:
+  python-version:
+    description: "Python version (e.g., '3.10', '3.11')"
+    required: true
+  installer:
+    description: "Which package installer to point at JFrog: pip, uv, or none"
+    required: false
+    default: pip
+  cache:
+    description: "Cache key for actions/setup-python (e.g., 'pip', or empty to disable)"
+    required: false
+    default: pip
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/jfrog-auth
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: ${{ inputs.cache }}
+
+    - name: Configure pip via JFrog
+      if: inputs.installer == 'pip'
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+        echo "pip configured to use JFrog registry"
+
+    - name: Configure uv via JFrog
+      if: inputs.installer == 'uv'
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "UV_DEFAULT_INDEX=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+        echo "uv configured to use JFrog registry"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -23,36 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-
-      - name: Configure pip
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip configured to use JFrog registry"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: ./.github/actions/setup-python-jfrog
         with:
           python-version: '3.10'
-          cache: 'pip'
 
       - name: Install dependencies
         working-directory: ./src
@@ -120,46 +93,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-
-      - name: Configure npm
-        run: |
-          set -euo pipefail
-          cat > ~/.npmrc << EOF
-          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
-          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
-          always-auth=true
-          EOF
-          echo "npm configured to use JFrog registry"
-          # yarn 1 with --frozen-lockfile honors `resolved` URLs in yarn.lock,
-          # bypassing the configured registry. Rewrite them to JFrog so CI
-          # (which has no egress to registry.yarnpkg.com) can fetch tarballs.
-          sed -i 's|https://registry.yarnpkg.com/|https://databricks.jfrog.io/artifactory/api/npm/db-npm/|g' src/frontend/yarn.lock
-          echo "yarn.lock registry URLs rewritten for JFrog"
-
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup-node-jfrog
         with:
           node-version: '24'
-          cache: 'yarn'
-          cache-dependency-path: './src/frontend/yarn.lock'
 
       - name: Install dependencies
         working-directory: ./src/frontend
@@ -218,58 +154,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-
-      - name: Configure pip
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip configured to use JFrog registry"
-
-      - name: Configure npm
-        run: |
-          set -euo pipefail
-          cat > ~/.npmrc << EOF
-          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
-          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
-          always-auth=true
-          EOF
-          echo "npm configured to use JFrog registry"
-          # yarn 1 with --frozen-lockfile honors `resolved` URLs in yarn.lock,
-          # bypassing the configured registry. Rewrite them to JFrog so CI
-          # (which has no egress to registry.yarnpkg.com) can fetch tarballs.
-          sed -i 's|https://registry.yarnpkg.com/|https://databricks.jfrog.io/artifactory/api/npm/db-npm/|g' src/frontend/yarn.lock
-          echo "yarn.lock registry URLs rewritten for JFrog"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: ./.github/actions/setup-python-jfrog
         with:
           python-version: '3.11'
-          cache: 'pip'
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup-node-jfrog
         with:
           node-version: '24'
-          cache: 'yarn'
-          cache-dependency-path: './src/frontend/yarn.lock'
 
       - name: Install backend dependencies
         working-directory: ./src
@@ -367,46 +258,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-
-      - name: Configure npm
-        run: |
-          set -euo pipefail
-          cat > ~/.npmrc << EOF
-          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
-          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
-          always-auth=true
-          EOF
-          echo "npm configured to use JFrog registry"
-          # yarn 1 with --frozen-lockfile honors `resolved` URLs in yarn.lock,
-          # bypassing the configured registry. Rewrite them to JFrog so CI
-          # (which has no egress to registry.yarnpkg.com) can fetch tarballs.
-          sed -i 's|https://registry.yarnpkg.com/|https://databricks.jfrog.io/artifactory/api/npm/db-npm/|g' src/frontend/yarn.lock
-          echo "yarn.lock registry URLs rewritten for JFrog"
-
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup-node-jfrog
         with:
           node-version: '24'
-          cache: 'yarn'
-          cache-dependency-path: './src/frontend/yarn.lock'
 
       - name: Install dependencies
         working-directory: ./src/frontend
@@ -437,35 +291,11 @@ jobs:
           # checkout when the secret isn't configured (older forks, etc.).
           token: ${{ secrets.LOCKFILE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-
-      - name: Configure uv
-        run: |
-          set -euo pipefail
-          echo "UV_DEFAULT_INDEX=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "uv configured to use JFrog registry"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: ./.github/actions/setup-python-jfrog
         with:
           python-version: '3.10'
+          installer: uv
+          cache: ''
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -533,46 +363,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-
-      - name: Configure npm
-        run: |
-          set -euo pipefail
-          cat > ~/.npmrc << EOF
-          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
-          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
-          always-auth=true
-          EOF
-          echo "npm configured to use JFrog registry"
-          # yarn 1 with --frozen-lockfile honors `resolved` URLs in yarn.lock,
-          # bypassing the configured registry. Rewrite them to JFrog so CI
-          # (which has no egress to registry.yarnpkg.com) can fetch tarballs.
-          sed -i 's|https://registry.yarnpkg.com/|https://databricks.jfrog.io/artifactory/api/npm/db-npm/|g' src/frontend/yarn.lock
-          echo "yarn.lock registry URLs rewritten for JFrog"
-
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup-node-jfrog
         with:
           node-version: '24'
-          cache: 'yarn'
-          cache-dependency-path: './src/frontend/yarn.lock'
 
       - name: Install dependencies
         working-directory: ./src/frontend


### PR DESCRIPTION
## Summary
Eliminate six near-identical copies of the JFrog OIDC token block, four copies of the npm-auth + yarn.lock rewrite block, and three pip/uv config variants from `test-coverage.yml` by extracting three composite actions.

## Why
Each duplicated block is ~15–18 lines of bash. Touching any of them — a registry URL change, a new audience, an extra header, a security tweak — currently means editing the same code in six places. The duplication has been quietly growing with every new job added to the workflow.

## What changed
**New composite actions (115 lines total):**
- `.github/actions/jfrog-auth/` — OIDC token exchange → `JFROG_ACCESS_TOKEN` in `$GITHUB_ENV`
- `.github/actions/setup-python-jfrog/` — chains `jfrog-auth`, runs `setup-python`, configures pip OR uv against JFrog (`inputs.installer: pip|uv|none`)
- `.github/actions/setup-node-jfrog/` — chains `jfrog-auth`, writes `~/.npmrc`, rewrites yarn.lock registry URLs, runs `setup-node`

**Workflow (`test-coverage.yml`): 622 → 414 lines (-208).** Each job's setup boilerplate collapses from ~30 lines to 3:
```yaml
- name: Checkout code
  uses: actions/checkout@de0fac2e... # v6
- uses: ./.github/actions/setup-node-jfrog
  with:
    node-version: '24'
```

**Net: -92 lines, +0 behavior change.**

## Behavior preservation
- All SHA-pinned upstream action versions kept verbatim (setup-python v6, setup-node v6.4.0)
- `yarn.lock` rewrite happens before `setup-node` cache-key hash (same order as before)
- `check-lockfiles` job uses `installer: uv` + `cache: ''` to match its prior config (no pip cache, uv index instead of pip index)
- `coverage-report` job didn't need JFrog and still doesn't — left untouched

## Test plan
- [ ] All existing jobs pass on this PR (backend-tests, frontend-tests, type-check, frontend-build, check-lockfiles)
- [ ] Coverage uploads to Codecov succeed with same flags (backend/frontend) — should match pre-refactor numbers exactly
- [ ] E2E tests skipped on PRs as before (only runs on push to main)

This pull request and its description were written by Isaac.