### PR TITLE
fix(e2e): seed certification levels at startup; pass workflow type in editor tests

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -133,7 +133,12 @@ jobs:
       labels: linux-ubuntu-latest
     timeout-minutes: 20
     # Run E2E tests only on pushes to main (not on PRs)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # TEMP: also run for this branch's PR to verify the E2E fixes land green
+    # before merge. Revert this block to a single condition before merging.
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.head_ref == 'fix/e2e-workflow-editor-and-cert-publication') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/fix/e2e-workflow-editor-and-cert-publication')
 
     services:
       postgres:

--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -379,11 +379,21 @@ def initialize_managers(app: FastAPI):
         # Defer SearchManager initialization until after initial data loading completes
         logger.info("Deferring SearchManager initialization until after initial data load.")
         
-        # --- Ensure default roles exist using the manager method --- 
+        # --- Ensure default roles exist using the manager method ---
         app.state.settings_manager.ensure_default_roles_exist()
-        
+
         # --- Ensure default team and project exist for admins ---
         app.state.settings_manager.ensure_default_team_and_project()
+
+        # --- Seed default certification levels (Bronze, Silver, Gold) if empty ---
+        # Lifecycle routes (handle-certify, /certify) resolve the requested
+        # certification_level by level_order; without seeds the table is empty
+        # and they 404.
+        try:
+            from src.repositories.certification_levels_repository import certification_levels_repo
+            certification_levels_repo.seed_defaults(db_session)
+        except Exception as e:
+            logger.error(f"Failed to seed default certification levels: {e}", exc_info=True)
 
         # --- Commit session potentially used for default role creation ---
         # This commit is crucial AFTER all managers are initialized AND

--- a/src/frontend/src/tests/workflow-editor-edges.spec.ts
+++ b/src/frontend/src/tests/workflow-editor-edges.spec.ts
@@ -17,7 +17,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 1. Workflow editor loads with step toolbar
   // -------------------------------------------------------------------------
   test('workflow editor loads with step toolbar and canvas', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
 
     // "Add Step" label in the toolbar panel
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
@@ -37,7 +37,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 2. Add nodes and verify auto-connection edge
   // -------------------------------------------------------------------------
   test('adding steps auto-creates connecting edges', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Start with just the trigger node
@@ -61,7 +61,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 3. Edge selection and visual feedback
   // -------------------------------------------------------------------------
   test('clicking an edge selects it and shows delete button', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Add two steps to get an edge between them
@@ -87,7 +87,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 4. Edge deletion via delete button
   // -------------------------------------------------------------------------
   test('clicking the delete button removes the edge', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Build a small graph: trigger → approval → notification
@@ -112,7 +112,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 5. Approval node has pass (green) and fail (red) source handles
   // -------------------------------------------------------------------------
   test('approval node exposes pass and fail handles', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Add an Approval step
@@ -132,7 +132,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 6. Drag from fail handle to create a fail edge
   // -------------------------------------------------------------------------
   test('drag from fail handle creates a fail-labeled edge', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Add Approval + two Notification nodes
@@ -189,7 +189,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 7. Save workflow with connections — no errors
   // -------------------------------------------------------------------------
   test('save workflow with steps and connections succeeds', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Fill in the workflow name (the inline Input with placeholder "Workflow name")


### PR DESCRIPTION
## Summary

Fixes the 10 E2E failures from run [#478](https://github.com/databrickslabs/ontos/actions/runs/26051426358). Two unrelated regressions, both visible in `chore(deps): bump psycopg2-binary` (#364) but neither caused by it.

### 1. `lifecycle-certification-publication.spec.ts` — 3 failures

`certification_levels_repo.seed_defaults()` (Bronze/Silver/Gold) was defined in `certification_levels_repository.py:117` but **never called**, so the table starts empty:

- `GET /api/certification-levels` returns `[]` (test at `:60` expects `>= 3` rows).
- `POST /data-products/{id}/handle-certify` raises 404 at `data_product_routes.py:495` (`certification_levels_repo.get_by_order(certification_level)` finds nothing). Tests at `:147` and `:559` expect `[200, 400, 409, 422]`.

Fix: invoke `seed_defaults(db_session)` from `initialize_managers` in `startup_tasks.py`, immediately after the existing `ensure_default_roles_exist()` / `ensure_default_team_and_project()` calls. Commit happens at the existing `db_session.commit()` ~5 lines later. Wrapped in try/except so a seeding failure logs but doesn't crash startup (consistent with how nearby defaults are guarded).

### 2. `workflow-editor-edges.spec.ts` — 7 failures

The "Add Step" toolbar lives inside the ReactFlow `<Panel>` (`workflow-designer.tsx:1186-1202`), which is only rendered when `workflowType !== null` (`:1158`). PR #279 ([`a9022d1d`](https://github.com/databrickslabs/ontos/commit/a9022d1d), 2026-04-24) added a workflow type chooser that gates the canvas behind a `?type=` query param. The tests ([`affb952a`](https://github.com/databrickslabs/ontos/commit/affb952a), 2026-04-02) pre-date that PR by ~3 weeks and still navigate to `/workflows/new`, so they hit the chooser and never see "Add Step".

All 7 tests target the **Process** palette (they click `Approval` and `Notification` buttons, which are `Request Approval` and `Notification` entries in `PROCESS_PALETTE_STEPS`). Fix: navigate to `/workflows/new?type=process` in all 7 `page.goto()` calls.

## Test plan

- [ ] CI passes on this branch (`test-coverage.yml`, including the `E2E Tests` job that runs on push to main).
- [ ] After merge, run #479+ on main shows 0 E2E failures in `lifecycle-certification-publication` and `workflow-editor-edges`.
- [ ] Local sanity (optional): `APP_DB_DROP_ON_START=true APP_DEMO_MODE=true` boot, then `curl localhost:8000/api/certification-levels` returns 3 rows.

This pull request and its description were written by Isaac.