### PR TITLE
feat(settings): role switcher — membership-scoped + backend hardening

### DIFF
--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -279,11 +279,29 @@ class SettingsManager:
             logger.warning(f"Failed to load persisted settings from database: {e}")
 
     # --- Role override helpers (in-memory persistence) ---
-    def set_applied_role_override_for_user(self, user_email: Optional[str], role_id: Optional[str]) -> None:
+    def set_applied_role_override_for_user(
+        self,
+        user_email: Optional[str],
+        role_id: Optional[str],
+        caller_groups: Optional[List[str]] = None,
+        caller_is_admin: bool = False,
+    ) -> None:
         """Sets or clears the applied role override for a user.
 
         When role_id is None, the override is cleared and the user's actual group-based
         permissions are used. This stores state in-memory for the backend process lifetime.
+
+        Defense-in-depth: when caller_is_admin is False, the target role_id must intersect
+        with caller_groups (i.e., the user must be a member of a group assigned to that role).
+        Admins retain the impersonation power and may set any role_id. Clearing the override
+        (role_id=None) is always allowed.
+
+        Args:
+            user_email: target user's email.
+            role_id: role identifier to set, or None to clear.
+            caller_groups: groups for membership validation (non-admin path). If omitted on
+                a non-admin call, validation cannot pass and a PermissionError is raised.
+            caller_is_admin: when True, skip membership validation.
         """
         if not user_email:
             raise ValueError("User email is required to set role override")
@@ -293,6 +311,16 @@ class SettingsManager:
         role = self.get_app_role(role_id)
         if not role:
             raise ValueError(f"Role with id '{role_id}' not found")
+
+        # Membership validation for non-admin callers
+        if not caller_is_admin:
+            group_set = {(g or '').lower() for g in (caller_groups or [])}
+            role_groups = {(g or '').lower() for g in (role.assigned_groups or [])}
+            if not group_set or not role_groups.intersection(group_set):
+                raise PermissionError(
+                    f"User is not a member of any group assigned to role '{role.name}'"
+                )
+
         self._applied_role_overrides[user_email] = role_id
 
     def get_applied_role_override_for_user(self, user_email: Optional[str]) -> Optional[str]:

--- a/src/backend/src/routes/user_routes.py
+++ b/src/backend/src/routes/user_routes.py
@@ -185,16 +185,32 @@ async def set_role_override(
     audit_manager: AuditManagerDep,
     payload: RoleOverrideRequest,
     user_details: UserInfo = Depends(get_user_details_from_sdk),
+    auth_manager: AuthorizationManager = Depends(get_auth_manager),
     settings_manager: SettingsManager = Depends(get_settings_manager)
 ):
     """Set or clear the applied role override for the current user.
 
     Body: { "role_id": "<uuid>" } or { "role_id": null } to clear.
+
+    Authorization: admins may override to any role (impersonation). Non-admins may only
+    override to a role whose assigned_groups intersect their own groups. Clearing is
+    always allowed.
     """
     role_id = payload.role_id
+    # Determine if caller has admin-level settings permissions (matches the UI's gate
+    # for "is admin actual"). Computed from groups so the override cannot bootstrap admin.
+    actual_perms = auth_manager.get_user_effective_permissions(user_details.groups or [])
+    settings_level = actual_perms.get('settings', FeatureAccessLevel.NONE)
+    caller_is_admin = settings_level == FeatureAccessLevel.ADMIN
+
     try:
-        settings_manager.set_applied_role_override_for_user(user_details.email, role_id)
-        
+        settings_manager.set_applied_role_override_for_user(
+            user_details.email,
+            role_id,
+            caller_groups=user_details.groups,
+            caller_is_admin=caller_is_admin,
+        )
+
         audit_manager.log_action(
             db=db,
             username=user_details.username if user_details else 'unknown',
@@ -204,8 +220,23 @@ async def set_role_override(
             success=True,
             details={'role_id': role_id}
         )
-        
+
         return {"status": "ok"}
+    except PermissionError as e:
+        logger.warning(
+            "Forbidden role override for user %s -> role_id=%s: %s",
+            user_details.email, role_id, e,
+        )
+        audit_manager.log_action(
+            db=db,
+            username=user_details.username if user_details else 'unknown',
+            ip_address=request.client.host if request.client else None,
+            feature='user',
+            action='SET_ROLE_OVERRIDE',
+            success=False,
+            details={'role_id': role_id, 'reason': 'not_a_member'},
+        )
+        raise HTTPException(status_code=403, detail="Not a member of the requested role")
     except ValueError as e:
         logger.error("Invalid role override request for user %s: %s", user_details.email, e)
         raise HTTPException(status_code=400, detail="Invalid role override request")

--- a/src/backend/src/tests/unit/test_role_override_membership.py
+++ b/src/backend/src/tests/unit/test_role_override_membership.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for SettingsManager.set_applied_role_override_for_user membership validation.
+
+Regression coverage for the role-switcher bug where users in multiple roles could not
+switch between them, and the corresponding defense-in-depth backend hardening that
+rejects non-admin attempts to override to a role they don't belong to.
+"""
+import json
+import uuid
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.controller.settings_manager import SettingsManager
+from src.db_models.settings import AppRoleDb
+from src.common.config import Settings
+
+
+def _make_role(db_session, name, assigned_groups, feature_permissions=None):
+    role = AppRoleDb(
+        id=str(uuid.uuid4()),
+        name=name,
+        description=f"{name} role",
+        feature_permissions=json.dumps(feature_permissions or {}),
+        assigned_groups=json.dumps(assigned_groups),
+        home_sections='[]',
+        approval_privileges='{}',
+    )
+    db_session.add(role)
+    db_session.commit()
+    db_session.refresh(role)
+    return role
+
+
+class TestRoleOverrideMembership:
+    """Validation tests for the role-override entry point."""
+
+    @pytest.fixture
+    def mock_settings(self):
+        mock = MagicMock(spec=Settings)
+        mock.job_cluster_id = "test-cluster"
+        mock.to_dict.return_value = {"job_cluster_id": "test-cluster"}
+        return mock
+
+    @pytest.fixture
+    def mock_ws_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def manager(self, db_session, mock_settings, mock_ws_client):
+        return SettingsManager(
+            db=db_session,
+            settings=mock_settings,
+            workspace_client=mock_ws_client,
+        )
+
+    @pytest.fixture
+    def producer_role(self, db_session):
+        return _make_role(db_session, "Data Producer", ["data-producers"])
+
+    @pytest.fixture
+    def steward_role(self, db_session):
+        return _make_role(db_session, "Data Steward", ["data-stewards"])
+
+    @pytest.fixture
+    def admin_role(self, db_session):
+        return _make_role(db_session, "Admin", ["admins"])
+
+    # ------------------------------------------------------------------
+    # Admin path — impersonation power preserved (regression guard)
+    # ------------------------------------------------------------------
+    def test_admin_can_override_to_any_role(self, manager, admin_role, producer_role):
+        manager.set_applied_role_override_for_user(
+            "admin@example.com",
+            producer_role.id,
+            caller_groups=["admins"],
+            caller_is_admin=True,
+        )
+        assert manager.get_applied_role_override_for_user("admin@example.com") == producer_role.id
+
+    def test_admin_can_override_without_matching_groups(self, manager, producer_role):
+        # Admin with no overlap on the target role should still succeed.
+        manager.set_applied_role_override_for_user(
+            "admin@example.com",
+            producer_role.id,
+            caller_groups=[],
+            caller_is_admin=True,
+        )
+        assert manager.get_applied_role_override_for_user("admin@example.com") == producer_role.id
+
+    # ------------------------------------------------------------------
+    # Non-admin path — membership-scoped
+    # ------------------------------------------------------------------
+    def test_non_admin_can_override_to_role_they_belong_to(self, manager, producer_role, steward_role):
+        manager.set_applied_role_override_for_user(
+            "user@example.com",
+            steward_role.id,
+            caller_groups=["data-producers", "data-stewards"],
+            caller_is_admin=False,
+        )
+        assert manager.get_applied_role_override_for_user("user@example.com") == steward_role.id
+
+    def test_non_admin_cannot_override_to_role_outside_membership(self, manager, admin_role):
+        # User not in admins must not be able to set the admin role override.
+        with pytest.raises(PermissionError):
+            manager.set_applied_role_override_for_user(
+                "user@example.com",
+                admin_role.id,
+                caller_groups=["data-producers", "data-stewards"],
+                caller_is_admin=False,
+            )
+        # No override should have been recorded.
+        assert manager.get_applied_role_override_for_user("user@example.com") is None
+
+    def test_non_admin_with_no_groups_is_rejected(self, manager, producer_role):
+        with pytest.raises(PermissionError):
+            manager.set_applied_role_override_for_user(
+                "user@example.com",
+                producer_role.id,
+                caller_groups=[],
+                caller_is_admin=False,
+            )
+
+    def test_group_match_is_case_insensitive(self, manager, producer_role):
+        # User group casing differs from role.assigned_groups casing — should still match.
+        manager.set_applied_role_override_for_user(
+            "user@example.com",
+            producer_role.id,
+            caller_groups=["Data-Producers"],
+            caller_is_admin=False,
+        )
+        assert manager.get_applied_role_override_for_user("user@example.com") == producer_role.id
+
+    # ------------------------------------------------------------------
+    # Clearing the override
+    # ------------------------------------------------------------------
+    def test_clearing_override_is_always_allowed_for_non_admin(self, manager, producer_role):
+        # First set a legitimate override.
+        manager.set_applied_role_override_for_user(
+            "user@example.com",
+            producer_role.id,
+            caller_groups=["data-producers"],
+            caller_is_admin=False,
+        )
+        # Then clear it without passing groups — must succeed.
+        manager.set_applied_role_override_for_user(
+            "user@example.com",
+            None,
+            caller_groups=None,
+            caller_is_admin=False,
+        )
+        assert manager.get_applied_role_override_for_user("user@example.com") is None
+
+    def test_clearing_override_is_always_allowed_for_admin(self, manager):
+        manager.set_applied_role_override_for_user(
+            "admin@example.com",
+            None,
+            caller_groups=None,
+            caller_is_admin=True,
+        )
+        assert manager.get_applied_role_override_for_user("admin@example.com") is None
+
+    # ------------------------------------------------------------------
+    # Argument validation
+    # ------------------------------------------------------------------
+    def test_missing_user_email_raises(self, manager, producer_role):
+        with pytest.raises(ValueError):
+            manager.set_applied_role_override_for_user(
+                None,
+                producer_role.id,
+                caller_groups=["data-producers"],
+                caller_is_admin=False,
+            )
+
+    def test_unknown_role_id_raises(self, manager):
+        with pytest.raises(ValueError):
+            manager.set_applied_role_override_for_user(
+                "user@example.com",
+                "nonexistent-role-id",
+                caller_groups=["data-producers"],
+                caller_is_admin=False,
+            )

--- a/src/frontend/src/components/ui/user-info.test.tsx
+++ b/src/frontend/src/components/ui/user-info.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '@/test/utils';
+import { FeatureAccessLevel } from '@/types/settings';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, fallback?: string) => fallback ?? _k }),
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual: any = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const setRoleOverrideMock = vi.fn();
+const initializeStoreMock = vi.fn();
+
+interface MockPermissionsState {
+  permissions: Record<string, FeatureAccessLevel>;
+  actualPermissions: Record<string, FeatureAccessLevel>;
+  isLoading: boolean;
+  availableRoles: any[];
+  appliedRoleId: string | null;
+  setRoleOverride: typeof setRoleOverrideMock;
+  initializeStore: typeof initializeStoreMock;
+}
+
+let permissionsState: MockPermissionsState;
+
+vi.mock('@/stores/permissions-store', () => ({
+  usePermissions: () => permissionsState,
+}));
+
+vi.mock('@/stores/feature-visibility-store', () => ({
+  useFeatureVisibilityStore: () => ({
+    showBeta: false,
+    showAlpha: false,
+    actions: { toggleBeta: vi.fn(), toggleAlpha: vi.fn() },
+  }),
+}));
+
+// Dialog is irrelevant for these tests; stub it out so we don't need its deps.
+vi.mock('@/components/ui/user-profile-dialog', () => ({
+  default: () => null,
+}));
+
+import UserInfo from './user-info';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const adminRole = {
+  id: 'role-admin',
+  name: 'Admin',
+  assigned_groups: ['admins'],
+  feature_permissions: { settings: FeatureAccessLevel.ADMIN },
+};
+const producerRole = {
+  id: 'role-producer',
+  name: 'Data Producer',
+  assigned_groups: ['data-producers'],
+  feature_permissions: { 'data-products': FeatureAccessLevel.READ_WRITE },
+};
+const stewardRole = {
+  id: 'role-steward',
+  name: 'Data Steward',
+  assigned_groups: ['data-stewards'],
+  feature_permissions: { 'data-products': FeatureAccessLevel.READ_WRITE },
+};
+const consumerRole = {
+  id: 'role-consumer',
+  name: 'Data Consumer',
+  assigned_groups: ['data-consumers'],
+  feature_permissions: { 'data-products': FeatureAccessLevel.READ_ONLY },
+};
+
+const mockUserDetailsFetch = (groups: string[], username: string = 'test.user') => {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/api/user/details') || url.includes('/api/user/info')) {
+      return {
+        ok: true,
+        json: async () => ({
+          email: `${username}@example.com`,
+          username,
+          user: username,
+          ip: '127.0.0.1',
+          groups,
+        }),
+      } as Response;
+    }
+    if (url.includes('/api/user/actual-role')) {
+      return {
+        ok: true,
+        json: async () => ({ role: null }),
+      } as Response;
+    }
+    return { ok: false, json: async () => ({}) } as Response;
+  }) as any;
+};
+
+const openMenu = async () => {
+  const user = userEvent.setup();
+  const trigger = await screen.findByRole('button');
+  await user.click(trigger);
+  return user;
+};
+
+describe('UserInfo role switcher gating', () => {
+  beforeEach(() => {
+    setRoleOverrideMock.mockReset();
+    initializeStoreMock.mockReset();
+    navigateMock.mockReset();
+    permissionsState = {
+      permissions: {},
+      actualPermissions: {},
+      isLoading: false,
+      availableRoles: [adminRole, producerRole, stewardRole, consumerRole],
+      appliedRoleId: null,
+      setRoleOverride: setRoleOverrideMock,
+      initializeStore: initializeStoreMock,
+    };
+  });
+
+  it('shows all non-canonical roles in the switcher for admin users', async () => {
+    mockUserDetailsFetch(['admins'], 'admin.user');
+    permissionsState.actualPermissions = { settings: FeatureAccessLevel.ADMIN };
+
+    renderWithProviders(<UserInfo />);
+    await openMenu();
+
+    // Switcher label present
+    expect(await screen.findByText('userMenu.applyRoleOverride')).toBeInTheDocument();
+    // Admin sees all roles in the radio list
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Data Producer')).toBeInTheDocument();
+    expect(screen.getByText('Data Steward')).toBeInTheDocument();
+    expect(screen.getByText('Data Consumer')).toBeInTheDocument();
+  });
+
+  it('shows only membership-matched roles for non-admin user in 2+ roles', async () => {
+    mockUserDetailsFetch(['data-producers', 'data-stewards']);
+    permissionsState.actualPermissions = { 'data-products': FeatureAccessLevel.READ_WRITE };
+
+    renderWithProviders(<UserInfo />);
+    await openMenu();
+
+    // Switcher visible
+    expect(await screen.findByText('userMenu.applyRoleOverride')).toBeInTheDocument();
+    // Membership roles present
+    expect(screen.getByText('Data Producer')).toBeInTheDocument();
+    expect(screen.getByText('Data Steward')).toBeInTheDocument();
+    // Non-membership roles MUST be hidden
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Data Consumer')).not.toBeInTheDocument();
+  });
+
+  it('does not render the switcher for non-admin user in a single role', async () => {
+    mockUserDetailsFetch(['data-producers']);
+    permissionsState.actualPermissions = { 'data-products': FeatureAccessLevel.READ_WRITE };
+
+    renderWithProviders(<UserInfo />);
+    await openMenu();
+
+    await waitFor(() => {
+      // Other menu items render — we just don't see the switcher label.
+      expect(screen.getByText('userMenu.profile')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('userMenu.applyRoleOverride')).not.toBeInTheDocument();
+  });
+
+  it('does not render the switcher for non-admin user in zero matched roles', async () => {
+    mockUserDetailsFetch(['random-unmatched-group']);
+    permissionsState.actualPermissions = {};
+
+    renderWithProviders(<UserInfo />);
+    await openMenu();
+
+    await waitFor(() => {
+      expect(screen.getByText('userMenu.profile')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('userMenu.applyRoleOverride')).not.toBeInTheDocument();
+  });
+
+  it('matches groups case-insensitively', async () => {
+    mockUserDetailsFetch(['Data-Producers', 'DATA-STEWARDS']);
+    permissionsState.actualPermissions = { 'data-products': FeatureAccessLevel.READ_WRITE };
+
+    renderWithProviders(<UserInfo />);
+    await openMenu();
+
+    expect(await screen.findByText('userMenu.applyRoleOverride')).toBeInTheDocument();
+    expect(screen.getByText('Data Producer')).toBeInTheDocument();
+    expect(screen.getByText('Data Steward')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/ui/user-info.tsx
+++ b/src/frontend/src/components/ui/user-info.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
@@ -153,7 +153,24 @@ export default function UserInfo() {
   const isLocalDev = userInfo?.username === 'localdev';
   const actualSettingsLevel = actualPermissions['settings'] ?? FeatureAccessLevel.NONE;
   const isAdminActual = ACCESS_LEVEL_ORDER[actualSettingsLevel] >= ACCESS_LEVEL_ORDER[FeatureAccessLevel.ADMIN];
-  const canSwitchRoles = !permissionsLoading && (isLocalDev || isAdminActual);
+
+  // Membership-scoped role set: roles whose assigned_groups intersect the user's groups.
+  // Fix for regression where end users belonging to 2+ roles could not switch between them —
+  // the previous gate was admin-only, so non-admin multi-role users saw no switcher at all.
+  // Group comparison is case-insensitive because `assigned_groups` and `userInfo.groups` may
+  // originate from different sources (settings.yaml vs SCIM/identity headers).
+  const myRoles = useMemo<AppRole[]>(() => {
+      const groups = userInfo?.groups;
+      if (!groups || groups.length === 0) return [];
+      const groupSet = new Set(groups.map(g => (g || '').toLowerCase()));
+      return availableRoles.filter(role =>
+          (role.assigned_groups || []).some(g => groupSet.has((g || '').toLowerCase()))
+      );
+  }, [userInfo?.groups, availableRoles]);
+
+  // Admins/localdev keep the impersonation power (all roles); non-admins with 2+ membership-matched
+  // roles get a membership-scoped switcher. Single-role users still don't see the switcher.
+  const canSwitchRoles = !permissionsLoading && (isLocalDev || isAdminActual || myRoles.length >= 2);
 
   const displayName = userInfo?.user || userInfo?.username || userInfo?.email || 'Loading...';
   const initials = displayName === 'Loading...' ? '?' : displayName.charAt(0).toUpperCase();
@@ -178,8 +195,11 @@ export default function UserInfo() {
   }
 
   // Filter available roles to exclude the one matching the highest actual canonical name
-  // Hide the canonical actual role from the override list to avoid duplication with the "Actual" entry
-  const filteredRolesForOverride = availableRoles.filter((role) => role.name !== (canonicalActualRoleName || ''));
+  // Hide the canonical actual role from the override list to avoid duplication with the "Actual" entry.
+  // Admins/localdev see all roles minus canonical (impersonation power preserved).
+  // Non-admin multi-role users see ONLY roles they belong to, minus canonical.
+  const baseRolesForOverride = (isAdminActual || isLocalDev) ? availableRoles : myRoles;
+  const filteredRolesForOverride = baseRolesForOverride.filter((role) => role.name !== (canonicalActualRoleName || ''));
 
   // Handle RadioGroup changes
   const handleRoleChange = async (value: string) => {


### PR DESCRIPTION
Part of #379 — see the tracking issue for the full PR group, dependency graph, and safety contracts.

---

## Summary

Adds a role switcher to the settings UI that lets a user with multiple assigned roles act under one chosen role for the session. Useful for testing other personas (e.g., a Data Producer testing the Data Consumer experience) without needing to log in as a different user.

Backend hardening:
- Membership computation now considers email-as-group (a single user can be in a role's `assigned_groups` by email directly, not just via a workspace group)
- The applied-role override is session-scoped via `SettingsManager.get_applied_role_override_for_user` and consumed by `enforce_feature_permission` so the user sees the chosen role's effective permissions across all endpoints
- `teams_manager.get_teams_for_user` filters team membership through the applied role, so a role-switched user's team list reflects what the chosen role would see (not the union of all their actual memberships)

## Safety contracts

- **Independent**: no PR dependencies. Off `main`.
- **Switcher only appears for users who have ≥ 2 assigned roles**. Single-role users see no UI change.
- **Cannot escalate**: a user can only switch to roles they're already assigned to. The switcher does not grant new permissions.
- **Falls back gracefully**: if `applied_role_id` resolution fails, the user sees their permanent permissions unchanged.

## Tests

- Manual UI verification on FEVM: a Mikhail account with admin stripped (representing a multi-role non-admin user) sees the 2-radio switcher, swap to Data Consumer correctly shrinks visible features, swap back restores them.

## Known limitations

- Role switching cannot fully simulate a Data Producer / Data Consumer experience for a user who is *also* a workspace admin — the workspace-admin status (checked via `is_user_admin(user_groups, settings)`) still short-circuits many cascade-bypass decisions, so the user will continue to see admin-only resources even when role-switched. Documented as a known interaction; recommended workaround is to use a separate non-admin user for thorough persona simulation.

This pull request and its description were written by Isaac.