### PR TITLE
fix(workflows): relax handle-approval outer gate to notifications:READ_ONLY

### DIFF
--- a/src/backend/src/routes/workflows_routes.py
+++ b/src/backend/src/routes/workflows_routes.py
@@ -572,17 +572,19 @@ WIZARD_PERMISSION_DISPATCH: Dict[str, Optional[tuple]] = {
     TriggerType.FOR_REQUEST_CERTIFY.value:       ("data-contracts", FeatureAccessLevel.READ_WRITE),
     TriggerType.FOR_REQUEST_STATUS_CHANGE.value: ("data-products",  FeatureAccessLevel.READ_WRITE),
     TriggerType.ON_FIRST_ACCESS.value:           None,  # authenticated only — first-login welcome screen
-    # `for_approval_response` — relaxed from `settings:READ_ONLY` to
-    # `notifications:READ_WRITE` (PR K). Non-admin Business Owners can be
-    # configured approvers but typically don't have settings access; the
-    # outer gate now reflects "must be able to receive + mark a
-    # notification" (universal minimum for approvers), and the real
-    # authorization is the per-execution check inside
+    # `for_approval_response` — relaxed from `notifications:READ_WRITE`
+    # (PR K) down to `notifications:READ_ONLY` (PR L). The outer gate
+    # only needs to confirm the user is part of the notification system
+    # at all; the real authorization is the per-execution check inside
     # `POST /api/workflows/handle-approval`
-    # (`_assert_caller_authorized_for_execution`) which verifies the
-    # caller is a recipient/role-member of the actual approval
+    # (`_assert_caller_authorized_for_execution`), which verifies the
+    # caller is the recipient (or role-member) of the actual approval
     # notification — preventing horizontal privilege escalation.
-    TriggerType.FOR_APPROVAL_RESPONSE.value:     ("notifications",  FeatureAccessLevel.READ_WRITE),
+    # READ_WRITE is too tight: typical Business Owners hold a business
+    # role on the entity but only have notifications:Read-only at the
+    # app-role level (they read + respond to notifications routed to
+    # them; they don't author or modify notifications).
+    TriggerType.FOR_APPROVAL_RESPONSE.value:     ("notifications",  FeatureAccessLevel.READ_ONLY),
 }
 
 
@@ -1238,15 +1240,29 @@ async def handle_workflow_approval(
     current_user: AuditCurrentUserDep,
     executor: WorkflowExecutor = Depends(get_workflow_executor),
     notifications_manager: NotificationsManager = Depends(get_notifications_manager),
-    # Outer gate intentionally `notifications:READ_WRITE` (not
-    # `settings:READ_WRITE`): the real authorization is the per-execution
-    # check below (`_assert_caller_authorized_for_execution`), which
-    # confirms the caller was an actual recipient/role-member of the
-    # approval notification. Anyone authorized to approve must already
-    # have `notifications:READ_WRITE` (it's the minimum to receive the
-    # approval notification + mark it read). PR K — was previously
-    # `settings:READ_WRITE` which blocked non-admin Business Owners.
-    _: bool = Depends(PermissionChecker('notifications', FeatureAccessLevel.READ_WRITE)),
+    # Outer gate is `notifications:READ_ONLY` (PR L). The real
+    # authorization is the per-execution check below
+    # (`_assert_caller_authorized_for_execution`), which confirms the
+    # caller was an actual recipient/role-member of the approval
+    # notification. The outer gate exists for defense-in-depth — it
+    # ensures the caller is part of the notification system at all
+    # (rejects users with `notifications:None`), but doesn't require
+    # write-level notification permissions which most non-admin
+    # Business Owners legitimately don't have. Approving a notification
+    # routed to you is *reading* + responding; not a separate "write"
+    # action on the notification feature itself.
+    #
+    # Two-layer defense satisfied (per OWASP API1+API5):
+    #   * Function-level (outer): you can see notifications → can be a
+    #     workflow recipient. Excludes users with no notification access.
+    #   * Object-level (inner): you must be the specific recipient of
+    #     this execution's approval notification (or have admin bypass).
+    #
+    # History: was `settings:READ_WRITE` (pre-PR-K, semantically wrong),
+    # then `notifications:READ_WRITE` (PR K, too tight for non-admin
+    # BOs), now `notifications:READ_ONLY` (PR L, the minimum that
+    # preserves defense-in-depth without blocking legitimate approvers).
+    _: bool = Depends(PermissionChecker('notifications', FeatureAccessLevel.READ_ONLY)),
 ) -> Dict[str, Any]:
     """Handle a workflow approval from a notification action.
 

--- a/src/backend/src/tests/unit/test_handle_approval_per_execution_check.py
+++ b/src/backend/src/tests/unit/test_handle_approval_per_execution_check.py
@@ -54,14 +54,19 @@ from src.routes.workflows_routes import (
 # ---------------------------------------------------------------------------
 
 
-def test_dispatch_for_approval_response_is_notifications_read_write() -> None:
-    """PR K — was ``("settings", READ_ONLY)``, now
-    ``("notifications", READ_WRITE)``. Outer gate represents
-    "minimum to receive an approval notification"; real authorization is
-    the per-execution check below."""
+def test_dispatch_for_approval_response_is_notifications_read_only() -> None:
+    """PR L — relaxed further from PR K's ``("notifications", READ_WRITE)``
+    to ``("notifications", READ_ONLY)``. The outer gate's only job is to
+    confirm the caller is part of the notification system at all
+    (defense-in-depth alongside the per-execution check). Requiring
+    READ_WRITE was too tight: typical Business Owners hold a business
+    role on the entity but only have notifications:Read-only at the
+    app-role level. The real authorization remains the per-execution
+    check (``_assert_caller_authorized_for_execution``) — see tests
+    below."""
     assert WIZARD_PERMISSION_DISPATCH[TriggerType.FOR_APPROVAL_RESPONSE.value] == (
         "notifications",
-        FeatureAccessLevel.READ_WRITE,
+        FeatureAccessLevel.READ_ONLY,
     )
 
 

--- a/src/backend/src/tests/unit/test_wizard_permission_dispatch.py
+++ b/src/backend/src/tests/unit/test_wizard_permission_dispatch.py
@@ -68,11 +68,15 @@ def test_dispatch_expected_features() -> None:
         TriggerType.FOR_REQUEST_CERTIFY.value:       ("data-contracts", FeatureAccessLevel.READ_WRITE),
         TriggerType.FOR_REQUEST_STATUS_CHANGE.value: ("data-products",  FeatureAccessLevel.READ_WRITE),
         TriggerType.ON_FIRST_ACCESS.value:           None,
-        # PR K — relaxed from settings:READ_ONLY so non-admin Business
-        # Owners can respond to approval wizards. The per-execution
-        # authorization check inside POST /handle-approval is the real
-        # gate; this outer gate is just "minimum to receive notifications".
-        TriggerType.FOR_APPROVAL_RESPONSE.value:     ("notifications",  FeatureAccessLevel.READ_WRITE),
+        # PR L — relaxed further from PR K's notifications:READ_WRITE
+        # down to notifications:READ_ONLY. The outer gate's only job is
+        # to confirm the caller is part of the notification system at
+        # all (rejects users with notifications:None). Approving a
+        # notification routed to you is read + respond, not a separate
+        # "write" action on the notifications feature itself. Real
+        # authorization remains the per-execution check inside
+        # POST /handle-approval.
+        TriggerType.FOR_APPROVAL_RESPONSE.value:     ("notifications",  FeatureAccessLevel.READ_ONLY),
     }
     assert WIZARD_PERMISSION_DISPATCH == expected
 
@@ -180,9 +184,12 @@ def test_on_first_access_any_authenticated_user_allowed() -> None:
     ))
 
 
-def test_for_approval_response_consumer_denied() -> None:
-    # PR K — outer gate is now notifications:READ_WRITE. A user with no
-    # notifications perms still fails the outer gate.
+def test_for_approval_response_user_without_notifications_denied() -> None:
+    """PR L — outer gate is `notifications:READ_ONLY`. A user with
+    `notifications:None` is rejected at the outer gate before reaching
+    the per-execution check inside POST /handle-approval. Defense-in-
+    depth: a recipient-matching bug in the per-execution check still
+    can't be probed by users with zero notification access."""
     request = _request_with_perms(effective={"notifications": FeatureAccessLevel.NONE})
     with pytest.raises(HTTPException) as exc:
         _run(enforce_wizard_permission(
@@ -191,10 +198,22 @@ def test_for_approval_response_consumer_denied() -> None:
     assert exc.value.status_code == 403
 
 
-def test_for_approval_response_business_owner_allowed() -> None:
-    # PR K — non-admin Business Owner with notifications:READ_WRITE clears
-    # the outer gate. Per-execution authorization happens INSIDE
-    # POST /handle-approval (see test_handle_approval_per_execution_check).
+def test_for_approval_response_business_owner_with_read_only_allowed() -> None:
+    """PR L — non-admin Business Owner with only `notifications:READ_ONLY`
+    (the typical Data Consumer / Daimler-shaped role) clears the outer
+    gate. Real authorization (caller is the assigned recipient of this
+    execution's approval notification) happens INSIDE POST
+    /handle-approval (see test_handle_approval_per_execution_check)."""
+    request = _request_with_perms(effective={"notifications": FeatureAccessLevel.READ_ONLY})
+    _run(enforce_wizard_permission(
+        TriggerType.FOR_APPROVAL_RESPONSE.value, _user(["business-owners"]), request
+    ))
+
+
+def test_for_approval_response_read_write_allowed() -> None:
+    """READ_WRITE still passes — strictly more permissive than the
+    relaxed READ_ONLY gate. Preserves PR K's behavior for users who
+    happen to have stronger notifications access."""
     request = _request_with_perms(effective={"notifications": FeatureAccessLevel.READ_WRITE})
     _run(enforce_wizard_permission(
         TriggerType.FOR_APPROVAL_RESPONSE.value, _user(["business-owners"]), request
@@ -202,7 +221,9 @@ def test_for_approval_response_business_owner_allowed() -> None:
 
 
 def test_for_approval_response_admin_allowed() -> None:
-    # Admin still has notifications:ADMIN > READ_WRITE → clears outer gate.
+    """Admin still has `notifications:ADMIN` > READ_ONLY → clears outer
+    gate. Per-execution check has an admin bypass for rescue/manual
+    intervention (intentional per PR K design)."""
     request = _request_with_perms(effective={"notifications": FeatureAccessLevel.ADMIN})
     _run(enforce_wizard_permission(
         TriggerType.FOR_APPROVAL_RESPONSE.value, _user(["admins"]), request


### PR DESCRIPTION
Part of #379 — see the tracking issue for the full PR group, dependency graph, and safety contracts.

Stacked on #393 (PR K). **Do not merge before #393.**

---

## Summary

Relaxes the outer feature gate on `POST /api/workflows/handle-approval` from `notifications:READ_WRITE` (introduced in #393/PR K) to `notifications:READ_ONLY`.

### Why

The endpoint's outer gate's job is **defense in depth** — function-level authorization (OWASP API5), not the primary authorization decision. The real "can this caller approve THIS execution?" question is answered by the per-execution check introduced in #393 (`_assert_caller_authorized_for_execution`), which verifies recipient identity, role-membership via `recipient_role_id`, or admin bypass.

Requiring `READ_WRITE` at the outer layer was too tight for the common case: typical non-admin Business Owners hold their BO assignment via the **business-role system** (the workflow's `approvers: business:<role-uuid>` declaration) but only have `notifications:Read-only` at the App-role level. They read + respond to notifications routed to them; they're not authoring or modifying notifications.

### What changes

- `WIZARD_PERMISSION_DISPATCH[FOR_APPROVAL_RESPONSE]`: `("notifications", READ_WRITE)` → `("notifications", READ_ONLY)`
- The `PermissionChecker` dependency on the `/handle-approval` route: same change

### Defense-in-depth preserved

Two layers still in place:

| Layer | Check |
|---|---|
| **Outer** (this PR) | `notifications:READ_ONLY` — rejects users with `notifications:None` (zero notification access) |
| **Inner** (PR K — #393) | Per-execution: caller must be the recipient of THIS execution's approval notification (or admin bypass) |

Both OWASP API1 (object-level authorization) and API5 (function-level authorization) satisfied.

### What does NOT change

- The authorization scope does not widen. Anyone who passes the outer gate still gets rejected by the inner check unless they're the assigned recipient.
- Admin behavior is unchanged.
- Pre-#393 users with `:READ_WRITE` still pass (strictly more permissive than the relaxed `:READ_ONLY`).

## Verification

For a representative customer-shaped role config (Admin / Data Producer / Data Consumer / Data Steward / DGO / Security Officer) where:
- Data Consumer has `notifications:Read-only`
- Data Producer has `notifications:None`

Before this PR, non-admin Business Owners had to be made full admins to approve AGRs (the customer ran into this and worked around with admin escalation). After this PR, Business Owners in any role with at least `notifications:Read-only` (including the default Data Consumer) can approve workflows routed to them via the business-role assignment. No customer-side role config required.

## Tests

- `test_dispatch_for_approval_response_is_notifications_read_only` — pins the new value
- `test_for_approval_response_user_without_notifications_denied` — defense-in-depth: zero notifications access still 403s at outer
- `test_for_approval_response_business_owner_with_read_only_allowed` — new pass case for the representative customer-shaped configuration
- `test_for_approval_response_read_write_allowed` — `:READ_WRITE` still passes (strictly more permissive)
- `test_for_approval_response_admin_allowed` — admin still passes

PR K's existing per-execution-check tests remain unchanged (`test_handle_approval_per_execution_check.py`).

## Empirical verification

End-to-end on a a customer-staging workspace clone (workflow `Access Grant Request`, AGR against `a test data product with consumer_principals configured`): non-admin BO submitted approval; outer gate passed (`:READ_ONLY`); inner check passed (BO is the assigned recipient); workflow resumed; webhook fired with `data_product_group` populated (separate enrichment in #380 / PR M).

This pull request and its description were written by Isaac.
