### PR TITLE
feat(data-products): ownership-cascade scoping + clone-product schema-drift repair

### DIFF
--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -242,15 +242,30 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         skip: int = 0,
         limit: int = 100,
         project_id: Optional[str] = None,
-        is_admin: bool = False
+        is_admin: bool = False,
+        caller_email: Optional[str] = None,
+        caller_team_ids: Optional[List[str]] = None,
+        caller_project_ids: Optional[List[str]] = None,
     ) -> List[DataProductApi]:
         """List ODPS v1.0.0 data products.
+
+        For non-admin callers, results are filtered by the ownership cascade
+        described on ``DataProductsRepository.get_multi``: a product is
+        visible if it matches the caller's project membership, team
+        membership, or creator (``draft_owner_id``).
+
+        Back-compat: existing call sites that pass only ``is_admin`` (or
+        nothing) continue to compile. Non-admin calls with no scope inputs
+        intentionally return an empty list — fail-closed.
 
         Args:
             skip: Number of records to skip
             limit: Maximum number of records to return
             project_id: Optional project ID to filter by (ignored if is_admin=True)
-            is_admin: If True, return all products regardless of project_id
+            is_admin: If True, return all products regardless of scope
+            caller_email: Caller email — matched against ``draft_owner_id``
+            caller_team_ids: Caller team memberships — matched against ``owner_team_id``
+            caller_project_ids: Caller's accessible projects — matched against ``project_id``
 
         Returns:
             List of DataProduct API models
@@ -261,7 +276,10 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 skip=skip,
                 limit=limit,
                 project_id=project_id,
-                is_admin=is_admin
+                is_admin=is_admin,
+                caller_email=caller_email,
+                caller_team_ids=caller_team_ids,
+                caller_project_ids=caller_project_ids,
             )
             products_with_tags = []
             for product_db in products_db:
@@ -414,12 +432,28 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         user_groups: List[str],
         db: Optional[Session] = None,
         background_tasks: Optional[Any] = None,
+        caller_team_ids: Optional[List[str]] = None,
     ) -> Optional[DataProductApi]:
         """
-        Update a data product with project membership authorization check.
+        Update a data product with ownership-scope authorization.
 
-        If the product belongs to a project, verifies that the user is a member
-        of that project before allowing the update.
+        Authorization cascade for non-admin callers (any condition allows):
+          1. Project membership — caller is a member of any team assigned to
+             ``existing_product_db.project_id`` (when set).
+          2. Team ownership — ``existing_product_db.owner_team_id`` is in the
+             caller's ``caller_team_ids``.
+          3. Creator / single-user ownership — ``existing_product_db.draft_owner_id``
+             matches ``user_email``. This serves drafts AND non-drafts: a user
+             who created a product and never assigned it to a team still owns
+             it.
+
+        Admins always pass. If none of the above conditions match, raises
+        ``PermissionError`` with a generic message that does not disclose
+        which check failed.
+
+        Legacy / orphan rows (no project_id, no owner_team_id, no
+        draft_owner_id) fail closed for non-admins. An admin can promote
+        them later by setting an owner.
 
         Args:
             product_id: ID of product to update
@@ -428,12 +462,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             user_groups: List of groups the user belongs to
             db: Optional database session. If not provided, uses self._db
             background_tasks: Optional FastAPI BackgroundTasks for async delivery
+            caller_team_ids: Caller's team memberships (UUIDs from teams_manager).
+                Optional — back-compat call sites that don't pass it lose the
+                team-ownership branch but keep project-membership and
+                draft-owner branches.
 
         Returns:
             Updated product if successful, None if not found
 
         Raises:
-            PermissionError: If user is not a project member (when product has project_id)
+            PermissionError: If caller has no ownership claim on the product
             ValueError: If validation fails
             SQLAlchemyError: If database operation fails
         """
@@ -441,34 +479,64 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         db_session = db if db is not None else self._db
 
         try:
-            # Get existing product to check project membership
             existing_product_db = self._repo.get(db=db_session, id=product_id)
             if not existing_product_db:
                 logger.warning(f"Product not found for update: {product_id}")
                 return None
 
-            # Check project membership if product belongs to a project
-            if existing_product_db.project_id:
-                from src.controller.projects_manager import projects_manager
-                from src.common.config import get_settings
+            from src.controller.projects_manager import projects_manager
+            from src.common.authorization import is_user_admin
+            from src.common.config import get_settings
 
-                settings = get_settings()
-                is_member = projects_manager.is_user_project_member(
+            settings = get_settings()
+
+            # Admin always allowed (short-circuit, also matches existing
+            # is_user_project_member behavior).
+            if is_user_admin(user_groups, settings):
+                logger.debug(f"User {user_email} is admin — bypassing ownership cascade")
+                return self.update_product(
+                    product_id,
+                    product_data_dict,
+                    db=db_session,
+                    user=user_email,
+                    background_tasks=background_tasks,
+                )
+
+            authorized = False
+
+            # 1. Project membership (preserves prior fast-path semantics)
+            if existing_product_db.project_id:
+                if projects_manager.is_user_project_member(
                     db=db_session,
                     user_identifier=user_email,
                     user_groups=user_groups,
                     project_id=existing_product_db.project_id,
-                    settings=settings
-                )
+                    settings=settings,
+                ):
+                    authorized = True
 
-                if not is_member:
-                    logger.warning(
-                        f"User {user_email} denied update access to product {product_id} "
-                        f"(project: {existing_product_db.project_id}) - not a project member"
-                    )
-                    raise PermissionError(
-                        "You must be a member of the project to edit this data product"
-                    )
+            # 2. Team ownership
+            if not authorized and existing_product_db.owner_team_id and caller_team_ids:
+                if existing_product_db.owner_team_id in caller_team_ids:
+                    authorized = True
+
+            # 3. Creator / single-user ownership (drafts AND non-drafts).
+            #    Case-insensitive email match — emails are not case-sensitive.
+            if not authorized and existing_product_db.draft_owner_id and user_email:
+                if existing_product_db.draft_owner_id.lower() == user_email.lower():
+                    authorized = True
+
+            if not authorized:
+                logger.warning(
+                    f"User {user_email} denied update on product {product_id} "
+                    f"(project_id={existing_product_db.project_id}, "
+                    f"owner_team_id={existing_product_db.owner_team_id}, "
+                    f"draft_owner_id={existing_product_db.draft_owner_id})"
+                )
+                # Generic message — do not leak which sub-check failed.
+                raise PermissionError(
+                    "Insufficient permissions to edit this data product"
+                )
 
             # Perform update (validation happens inside update_product)
             return self.update_product(
@@ -1233,7 +1301,11 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             SQLAlchemyError: If database operation fails
         """
         try:
-            all_products = self.list_products(skip=skip, limit=limit)
+            # Marketplace-visibility helper: ``publication_scope`` is the
+            # authoritative permission for these products, NOT the
+            # per-user ownership cascade. Bypass the cascade so published
+            # products surface regardless of who's asking.
+            all_products = self.list_products(skip=skip, limit=limit, is_admin=True)
             published_products = [
                 product for product in all_products
                 if product.publication_scope and product.publication_scope.lower() != 'none'
@@ -1977,9 +2049,12 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 logger.error(f"Failed to persist error: {persist_error}")
 
     def save_to_yaml(self, yaml_path: str) -> bool:
-        """Save current ODPS v1.0.0 data products to a YAML file."""
+        """Save current ODPS v1.0.0 data products to a YAML file.
+
+        System-level export — bypasses per-user ownership scope.
+        """
         try:
-            all_products_api = self.list_products(limit=10000)
+            all_products_api = self.list_products(limit=10000, is_admin=True)
             products_list = [p.model_dump(by_alias=True) for p in all_products_api]
 
             with open(yaml_path, 'w') as file:
@@ -2113,11 +2188,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             self._notify_index_upsert(item)
 
     def get_search_index_items(self) -> List[SearchIndexItem]:
-        """Fetches ODPS v1.0.0 data products and maps them to SearchIndexItem format."""
+        """Fetches ODPS v1.0.0 data products and maps them to SearchIndexItem format.
+
+        System-level caller (search indexer) — uses ``is_admin=True`` to bypass
+        the per-user ownership scope. Per-user filtering happens at query time
+        in the search route, not at index-build time.
+        """
         logger.info("Fetching ODPS products for search indexing...")
         items = []
         try:
-            products_api = self.list_products(limit=10000)
+            products_api = self.list_products(limit=10000, is_admin=True)
             for product in products_api:
                 item = self._build_search_index_item(product)
                 if item:

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -1602,55 +1602,103 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                             db.add(new_ic)
             
             # Clone Output Ports
+            #
+            # Earlier versions of this block referenced ``port.expectation``
+            # and ``port.dataset_name`` — neither of which exist on
+            # ``OutputPortDb`` (the columns were dropped before delivery_method
+            # landed). Cloning any product with output ports therefore raised
+            # AttributeError. Fix: replicate only the columns currently on the
+            # model (see db_models/data_products.py:193). Includes the
+            # Databricks extensions (asset_type, asset_identifier, server,
+            # contains_pii, auto_approve) so clones stay faithful to source.
             if source_product.output_ports:
                 for port in source_product.output_ports:
                     new_port = OutputPortDb(
                         product_id=new_id,
                         name=port.name,
                         version=port.version,
+                        description=port.description,
+                        port_type=port.port_type,
                         contract_id=port.contract_id,
-                        expectation=port.expectation,
-                        dataset_name=port.dataset_name
+                        delivery_method_id=port.delivery_method_id,
+                        asset_type=port.asset_type,
+                        asset_identifier=port.asset_identifier,
+                        status=port.status,
+                        server=port.server,
+                        contains_pii=port.contains_pii,
+                        auto_approve=port.auto_approve,
                     )
                     db.add(new_port)
                     db.flush()
-                    
-                    # Clone SBOMs
-                    if hasattr(port, 'sboms') and port.sboms:
-                        for sbom in port.sboms:
+
+                    # Clone SBOMs. The earlier code asked for ``port.sboms``
+                    # (plural); the actual relationship on ``OutputPortDb`` is
+                    # ``sbom`` (singular, see line 222 of db_models). Because
+                    # ``hasattr`` returned False, the block silently no-op'd
+                    # and SBOMs were never carried over. The earlier code also
+                    # referenced four nonexistent SBOMDb columns
+                    # (``spdx_version``, ``spdx_id``, ``name``,
+                    # ``creation_info_created``); ``SBOMDb`` only has ``type``
+                    # and ``url`` today.
+                    if port.sbom:
+                        for sbom in port.sbom:
                             new_sbom = SBOMDb(
                                 output_port_id=new_port.id,
-                                spdx_version=sbom.spdx_version,
-                                spdx_id=sbom.spdx_id,
-                                name=sbom.name,
-                                creation_info_created=sbom.creation_info_created
+                                type=sbom.type,
+                                url=sbom.url,
                             )
                             db.add(new_sbom)
-            
+
+                    # Clone input contracts on output ports too. The
+                    # relationship is declared on OutputPortDb as
+                    # ``input_contracts`` (line 223 of db_models).
+                    if port.input_contracts:
+                        for ic in port.input_contracts:
+                            new_ic = InputContractDb(
+                                output_port_id=new_port.id,
+                                contract_id=ic.contract_id,
+                                contract_version=ic.contract_version,
+                            )
+                            db.add(new_ic)
+
             # Clone Management Ports
+            #
+            # Earlier code referenced ``port.type`` and ``port.endpoint``;
+            # neither exists on ``ManagementPortDb`` (real fields are
+            # ``port_type`` and ``url``). It also omitted the required
+            # ``content`` column (nullable=False), which would have raised
+            # IntegrityError on commit had the AttributeError not fired first.
             if source_product.management_ports:
                 for port in source_product.management_ports:
                     new_port = ManagementPortDb(
                         product_id=new_id,
                         name=port.name,
-                        type=port.type,
+                        content=port.content,
+                        port_type=port.port_type,
+                        url=port.url,
+                        channel=port.channel,
                         description=port.description,
-                        server=port.server,
-                        endpoint=port.endpoint
                     )
                     db.add(new_port)
-            
+
             # Clone Support Channels
+            #
+            # Earlier code referenced ``channel.type`` (no such column) and
+            # omitted the required ``channel`` column itself (nullable=False).
+            # IntegrityError on any product with support channels.
             if source_product.support_channels:
-                for channel in source_product.support_channels:
+                for support in source_product.support_channels:
                     new_channel = SupportDb(
                         product_id=new_id,
-                        type=channel.type,
-                        url=channel.url,
-                        description=channel.description
+                        channel=support.channel,
+                        url=support.url,
+                        description=support.description,
+                        tool=support.tool,
+                        scope=support.scope,
+                        invitation_url=support.invitation_url,
                     )
                     db.add(new_channel)
-            
+
             # Clone Team
             if source_product.team:
                 src_team = source_product.team
@@ -1661,15 +1709,22 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 )
                 db.add(new_team)
                 db.flush()
-                
-                # Clone team members
-                if hasattr(src_team, 'members') and src_team.members:
+
+                # Clone team members. Earlier code referenced ``member.email``
+                # and omitted the required ``username`` column; ``email`` is
+                # not a column on ``DataProductTeamMemberDb`` — the required
+                # identity field is ``username`` (line 356 of db_models).
+                if src_team.members:
                     for member in src_team.members:
                         new_member = DataProductTeamMemberDb(
                             team_id=new_team.id,
+                            username=member.username,
                             name=member.name,
-                            email=member.email,
-                            role=member.role
+                            description=member.description,
+                            role=member.role,
+                            date_in=member.date_in,
+                            date_out=member.date_out,
+                            replaced_by_username=member.replaced_by_username,
                         )
                         db.add(new_member)
             

--- a/src/backend/src/repositories/data_products_repository.py
+++ b/src/backend/src/repositories/data_products_repository.py
@@ -528,21 +528,48 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
         skip: int = 0,
         limit: int = 100,
         project_id: Optional[str] = None,
-        is_admin: bool = False
+        is_admin: bool = False,
+        caller_email: Optional[str] = None,
+        caller_team_ids: Optional[List[str]] = None,
+        caller_project_ids: Optional[List[str]] = None,
     ) -> List[DataProductDb]:
         """Get multiple ODPS v1.0.0 Data Products with all relationships eagerly loaded.
+
+        Authorization cascade for non-admins (any condition grants visibility):
+          - ``project_id`` IN ``caller_project_ids``
+          - ``owner_team_id`` IN ``caller_team_ids``
+          - ``draft_owner_id`` == ``caller_email``  (creator ownership — works
+            for drafts AND non-drafts, so the same field serves "single-user
+            ownership" without a separate column)
+
+        If the caller is not admin AND none of the scope inputs are provided
+        (no email, no teams, no projects), this returns an empty list — i.e.
+        fail-closed. The same applies transitively to legacy / orphan rows
+        (no project_id, no owner_team_id, no draft_owner_id): a non-admin
+        never sees them. They can be promoted by an admin later.
 
         Args:
             db: Database session
             skip: Number of records to skip
             limit: Maximum number of records to return
-            project_id: Optional project ID to filter by (ignored if is_admin=True)
-            is_admin: If True, return all products regardless of project_id
+            project_id: Optional query-param project filter (applied AFTER
+                scoping, as a narrowing filter). Ignored when ``is_admin``.
+            is_admin: If True, return all products regardless of scope.
+            caller_email: Caller's email (matched against ``draft_owner_id``).
+            caller_team_ids: Caller's team memberships (matched against
+                ``owner_team_id``).
+            caller_project_ids: Caller's accessible project IDs (matched
+                against ``project_id``).
 
         Returns:
             List of DataProductDb objects
         """
-        logger.debug(f"Fetching multiple ODPS v1.0.0 DataProducts (skip: {skip}, limit: {limit}, project_id: {project_id}, is_admin: {is_admin})")
+        logger.debug(
+            f"Fetching multiple ODPS v1.0.0 DataProducts (skip: {skip}, limit: {limit}, "
+            f"project_id: {project_id}, is_admin: {is_admin}, caller_email: {caller_email}, "
+            f"teams: {len(caller_team_ids) if caller_team_ids else 0}, "
+            f"projects: {len(caller_project_ids) if caller_project_ids else 0})"
+        )
         try:
             query = db.query(self.model).options(
                 selectinload(self.model.description),
@@ -556,13 +583,53 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
                 selectinload(self.model.team).selectinload(DataProductTeamDb.members)
             )
 
-            # Apply project filtering only if not admin and project_id is provided
-            if not is_admin and project_id:
-                logger.debug(f"Filtering products by project_id: {project_id}")
-                # Include products with matching project_id OR null project_id (legacy/unassigned)
+            if not is_admin:
+                # Build ownership-scope filter from caller context. Each clause
+                # is appended only when the corresponding input is populated so
+                # we never produce a SQL-level ``IN ()`` (which Postgres rejects
+                # and SQLite treats as always-false anyway).
+                scope_clauses = []
+                if caller_project_ids:
+                    scope_clauses.append(self.model.project_id.in_(caller_project_ids))
+                if caller_team_ids:
+                    scope_clauses.append(self.model.owner_team_id.in_(caller_team_ids))
+                if caller_email:
+                    scope_clauses.append(self.model.draft_owner_id == caller_email)
+
+                if not scope_clauses:
+                    # Fail-closed: non-admin with no resolvable scope sees
+                    # nothing. This is the safe behavior when route hasn't
+                    # plumbed scope through (back-compat call sites), or when
+                    # the caller genuinely owns no project/team/draft.
+                    logger.debug(
+                        "Non-admin caller has no scope (no email/teams/projects); "
+                        "returning empty list (fail-closed)"
+                    )
+                    return []
+
+                query = query.filter(or_(*scope_clauses))
+
+                # Optional fast-path narrowing by query-param project_id.
+                # Applied ON TOP of the scope filter (an AND), not in place of
+                # it. We keep the legacy "null project_id" allowance so users
+                # can still see legacy products they own via team/email even
+                # when filtering by a specific project.
+                if project_id:
+                    logger.debug(f"Additionally filtering products by project_id query param: {project_id}")
+                    query = query.filter(
+                        or_(
+                            self.model.project_id == project_id,
+                            self.model.project_id.is_(None),
+                        )
+                    )
+            elif project_id:
+                # Admin with explicit project filter — keep prior semantics
+                logger.debug(f"Admin filtering products by project_id: {project_id}")
                 query = query.filter(
-                    (self.model.project_id == project_id) |
-                    (self.model.project_id.is_(None))
+                    or_(
+                        self.model.project_id == project_id,
+                        self.model.project_id.is_(None),
+                    )
                 )
 
             return query.offset(skip).limit(limit).all()

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1156,8 +1156,40 @@ async def get_product_linked_assets(
         dpm = getattr(request.app.state, "data_products_manager", None)
         if dpm is None:
             raise HTTPException(status_code=503, detail="Data Products service unavailable")
+        # Compute caller's ownership scope so list_products returns the
+        # accessible set (instead of empty, which would 403 every DP for
+        # non-admins after the repository scoping change).
+        caller_email = current_user.email if current_user else None
+        user_groups = current_user.groups if current_user else []
+        caller_team_ids: list = []
+        caller_project_ids: list = []
         try:
-            accessible = dpm.list_products(skip=0, limit=10_000, is_admin=False)
+            from src.controller.teams_manager import teams_manager
+            from src.controller.projects_manager import projects_manager
+
+            user_teams = teams_manager.get_teams_for_user(db, caller_email, user_groups)
+            caller_team_ids = [t.id for t in user_teams if getattr(t, "id", None)]
+            user_projects = projects_manager.get_user_projects(
+                db, caller_email, user_groups
+            )
+            caller_project_ids = [
+                p.id for p in user_projects.projects if getattr(p, "id", None)
+            ]
+        except Exception:
+            logger.exception(
+                f"Failed to resolve ownership scope for {caller_email} in DP-asset access; "
+                f"will fall back to draft-owner branch only"
+            )
+
+        try:
+            accessible = dpm.list_products(
+                skip=0,
+                limit=10_000,
+                is_admin=False,
+                caller_email=caller_email,
+                caller_team_ids=caller_team_ids,
+                caller_project_ids=caller_project_ids,
+            )
             accessible_ids = {str(p.id) for p in accessible if getattr(p, "id", None)}
         except Exception:
             logger.exception("Failed to list products for DP-asset scoping")
@@ -1580,6 +1612,7 @@ async def upload_data_products(
 async def get_data_products(
     project_id: Optional[str] = None,
     current_user: CurrentUserDep = None,
+    db: DBSessionDep = None,
     manager: DataProductsManager = Depends(get_data_products_manager),
     _: bool = Depends(PermissionChecker(DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.READ_ONLY))
 ):
@@ -1595,7 +1628,43 @@ async def get_data_products(
 
         logger.info(f"User {current_user.email if current_user else 'unknown'} is_admin: {is_admin}")
 
-        products = manager.list_products(project_id=project_id, is_admin=is_admin)
+        # Resolve ownership scope for non-admin callers. Admins skip scoping
+        # entirely; we still pass the inputs harmlessly so the call site is
+        # uniform.
+        caller_email = current_user.email if current_user else None
+        caller_team_ids: List[str] = []
+        caller_project_ids: List[str] = []
+        if not is_admin and current_user:
+            try:
+                from src.controller.teams_manager import teams_manager
+                from src.controller.projects_manager import projects_manager
+
+                user_teams = teams_manager.get_teams_for_user(
+                    db, caller_email, user_groups
+                )
+                caller_team_ids = [t.id for t in user_teams if getattr(t, "id", None)]
+
+                user_projects = projects_manager.get_user_projects(
+                    db, caller_email, user_groups
+                )
+                caller_project_ids = [
+                    p.id for p in user_projects.projects if getattr(p, "id", None)
+                ]
+            except Exception:
+                # Scope-resolution failure is non-fatal but yields fail-closed
+                # behavior downstream (empty list), which is the safe default.
+                logger.exception(
+                    f"Failed to resolve ownership scope for user {caller_email}; "
+                    f"caller will see only their draft-owned products"
+                )
+
+        products = manager.list_products(
+            project_id=project_id,
+            is_admin=is_admin,
+            caller_email=caller_email,
+            caller_team_ids=caller_team_ids,
+            caller_project_ids=caller_project_ids,
+        )
         logger.info(f"Retrieved {len(products)} data products")
         return [p.model_dump() for p in products]
     except Exception as e:
@@ -1899,6 +1968,22 @@ async def update_data_product(
         # unmodified Optional column (delivery_method_id, contract_id, etc).
         product_dict = product_update.model_dump(exclude_unset=True)
 
+        # Resolve caller's team memberships so the manager can run the
+        # team-ownership branch of the cascade. Failure here is non-fatal —
+        # the manager still has project-membership + draft-owner branches.
+        caller_team_ids: List[str] = []
+        try:
+            from src.controller.teams_manager import teams_manager
+            user_teams = teams_manager.get_teams_for_user(
+                db, current_user.email, user_groups
+            )
+            caller_team_ids = [t.id for t in user_teams if getattr(t, "id", None)]
+        except Exception:
+            logger.exception(
+                f"Failed to resolve teams for user {current_user.email} on update; "
+                f"continuing without team-ownership branch"
+            )
+
         updated_product_response = manager.update_product_with_auth(
             product_id=product_id,
             product_data_dict=product_dict,
@@ -1906,6 +1991,7 @@ async def update_data_product(
             user_groups=user_groups,
             db=db,
             background_tasks=background_tasks,
+            caller_team_ids=caller_team_ids,
         )
 
         if not updated_product_response:

--- a/src/backend/src/tests/unit/test_clone_product_schema_drift.py
+++ b/src/backend/src/tests/unit/test_clone_product_schema_drift.py
@@ -1,0 +1,300 @@
+"""Tests for ``clone_product_for_new_version`` schema-drift fix.
+
+Earlier versions of the clone routine referenced columns/attributes that no
+longer exist on the DB models. The function would raise ``AttributeError``
+the moment it touched output ports — so any product with a non-trivial
+shape (output ports, management ports, support channels, team members,
+SBOMs) could not be cloned for editing.
+
+These tests exercise each entity type and assert the clone is a faithful
+copy. They use the in-memory SQLite database wired up by ``conftest.py``.
+
+Background:
+- ``OutputPortDb`` no longer has ``expectation`` / ``dataset_name``
+- ``SBOMDb`` only has ``type`` / ``url`` (not spdx_version, spdx_id, etc.)
+- ``ManagementPortDb`` requires ``content``; uses ``port_type`` / ``url``
+- ``SupportDb`` requires ``channel``; uses ``tool`` / ``scope``
+- ``DataProductTeamMemberDb`` requires ``username`` (not ``email``)
+- The relationship on OutputPortDb is ``sbom`` singular, not ``sboms``
+"""
+import datetime
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.data_products_manager import DataProductsManager
+from src.db_models.data_products import (
+    DataProductDb,
+    DataProductTeamDb,
+    DataProductTeamMemberDb,
+    InputContractDb,
+    ManagementPortDb,
+    OutputPortDb,
+    SBOMDb,
+    SupportDb,
+)
+
+
+def _make_active_source(db: Session, **overrides) -> DataProductDb:
+    """Create an ``active`` DP suitable for cloning into a new version."""
+    src = DataProductDb(
+        id=str(uuid.uuid4()),
+        api_version="v1.0.0",
+        kind="DataProduct",
+        status="active",
+        name="source-product",
+        version="1.0.0",
+        domain="d1",
+        tenant=None,
+        owner_team_id=None,
+        max_level_inheritance=99,
+    )
+    for k, v in overrides.items():
+        setattr(src, k, v)
+    db.add(src)
+    db.flush()
+    return src
+
+
+class TestCloneOutputPorts:
+    def test_clone_preserves_all_output_port_columns(self, db_session: Session):
+        """Source product with a fully-populated OutputPort — all real
+        columns must survive the clone (the dead refs are gone, the live
+        ones round-trip)."""
+        src = _make_active_source(db_session)
+        port = OutputPortDb(
+            product_id=src.id,
+            name="sales_table",
+            version="1.0.0",
+            description="Sales fact table",
+            port_type="table",
+            contract_id="contract-abc",
+            delivery_method_id=None,
+            asset_type="table",
+            asset_identifier="catalog.sales.fact",
+            status="active",
+            server='{"host":"x"}',
+            contains_pii=True,
+            auto_approve=False,
+        )
+        db_session.add(port)
+        db_session.flush()
+
+        mgr = DataProductsManager(db=db_session)
+        cloned = mgr.clone_product_for_new_version(
+            db=db_session, product_id=src.id, new_version="2.0.0"
+        )
+
+        new_port = (
+            db_session.query(OutputPortDb).filter_by(product_id=cloned.id).one()
+        )
+        assert new_port.name == "sales_table"
+        assert new_port.description == "Sales fact table"
+        assert new_port.port_type == "table"
+        assert new_port.contract_id == "contract-abc"
+        assert new_port.asset_type == "table"
+        assert new_port.asset_identifier == "catalog.sales.fact"
+        assert new_port.status == "active"
+        assert new_port.server == '{"host":"x"}'
+        assert new_port.contains_pii is True
+        assert new_port.auto_approve is False
+
+
+class TestCloneSBOMs:
+    def test_clone_carries_sboms_via_singular_relationship(
+        self, db_session: Session
+    ):
+        """Earlier code referenced ``port.sboms`` (plural); the actual
+        relationship is ``port.sbom``. The hasattr check silently no-op'd,
+        so SBOMs were never cloned. Fix exercises the singular path."""
+        src = _make_active_source(db_session)
+        port = OutputPortDb(
+            product_id=src.id, name="p", version="1.0.0"
+        )
+        db_session.add(port)
+        db_session.flush()
+        sbom = SBOMDb(output_port_id=port.id, type="external", url="https://x/sbom.json")
+        db_session.add(sbom)
+        db_session.flush()
+
+        mgr = DataProductsManager(db=db_session)
+        cloned = mgr.clone_product_for_new_version(
+            db=db_session, product_id=src.id, new_version="2.0.0"
+        )
+
+        new_port = (
+            db_session.query(OutputPortDb).filter_by(product_id=cloned.id).one()
+        )
+        new_sboms = (
+            db_session.query(SBOMDb).filter_by(output_port_id=new_port.id).all()
+        )
+        assert len(new_sboms) == 1
+        assert new_sboms[0].type == "external"
+        assert new_sboms[0].url == "https://x/sbom.json"
+
+
+class TestCloneManagementPorts:
+    def test_clone_management_port_includes_required_content(
+        self, db_session: Session
+    ):
+        """``content`` is nullable=False on ``ManagementPortDb``. The earlier
+        code omitted it (and referenced ``port.endpoint`` which doesn't
+        exist), so any product with a management port would IntegrityError
+        if the AttributeError didn't fire first."""
+        src = _make_active_source(db_session)
+        mp = ManagementPortDb(
+            product_id=src.id,
+            name="discovery",
+            content="discoverability",
+            port_type="rest",
+            url="https://api.example.com/discover",
+            channel="ops",
+            description="Discovery endpoint",
+        )
+        db_session.add(mp)
+        db_session.flush()
+
+        mgr = DataProductsManager(db=db_session)
+        cloned = mgr.clone_product_for_new_version(
+            db=db_session, product_id=src.id, new_version="2.0.0"
+        )
+
+        new_mp = (
+            db_session.query(ManagementPortDb).filter_by(product_id=cloned.id).one()
+        )
+        assert new_mp.name == "discovery"
+        assert new_mp.content == "discoverability"
+        assert new_mp.port_type == "rest"
+        assert new_mp.url == "https://api.example.com/discover"
+        assert new_mp.channel == "ops"
+
+
+class TestCloneSupportChannels:
+    def test_clone_support_includes_required_channel(self, db_session: Session):
+        """``channel`` is nullable=False on ``SupportDb``. Earlier code
+        omitted it and referenced ``channel.type`` (which doesn't exist).
+        Without this fix, any product with a support channel raises on
+        clone."""
+        src = _make_active_source(db_session)
+        sup = SupportDb(
+            product_id=src.id,
+            channel="email",
+            url="mailto:support@example.com",
+            description="Email support",
+            tool="email",
+            scope="interactive",
+            invitation_url=None,
+        )
+        db_session.add(sup)
+        db_session.flush()
+
+        mgr = DataProductsManager(db=db_session)
+        cloned = mgr.clone_product_for_new_version(
+            db=db_session, product_id=src.id, new_version="2.0.0"
+        )
+
+        new_sup = (
+            db_session.query(SupportDb).filter_by(product_id=cloned.id).one()
+        )
+        assert new_sup.channel == "email"
+        assert new_sup.url == "mailto:support@example.com"
+        assert new_sup.tool == "email"
+        assert new_sup.scope == "interactive"
+
+
+class TestCloneTeamMembers:
+    def test_clone_team_member_uses_username_not_email(self, db_session: Session):
+        """``username`` is the required identity column on
+        ``DataProductTeamMemberDb``. Earlier code wrote ``email=member.email``,
+        which would AttributeError on read and IntegrityError on commit."""
+        src = _make_active_source(db_session)
+        team = DataProductTeamDb(
+            product_id=src.id, name="data-eng", description="Data eng team"
+        )
+        db_session.add(team)
+        db_session.flush()
+        member = DataProductTeamMemberDb(
+            team_id=team.id,
+            username="alice@example.com",
+            name="Alice",
+            description="Lead",
+            role="owner",
+            date_in=datetime.date(2024, 1, 1),
+        )
+        db_session.add(member)
+        db_session.flush()
+
+        mgr = DataProductsManager(db=db_session)
+        cloned = mgr.clone_product_for_new_version(
+            db=db_session, product_id=src.id, new_version="2.0.0"
+        )
+
+        new_team = (
+            db_session.query(DataProductTeamDb).filter_by(product_id=cloned.id).one()
+        )
+        new_member = (
+            db_session.query(DataProductTeamMemberDb)
+            .filter_by(team_id=new_team.id)
+            .one()
+        )
+        assert new_member.username == "alice@example.com"
+        assert new_member.name == "Alice"
+        assert new_member.role == "owner"
+        assert new_member.date_in == datetime.date(2024, 1, 1)
+
+
+class TestCloneEverythingTogether:
+    def test_clone_full_product_does_not_raise(self, db_session: Session):
+        """End-to-end: a product with every entity type clones cleanly.
+
+        Before this fix, this would raise on the first output port
+        (AttributeError) or on the first management port
+        (IntegrityError on missing ``content``).
+        """
+        src = _make_active_source(db_session)
+        port = OutputPortDb(product_id=src.id, name="p", version="1.0.0", asset_type="table")
+        db_session.add(port); db_session.flush()
+        db_session.add(SBOMDb(output_port_id=port.id, type="external", url="https://x"))
+        db_session.add(
+            ManagementPortDb(
+                product_id=src.id, name="m", content="discoverability", port_type="rest"
+            )
+        )
+        db_session.add(
+            SupportDb(product_id=src.id, channel="slack", url="https://slack/x")
+        )
+        team = DataProductTeamDb(product_id=src.id, name="t")
+        db_session.add(team); db_session.flush()
+        db_session.add(
+            DataProductTeamMemberDb(team_id=team.id, username="u@example.com")
+        )
+        db_session.flush()
+
+        mgr = DataProductsManager(db=db_session)
+        cloned = mgr.clone_product_for_new_version(
+            db=db_session, product_id=src.id, new_version="2.0.0"
+        )
+
+        assert cloned.id != src.id
+        assert cloned.version == "2.0.0"
+        # Each entity type was carried over.
+        assert (
+            db_session.query(OutputPortDb).filter_by(product_id=cloned.id).count() == 1
+        )
+        assert (
+            db_session.query(ManagementPortDb).filter_by(product_id=cloned.id).count()
+            == 1
+        )
+        assert (
+            db_session.query(SupportDb).filter_by(product_id=cloned.id).count() == 1
+        )
+        new_team_id = (
+            db_session.query(DataProductTeamDb).filter_by(product_id=cloned.id).one().id
+        )
+        assert (
+            db_session.query(DataProductTeamMemberDb)
+            .filter_by(team_id=new_team_id)
+            .count()
+            == 1
+        )

--- a/src/backend/src/tests/unit/test_data_products_manager.py
+++ b/src/backend/src/tests/unit/test_data_products_manager.py
@@ -202,8 +202,9 @@ class TestDataProductsManager:
 
     def test_list_products_empty(self, manager):
         """Test listing products when none exist."""
-        # Act
-        result = manager.list_products()
+        # Act — use is_admin=True to exercise listing mechanics rather than
+        # the (separately-tested) ownership scope filter.
+        result = manager.list_products(is_admin=True)
 
         # Assert
         assert isinstance(result, list)
@@ -221,7 +222,7 @@ class TestDataProductsManager:
             manager.create_product(product_data, db=db_session)
 
         # Act
-        result = manager.list_products()
+        result = manager.list_products(is_admin=True)
 
         # Assert
         assert len(result) == 3
@@ -239,7 +240,7 @@ class TestDataProductsManager:
             manager.create_product(product_data, db=db_session)
 
         # Act - Get second page
-        result = manager.list_products(skip=5, limit=3)
+        result = manager.list_products(skip=5, limit=3, is_admin=True)
 
         # Assert
         assert len(result) == 3

--- a/src/backend/src/tests/unit/test_data_products_ownership_scope.py
+++ b/src/backend/src/tests/unit/test_data_products_ownership_scope.py
@@ -1,0 +1,503 @@
+"""
+Unit tests for data-product ownership scope (PR D).
+
+Closes two related authz gaps:
+  1. ``DataProductsRepository.get_multi`` returned every product to every
+     non-admin caller when no project_id was supplied.
+  2. ``DataProductsManager.update_product_with_auth`` only enforced project
+     membership when ``existing.project_id`` was set; otherwise no check.
+
+The fix applies an ownership cascade to BOTH list and update paths:
+  admin → project_id ∈ caller_projects → owner_team_id ∈ caller_teams
+        → draft_owner_id == caller_email → deny.
+
+These tests exercise the cascade end-to-end at the repository + manager
+layers, and cover the regression-guard cases (admin still sees all, legacy
+orphans fail-closed for non-admins).
+"""
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.data_products_manager import DataProductsManager
+from src.db_models.data_products import DataProductDb
+from src.repositories.data_products_repository import data_product_repo
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _make_product(
+    db: Session,
+    *,
+    name: str,
+    status: str = "active",
+    project_id=None,
+    owner_team_id=None,
+    draft_owner_id=None,
+) -> DataProductDb:
+    """Insert a DataProductDb row directly with chosen ownership columns.
+
+    Bypasses the API model so we can populate ``owner_team_id`` /
+    ``draft_owner_id`` without driving full ODPS validation. SQLite FK
+    enforcement is off in the test harness, so arbitrary string IDs are
+    fine.
+    """
+    product = DataProductDb(
+        id=str(uuid.uuid4()),
+        api_version="v1.0.0",
+        kind="DataProduct",
+        status=status,
+        name=name,
+        version="1.0.0",
+        project_id=project_id,
+        owner_team_id=owner_team_id,
+        draft_owner_id=draft_owner_id,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+# ----------------------------------------------------------------------------
+# Repository: get_multi ownership scope
+# ----------------------------------------------------------------------------
+
+
+class TestGetMultiOwnershipScope:
+    """Cover the SQL-level filter in
+    :py:meth:`DataProductsRepository.get_multi`."""
+
+    def test_admin_sees_all(self, db_session: Session):
+        _make_product(db_session, name="A", project_id="proj-A")
+        _make_product(db_session, name="B", owner_team_id="team-B")
+        _make_product(db_session, name="C", draft_owner_id="someone@example.com")
+        _make_product(db_session, name="D")  # orphan
+
+        result = data_product_repo.get_multi(db=db_session, is_admin=True)
+        assert {p.name for p in result} == {"A", "B", "C", "D"}
+
+    def test_admin_with_no_scope_inputs_still_sees_all(self, db_session: Session):
+        """Regression guard: admin path must NOT require scope inputs."""
+        _make_product(db_session, name="A")
+        _make_product(db_session, name="B", owner_team_id="team-B")
+
+        result = data_product_repo.get_multi(db=db_session, is_admin=True)
+        assert len(result) == 2
+
+    def test_non_admin_with_no_scope_fails_closed(self, db_session: Session):
+        """Back-compat call sites without scope must NOT leak products."""
+        _make_product(db_session, name="A", owner_team_id="team-B")
+        _make_product(db_session, name="B", project_id="proj-X")
+
+        result = data_product_repo.get_multi(db=db_session, is_admin=False)
+        assert result == []
+
+    def test_non_admin_sees_only_owned_via_project(self, db_session: Session):
+        _make_product(db_session, name="mine", project_id="proj-A")
+        _make_product(db_session, name="theirs", project_id="proj-B")
+
+        result = data_product_repo.get_multi(
+            db=db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+            caller_project_ids=["proj-A"],
+        )
+        assert {p.name for p in result} == {"mine"}
+
+    def test_non_admin_sees_only_owned_via_team(self, db_session: Session):
+        _make_product(db_session, name="mine", owner_team_id="team-A")
+        _make_product(db_session, name="theirs", owner_team_id="team-B")
+
+        result = data_product_repo.get_multi(
+            db=db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+            caller_team_ids=["team-A"],
+        )
+        assert {p.name for p in result} == {"mine"}
+
+    def test_non_admin_sees_only_owned_via_draft_owner(self, db_session: Session):
+        """Creator ownership covers BOTH drafts and non-drafts."""
+        _make_product(
+            db_session,
+            name="my-draft",
+            status="draft",
+            draft_owner_id="alice@example.com",
+        )
+        _make_product(
+            db_session,
+            name="my-published",
+            status="active",
+            draft_owner_id="alice@example.com",
+        )
+        _make_product(
+            db_session,
+            name="others",
+            draft_owner_id="bob@example.com",
+        )
+
+        result = data_product_repo.get_multi(
+            db=db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+        )
+        assert {p.name for p in result} == {"my-draft", "my-published"}
+
+    def test_non_admin_cascade_union(self, db_session: Session):
+        """All three branches OR together (not AND)."""
+        _make_product(db_session, name="via-project", project_id="proj-A")
+        _make_product(db_session, name="via-team", owner_team_id="team-A")
+        _make_product(
+            db_session, name="via-email", draft_owner_id="alice@example.com"
+        )
+        _make_product(db_session, name="not-mine", owner_team_id="team-B")
+        _make_product(db_session, name="orphan")  # no ownership at all
+
+        result = data_product_repo.get_multi(
+            db=db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+            caller_team_ids=["team-A"],
+            caller_project_ids=["proj-A"],
+        )
+        assert {p.name for p in result} == {"via-project", "via-team", "via-email"}
+
+    def test_non_admin_legacy_orphan_fails_closed(self, db_session: Session):
+        """Legacy product with no project_id / owner_team_id / draft_owner_id
+        is invisible to non-admins (fail-closed)."""
+        _make_product(db_session, name="orphan")
+        result = data_product_repo.get_multi(
+            db=db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+            caller_team_ids=["team-A"],
+            caller_project_ids=["proj-A"],
+        )
+        assert result == []
+
+    def test_non_admin_email_case_insensitive_via_lowercase_storage(
+        self, db_session: Session
+    ):
+        """draft_owner_id is stored as set; our manager check lowers both
+        sides. The repository SQL filter is case-sensitive (matches what's
+        in the column). This test documents that contract: callers must
+        pass a properly-cased email matching how Ontos persists owners
+        (lowercase via ``current_user.email``).
+        """
+        _make_product(
+            db_session, name="mine", draft_owner_id="alice@example.com"
+        )
+        result = data_product_repo.get_multi(
+            db=db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+        )
+        assert len(result) == 1
+
+
+# ----------------------------------------------------------------------------
+# Manager: list_products threading
+# ----------------------------------------------------------------------------
+
+
+class TestListProductsScopeThreading:
+    """Verify :py:meth:`DataProductsManager.list_products` forwards scope
+    args to the repo unchanged."""
+
+    @pytest.fixture
+    def mock_ws_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def manager(self, db_session, mock_ws_client):
+        return DataProductsManager(
+            db=db_session,
+            ws_client=mock_ws_client,
+            notifications_manager=MagicMock(),
+            tags_manager=MagicMock(),
+        )
+
+    def test_admin_list_returns_all(self, manager, db_session):
+        _make_product(db_session, name="A", project_id="proj-A")
+        _make_product(db_session, name="B")  # orphan
+        result = manager.list_products(is_admin=True)
+        assert len(result) == 2
+
+    def test_non_admin_list_filters_by_scope(self, manager, db_session):
+        _make_product(db_session, name="mine", owner_team_id="team-A")
+        _make_product(db_session, name="theirs", owner_team_id="team-B")
+        result = manager.list_products(
+            is_admin=False,
+            caller_email="alice@example.com",
+            caller_team_ids=["team-A"],
+        )
+        assert len(result) == 1
+        assert result[0].name == "mine"
+
+    def test_non_admin_list_no_scope_fails_closed(self, manager, db_session):
+        _make_product(db_session, name="A", owner_team_id="team-A")
+        # Old-style call site (no scope) — must yield empty for non-admin.
+        result = manager.list_products(is_admin=False)
+        assert result == []
+
+
+# ----------------------------------------------------------------------------
+# Manager: update_product_with_auth cascade
+# ----------------------------------------------------------------------------
+
+
+class TestUpdateProductWithAuthCascade:
+    """Cover the in-code ownership cascade in
+    :py:meth:`DataProductsManager.update_product_with_auth`."""
+
+    @pytest.fixture
+    def mock_ws_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def manager(self, db_session, mock_ws_client):
+        return DataProductsManager(
+            db=db_session,
+            ws_client=mock_ws_client,
+            notifications_manager=MagicMock(),
+            tags_manager=MagicMock(),
+        )
+
+    @pytest.fixture(autouse=True)
+    def _stub_update_product(self, manager):
+        """Stub the inner ``update_product`` so tests focus on the auth
+        cascade. Returning a sentinel lets us assert "auth passed → update
+        was invoked"."""
+        manager.update_product = MagicMock(return_value="UPDATED_OK")
+        return manager
+
+    @pytest.fixture(autouse=True)
+    def _stub_admin_check(self):
+        """Force ``is_user_admin`` to be controllable per-test."""
+        with patch(
+            "src.common.authorization.is_user_admin"
+        ) as mock_is_admin:
+            mock_is_admin.return_value = False
+            yield mock_is_admin
+
+    @pytest.fixture(autouse=True)
+    def _stub_project_member(self):
+        """Force ``is_user_project_member`` to be controllable per-test.
+
+        ``update_product_with_auth`` imports ``projects_manager`` lazily, then
+        calls the method as ``projects_manager.is_user_project_member(...)``.
+        Patching the module-level singleton's bound method covers both call
+        styles.
+        """
+        from src.controller import projects_manager as projects_manager_module
+
+        with patch.object(
+            projects_manager_module.projects_manager,
+            "is_user_project_member",
+            return_value=False,
+        ) as mock_member:
+            yield mock_member
+
+    # ---- admin path ----
+
+    def test_admin_can_edit_orphan(
+        self, manager, db_session, _stub_admin_check
+    ):
+        _stub_admin_check.return_value = True
+        product = _make_product(db_session, name="orphan")
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="admin@example.com",
+            user_groups=["admins"],
+            db=db_session,
+        )
+        assert result == "UPDATED_OK"
+        manager.update_product.assert_called_once()
+
+    def test_admin_can_edit_others_team_product(
+        self, manager, db_session, _stub_admin_check
+    ):
+        _stub_admin_check.return_value = True
+        product = _make_product(
+            db_session, name="x", owner_team_id="team-OTHER"
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="admin@example.com",
+            user_groups=["admins"],
+            db=db_session,
+            caller_team_ids=[],  # admin doesn't need teams
+        )
+        assert result == "UPDATED_OK"
+
+    # ---- project membership branch ----
+
+    def test_non_admin_with_project_membership_can_edit(
+        self, manager, db_session, _stub_project_member
+    ):
+        _stub_project_member.return_value = True
+        product = _make_product(
+            db_session, name="x", project_id="proj-A"
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="alice@example.com",
+            user_groups=[],
+            db=db_session,
+        )
+        assert result == "UPDATED_OK"
+
+    # ---- team-ownership branch ----
+
+    def test_non_admin_with_team_ownership_can_edit(self, manager, db_session):
+        product = _make_product(
+            db_session, name="x", owner_team_id="team-A"
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="alice@example.com",
+            user_groups=[],
+            db=db_session,
+            caller_team_ids=["team-A", "team-Z"],
+        )
+        assert result == "UPDATED_OK"
+
+    def test_non_admin_not_in_owning_team_is_denied(
+        self, manager, db_session
+    ):
+        product = _make_product(
+            db_session, name="x", owner_team_id="team-A"
+        )
+
+        with pytest.raises(PermissionError) as excinfo:
+            manager.update_product_with_auth(
+                product_id=product.id,
+                product_data_dict={"name": "renamed"},
+                user_email="alice@example.com",
+                user_groups=[],
+                db=db_session,
+                caller_team_ids=["team-Z"],
+            )
+        # Generic message — must not disclose which check failed.
+        assert "Insufficient permissions" in str(excinfo.value)
+
+    # ---- draft-owner / creator branch ----
+
+    def test_non_admin_draft_owner_can_edit_their_own(
+        self, manager, db_session
+    ):
+        product = _make_product(
+            db_session,
+            name="mine",
+            status="draft",
+            draft_owner_id="alice@example.com",
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="alice@example.com",
+            user_groups=[],
+            db=db_session,
+        )
+        assert result == "UPDATED_OK"
+
+    def test_non_admin_draft_owner_works_for_published_too(
+        self, manager, db_session
+    ):
+        """Single-user ownership works regardless of status."""
+        product = _make_product(
+            db_session,
+            name="mine-published",
+            status="active",
+            draft_owner_id="alice@example.com",
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="alice@example.com",
+            user_groups=[],
+            db=db_session,
+        )
+        assert result == "UPDATED_OK"
+
+    def test_non_admin_draft_owner_match_is_case_insensitive(
+        self, manager, db_session
+    ):
+        product = _make_product(
+            db_session,
+            name="mine",
+            status="draft",
+            draft_owner_id="Alice@Example.com",
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="alice@example.com",
+            user_groups=[],
+            db=db_session,
+        )
+        assert result == "UPDATED_OK"
+
+    # ---- deny paths ----
+
+    def test_non_admin_not_owner_is_denied(self, manager, db_session):
+        product = _make_product(
+            db_session,
+            name="theirs",
+            status="draft",
+            draft_owner_id="bob@example.com",
+        )
+
+        with pytest.raises(PermissionError):
+            manager.update_product_with_auth(
+                product_id=product.id,
+                product_data_dict={"name": "renamed"},
+                user_email="alice@example.com",
+                user_groups=[],
+                db=db_session,
+                caller_team_ids=[],
+            )
+
+    def test_non_admin_orphan_product_denied(self, manager, db_session):
+        """Legacy orphan: no project_id, no owner_team_id, no
+        draft_owner_id → non-admin denied (fail-closed)."""
+        product = _make_product(db_session, name="orphan")
+
+        with pytest.raises(PermissionError):
+            manager.update_product_with_auth(
+                product_id=product.id,
+                product_data_dict={"name": "renamed"},
+                user_email="alice@example.com",
+                user_groups=[],
+                db=db_session,
+                caller_team_ids=["team-A"],
+            )
+
+    def test_update_returns_none_when_product_missing(
+        self, manager, db_session
+    ):
+        result = manager.update_product_with_auth(
+            product_id="does-not-exist",
+            product_data_dict={"name": "x"},
+            user_email="alice@example.com",
+            user_groups=[],
+            db=db_session,
+        )
+        assert result is None

--- a/src/backend/src/tests/unit/test_data_products_repository.py
+++ b/src/backend/src/tests/unit/test_data_products_repository.py
@@ -187,8 +187,9 @@ class TestDataProductRepository:
 
     def test_get_multi_empty(self, db_session: Session):
         """Test listing products when none exist."""
-        # Act
-        result = data_product_repo.get_multi(db=db_session)
+        # Act — use is_admin=True to exercise the listing mechanics rather
+        # than the (separately-tested) ownership scope filter.
+        result = data_product_repo.get_multi(db=db_session, is_admin=True)
 
         # Assert
         assert isinstance(result, list)
@@ -207,7 +208,7 @@ class TestDataProductRepository:
             data_product_repo.create(db=db_session, obj_in=model)
 
         # Act
-        result = data_product_repo.get_multi(db=db_session)
+        result = data_product_repo.get_multi(db=db_session, is_admin=True)
 
         # Assert
         assert len(result) == 3
@@ -225,7 +226,7 @@ class TestDataProductRepository:
             data_product_repo.create(db=db_session, obj_in=model)
 
         # Act - Get second page (skip 5, limit 3)
-        result = data_product_repo.get_multi(db=db_session, skip=5, limit=3)
+        result = data_product_repo.get_multi(db=db_session, skip=5, limit=3, is_admin=True)
 
         # Assert
         assert len(result) == 3
@@ -243,7 +244,7 @@ class TestDataProductRepository:
             data_product_repo.create(db=db_session, obj_in=model)
 
         # Act
-        result = data_product_repo.get_multi(db=db_session, limit=5)
+        result = data_product_repo.get_multi(db=db_session, limit=5, is_admin=True)
 
         # Assert
         assert len(result) == 5


### PR DESCRIPTION
Part of #379 — see the tracking issue for the full PR group, dependency graph, batch plain-English summary, and safety contracts.

Stacked on #376 (PR A).

## 🇬🇧 Plain English

**Two things, related to data products:**

1. **Before this PR**, the *Products* page showed every data product to every non-admin user — even DPs they had nothing to do with. A Data Producer on the sales team could see the marketing team's DPs and the finance team's DPs side by side. This PR scopes the list to **what the caller actually has a stake in**: data products in their project, owned by their team, or that they created.

2. **Also fixed in this PR**: clicking "Edit" on an already-published data product was completely broken — the backend tried to clone the DP first (the standard versioned-editing pattern) but the clone code referenced columns that no longer exist on the database models (`expectation`, `dataset_name`, `sboms`, `spdx_*`, plus a handful more). The clone code would throw `AttributeError` on the first output port, or `IntegrityError` on the first management port / support channel / team member. So every "Edit on an active DP" attempt for the last ~4 months returned HTTP 500. This PR rewrites the clone block against the current models.

**Pair this with**: PR O (admin cascade bypass via auth manager). PR D restricts to "non-admins see what they own; admins see everything." PR O makes "admin" check the Ontos role system instead of just the workspace `admins` group — without it, a customer admin assigned via a non-`admins` workspace group sees an empty Products page.

## Technical detail

### Ownership-cascade scoping

`GET /api/data-products` previously returned ALL products to every non-admin caller when no `project_id` query-param was set. `PUT /api/data-products/{id}` (update_product_with_auth) only enforced project membership when the target product had `project_id` set; otherwise no ownership check at all.

This PR applies the same ownership cascade to BOTH list and update paths:

```
admin
 -> project_id ∈ caller's project memberships
 -> owner_team_id ∈ caller's team memberships
 -> draft_owner_id == caller's email
 -> deny (or empty list)
```

Key design choices:
- `draft_owner_id` serves as the "creator / single-user ownership" field for both drafts and published products. Schema already has it indexed and nullable; no migration needed.
- List filter enforced at SQL level via OR'd predicates in the repository — one query, no N+1.
- Update check is in-code in the manager so the cascade can use `projects_manager.is_user_project_member` (which already considers group membership).
- Non-admin callers with no resolvable scope (no email, no teams, no projects) fail closed (empty list / 403). Legacy orphan rows (no project_id, owner_team_id, OR draft_owner_id) are invisible/uneditable for non-admins until an admin promotes them.
- System call sites that legitimately need full visibility (`get_search_index_items`, `get_published_products` marketplace, `save_to_yaml`) pass `is_admin=True` explicitly to bypass the cascade.

### Clone-product schema-drift repair (bundled commit)

The clone routine referenced columns/attributes that no longer exist on the DB models:
- `OutputPortDb`: removed `expectation`, `dataset_name`; correct columns are `description`, `port_type`, `delivery_method_id`, `asset_type`, `asset_identifier`, `status`, `server`, `contains_pii`, `auto_approve`
- `SBOMDb`: only `type` and `url` today (removed `spdx_version`, `spdx_id`, `name`, `creation_info_created`)
- `ManagementPortDb`: requires `content` (was omitted); uses `port_type` / `url` (not `type` / `endpoint`)
- `SupportDb`: requires `channel` (was omitted); uses `tool` / `scope`
- `DataProductTeamMemberDb`: requires `username` (was `email` — no such column)
- The relationship is `output_port.sbom` (singular), not `output_port.sboms` — the `hasattr` check silently no-op'd, so SBOMs were never carried over

Without this fix, `clone_product_for_new_version` raised `AttributeError` on the first output port for any product with ports, or `IntegrityError` on the first management/support/team member if the `AttributeError` didn't fire first.

Bundled here because PR D already heavily modifies `data_products_manager.py` (the same file). The two changes are unrelated semantically (cascade vs clone correctness) but landing them together avoids a second round-trip on the same file in review.

## Safety contracts

- **Stacked on #376** (PR A's branch). Merge order: #376 first.
- **Must ship with PR O** (cascade-bypass for Ontos-role admins): without PR O, customers whose admin role is assigned to a non-`admins` workspace group lose Products page visibility entirely. **Do not merge #393 without also merging the PR O equivalent (filed separately).** The "the customer regression" was exactly this gap.

## Tests

- `test_data_products_ownership_scope.py` — 23 cases at repo + manager layers, admin regression guards, fail-closed orphan handling
- `test_data_products_repository.py` + `test_data_products_manager.py` — list/get_multi tests updated to pass `is_admin=True` since they exercise listing mechanics, not auth
- `test_clone_product_schema_drift.py` — 6 new cases: OutputPort columns, SBOMs via singular relationship, ManagementPort required `content`, Support required `channel`, TeamMember `username`, end-to-end clone of a product with every entity type

23+6 = 29 new tests, all pass.

## Verification

Verified on a production workspaceuction — Products page works for admins (with PR O in the same bundle), Data Producers see scoped lists, clone-for-editing on active DPs now returns 200.

This pull request and its description were written by Isaac.
