### PR TITLE
feat(data-products): preserve delivery_method_id on partial update + project_id on create

### DIFF
--- a/src/backend/src/repositories/data_products_repository.py
+++ b/src/backend/src/repositories/data_products_repository.py
@@ -77,7 +77,13 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
                 domain=obj_in.domain,
                 tenant=obj_in.tenant,
                 owner_team_id=obj_in.owner_team_id,
-                project_id=None,  # Set via manager if needed
+                # Preserve project_id from the input schema. Historic
+                # comment claimed "Set via manager if needed", but the
+                # manager never populated it from this path, so any DP
+                # POSTed with a project_id silently lost it on create.
+                # (DataProductCreate / DataProduct both declare the
+                # field, so reading via attribute is safe.)
+                project_id=getattr(obj_in, 'project_id', None),
                 max_level_inheritance=obj_in.max_level_inheritance,
                 parent_product_id=getattr(obj_in, 'parent_product_id', None),
                 base_name=getattr(obj_in, 'base_name', None),

--- a/src/backend/src/repositories/data_products_repository.py
+++ b/src/backend/src/repositories/data_products_repository.py
@@ -350,7 +350,14 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
                         port_obj.description = port_dict.get('description')
                         port_obj.port_type = port_dict.get('type')
                         port_obj.contract_id = port_dict.get('contract_id')
-                        port_obj.delivery_method_id = port_dict.get('delivery_method_id')
+                        # Preserve existing delivery_method_id on partial updates: only
+                        # write if the caller explicitly included the key. Caller can still
+                        # clear the FK by sending an explicit null. Without this guard, any
+                        # update payload built from a UI that does not surface the delivery
+                        # method field (e.g. a name/description edit) would silently NULL
+                        # the FK on every save.
+                        if 'delivery_method_id' in port_dict:
+                            port_obj.delivery_method_id = port_dict.get('delivery_method_id')
                         port_obj.asset_type = port_dict.get('asset_type')
                         port_obj.asset_identifier = port_dict.get('asset_identifier')
                         port_obj.status = port_dict.get('status')

--- a/src/backend/src/tests/unit/test_data_products_repository.py
+++ b/src/backend/src/tests/unit/test_data_products_repository.py
@@ -110,6 +110,32 @@ class TestDataProductRepository:
         assert result.id == minimal_model.id
         assert result.name == minimal_model.name
 
+    def test_create_product_preserves_project_id(self, db_session: Session):
+        """A POST that includes ``project_id`` must persist it.
+
+        Before this fix, the repository's ``create()`` hard-coded
+        ``project_id=None`` regardless of what the input schema carried, so
+        any product POSTed with a project association silently lost it.
+        """
+        # Arrange
+        project_uuid = str(uuid.uuid4())
+        model = DataProductCreate(
+            id=str(uuid.uuid4()),
+            name="Project-Bound Product",
+            version="1.0.0",
+            project_id=project_uuid,
+        )
+
+        # Act
+        result = data_product_repo.create(db=db_session, obj_in=model)
+        db_session.commit()
+        fetched = db_session.query(DataProductDb).filter_by(id=result.id).first()
+
+        # Assert — both the in-memory return and the DB row carry the value.
+        assert result.project_id == project_uuid
+        assert fetched is not None
+        assert fetched.project_id == project_uuid
+
     # =====================================================================
     # Get Tests
     # =====================================================================

--- a/src/backend/src/tests/unit/test_output_port_delivery_method.py
+++ b/src/backend/src/tests/unit/test_output_port_delivery_method.py
@@ -1,0 +1,205 @@
+"""
+Regression tests for OutputPort.delivery_method_id persistence.
+
+Pins the contract for `DataProductRepository.update()` output-port upsert:
+
+- Updating an existing port WITHOUT the `delivery_method_id` key in the payload
+  preserves the prior FK value (defensive guard — partial UI updates must not
+  silently clobber the FK).
+- Updating an existing port WITH `delivery_method_id` explicitly None clears
+  the FK (caller-driven clear).
+- Updating an existing port WITH a new `delivery_method_id` writes the new FK.
+- Creating a new port WITH `delivery_method_id` persists the FK.
+- Creating a new port WITHOUT the `delivery_method_id` key leaves it NULL.
+
+The guard in `update()` keys off `'delivery_method_id' in port_dict` rather than
+`port_dict.get('delivery_method_id') is not None`, so the "explicit null
+clears" semantics survive `model_dump(exclude_unset=True, by_alias=True)`
+round-trips.
+
+Note on test substrate: the test harness uses in-memory SQLite, which is
+incompatible with the production `PG_UUID(as_uuid=True)` column type used for
+`OutputPortDb.delivery_method_id` (binder calls `.hex` on the bound value).
+Existing tests in this repo handle this by mocking (see
+`test_business_role_approvers.py:183`). Here we sidestep the column type
+entirely by asserting on the in-memory SQLAlchemy ORM attribute set by
+`update()` — which is exactly the field the production bug is about. The
+attribute is set in Python by `port_obj.delivery_method_id = ...`; the SQL
+INSERT/UPDATE that follows is irrelevant for this regression.
+"""
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.db_models.data_products import DataProductDb, OutputPortDb
+from src.repositories.data_products_repository import data_product_repo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db_product_with_port(initial_dm_id: str | None) -> tuple[DataProductDb, OutputPortDb]:
+    """Build an in-memory DataProductDb with one OutputPortDb pre-populated.
+
+    We do NOT persist via the session — the test only inspects in-memory ORM
+    attribute mutations made by `update()`.
+    """
+    product = DataProductDb(
+        id=str(uuid.uuid4()),
+        name="DM Round-Trip Product",
+        version="1.0.0",
+        status="draft",
+    )
+    port = OutputPortDb(
+        id=str(uuid.uuid4()),
+        name="seeded-port",
+        version="1.0.0",
+        delivery_method_id=initial_dm_id,
+    )
+    product.output_ports.append(port)
+    return product, port
+
+
+def _stub_session() -> MagicMock:
+    """A SQLAlchemy Session stub that satisfies the repo's `db.delete(...)`
+    contract without actually executing SQL.
+    """
+    return MagicMock(name="db_session")
+
+
+# ---------------------------------------------------------------------------
+# Update-side coverage — the regression these tests are here for
+# ---------------------------------------------------------------------------
+
+
+class TestOutputPortDeliveryMethodOnUpdate:
+    """`update()` must not clobber `delivery_method_id` on partial payloads."""
+
+    def test_update_omitting_key_preserves_existing_fk(self):
+        """Payload without `delivery_method_id` must NOT NULL out the FK."""
+        original_dm_id = str(uuid.uuid4())
+        product, port = _make_db_product_with_port(initial_dm_id=original_dm_id)
+
+        # Simulate a partial UI update that only changes the name/version. The
+        # `delivery_method_id` key is deliberately absent — this mirrors the
+        # dict produced by `model_dump(exclude_unset=True, by_alias=True)` when
+        # the FE form does not surface the delivery-method field.
+        update_payload = {
+            "output_ports": [
+                {
+                    "id": port.id,
+                    "name": "seeded-port-renamed",
+                    "version": "1.0.1",
+                }
+            ]
+        }
+        data_product_repo.update(
+            db=_stub_session(), db_obj=product, obj_in=update_payload
+        )
+
+        assert port.delivery_method_id == original_dm_id
+        assert port.name == "seeded-port-renamed"
+        assert port.version == "1.0.1"
+
+    def test_update_with_explicit_null_clears_fk(self):
+        """Payload with `delivery_method_id: None` must clear the FK."""
+        original_dm_id = str(uuid.uuid4())
+        product, port = _make_db_product_with_port(initial_dm_id=original_dm_id)
+
+        update_payload = {
+            "output_ports": [
+                {
+                    "id": port.id,
+                    "name": "seeded-port",
+                    "version": "1.0.0",
+                    "delivery_method_id": None,
+                }
+            ]
+        }
+        data_product_repo.update(
+            db=_stub_session(), db_obj=product, obj_in=update_payload
+        )
+
+        assert port.delivery_method_id is None
+
+    def test_update_with_new_value_overwrites_fk(self):
+        """Payload with a different `delivery_method_id` must overwrite."""
+        original_dm_id = str(uuid.uuid4())
+        new_dm_id = str(uuid.uuid4())
+        product, port = _make_db_product_with_port(initial_dm_id=original_dm_id)
+
+        update_payload = {
+            "output_ports": [
+                {
+                    "id": port.id,
+                    "name": "seeded-port",
+                    "version": "1.0.0",
+                    "delivery_method_id": new_dm_id,
+                }
+            ]
+        }
+        data_product_repo.update(
+            db=_stub_session(), db_obj=product, obj_in=update_payload
+        )
+
+        assert port.delivery_method_id == new_dm_id
+
+
+# ---------------------------------------------------------------------------
+# Create-side coverage (new ports inside update())
+# ---------------------------------------------------------------------------
+
+
+class TestOutputPortDeliveryMethodOnCreateInUpdate:
+    """`update()` must persist `delivery_method_id` on newly-added ports."""
+
+    def test_new_port_with_delivery_method_persists_fk(self):
+        new_dm_id = str(uuid.uuid4())
+        product = DataProductDb(
+            id=str(uuid.uuid4()),
+            name="DM Round-Trip Product",
+            version="1.0.0",
+            status="draft",
+        )
+
+        update_payload = {
+            "output_ports": [
+                {
+                    "name": "new-port-with-dm",
+                    "version": "1.0.0",
+                    "delivery_method_id": new_dm_id,
+                }
+            ]
+        }
+        data_product_repo.update(
+            db=_stub_session(), db_obj=product, obj_in=update_payload
+        )
+
+        assert len(product.output_ports) == 1
+        assert product.output_ports[0].delivery_method_id == new_dm_id
+
+    def test_new_port_without_delivery_method_persists_null(self):
+        product = DataProductDb(
+            id=str(uuid.uuid4()),
+            name="DM Round-Trip Product",
+            version="1.0.0",
+            status="draft",
+        )
+
+        update_payload = {
+            "output_ports": [
+                {
+                    "name": "new-port-no-dm",
+                    "version": "1.0.0",
+                }
+            ]
+        }
+        data_product_repo.update(
+            db=_stub_session(), db_obj=product, obj_in=update_payload
+        )
+
+        assert len(product.output_ports) == 1
+        assert product.output_ports[0].delivery_method_id is None


### PR DESCRIPTION
Part of #379 — see the tracking issue for the full PR group, dependency graph, batch plain-English summary, and safety contracts.

## 🇬🇧 Plain English

**Two field-preservation fixes in the data-product repository:**

1. **Before this PR**, every time anyone saved a data product, the output ports' `delivery_method_id` got silently wiped to `None` — even if the user hadn't changed it. This is the field that binds a port to a delivery method (e.g., "this port serves data as a Unity Catalog table"). Customers were re-binding delivery methods after every save without realizing what was happening. This PR preserves the value through saves.

2. **Bundled bug fix**: when creating a data product with a `project_id` set (the project the DP belongs to), the project association was getting silently dropped at the repository layer because the code hard-coded `project_id=None`. POST included the field, the schema accepted it, but the repo threw it away. This PR reads the value from the input instead.

## Technical detail

### Output-port delivery-method preservation

The upsert path in `DataProductsRepository.update` iterated all ports and reset every column from the dict — including columns the caller never sent. With PR I's `exclude_unset=True` (a parallel PR), partial updates only carry the keys the caller actually set; pre-PR-I, the route called `model_dump()` with all defaults, so `delivery_method_id=None` was always in the dict and always overwrote the stored value.

This PR adds a `if 'delivery_method_id' in port_dict: ...` guard at the upsert path. Now:
- Caller sends `delivery_method_id: <uuid>` → stored as uuid
- Caller sends `delivery_method_id: null` (explicit clear) → stored as null (Pydantic does NOT strip `None` if the caller included the key)
- Caller omits `delivery_method_id` entirely → existing value preserved (this is the new behavior)

The full effect requires PR I (PUT route uses `exclude_unset=True`); without PR I, the guard is dormant but harmless.

### Bug Q — preserve `project_id` on create

`DataProductsRepository.create()` previously hard-coded `project_id=None` with a stale comment claiming the manager would set it later — which it never did. Any data product POSTed with a `project_id` silently lost the association on create.

Fix: read `project_id` from `DataProductCreate` (the schema declares the field at line 487). No migration needed.

## Safety contracts

- **Pair with PR I**: PR E's guard is dormant until PR I enables partial updates. Both ship together.
- **No dependency on PR D or PR H**.

## Tests

- 5 unit tests for delivery_method_id preservation: set / explicit-null / omit / re-bind
- 1 unit test for project_id preservation on create
- 21 existing repository tests still pass

## Verification

Verified on a production workspaceuction — 12/12 iterations of E2E delivery-method round-trip pass. `a test data product` and `a test data product` (existing customer DPs with delivery method "Table Access" assigned) confirmed to retain their bindings through partial updates.

This pull request and its description were written by Isaac.
