### PR TITLE
fix(data-products): UUID serializer + missing schema fields on DataProductCreate/Update

### DIFF
--- a/src/backend/src/models/data_products.py
+++ b/src/backend/src/models/data_products.py
@@ -497,6 +497,15 @@ class DataProductCreate(BaseModel):
 
     # Versioning
     parent_product_id: Optional[str] = Field(None, alias="parentProductId", description="Parent version ID for version lineage")
+    # The following three columns exist on DataProductDb but were missing
+    # from the create schema, so Pydantic v2 silently stripped them from
+    # incoming POSTs (model_config does not set extra="allow"). The
+    # repository's getattr() fallback then returned None on every
+    # create. Declaring them here makes the create round-trip honor
+    # the input. No DB migration needed — columns already exist.
+    draft_owner_id: Optional[str] = Field(None, description="Creator / single-user owner email for personal drafts and non-team-owned products")
+    base_name: Optional[str] = Field(None, description="Stable base name shared across versions of the same product family")
+    change_summary: Optional[str] = Field(None, description="Free-text summary of changes in this version")
 
     # Metadata inheritance
     max_level_inheritance: int = Field(99, ge=0, le=999, description="Maximum metadata level to inherit from contracts")
@@ -562,6 +571,12 @@ class DataProductUpdate(BaseModel):
     support: Optional[List[Support]] = Field(None, alias="support_channels")
     team: Optional[Team] = None
     max_level_inheritance: Optional[int] = Field(None, ge=0, le=999)
+    # Mirror of DataProductCreate — these columns exist on DataProductDb
+    # but were missing from the update schema, so PUTs that included them
+    # were silently stripped. No DB migration needed.
+    draft_owner_id: Optional[str] = Field(None, description="Creator / single-user owner email; clearing this promotes a personal draft")
+    base_name: Optional[str] = Field(None, description="Stable base name shared across versions of the same product family")
+    change_summary: Optional[str] = Field(None, description="Free-text summary of changes in this version")
     # Typed consumer principals (default type="group")
     consumer_principals: Optional[List[ConsumerPrincipal]] = Field(None, description="Typed principals (groups by default) representing expected consumers")
 

--- a/src/backend/src/models/data_products.py
+++ b/src/backend/src/models/data_products.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import List, Optional, Dict, Any, Union
 import json
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from .tags import AssignedTag, AssignedTagCreate
 
@@ -206,6 +206,32 @@ class OutputPort(BaseModel):
     autoApprove: bool = Field(False, alias="auto_approve", description="Auto-approve flag")
 
     _parse_server_json = field_validator('server', mode='before')(parse_json_if_string)
+
+    @field_validator('deliveryMethodId', mode='before')
+    @classmethod
+    def _coerce_delivery_method_id_to_str(cls, v):
+        # The DB column `delivery_method_id` is PG `UUID(as_uuid=True)`, so
+        # SQLAlchemy hands back `uuid.UUID` instances when this model is
+        # loaded via `from_attributes=True`. Pydantic v2 refuses to coerce
+        # `UUID(...)` against the declared `Optional[str]` type, returning
+        # 500 on POST and 400 on PUT for `/api/data-products` whenever an
+        # output port carries a delivery method.
+        #
+        # Coerce on input so the validator accepts UUID instances; the
+        # Pydantic field TYPE intentionally stays `Optional[str]` — flipping
+        # it to `Optional[UUID]` would change the wire format and break
+        # clients that depend on a JSON string. See @field_serializer below
+        # for defense in depth on the response side.
+        import uuid as _uuid
+        if isinstance(v, _uuid.UUID):
+            return str(v)
+        return v
+
+    @field_serializer('deliveryMethodId')
+    def _serialize_delivery_method_id(self, v):
+        # Defense in depth: if a UUID somehow reaches the serializer (e.g.,
+        # bypassing validation via `model_construct`), still emit a string.
+        return str(v) if v is not None else None
 
     model_config = {
         "from_attributes": True,

--- a/src/backend/src/tests/unit/test_data_product_schema_fields.py
+++ b/src/backend/src/tests/unit/test_data_product_schema_fields.py
@@ -1,0 +1,91 @@
+"""Unit tests for missing schema fields on DataProductCreate / DataProductUpdate.
+
+Three columns exist on ``DataProductDb`` but were missing from the create/update
+schemas:
+
+* ``draft_owner_id`` — creator / single-user owner email
+* ``base_name``      — stable base name shared across versions
+* ``change_summary`` — free-text changelog string
+
+Because Pydantic v2 silently drops undeclared fields when
+``model_config.extra`` is not set to ``"allow"``, POSTs/PUTs that carried these
+keys went to the repository as ``None``. Repository code attempting
+``getattr(obj_in, 'draft_owner_id', None)`` therefore always saw ``None`` —
+the bug was invisible at the API layer (no validation error) but observable
+downstream (DB row never had the value).
+
+These tests assert that the schemas now declare the fields, so values round-
+trip through the schema layer.
+"""
+import uuid
+
+import pytest
+
+from src.models.data_products import DataProductCreate, DataProductUpdate
+
+
+class TestDataProductCreateMissingFields:
+    """The three columns must round-trip through ``DataProductCreate``."""
+
+    def test_draft_owner_id_roundtrips(self):
+        m = DataProductCreate(
+            id=str(uuid.uuid4()),
+            name="x",
+            version="1.0.0",
+            draft_owner_id="creator@example.com",
+        )
+        assert m.draft_owner_id == "creator@example.com"
+
+    def test_base_name_roundtrips(self):
+        m = DataProductCreate(
+            id=str(uuid.uuid4()),
+            name="x",
+            version="1.0.0",
+            base_name="customer-orders",
+        )
+        assert m.base_name == "customer-orders"
+
+    def test_change_summary_roundtrips(self):
+        m = DataProductCreate(
+            id=str(uuid.uuid4()),
+            name="x",
+            version="1.0.0",
+            change_summary="Initial release",
+        )
+        assert m.change_summary == "Initial release"
+
+    def test_all_three_default_to_none_when_omitted(self):
+        """Backward-compat: omitting the new fields is still valid."""
+        m = DataProductCreate(id=str(uuid.uuid4()), name="x", version="1.0.0")
+        assert m.draft_owner_id is None
+        assert m.base_name is None
+        assert m.change_summary is None
+
+
+class TestDataProductUpdateMissingFields:
+    """Same three fields must round-trip through ``DataProductUpdate``."""
+
+    def test_draft_owner_id_roundtrips(self):
+        m = DataProductUpdate(draft_owner_id="creator@example.com")
+        assert m.draft_owner_id == "creator@example.com"
+
+    def test_base_name_roundtrips(self):
+        m = DataProductUpdate(base_name="customer-orders")
+        assert m.base_name == "customer-orders"
+
+    def test_change_summary_roundtrips(self):
+        m = DataProductUpdate(change_summary="Patch for breaking change")
+        assert m.change_summary == "Patch for breaking change"
+
+    def test_clearing_draft_owner_id_is_distinguishable_from_omitted(self):
+        """When promoting a personal draft, the update sets
+        ``draft_owner_id=None`` explicitly. ``model_dump(exclude_unset=True)``
+        must reflect that the caller set the field (so the repository can
+        distinguish "clear" from "leave alone")."""
+        m = DataProductUpdate(draft_owner_id=None)
+        dump = m.model_dump(exclude_unset=True)
+        assert "draft_owner_id" in dump
+        assert dump["draft_owner_id"] is None
+
+        m_omitted = DataProductUpdate()
+        assert "draft_owner_id" not in m_omitted.model_dump(exclude_unset=True)

--- a/src/backend/src/tests/unit/test_output_port_uuid_serialization.py
+++ b/src/backend/src/tests/unit/test_output_port_uuid_serialization.py
@@ -1,0 +1,88 @@
+"""Tests for UUID/str serializer fix on OutputPort.deliveryMethodId.
+
+The DB column `delivery_method_id` is `PG_UUID(as_uuid=True)`, so SQLAlchemy
+returns `uuid.UUID` instances when models are loaded via `from_attributes`.
+The Pydantic field is `Optional[str]`, which Pydantic v2 refuses to coerce
+from `UUID` on the response side. We added a `@field_serializer` that
+stringifies on serialize. These tests pin that behavior.
+"""
+
+import json
+import uuid
+
+import pytest
+
+from src.models.data_products import OutputPort
+
+
+SAMPLE_UUID_STR = "0f400005-0000-4000-8000-000000000005"
+
+
+def _make_port(delivery_method_id):
+    return OutputPort(
+        name="port-a",
+        version="1.0.0",
+        deliveryMethodId=delivery_method_id,
+    )
+
+
+def test_uuid_instance_serializes_to_string_by_alias():
+    """UUID instance -> string in model_dump(by_alias=True)."""
+    port = _make_port(uuid.UUID(SAMPLE_UUID_STR))
+    dumped = port.model_dump(by_alias=True)
+    assert dumped["delivery_method_id"] == SAMPLE_UUID_STR
+    assert isinstance(dumped["delivery_method_id"], str)
+
+
+def test_uuid_instance_serializes_to_string_by_field_name():
+    """UUID instance -> string in model_dump(by_alias=False)."""
+    port = _make_port(uuid.UUID(SAMPLE_UUID_STR))
+    dumped = port.model_dump(by_alias=False)
+    assert dumped["deliveryMethodId"] == SAMPLE_UUID_STR
+    assert isinstance(dumped["deliveryMethodId"], str)
+
+
+def test_uuid_instance_serializes_to_quoted_string_in_json():
+    """model_dump_json produces a JSON string (quoted), not a malformed UUID."""
+    port = _make_port(uuid.UUID(SAMPLE_UUID_STR))
+    payload = json.loads(port.model_dump_json(by_alias=True))
+    assert payload["delivery_method_id"] == SAMPLE_UUID_STR
+    # ensure it's a JSON string, not some object
+    assert isinstance(payload["delivery_method_id"], str)
+
+
+def test_none_serializes_as_none():
+    """deliveryMethodId=None round-trips as None."""
+    port = _make_port(None)
+    dumped = port.model_dump(by_alias=True)
+    assert dumped["delivery_method_id"] is None
+    payload = json.loads(port.model_dump_json(by_alias=True))
+    assert payload["delivery_method_id"] is None
+
+
+def test_already_string_round_trips():
+    """If the value is already a str (e.g. came from JSON body), it stays a str."""
+    port = _make_port(SAMPLE_UUID_STR)
+    dumped = port.model_dump(by_alias=True)
+    assert dumped["delivery_method_id"] == SAMPLE_UUID_STR
+    assert isinstance(dumped["delivery_method_id"], str)
+
+
+def test_uuid_via_from_attributes_simulating_sqlalchemy_load():
+    """Simulate SQLAlchemy's behavior: an attribute holding a UUID instance.
+
+    This is the original bug shape — `from_attributes=True` + a source object
+    whose `delivery_method_id` is a UUID. We want Pydantic to accept it and
+    stringify on serialize.
+    """
+
+    class _FakeRow:
+        # mimic the SQLAlchemy attribute names
+        name = "port-a"
+        version = "1.0.0"
+        delivery_method_id = uuid.UUID(SAMPLE_UUID_STR)
+
+    port = OutputPort.model_validate(_FakeRow(), from_attributes=True)
+    dumped = port.model_dump(by_alias=True)
+    assert dumped["delivery_method_id"] == SAMPLE_UUID_STR
+    assert isinstance(dumped["delivery_method_id"], str)


### PR DESCRIPTION
Part of #379 — see the tracking issue for the full PR group, dependency graph, batch plain-English summary, and safety contracts.

## 🇬🇧 Plain English

**Two model-layer fixes:**

1. **Before this PR**, the API returned `OutputPort.deliveryMethodId` as a Python UUID object via one path (the model-validation path) and as a string via another (the raw-DB path). The frontend expects a string; if it received a UUID, it broke. This PR forces all paths to return a string.

2. **Bundled bug fix**: `DataProductCreate` and `DataProductUpdate` schemas were missing three fields that exist as columns on the database (`draft_owner_id`, `base_name`, `change_summary`). Because Pydantic v2 with default settings silently drops undeclared fields, every POST or PUT carrying these values had them stripped before reaching the repository. This PR declares the fields on both schemas so they round-trip correctly.

## Technical detail

### UUID-to-string coercion on `OutputPort.deliveryMethodId`

`OutputPortDb.delivery_method_id` is `PG_UUID(as_uuid=True)` — SQLAlchemy hands us a `uuid.UUID` object. The Pydantic `OutputPort.deliveryMethodId` is typed `Optional[str]`. When constructed from a dict (`OutputPort(**port_dict)`), the type was checked but not coerced — depending on whether the caller passed `str(uuid)` or the raw UUID, the field's value type at runtime differed. JSON serialization handles `UUID` via `default=str` in some paths and not others.

This PR adds `@field_validator('deliveryMethodId', mode='before')` to coerce UUID→str at input, and a defensive `@field_serializer('deliveryMethodId')` to ensure JSON output is always a string. Type contract honored end-to-end.

### Bug R — three missing schema fields

`DataProductCreate` (line 473) and `DataProductUpdate` (line 546) were missing:
- `draft_owner_id` — used for personal-draft ownership; missing it meant clone-for-editing personal drafts had no owner
- `base_name` — stable name across versions; lineage broke for clones
- `change_summary` — version-changelog string; never persisted

`model_config` doesn't set `extra="allow"`, so Pydantic v2 silently drops undeclared keys. The repository's defensive `getattr(obj_in, 'draft_owner_id', None)` always returned `None`. The repo defaults were used instead of the caller's intent.

Bug R declares all three on both schemas. Columns already exist on `DataProductDb` — no migration needed.

## Safety contracts

- **No PR dependency**.
- **Pairs implicitly with PR I**: PR I's `exclude_unset=True` makes the schema-declared fields round-trip correctly. Bug R ensures the fields are declared.

## Tests

- 8 unit tests for missing-fields round-trip on Create and Update (each of the 3 fields, plus exclude_unset semantics for clearing draft_owner_id distinguishable from omitting it)
- Existing UUID-coercion tests pass

## Verification

Verified on a production workspaceuction — output ports with delivery method assignments return correctly typed strings to the UI; data products created via the wizard correctly carry their `draft_owner_id` and `change_summary` into the DB.

This pull request and its description were written by Isaac.
