### PR TITLE
fix(data-products): admin cascade-bypass uses Ontos role, not just workspace group

### DIFF
--- a/src/backend/src/common/authorization.py
+++ b/src/backend/src/common/authorization.py
@@ -52,6 +52,90 @@ def is_user_admin(user_groups: Optional[List[str]], settings: Settings) -> bool:
         return "admins" in [g.lower() for g in user_groups]
 
 
+async def is_user_feature_admin(
+    user_email: Optional[str],
+    user_groups: Optional[List[str]],
+    feature_id: str,
+    request: Request,
+) -> bool:
+    """Return True if the user has admin-level rights for the given feature.
+
+    Distinct from :func:`is_user_admin`, which only checks workspace-group
+    membership (``APP_ADMIN_DEFAULT_GROUPS``). This helper also consults the
+    Ontos role system: a user whose effective permissions include
+    ``FeatureAccessLevel.ADMIN`` on ``feature_id`` is considered admin for
+    cascade-bypass purposes — even when their workspace groups don't include
+    the literal ``admins`` group.
+
+    Use this when deciding whether a user should bypass ownership scoping
+    on a specific feature (e.g., "should this user see all data products?").
+    It mirrors the resolution used by :func:`enforce_feature_permission`
+    (team-role override → applied-role override → group-based merge) so the
+    bypass stays consistent with whatever role the user is currently acting
+    under.
+
+    Resolution failures fall back to the workspace-admin check only — i.e.,
+    a transient DB error never flips a non-admin into admin.
+
+    Args:
+        user_email: Caller's email (matched against role ``assigned_groups``
+            via the auth manager's email-as-group support).
+        user_groups: Caller's workspace groups.
+        feature_id: Feature identifier (e.g., ``"data-products"``).
+        request: FastAPI request — used to reach ``auth_manager`` and
+            ``settings_manager`` from ``request.app.state``.
+
+    Returns:
+        True if the user is admin via workspace group OR Ontos role.
+    """
+    workspace_admin = is_user_admin(user_groups or [], get_settings())
+    if workspace_admin:
+        return True
+    if not user_email:
+        return False
+    try:
+        auth_manager: Optional[AuthorizationManager] = getattr(
+            request.app.state, "authorization_manager", None
+        )
+        settings_manager: Optional[SettingsManager] = getattr(
+            request.app.state, "settings_manager", None
+        )
+        if auth_manager is None:
+            return False
+
+        team_role_override = await get_user_team_role_overrides(
+            user_email, user_groups or [], request
+        )
+
+        applied_role_id: Optional[str] = None
+        if settings_manager is not None:
+            try:
+                applied_role_id = settings_manager.get_applied_role_override_for_user(
+                    user_email
+                )
+            except Exception:
+                applied_role_id = None
+
+        if applied_role_id and settings_manager is not None:
+            effective = settings_manager.get_feature_permissions_for_role_id(
+                applied_role_id
+            )
+        else:
+            effective = auth_manager.get_user_effective_permissions(
+                user_groups or [], team_role_override
+            )
+
+        return effective.get(feature_id) == FeatureAccessLevel.ADMIN
+    except Exception:
+        logger.exception(
+            "is_user_feature_admin: failed to resolve Ontos-role admin for user '%s' on feature '%s'; "
+            "falling back to workspace-admin check (False)",
+            user_email,
+            feature_id,
+        )
+        return False
+
+
 # Local Dev Mock User (keep here for the dependency function)
 LOCAL_DEV_USER = UserInfo(
     email="localdev@example.com",  # Use example.com which is reserved for documentation

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1610,6 +1610,7 @@ async def upload_data_products(
 
 @router.get('/data-products', response_model=Any)
 async def get_data_products(
+    request: Request,
     project_id: Optional[str] = None,
     current_user: CurrentUserDep = None,
     db: DBSessionDep = None,
@@ -1619,19 +1620,36 @@ async def get_data_products(
     try:
         logger.info(f"Retrieving data products via get_data_products route (project_id: {project_id})...")
 
-        # Check if user is admin
-        from src.common.authorization import is_user_admin
-        from src.common.config import get_settings
-        settings = get_settings()
+        # Cascade-bypass admin check.
+        #
+        # PR D originally used ``is_user_admin(user_groups, settings)`` here,
+        # which only matches workspace-``APP_ADMIN_DEFAULT_GROUPS`` membership.
+        # That mis-classifies users whose admin status comes from the Ontos
+        # role system (e.g., a customer's "Admin" role assigned to a non-
+        # ``admins`` workspace group): they have FeatureAccessLevel.ADMIN on
+        # data-products via their role, but get cascade-restricted and see
+        # an empty Products page.
+        #
+        # ``is_user_feature_admin`` consults the same auth manager that
+        # ``/api/user/permissions`` uses, so the bypass aligns with the
+        # user's effective permissions. The behavior for workspace-``admins``
+        # users is unchanged (the helper short-circuits on workspace-admin
+        # membership before doing role resolution).
+        from src.common.authorization import is_user_feature_admin
         user_groups = current_user.groups if current_user else []
-        is_admin = is_user_admin(user_groups, settings)
+        caller_email = current_user.email if current_user else None
+        is_admin = await is_user_feature_admin(
+            user_email=caller_email,
+            user_groups=user_groups,
+            feature_id=DATA_PRODUCTS_FEATURE_ID,
+            request=request,
+        )
 
         logger.info(f"User {current_user.email if current_user else 'unknown'} is_admin: {is_admin}")
 
         # Resolve ownership scope for non-admin callers. Admins skip scoping
         # entirely; we still pass the inputs harmlessly so the call site is
         # uniform.
-        caller_email = current_user.email if current_user else None
         caller_team_ids: List[str] = []
         caller_project_ids: List[str] = []
         if not is_admin and current_user:

--- a/src/backend/src/tests/unit/test_is_user_feature_admin.py
+++ b/src/backend/src/tests/unit/test_is_user_feature_admin.py
@@ -1,0 +1,221 @@
+"""Unit tests for ``is_user_feature_admin``.
+
+Covers the cascade-bypass admin check used by data-products listing
+(and any other PR D-style ownership scope). The helper must:
+
+1. Short-circuit True when the user belongs to a workspace admin group.
+2. Return True when the user's effective Ontos-role permissions grant
+   ``FeatureAccessLevel.ADMIN`` on the named feature, even when they
+   are *not* a workspace admin (the Daimler regression case).
+3. Return False otherwise.
+4. Honor applied-role overrides (the role-switcher path) when set.
+5. Fail-closed on auth-manager errors — i.e., a transient resolution
+   failure never flips a non-admin into admin.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.common.features import FeatureAccessLevel
+
+
+def _make_request(*, auth_manager=None, settings_manager=None):
+    """Construct a minimal FastAPI ``Request`` stand-in.
+
+    The helper only reads ``request.app.state.authorization_manager`` and
+    ``request.app.state.settings_manager`` — everything else is irrelevant.
+    """
+    request = MagicMock()
+    request.app.state.authorization_manager = auth_manager
+    request.app.state.settings_manager = settings_manager
+    return request
+
+
+@pytest.fixture
+def mock_settings(monkeypatch):
+    """Patch ``get_settings`` so ``is_user_admin`` reads a deterministic
+    ``APP_ADMIN_DEFAULT_GROUPS`` value (the default ``["admins"]``)."""
+    settings = MagicMock()
+    settings.APP_ADMIN_DEFAULT_GROUPS = '["admins"]'
+    monkeypatch.setattr(
+        "src.common.authorization.get_settings", lambda: settings
+    )
+    return settings
+
+
+@pytest.mark.asyncio
+async def test_workspace_admin_short_circuits_true(mock_settings):
+    """User in workspace ``admins`` group → True, no auth_manager call."""
+    from src.common.authorization import is_user_feature_admin
+
+    auth_manager = MagicMock()
+    result = await is_user_feature_admin(
+        user_email="someone@example.com",
+        user_groups=["admins", "users"],
+        feature_id="data-products",
+        request=_make_request(auth_manager=auth_manager),
+    )
+
+    assert result is True
+    # Short-circuit: auth manager must not be consulted at all.
+    auth_manager.get_user_effective_permissions.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ontos_role_admin_grants_bypass(mock_settings):
+    """Not a workspace admin, but role permissions grant ADMIN → True.
+
+    This is the Daimler / FEVM-Mikhail regression case: the Ontos
+    ``Admin`` role is assigned to a non-``admins`` workspace group
+    (or via email-as-group), and the user's effective permissions
+    include ``ADMIN`` on data-products.
+    """
+    from src.common.authorization import is_user_feature_admin
+
+    auth_manager = MagicMock()
+    auth_manager.get_user_effective_permissions.return_value = {
+        "data-products": FeatureAccessLevel.ADMIN,
+        "data-contracts": FeatureAccessLevel.READ_WRITE,
+    }
+    with patch(
+        "src.common.authorization.get_user_team_role_overrides",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await is_user_feature_admin(
+            user_email="mikhail@example.com",
+            user_groups=["099_Treasure_DataProducer", "users"],
+            feature_id="data-products",
+            request=_make_request(auth_manager=auth_manager),
+        )
+
+    assert result is True
+    auth_manager.get_user_effective_permissions.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_read_write_role_does_not_grant_bypass(mock_settings):
+    """User has READ_WRITE (Data Producer) — not ADMIN → False.
+
+    Ensures Data Producers, who PR D *intentionally* restricts via the
+    ownership cascade, are not accidentally promoted to admin.
+    """
+    from src.common.authorization import is_user_feature_admin
+
+    auth_manager = MagicMock()
+    auth_manager.get_user_effective_permissions.return_value = {
+        "data-products": FeatureAccessLevel.READ_WRITE,
+    }
+    with patch(
+        "src.common.authorization.get_user_team_role_overrides",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await is_user_feature_admin(
+            user_email="producer@example.com",
+            user_groups=["099_Treasure_DataProducer"],
+            feature_id="data-products",
+            request=_make_request(auth_manager=auth_manager),
+        )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_no_email_returns_false_for_non_workspace_admin(mock_settings):
+    """No email + not a workspace admin → False (can't resolve role)."""
+    from src.common.authorization import is_user_feature_admin
+
+    auth_manager = MagicMock()
+    result = await is_user_feature_admin(
+        user_email=None,
+        user_groups=["random-group"],
+        feature_id="data-products",
+        request=_make_request(auth_manager=auth_manager),
+    )
+
+    assert result is False
+    auth_manager.get_user_effective_permissions.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_manager_failure_falls_back_to_false(mock_settings, caplog):
+    """Auth-manager exception → False; the workspace-admin signal is the
+    only thing that could have flipped it True, and it didn't."""
+    from src.common.authorization import is_user_feature_admin
+
+    auth_manager = MagicMock()
+    auth_manager.get_user_effective_permissions.side_effect = RuntimeError("db down")
+    with patch(
+        "src.common.authorization.get_user_team_role_overrides",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await is_user_feature_admin(
+            user_email="user@example.com",
+            user_groups=["users"],
+            feature_id="data-products",
+            request=_make_request(auth_manager=auth_manager),
+        )
+
+    assert result is False
+    # Failure was logged (not silently swallowed).
+    assert any(
+        "is_user_feature_admin" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_applied_role_override_path_uses_override(mock_settings):
+    """When a session-scoped role override is active, the helper uses
+    the override's permissions (matches ``enforce_feature_permission``).
+
+    Override grants ADMIN → True.
+    """
+    from src.common.authorization import is_user_feature_admin
+
+    auth_manager = MagicMock()
+    # Permanent permissions only grant READ_WRITE — the override is what
+    # should flip the answer.
+    auth_manager.get_user_effective_permissions.return_value = {
+        "data-products": FeatureAccessLevel.READ_WRITE,
+    }
+
+    settings_manager = MagicMock()
+    settings_manager.get_applied_role_override_for_user.return_value = "admin-role-id"
+    settings_manager.get_feature_permissions_for_role_id.return_value = {
+        "data-products": FeatureAccessLevel.ADMIN,
+    }
+
+    with patch(
+        "src.common.authorization.get_user_team_role_overrides",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await is_user_feature_admin(
+            user_email="role-switcher@example.com",
+            user_groups=["users"],
+            feature_id="data-products",
+            request=_make_request(
+                auth_manager=auth_manager, settings_manager=settings_manager
+            ),
+        )
+
+    assert result is True
+    # Override path used — group-based resolution must not be consulted.
+    auth_manager.get_user_effective_permissions.assert_not_called()
+    settings_manager.get_feature_permissions_for_role_id.assert_called_once_with(
+        "admin-role-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_auth_manager_returns_false(mock_settings):
+    """Defensive: ``authorization_manager`` missing from app state → False
+    (no way to resolve Ontos-role permissions)."""
+    from src.common.authorization import is_user_feature_admin
+
+    result = await is_user_feature_admin(
+        user_email="user@example.com",
+        user_groups=["users"],
+        feature_id="data-products",
+        request=_make_request(auth_manager=None),
+    )
+
+    assert result is False


### PR DESCRIPTION
Part of #379 — see the tracking issue for the full PR group, dependency graph, batch plain-English summary, and safety contracts.

Stacked on PR D — **do not merge before** the PR D PR is merged. (See PR D in the tracking issue; this PR is the safety net for the regression PR D introduces.)

## 🇬🇧 Plain English

**The problem this PR fixes** (introduced by PR D):

PR D scopes the Products page so non-admins only see DPs they have a stake in, and admins see everything. But to decide who's an "admin," PR D checks whether the user is in the workspace `admins` group (a Databricks-platform concept).

Many customers grant the Ontos `Admin` *role* to users in a different group (e.g., `MyCompany_Ontos_Admins`), NOT the workspace `admins` group. PR D mis-classifies those users as non-admins, and they end up with an empty Products page — even though everywhere else in Ontos they have full admin powers.

**This PR adds a second admin check**: a user is treated as admin-for-cascade-bypass if EITHER (a) they're in `APP_ADMIN_DEFAULT_GROUPS` (PR D's check, preserved) OR (b) their effective Ontos-role permissions grant `FeatureAccessLevel.ADMIN` on `data-products`.

After this PR, the cascade-bypass aligns with the rest of Ontos's admin detection (the auth manager that powers `/api/user/permissions`). Customers whose Ontos `Admin` role is assigned to a non-workspace-`admins` group are no longer locked out of their Products page.

## Technical detail

Introduces `is_user_feature_admin(user_email, user_groups, feature_id, request)` in `common/authorization.py`:
1. Short-circuits True if user is in `APP_ADMIN_DEFAULT_GROUPS` (workspace-admin path)
2. Otherwise, resolves the user's effective permissions via the auth manager (same path `enforce_feature_permission` uses), checking team-role override → applied-role override → group-based merge
3. Returns True if `effective[feature_id] == FeatureAccessLevel.ADMIN`
4. Auth-resolution failures fall back to the workspace-admin check only (fail-closed)

Replaces the `is_user_admin(...)` call in `data_product_routes.get_data_products()` with `is_user_feature_admin(..., DATA_PRODUCTS_FEATURE_ID, request)`. The cascade in the repository remains unchanged — only the bypass decision changes.

## Safety contracts

- **Stacked on PR D**. Cannot merge alone (depends on PR D's cascade existing in the first place).
- **No behavior change for workspace-`admins` users** — the helper short-circuits on the workspace-admin check before ever consulting the auth manager.
- **No behavior change for non-admin Data Producers** — the helper's second branch only returns True for `FeatureAccessLevel.ADMIN`, which Data Producers don't have.
- **Auth-manager failure is fail-closed** — a transient DB error never flips a non-admin into admin.

## Tests

- 7 unit tests for `is_user_feature_admin`:
 - Workspace-admin short-circuits True (no auth manager call)
 - Ontos-role ADMIN via auth manager → True
 - READ_WRITE level → False (does not over-promote)
 - No email + no workspace admin → False
 - Auth manager failure → False (fail-closed)
 - Applied-role-override path used when present
 - Missing auth manager → False
- 23 existing PR D ownership-scope tests still pass

## Verification

Verified on a production workspaceuction — Products page count restored from 0/1 (broken) to all DPs (working) for the the customer-shape admin configuration.

This pull request and its description were written by Isaac.
