### PR TITLE
feat(directory): Phase 1 frontend — Settings tab + PrincipalPicker

### DIFF
--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -74,6 +74,7 @@ from src.routes import (
     readiness_routes,
     suggestion_routes,
     certification_levels_routes,
+    directory_routes,
 )
 
 from src.common.database import init_db, get_session_factory, SQLAlchemySession
@@ -383,6 +384,7 @@ mcp_tokens_routes.register_routes(app)
 self_service_routes.register_routes(app)
 workflows_routes.register_routes(app)
 settings_routes.register_routes(app)
+directory_routes.register_routes(app)
 connection_routes.register_routes(app)
 schema_import_routes.register_routes(app)
 

--- a/src/backend/src/common/dependencies.py
+++ b/src/backend/src/common/dependencies.py
@@ -25,6 +25,7 @@ from src.controller.business_roles_manager import BusinessRolesManager
 from src.controller.business_owners_manager import BusinessOwnersManager
 from src.controller.delivery_methods_manager import DeliveryMethodsManager
 from src.controller.ontology_generator_manager import OntologyGeneratorManager
+from src.controller.directory_manager import DirectoryManager
 
 # Import base dependencies
 from src.common.database import get_session_factory # Import the factory function
@@ -55,6 +56,7 @@ from src.common.manager_dependencies import (
     get_business_owners_manager,
     get_delivery_methods_manager,
     get_ontology_generator_manager,
+    get_directory_manager,
 )
 # Import workspace client getter separately as it might be structured differently
 from src.common.workspace_client import get_workspace_client_dependency  # Fixed to use proper wrapper
@@ -132,6 +134,7 @@ BusinessRolesManagerDep = Annotated[BusinessRolesManager, Depends(get_business_r
 BusinessOwnersManagerDep = Annotated[BusinessOwnersManager, Depends(get_business_owners_manager)]
 DeliveryMethodsManagerDep = Annotated[DeliveryMethodsManager, Depends(get_delivery_methods_manager)]
 OntologyGeneratorManagerDep = Annotated[OntologyGeneratorManager, Depends(get_ontology_generator_manager)]
+DirectoryManagerDep = Annotated[DirectoryManager, Depends(get_directory_manager)]
 
 # Permission Checker Dependency
 PermissionCheckerDep = AuthorizationManagerDep 

--- a/src/backend/src/common/manager_dependencies.py
+++ b/src/backend/src/common/manager_dependencies.py
@@ -29,6 +29,7 @@ from src.controller.business_roles_manager import BusinessRolesManager
 from src.controller.business_owners_manager import BusinessOwnersManager
 from src.controller.delivery_methods_manager import DeliveryMethodsManager
 from src.controller.ontology_generator_manager import OntologyGeneratorManager
+from src.controller.directory_manager import DirectoryManager
 
 # Import other dependencies needed by these providers
 from src.common.database import get_db
@@ -219,6 +220,13 @@ def get_ontology_generator_manager(request: Request) -> OntologyGeneratorManager
     if not manager:
         logger.critical("OntologyGeneratorManager not found in application state!")
         raise HTTPException(status_code=503, detail="Ontology Generator service not configured.")
+    return manager
+
+def get_directory_manager(request: Request) -> DirectoryManager:
+    manager = getattr(request.app.state, "directory_manager", None)
+    if not manager:
+        logger.critical("DirectoryManager not found in application state!")
+        raise HTTPException(status_code=503, detail="Directory service not configured.")
     return manager
 
 # --- Add other manager getters if needed --- #

--- a/src/backend/src/common/uc_connections.py
+++ b/src/backend/src/common/uc_connections.py
@@ -1,0 +1,47 @@
+"""Shared helpers for working with Unity Catalog Connections.
+
+Today these are HTTP-type connections used by workflow webhook steps
+and by the Directory layer. Centralising the listing logic so both
+routes return the same shape and behave identically on SDK errors.
+"""
+
+from typing import Any, Dict, List
+
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def list_http_connections(ws_client: Any) -> List[Dict[str, Any]]:
+    """Return all HTTP-type Unity Catalog connections.
+
+    Output shape matches the legacy ``/api/workflows/http-connections``
+    response: ``[{name, connection_type, comment, owner, created_at,
+    updated_at}, ...]``. On SDK errors an empty list is returned and a
+    warning is logged -- the workspace may simply not expose HTTP
+    connections yet, and surfacing the error as 500 was deemed worse
+    than returning the no-op set.
+    """
+
+    try:
+        connections: List[Dict[str, Any]] = []
+        for conn in ws_client.connections.list():
+            # ``ConnectionType.HTTP`` is not present in every SDK
+            # version, so match the existing string-based check.
+            conn_type = str(conn.connection_type) if conn.connection_type else ""
+            if "HTTP" not in conn_type.upper():
+                continue
+            connections.append(
+                {
+                    "name": conn.name,
+                    "connection_type": conn_type,
+                    "comment": conn.comment,
+                    "owner": conn.owner,
+                    "created_at": conn.created_at,
+                    "updated_at": conn.updated_at,
+                }
+            )
+        return connections
+    except Exception as exc:
+        logger.warning(f"Failed to list HTTP connections: {exc}")
+        return []

--- a/src/backend/src/controller/directory_manager.py
+++ b/src/backend/src/controller/directory_manager.py
@@ -1,0 +1,219 @@
+"""Directory layer manager.
+
+Reads provider configuration from ``app_settings``, dispatches to the
+right concrete ``DirectoryProvider``, and caches search results in
+memory for 5 minutes per (provider_type, query_shape) key. The cache
+is per-instance and the manager is held as a singleton on
+``app.state``.
+
+The manager itself is provider-agnostic: adding a new provider is a
+matter of registering another class in ``_PROVIDER_REGISTRY``.
+"""
+
+import time
+from threading import Lock
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.controller.directory_providers import (
+    DirectoryError,
+    DirectoryProvider,
+    EntraIdProvider,
+)
+from src.models.directory import (
+    DirectoryProviderType,
+    DirectoryStatus,
+    Principal,
+    SETTING_KEY_CONNECTION_NAME,
+    SETTING_KEY_PROVIDER_TYPE,
+)
+from src.repositories.app_settings_repository import app_settings_repo
+
+logger = get_logger(__name__)
+
+
+_CACHE_TTL_SECONDS = 5 * 60
+_DEFAULT_SEARCH_LIMIT = 20
+
+
+# Provider registry. Adding a new provider requires only an entry here
+# plus an implementation in src.controller.directory_providers; the
+# manager, routes, and models stay untouched.
+_PROVIDER_REGISTRY: Dict[str, Callable[[Any, str], DirectoryProvider]] = {
+    DirectoryProviderType.ENTRA.value: EntraIdProvider,
+}
+
+
+class DirectoryManager:
+    """Stateless dispatcher + per-instance TTL cache.
+
+    All methods are safe to call from concurrent request handlers; the
+    internal cache is guarded by a lock.
+    """
+
+    def __init__(self) -> None:
+        self._cache: Dict[Tuple[str, str, str, str], Tuple[float, List[Principal]]] = {}
+        self._lock = Lock()
+        # Track which (provider_type, connection_name) tuple the cache
+        # was filled for; flip => purge.
+        self._cache_keyed_on: Optional[Tuple[str, str]] = None
+
+    # ----- public API ---------------------------------------------------------
+
+    def get_status(self, db: Session) -> DirectoryStatus:
+        """Return the live ``configured`` flag plus a redaction-safe summary."""
+
+        provider_type = app_settings_repo.get_by_key(db, SETTING_KEY_PROVIDER_TYPE)
+        connection_name = app_settings_repo.get_by_key(db, SETTING_KEY_CONNECTION_NAME)
+        configured = bool(provider_type) and bool(connection_name) and provider_type in _PROVIDER_REGISTRY
+        return DirectoryStatus(
+            configured=configured,
+            provider_type=provider_type if provider_type else None,
+            connection_name=connection_name if connection_name else None,
+        )
+
+    def search(
+        self,
+        db: Session,
+        ws_client: Any,
+        query: str,
+        types: List[str],
+        limit: int = _DEFAULT_SEARCH_LIMIT,
+    ) -> List[Principal]:
+        """Return up to ``limit`` principals matching ``query`` across ``types``.
+
+        ``types`` may include any combination of ``"user"`` and
+        ``"group"``. Results are de-duplicated by ``(type, id)`` to
+        survive partial cache hits. Returns an empty list when the
+        directory is not configured.
+        """
+
+        provider_type, connection_name = self._read_settings(db)
+        if not provider_type or not connection_name:
+            return []
+
+        self._invalidate_if_keyed_changed(provider_type, connection_name)
+
+        wanted = {t for t in types if t in {"user", "group"}} or {"user", "group"}
+        results: List[Principal] = []
+        seen: set = set()
+
+        provider = self._build_provider(provider_type, ws_client, connection_name)
+
+        if "user" in wanted:
+            for p in self._cached(provider_type, connection_name, "user", query, limit,
+                                  lambda: provider.search_users(query, limit)):
+                key = (p.type, p.id)
+                if key not in seen:
+                    seen.add(key)
+                    results.append(p)
+
+        if "group" in wanted:
+            for p in self._cached(provider_type, connection_name, "group", query, limit,
+                                  lambda: provider.search_groups(query, limit)):
+                key = (p.type, p.id)
+                if key not in seen:
+                    seen.add(key)
+                    results.append(p)
+
+        # Honour the caller's overall limit even after cross-type merge.
+        return results[:limit]
+
+    def test(self, db: Session, ws_client: Any) -> None:
+        """Probe the configured provider. Raises ``DirectoryError`` if unhealthy."""
+
+        provider_type, connection_name = self._read_settings(db)
+        if not provider_type:
+            raise DirectoryError("Directory provider is not configured")
+        if not connection_name:
+            raise DirectoryError("UC HTTP connection name is not configured")
+        provider = self._build_provider(provider_type, ws_client, connection_name)
+        provider.test()
+
+    def invalidate_cache(self) -> None:
+        """Drop all cached results. Call after any setting change."""
+
+        with self._lock:
+            self._cache.clear()
+            self._cache_keyed_on = None
+
+    # ----- internals ----------------------------------------------------------
+
+    def _read_settings(self, db: Session) -> Tuple[Optional[str], Optional[str]]:
+        provider_type = app_settings_repo.get_by_key(db, SETTING_KEY_PROVIDER_TYPE)
+        connection_name = app_settings_repo.get_by_key(db, SETTING_KEY_CONNECTION_NAME)
+        return (provider_type or None), (connection_name or None)
+
+    def _build_provider(
+        self,
+        provider_type: str,
+        ws_client: Any,
+        connection_name: str,
+    ) -> DirectoryProvider:
+        factory = _PROVIDER_REGISTRY.get(provider_type)
+        if factory is None:
+            raise DirectoryError(
+                f"Unknown directory provider type: {provider_type!r}"
+            )
+        return factory(ws_client, connection_name)
+
+    def _invalidate_if_keyed_changed(self, provider_type: str, connection_name: str) -> None:
+        with self._lock:
+            current = (provider_type, connection_name)
+            if self._cache_keyed_on is not None and self._cache_keyed_on != current:
+                self._cache.clear()
+            self._cache_keyed_on = current
+
+    def _cached(
+        self,
+        provider_type: str,
+        connection_name: str,
+        kind: str,
+        query: str,
+        limit: int,
+        loader: Callable[[], List[Principal]],
+    ) -> List[Principal]:
+        # Normalise the query so capitalisation / surrounding whitespace
+        # doesn't bypass the cache.
+        cache_key = (provider_type, connection_name, kind, f"{query.strip().lower()}|{limit}")
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry and (now - entry[0]) < _CACHE_TTL_SECONDS:
+                return entry[1]
+
+        try:
+            values = loader()
+        except DirectoryError:
+            raise
+        except Exception as exc:
+            raise DirectoryError(f"Directory lookup failed: {exc}") from exc
+
+        with self._lock:
+            self._cache[cache_key] = (time.monotonic(), values)
+        return values
+
+
+# Re-export for routes that only need the registry knowledge.
+SUPPORTED_PROVIDER_TYPES: List[str] = list(_PROVIDER_REGISTRY.keys())
+
+
+def register_provider(
+    provider_type: str,
+    factory: Callable[[Any, str], DirectoryProvider],
+) -> None:
+    """Register an additional provider implementation at runtime.
+
+    Used by tests to inject stub providers without touching the
+    production registry.
+    """
+
+    _PROVIDER_REGISTRY[provider_type] = factory
+
+
+def unregister_provider(provider_type: str) -> None:
+    """Inverse of :func:`register_provider`, primarily for test teardown."""
+
+    _PROVIDER_REGISTRY.pop(provider_type, None)

--- a/src/backend/src/controller/directory_providers/__init__.py
+++ b/src/backend/src/controller/directory_providers/__init__.py
@@ -1,0 +1,25 @@
+"""Directory provider plug-ins.
+
+Each concrete provider talks to its IdP exclusively via a Unity Catalog
+HTTP Connection so UC owns OAuth2 client-credentials acquisition,
+caching, and refresh. The app stores no client secret and no token
+cache.
+
+Field mapping (Graph ``userPrincipalName`` vs Okta ``profile.login`` vs
+...) lives entirely inside each provider; the manager and routes only
+ever see normalised ``Principal`` instances.
+"""
+
+from src.controller.directory_providers.base import (
+    DirectoryError,
+    DirectoryProvider,
+)
+from src.controller.directory_providers.entra_id_provider import (
+    EntraIdProvider,
+)
+
+__all__ = [
+    "DirectoryError",
+    "DirectoryProvider",
+    "EntraIdProvider",
+]

--- a/src/backend/src/controller/directory_providers/base.py
+++ b/src/backend/src/controller/directory_providers/base.py
@@ -1,0 +1,45 @@
+"""Abstract DirectoryProvider interface implemented by every concrete provider."""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from src.models.directory import Principal
+
+
+class DirectoryError(Exception):
+    """Raised when a provider fails to talk to its IdP.
+
+    The string is surfaced to the UI via the ``/api/directory/test``
+    endpoint and (one-shot) via the picker's graceful-degradation log
+    line. It must not contain secrets.
+    """
+
+
+class DirectoryProvider(ABC):
+    """Provider plug-in contract.
+
+    Every method must return normalised ``Principal`` instances and is
+    responsible for safe escaping of the caller-supplied ``prefix`` /
+    ``id`` against its own query syntax (OData for Graph, SCIM for
+    Okta, etc.). The manager does not sanitise these strings.
+    """
+
+    @abstractmethod
+    def search_users(self, prefix: str, top: int) -> List[Principal]:
+        """Search users whose display name or UPN starts with ``prefix``."""
+
+    @abstractmethod
+    def search_groups(self, prefix: str, top: int) -> List[Principal]:
+        """Search groups whose display name starts with ``prefix``."""
+
+    @abstractmethod
+    def get_user(self, id: str) -> Principal:
+        """Resolve a single user by ``id`` (UPN/email)."""
+
+    @abstractmethod
+    def get_group(self, id: str) -> Principal:
+        """Resolve a single group by ``id`` (display name)."""
+
+    @abstractmethod
+    def test(self) -> None:
+        """Probe the IdP. Raise ``DirectoryError`` on failure, return on success."""

--- a/src/backend/src/controller/directory_providers/entra_id_provider.py
+++ b/src/backend/src/controller/directory_providers/entra_id_provider.py
@@ -1,0 +1,259 @@
+"""Microsoft Entra ID provider via Microsoft Graph + UC HTTP Connection.
+
+Auth: all calls go through ``ws.serving_endpoints.http_request(connection_name=...)``
+so UC handles OAuth2 client-credentials acquisition and token caching.
+
+Endpoints used:
+- ``GET /v1.0/users?$filter=...&$select=...&$top=...`` (search users)
+- ``GET /v1.0/groups?$filter=...&$select=...&$top=...`` (search groups)
+- ``GET /v1.0/users/<id>?$select=...`` (resolve user)
+- ``GET /v1.0/groups/<id>?$select=...`` (resolve group)
+
+The UC HTTP Connection is expected to be configured against Microsoft
+Graph (``https://graph.microsoft.com``) with the
+``https://graph.microsoft.com/.default`` scope so the entire ``/v1.0``
+path is reachable.
+"""
+
+import json
+from typing import Any, Callable, Dict, List, Optional
+
+from src.common.logging import get_logger
+from src.controller.directory_providers.base import (
+    DirectoryError,
+    DirectoryProvider,
+)
+from src.models.directory import Principal, PrincipalType
+
+logger = get_logger(__name__)
+
+
+# Field projections kept tight so responses stay small.
+_USER_SELECT = "id,displayName,userPrincipalName,mail"
+_GROUP_SELECT = "id,displayName,description"
+
+# Graph requires this header for ``startswith`` filters against the
+# directory's eventually-consistent indexes.
+_EVENTUAL_CONSISTENCY_HEADERS = {"ConsistencyLevel": "eventual"}
+
+
+def _escape_odata(value: str) -> str:
+    """Escape a string for safe inclusion in an OData filter literal.
+
+    Single quotes are the only OData string-literal terminator, so the
+    only thing we ever need to do is double them (``O'Brien`` ->
+    ``O''Brien``). We never inject the raw value anywhere else in the
+    URL.
+    """
+
+    return value.replace("'", "''")
+
+
+class EntraIdProvider(DirectoryProvider):
+    """DirectoryProvider implementation for Microsoft Graph.
+
+    The provider holds a reference to a Databricks ``WorkspaceClient``
+    and the UC HTTP Connection name. It does not cache results -- that
+    lives in ``DirectoryManager``.
+    """
+
+    def __init__(self, ws_client: Any, connection_name: str) -> None:
+        if not connection_name:
+            raise DirectoryError("UC HTTP connection name is required")
+        self._ws = ws_client
+        self._connection_name = connection_name
+
+    # ----- DirectoryProvider --------------------------------------------------
+
+    def search_users(self, prefix: str, top: int) -> List[Principal]:
+        if not prefix:
+            return []
+        safe = _escape_odata(prefix)
+        # ``startswith`` against three fields covers display name plus
+        # the two most common login shapes users actually type. The
+        # ``eventual`` consistency header is required for these filters.
+        filter_expr = (
+            f"startswith(displayName,'{safe}') "
+            f"or startswith(userPrincipalName,'{safe}') "
+            f"or startswith(mail,'{safe}')"
+        )
+        path = (
+            f"/v1.0/users?"
+            f"$filter={_url_quote(filter_expr)}&"
+            f"$select={_USER_SELECT}&"
+            f"$top={int(top)}&"
+            f"$count=true"
+        )
+        body = self._graph_get(path, headers=_EVENTUAL_CONSISTENCY_HEADERS)
+        return [self._user_to_principal(u) for u in body.get("value", [])]
+
+    def search_groups(self, prefix: str, top: int) -> List[Principal]:
+        if not prefix:
+            return []
+        safe = _escape_odata(prefix)
+        filter_expr = f"startswith(displayName,'{safe}')"
+        path = (
+            f"/v1.0/groups?"
+            f"$filter={_url_quote(filter_expr)}&"
+            f"$select={_GROUP_SELECT}&"
+            f"$top={int(top)}&"
+            f"$count=true"
+        )
+        body = self._graph_get(path, headers=_EVENTUAL_CONSISTENCY_HEADERS)
+        return [self._group_to_principal(g) for g in body.get("value", [])]
+
+    def get_user(self, id: str) -> Principal:
+        if not id:
+            raise DirectoryError("Empty user id")
+        # Graph accepts either GUID or UPN/email in the path segment.
+        # Path-segment values are URL-encoded; OData escaping does not
+        # apply here because we are not embedding into a filter literal.
+        path = f"/v1.0/users/{_url_quote(id)}?$select={_USER_SELECT}"
+        return self._user_to_principal(self._graph_get(path))
+
+    def get_group(self, id: str) -> Principal:
+        if not id:
+            raise DirectoryError("Empty group id")
+        # Graph's path-segment lookup for groups only accepts the GUID;
+        # callers that have a display name need to use search_groups.
+        # We surface that as a DirectoryError so the manager can fall
+        # back gracefully.
+        path = f"/v1.0/groups/{_url_quote(id)}?$select={_GROUP_SELECT}"
+        return self._group_to_principal(self._graph_get(path))
+
+    def test(self) -> None:
+        # ``$top=1`` minimises payload while still exercising auth + a
+        # real Graph response shape.
+        path = "/v1.0/users?$select=id&$top=1"
+        self._graph_get(path)
+
+    # ----- mapping ------------------------------------------------------------
+
+    @staticmethod
+    def _user_to_principal(u: Dict[str, Any]) -> Principal:
+        # UPN is the persisted identifier; ``mail`` is a fallback for
+        # accounts that only carry a mail attribute.
+        identifier = u.get("userPrincipalName") or u.get("mail") or u.get("id", "")
+        display_name = u.get("displayName") or identifier
+        sub_label = u.get("mail") or u.get("userPrincipalName")
+        # Don't duplicate the same value across both lines.
+        if sub_label == display_name:
+            sub_label = u.get("userPrincipalName") if sub_label != u.get("userPrincipalName") else None
+        return Principal(
+            type=PrincipalType.USER,
+            id=identifier,
+            display_name=display_name,
+            sub_label=sub_label,
+        )
+
+    @staticmethod
+    def _group_to_principal(g: Dict[str, Any]) -> Principal:
+        display_name = g.get("displayName") or g.get("id", "")
+        sub_label = g.get("id") or g.get("description")
+        return Principal(
+            type=PrincipalType.GROUP,
+            id=display_name,
+            display_name=display_name,
+            sub_label=sub_label,
+        )
+
+    # ----- transport ----------------------------------------------------------
+
+    def _graph_get(
+        self,
+        path: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Issue a GET against Graph via UC HTTP Connection, return parsed JSON.
+
+        The SDK ``http_request`` returns ``HttpRequestResponse(contents=
+        BinaryIO)``; we read, decode, and parse as JSON. Any transport
+        error or non-JSON / Graph-error body is translated into a
+        ``DirectoryError``.
+        """
+
+        try:
+            from databricks.sdk.service.serving import (
+                ExternalFunctionRequestHttpMethod,
+            )
+        except ImportError as exc:  # pragma: no cover - SDK always present
+            raise DirectoryError(
+                "Databricks SDK does not support serving HTTP requests"
+            ) from exc
+
+        try:
+            response = self._ws.serving_endpoints.http_request(
+                connection_name=self._connection_name,
+                method=ExternalFunctionRequestHttpMethod.GET,
+                path=path,
+                headers=headers if headers else None,
+            )
+        except Exception as exc:
+            # Transport / auth failures bubble up here.
+            raise DirectoryError(f"Graph request failed: {exc}") from exc
+
+        body = _read_response_body(response)
+        if not body:
+            raise DirectoryError("Graph returned an empty response")
+
+        try:
+            parsed = json.loads(body)
+        except (TypeError, ValueError) as exc:
+            raise DirectoryError(
+                f"Graph returned a non-JSON response: {body[:200]}"
+            ) from exc
+
+        # Graph error responses are ``{"error": {"code": "...",
+        # "message": "..."}}``. UC HTTP Connections do not surface
+        # status codes via the SDK, so the response body is the only
+        # signal we have.
+        if isinstance(parsed, dict) and "error" in parsed and isinstance(parsed["error"], dict):
+            err = parsed["error"]
+            raise DirectoryError(
+                f"Graph error: {err.get('code', '?')}: {err.get('message', '')}"
+            )
+
+        if not isinstance(parsed, dict):
+            raise DirectoryError(
+                f"Graph returned unexpected JSON shape: {type(parsed).__name__}"
+            )
+
+        return parsed
+
+
+# ----- helpers ----------------------------------------------------------------
+
+def _url_quote(value: str) -> str:
+    """URL-encode a string with safe defaults for OData query strings."""
+
+    from urllib.parse import quote
+
+    # ``$`` and ``,`` are commonly present in OData and don't need
+    # escaping. Single quotes inside literals are already doubled by
+    # ``_escape_odata`` before we hit this function.
+    return quote(value, safe="$',()")
+
+
+def _read_response_body(response: Any) -> str:
+    """Read the body out of an SDK ``HttpRequestResponse`` defensively.
+
+    The SDK exposes ``response.contents`` as ``Optional[BinaryIO]``.
+    Different SDK versions and the underlying transport have surfaced
+    this as bytes, str, or a read()-able stream, so we accept all
+    three shapes.
+    """
+
+    contents = getattr(response, "contents", None)
+    if contents is None:
+        return ""
+    if isinstance(contents, (bytes, bytearray)):
+        return contents.decode("utf-8", errors="replace")
+    if isinstance(contents, str):
+        return contents
+    read: Optional[Callable[[], Any]] = getattr(contents, "read", None)
+    if callable(read):
+        raw = read()
+        if isinstance(raw, (bytes, bytearray)):
+            return raw.decode("utf-8", errors="replace")
+        return str(raw)
+    return str(contents)

--- a/src/backend/src/models/directory.py
+++ b/src/backend/src/models/directory.py
@@ -1,0 +1,103 @@
+"""Pydantic API models for the Directory layer (external IdP lookups).
+
+The Directory layer is the generic abstraction over identity providers.
+v1 ships one concrete provider (Microsoft Entra ID via Microsoft Graph),
+but the manager / routes / models are provider-agnostic so future
+providers (Okta, Ping, ...) can be added without breaking changes.
+
+See plans/directory-lookup-and-principal-picker.md.
+"""
+
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PrincipalType(str, Enum):
+    """Type of a directory principal.
+
+    ``unknown`` is reserved for legacy values that no longer resolve in
+    the directory but still need to render in the UI.
+    Service principals are reserved for v2.
+    """
+
+    USER = "user"
+    GROUP = "group"
+    UNKNOWN = "unknown"
+
+
+class Principal(BaseModel):
+    """Normalised representation of an external directory principal.
+
+    Every concrete ``DirectoryProvider`` maps its native fields onto
+    this shape. The ``id`` field is the persisted identifier (UPN or
+    email for users, displayName for groups -- NOT GUIDs), which keeps
+    every existing storage column shape unchanged.
+    """
+
+    type: PrincipalType = Field(..., description="user | group | unknown")
+    id: str = Field(
+        ...,
+        description=(
+            "Persisted identifier. UPN/email for users, displayName for "
+            "groups. Used as the value sent back from the picker."
+        ),
+    )
+    display_name: str = Field(..., description="Friendly name shown in UI")
+    sub_label: Optional[str] = Field(
+        default=None,
+        description=(
+            "Secondary identifier shown on row two and as tooltip on "
+            "selected badges. Email/UPN for users, GUID for groups."
+        ),
+    )
+
+
+class DirectoryProviderType(str, Enum):
+    """Supported directory provider plug-ins.
+
+    Unknown values persisted in settings are treated as not-configured.
+    """
+
+    ENTRA = "entra"
+
+
+class DirectoryStatus(BaseModel):
+    """Reports whether the directory is wired up.
+
+    ``configured`` is True iff both a recognised provider type and a UC
+    HTTP connection name are persisted in settings.
+    """
+
+    configured: bool
+    provider_type: Optional[str] = None
+    connection_name: Optional[str] = None
+
+
+class DirectoryTestResult(BaseModel):
+    """Result of probing the configured provider for connectivity."""
+
+    healthy: bool
+    error: Optional[str] = None
+
+
+class DirectorySearchResponse(BaseModel):
+    """Envelope for ``GET /api/directory/search`` results."""
+
+    results: List[Principal]
+
+
+class DirectorySettingsUpdate(BaseModel):
+    """Payload accepted by ``PUT /api/directory/settings``.
+
+    Either field may be ``None`` to clear that setting.
+    """
+
+    provider_type: Optional[str] = None
+    connection_name: Optional[str] = None
+
+
+# Setting keys (single source of truth)
+SETTING_KEY_PROVIDER_TYPE = "DIRECTORY_PROVIDER_TYPE"
+SETTING_KEY_CONNECTION_NAME = "DIRECTORY_UC_HTTP_CONNECTION_NAME"

--- a/src/backend/src/routes/directory_routes.py
+++ b/src/backend/src/routes/directory_routes.py
@@ -1,0 +1,164 @@
+"""Directory layer API: status, search, test, and provider-agnostic settings.
+
+Settings keys live in the existing ``app_settings`` key/value table so
+no Alembic migration is required. All Graph traffic flows through a UC
+HTTP Connection; the app never holds a client secret or token.
+
+See plans/directory-lookup-and-principal-picker.md.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.orm import Session
+
+from src.common.authorization import PermissionChecker
+from src.common.database import get_db
+from src.common.dependencies import DirectoryManagerDep
+from src.common.features import FeatureAccessLevel
+from src.common.logging import get_logger
+from src.common.uc_connections import list_http_connections
+from src.controller.directory_providers import DirectoryError
+from src.models.directory import (
+    DirectorySearchResponse,
+    DirectorySettingsUpdate,
+    DirectoryStatus,
+    DirectoryTestResult,
+    SETTING_KEY_CONNECTION_NAME,
+    SETTING_KEY_PROVIDER_TYPE,
+)
+from src.repositories.app_settings_repository import app_settings_repo
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/directory", tags=["Directory"])
+
+
+@router.get("/status", response_model=DirectoryStatus)
+async def get_status(
+    manager: DirectoryManagerDep,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker("settings", FeatureAccessLevel.READ_ONLY)),
+) -> DirectoryStatus:
+    """Lightweight status check.
+
+    Returned to every picker instance on first render so the UI knows
+    whether to switch into configured mode.
+    """
+
+    return manager.get_status(db)
+
+
+@router.get("/search", response_model=DirectorySearchResponse)
+async def search(
+    request: Request,
+    manager: DirectoryManagerDep,
+    q: str = Query(..., min_length=1, max_length=200),
+    types: Optional[str] = Query(
+        default=None,
+        description="Comma-separated subset of 'user,group'. Defaults to both.",
+    ),
+    limit: int = Query(default=20, ge=1, le=50),
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker("settings", FeatureAccessLevel.READ_ONLY)),
+) -> DirectorySearchResponse:
+    """Search the configured directory and return normalised principals.
+
+    Returns an empty list when the directory is not configured -- the
+    picker's unconfigured mode handles the UX from there.
+    """
+
+    from src.common.workspace_client import get_obo_workspace_client
+
+    parsed_types: List[str] = []
+    if types:
+        parsed_types = [t.strip() for t in types.split(",") if t.strip()]
+    try:
+        ws = get_obo_workspace_client(request)
+    except Exception:
+        # The picker is expected to degrade gracefully; treat workspace
+        # client failure the same as an empty result.
+        return DirectorySearchResponse(results=[])
+
+    try:
+        results = manager.search(db, ws, query=q, types=parsed_types, limit=limit)
+    except DirectoryError as exc:
+        logger.warning(f"Directory search failed: {exc}")
+        return DirectorySearchResponse(results=[])
+    return DirectorySearchResponse(results=results)
+
+
+@router.post("/test", response_model=DirectoryTestResult)
+async def test(
+    request: Request,
+    manager: DirectoryManagerDep,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker("settings", FeatureAccessLevel.READ_WRITE)),
+) -> DirectoryTestResult:
+    """Probe the configured provider; surfaces a typed success/error to the UI."""
+
+    from src.common.workspace_client import get_obo_workspace_client
+
+    try:
+        ws = get_obo_workspace_client(request)
+    except Exception as exc:
+        return DirectoryTestResult(healthy=False, error=f"Workspace client error: {exc}")
+
+    try:
+        manager.test(db, ws)
+    except DirectoryError as exc:
+        return DirectoryTestResult(healthy=False, error=str(exc))
+    except Exception as exc:
+        logger.exception("Unexpected error during directory test")
+        return DirectoryTestResult(healthy=False, error=f"Unexpected error: {exc}")
+    return DirectoryTestResult(healthy=True)
+
+
+@router.put("/settings", response_model=DirectoryStatus)
+async def update_settings(
+    body: DirectorySettingsUpdate,
+    manager: DirectoryManagerDep,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker("settings", FeatureAccessLevel.READ_WRITE)),
+) -> DirectoryStatus:
+    """Persist provider type and/or connection name, then invalidate cache.
+
+    Either field may be ``None`` (or empty string) to clear that
+    setting. Caller passes both for full updates; passing just one is
+    an "edit one field" shortcut.
+    """
+
+    if body.provider_type is not None:
+        app_settings_repo.set(db, SETTING_KEY_PROVIDER_TYPE, body.provider_type or None)
+    if body.connection_name is not None:
+        app_settings_repo.set(db, SETTING_KEY_CONNECTION_NAME, body.connection_name or None)
+    manager.invalidate_cache()
+    return manager.get_status(db)
+
+
+@router.get("/uc-http-connections")
+async def list_uc_http_connections(
+    request: Request,
+    _: bool = Depends(PermissionChecker("settings", FeatureAccessLevel.READ_WRITE)),
+) -> List[dict]:
+    """List HTTP-type UC connections so the Settings tab can populate its dropdown.
+
+    Same payload shape as ``/api/workflows/http-connections``; both
+    routes delegate to ``src.common.uc_connections.list_http_connections``.
+    """
+
+    from src.common.workspace_client import get_obo_workspace_client
+
+    try:
+        ws = get_obo_workspace_client(request)
+    except Exception as exc:
+        logger.warning(f"Workspace client unavailable for UC connections listing: {exc}")
+        return []
+    return list_http_connections(ws)
+
+
+def register_routes(app):
+    """Register directory routes with the FastAPI app."""
+
+    app.include_router(router)
+    logger.info("Directory routes registered with prefix /api/directory")

--- a/src/backend/src/routes/workflows_routes.py
+++ b/src/backend/src/routes/workflows_routes.py
@@ -453,37 +453,15 @@ async def list_http_connections_for_workflows(
     _: bool = Depends(PermissionChecker('settings', FeatureAccessLevel.READ_ONLY)),
 ) -> List[Dict[str, Any]]:
     """List Unity Catalog HTTP connections for webhook step configuration.
-    
+
     Returns HTTP-type connections that can be used with the webhook step type.
     These connections are pre-configured in Unity Catalog with credentials.
     """
     from src.common.workspace_client import get_obo_workspace_client
-    
-    try:
-        ws = get_obo_workspace_client(request)
-        connections = []
-        
-        # List all connections and filter for HTTP type
-        for conn in ws.connections.list():
-            # Check if connection is HTTP type
-            # ConnectionType.HTTP may not be available in all SDK versions
-            conn_type = str(conn.connection_type) if conn.connection_type else ''
-            if 'HTTP' in conn_type.upper():
-                connections.append({
-                    "name": conn.name,
-                    "connection_type": conn_type,
-                    "comment": conn.comment,
-                    "owner": conn.owner,
-                    "created_at": conn.created_at,
-                    "updated_at": conn.updated_at,
-                })
-        
-        return connections
-        
-    except Exception as e:
-        logger.warning(f"Failed to list HTTP connections: {e}")
-        # Return empty list on error - connections may not be available
-        return []
+    from src.common.uc_connections import list_http_connections
+
+    ws = get_obo_workspace_client(request)
+    return list_http_connections(ws)
 
 
 @router.get("/policy-usage/{policy_id}")

--- a/src/backend/src/tests/conftest.py
+++ b/src/backend/src/tests/conftest.py
@@ -1,8 +1,17 @@
 # Set test environment variables BEFORE any app imports
 # This prevents the app from running startup tasks (database init, etc.) during import
 import os
+import tempfile as _tempfile
+
 os.environ['TESTING'] = 'true'
 os.environ['SKIP_STARTUP_TASKS'] = 'true'
+
+# Provide non-secret defaults for required Settings fields so the suite
+# is runnable without a local .env. Real environments (CI or developer
+# .env) still take precedence via setdefault.
+os.environ.setdefault('DATABRICKS_HOST', 'https://test-databricks.local')
+os.environ.setdefault('DATABRICKS_WAREHOUSE_ID', 'test-warehouse')
+os.environ.setdefault('APP_AUDIT_LOG_DIR', _tempfile.gettempdir())
 
 import pytest
 from fastapi.testclient import TestClient

--- a/src/backend/src/tests/unit/test_directory_manager.py
+++ b/src/backend/src/tests/unit/test_directory_manager.py
@@ -1,0 +1,269 @@
+"""Unit tests for DirectoryManager.
+
+Covers settings-driven provider selection, cache hit/miss + invalidation,
+and the abstraction guarantee: a stub provider can be registered without
+touching the manager or routes.
+"""
+
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.controller.directory_manager import (
+    DirectoryManager,
+    register_provider,
+    unregister_provider,
+)
+from src.controller.directory_providers import DirectoryError, DirectoryProvider
+from src.models.directory import (
+    Principal,
+    PrincipalType,
+    SETTING_KEY_CONNECTION_NAME,
+    SETTING_KEY_PROVIDER_TYPE,
+)
+
+
+class _StubProvider(DirectoryProvider):
+    """Test double; lets us prove the abstraction is enough on its own."""
+
+    def __init__(self, ws_client, connection_name):
+        self.ws = ws_client
+        self.connection_name = connection_name
+        self.search_users_calls = 0
+        self.search_groups_calls = 0
+        self.test_calls = 0
+        self.next_users: List[Principal] = []
+        self.next_groups: List[Principal] = []
+
+    def search_users(self, prefix, top):
+        self.search_users_calls += 1
+        return list(self.next_users)
+
+    def search_groups(self, prefix, top):
+        self.search_groups_calls += 1
+        return list(self.next_groups)
+
+    def get_user(self, id):
+        raise NotImplementedError
+
+    def get_group(self, id):
+        raise NotImplementedError
+
+    def test(self):
+        self.test_calls += 1
+
+
+@pytest.fixture
+def stub_registered():
+    """Register a 'stub' provider for the duration of the test."""
+
+    instances: List[_StubProvider] = []
+
+    def factory(ws_client, connection_name):
+        inst = _StubProvider(ws_client, connection_name)
+        instances.append(inst)
+        return inst
+
+    register_provider("stub", factory)
+    try:
+        yield instances
+    finally:
+        unregister_provider("stub")
+
+
+@pytest.fixture
+def db_with_settings():
+    """Fake DB session where ``app_settings_repo.get_by_key`` is dict-backed."""
+
+    return MagicMock()
+
+
+def _patch_settings(values):
+    """Patch ``app_settings_repo.get_by_key`` to read from ``values`` dict."""
+
+    def fake_get(_db, key):
+        return values.get(key)
+
+    return patch(
+        "src.controller.directory_manager.app_settings_repo.get_by_key",
+        side_effect=fake_get,
+    )
+
+
+class TestStatus:
+    def test_not_configured_when_no_settings(self, db_with_settings):
+        with _patch_settings({}):
+            status = DirectoryManager().get_status(db_with_settings)
+        assert status.configured is False
+
+    def test_not_configured_when_provider_unknown(self, db_with_settings):
+        with _patch_settings({
+            SETTING_KEY_PROVIDER_TYPE: "okta",
+            SETTING_KEY_CONNECTION_NAME: "my-graph",
+        }):
+            status = DirectoryManager().get_status(db_with_settings)
+        # Unknown provider type => not configured (per architectural decision).
+        assert status.configured is False
+        assert status.provider_type == "okta"
+        assert status.connection_name == "my-graph"
+
+    def test_configured_when_provider_recognised(self, db_with_settings, stub_registered):
+        with _patch_settings({
+            SETTING_KEY_PROVIDER_TYPE: "stub",
+            SETTING_KEY_CONNECTION_NAME: "my-graph",
+        }):
+            status = DirectoryManager().get_status(db_with_settings)
+        assert status.configured is True
+
+
+class TestSearch:
+    def test_empty_when_not_configured(self, db_with_settings):
+        with _patch_settings({}):
+            results = DirectoryManager().search(db_with_settings, MagicMock(), query="a", types=["user"])
+        assert results == []
+
+    def test_dispatches_to_registered_provider(self, db_with_settings, stub_registered):
+        with _patch_settings({
+            SETTING_KEY_PROVIDER_TYPE: "stub",
+            SETTING_KEY_CONNECTION_NAME: "conn",
+        }):
+            mgr = DirectoryManager()
+            # Pre-arm the next stub instance via the factory side-effect.
+            # We have to call search first so the instance exists; arrange
+            # the data on the next-created instance.
+            captured = stub_registered
+
+            # Trick: monkey-patch the factory to return a pre-seeded stub.
+            def seeded_factory(ws_client, connection_name):
+                inst = _StubProvider(ws_client, connection_name)
+                inst.next_users = [
+                    Principal(type=PrincipalType.USER, id="alice@x", display_name="Alice", sub_label="alice@x"),
+                ]
+                captured.append(inst)
+                return inst
+
+            register_provider("stub", seeded_factory)
+            results = mgr.search(db_with_settings, MagicMock(), query="ali", types=["user"])
+
+        assert [(p.type, p.id) for p in results] == [(PrincipalType.USER, "alice@x")]
+
+    def test_cache_hits_on_second_call(self, db_with_settings, stub_registered):
+        # Replace factory with a counting one
+        created = []
+
+        def factory(ws_client, connection_name):
+            stub = _StubProvider(ws_client, connection_name)
+            stub.next_users = [
+                Principal(type=PrincipalType.USER, id="alice@x", display_name="Alice", sub_label="alice@x"),
+            ]
+            created.append(stub)
+            return stub
+
+        register_provider("stub", factory)
+        try:
+            with _patch_settings({
+                SETTING_KEY_PROVIDER_TYPE: "stub",
+                SETTING_KEY_CONNECTION_NAME: "conn",
+            }):
+                mgr = DirectoryManager()
+                mgr.search(db_with_settings, MagicMock(), query="ali", types=["user"])
+                mgr.search(db_with_settings, MagicMock(), query="ali", types=["user"])
+                mgr.search(db_with_settings, MagicMock(), query="ALI", types=["user"])  # case-insensitive
+                mgr.search(db_with_settings, MagicMock(), query=" ali ", types=["user"])  # whitespace
+            # Provider instances are cheap to create; what we care about
+            # is that the underlying search_users was only called once.
+            assert sum(s.search_users_calls for s in created) == 1
+        finally:
+            unregister_provider("stub")
+
+    def test_cache_invalidates_when_settings_change(self, db_with_settings, stub_registered):
+        created = []
+
+        def factory(ws_client, connection_name):
+            stub = _StubProvider(ws_client, connection_name)
+            stub.next_users = [
+                Principal(type=PrincipalType.USER, id=f"u@{connection_name}", display_name="U", sub_label=None),
+            ]
+            created.append(stub)
+            return stub
+
+        register_provider("stub", factory)
+        try:
+            mgr = DirectoryManager()
+            # First settings
+            with _patch_settings({
+                SETTING_KEY_PROVIDER_TYPE: "stub",
+                SETTING_KEY_CONNECTION_NAME: "conn-A",
+            }):
+                mgr.search(db_with_settings, MagicMock(), query="a", types=["user"])
+            # Different connection name => same query should re-hit provider
+            with _patch_settings({
+                SETTING_KEY_PROVIDER_TYPE: "stub",
+                SETTING_KEY_CONNECTION_NAME: "conn-B",
+            }):
+                mgr.search(db_with_settings, MagicMock(), query="a", types=["user"])
+            assert sum(s.search_users_calls for s in created) == 2
+        finally:
+            unregister_provider("stub")
+
+    def test_explicit_invalidate_drops_cache(self, db_with_settings, stub_registered):
+        created = []
+
+        def factory(ws_client, connection_name):
+            stub = _StubProvider(ws_client, connection_name)
+            stub.next_users = [
+                Principal(type=PrincipalType.USER, id="x@x", display_name="X", sub_label=None),
+            ]
+            created.append(stub)
+            return stub
+
+        register_provider("stub", factory)
+        try:
+            mgr = DirectoryManager()
+            with _patch_settings({
+                SETTING_KEY_PROVIDER_TYPE: "stub",
+                SETTING_KEY_CONNECTION_NAME: "conn",
+            }):
+                mgr.search(db_with_settings, MagicMock(), query="a", types=["user"])
+                mgr.invalidate_cache()
+                mgr.search(db_with_settings, MagicMock(), query="a", types=["user"])
+            assert sum(s.search_users_calls for s in created) == 2
+        finally:
+            unregister_provider("stub")
+
+    def test_types_filter_narrows_calls(self, db_with_settings, stub_registered):
+        created = []
+
+        def factory(ws_client, connection_name):
+            stub = _StubProvider(ws_client, connection_name)
+            created.append(stub)
+            return stub
+
+        register_provider("stub", factory)
+        try:
+            mgr = DirectoryManager()
+            with _patch_settings({
+                SETTING_KEY_PROVIDER_TYPE: "stub",
+                SETTING_KEY_CONNECTION_NAME: "conn",
+            }):
+                mgr.search(db_with_settings, MagicMock(), query="x", types=["user"])
+            assert sum(s.search_users_calls for s in created) == 1
+            assert sum(s.search_groups_calls for s in created) == 0
+        finally:
+            unregister_provider("stub")
+
+
+class TestTestProbe:
+    def test_raises_when_unconfigured(self, db_with_settings):
+        with _patch_settings({}):
+            with pytest.raises(DirectoryError, match="not configured"):
+                DirectoryManager().test(db_with_settings, MagicMock())
+
+    def test_dispatches_to_provider(self, db_with_settings, stub_registered):
+        with _patch_settings({
+            SETTING_KEY_PROVIDER_TYPE: "stub",
+            SETTING_KEY_CONNECTION_NAME: "conn",
+        }):
+            DirectoryManager().test(db_with_settings, MagicMock())
+        # If we got here, dispatch worked (StubProvider.test() is a no-op).

--- a/src/backend/src/tests/unit/test_entra_id_provider.py
+++ b/src/backend/src/tests/unit/test_entra_id_provider.py
@@ -1,0 +1,181 @@
+"""Unit tests for EntraIdProvider.
+
+Covers OData escaping, $select projections, Principal normalisation
+for users (UPN -> id) and groups (displayName -> id), and test()
+happy/error paths against a mocked ``serving_endpoints.http_request``.
+"""
+
+import io
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.controller.directory_providers import (
+    DirectoryError,
+    EntraIdProvider,
+)
+from src.controller.directory_providers.entra_id_provider import (
+    _escape_odata,
+    _read_response_body,
+)
+from src.models.directory import PrincipalType
+
+
+def _stub_response(payload):
+    """Build an SDK-shaped HttpRequestResponse-like object."""
+
+    body = json.dumps(payload).encode("utf-8") if not isinstance(payload, str) else payload.encode("utf-8")
+    resp = MagicMock()
+    resp.contents = io.BytesIO(body)
+    return resp
+
+
+def _ws_returning(payload):
+    """Build a fake WorkspaceClient whose http_request returns ``payload``."""
+
+    ws = MagicMock()
+    ws.serving_endpoints.http_request.return_value = _stub_response(payload)
+    return ws
+
+
+class TestOdataEscaping:
+    def test_doubles_single_quote(self):
+        assert _escape_odata("O'Brien") == "O''Brien"
+
+    def test_passthrough_for_safe_string(self):
+        assert _escape_odata("alice") == "alice"
+
+    def test_doubles_multiple_quotes(self):
+        assert _escape_odata("a'b'c") == "a''b''c"
+
+
+class TestReadResponseBody:
+    def test_handles_bytes(self):
+        resp = MagicMock()
+        resp.contents = b'{"value": []}'
+        assert _read_response_body(resp) == '{"value": []}'
+
+    def test_handles_str(self):
+        resp = MagicMock()
+        resp.contents = '{"value": []}'
+        assert _read_response_body(resp) == '{"value": []}'
+
+    def test_handles_stream(self):
+        resp = MagicMock()
+        resp.contents = io.BytesIO(b'{"value": []}')
+        assert _read_response_body(resp) == '{"value": []}'
+
+    def test_handles_none(self):
+        resp = MagicMock()
+        resp.contents = None
+        assert _read_response_body(resp) == ""
+
+
+class TestSearchUsers:
+    def test_maps_userPrincipalName_to_id(self):
+        ws = _ws_returning({
+            "value": [
+                {"id": "guid-1", "displayName": "Alice", "userPrincipalName": "alice@contoso.com", "mail": "alice@contoso.com"},
+            ]
+        })
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        results = provider.search_users("ali", top=20)
+        assert len(results) == 1
+        p = results[0]
+        assert p.type == PrincipalType.USER
+        assert p.id == "alice@contoso.com"   # UPN, not GUID
+        assert p.display_name == "Alice"
+        # sub_label exists and is non-empty
+        assert p.sub_label
+
+    def test_escapes_quote_in_query(self):
+        ws = _ws_returning({"value": []})
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        provider.search_users("O'Brien", top=20)
+        call = ws.serving_endpoints.http_request.call_args
+        path = call.kwargs["path"]
+        # Doubled quote present, raw single quote not adjacent to "Brien"
+        assert "O''Brien" in path
+        # Ensure consistency header attached for startswith filters
+        assert call.kwargs["headers"] == {"ConsistencyLevel": "eventual"}
+
+    def test_uses_select_projection(self):
+        ws = _ws_returning({"value": []})
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        provider.search_users("a", top=5)
+        path = ws.serving_endpoints.http_request.call_args.kwargs["path"]
+        assert "$select=id,displayName,userPrincipalName,mail" in path
+        assert "$top=5" in path
+
+    def test_empty_query_short_circuits(self):
+        ws = MagicMock()
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        assert provider.search_users("", top=20) == []
+        ws.serving_endpoints.http_request.assert_not_called()
+
+    def test_falls_back_to_mail_when_no_upn(self):
+        ws = _ws_returning({
+            "value": [{"id": "guid-2", "displayName": "Bob", "mail": "bob@x"}]
+        })
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        p = provider.search_users("b", top=20)[0]
+        assert p.id == "bob@x"
+
+
+class TestSearchGroups:
+    def test_maps_displayName_to_id(self):
+        ws = _ws_returning({
+            "value": [
+                {"id": "group-guid", "displayName": "Data Producers", "description": "all DPs"},
+            ]
+        })
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        results = provider.search_groups("Data", top=20)
+        assert len(results) == 1
+        p = results[0]
+        assert p.type == PrincipalType.GROUP
+        assert p.id == "Data Producers"     # displayName, not GUID
+        assert p.display_name == "Data Producers"
+        assert p.sub_label == "group-guid"  # GUID exposed in sub_label
+
+    def test_uses_group_select_projection(self):
+        ws = _ws_returning({"value": []})
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        provider.search_groups("X", top=20)
+        path = ws.serving_endpoints.http_request.call_args.kwargs["path"]
+        assert "$select=id,displayName,description" in path
+
+
+class TestTest:
+    def test_happy_path(self):
+        ws = _ws_returning({"value": [{"id": "guid"}]})
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        provider.test()  # no exception
+        path = ws.serving_endpoints.http_request.call_args.kwargs["path"]
+        assert path.startswith("/v1.0/users")
+        assert "$top=1" in path
+
+    def test_raises_on_graph_error_body(self):
+        ws = _ws_returning({"error": {"code": "InvalidAuthenticationToken", "message": "Access token is empty."}})
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        with pytest.raises(DirectoryError, match="InvalidAuthenticationToken"):
+            provider.test()
+
+    def test_raises_on_transport_error(self):
+        ws = MagicMock()
+        ws.serving_endpoints.http_request.side_effect = RuntimeError("connection refused")
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        with pytest.raises(DirectoryError, match="connection refused"):
+            provider.test()
+
+    def test_raises_on_non_json_body(self):
+        ws = MagicMock()
+        ws.serving_endpoints.http_request.return_value = _stub_response("not json at all")
+        provider = EntraIdProvider(ws, connection_name="my-graph")
+        with pytest.raises(DirectoryError, match="non-JSON"):
+            provider.test()
+
+    def test_raises_on_empty_connection_name(self):
+        with pytest.raises(DirectoryError):
+            EntraIdProvider(MagicMock(), connection_name="")

--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -374,6 +374,13 @@ def initialize_managers(app: FastAPI):
         except Exception as e:
             logger.error(f"Failed to initialize EntitySubscriptionsManager: {e}", exc_info=True)
 
+        try:
+            from src.controller.directory_manager import DirectoryManager
+            app.state.directory_manager = DirectoryManager()
+            logger.info("DirectoryManager initialized.")
+        except Exception as e:
+            logger.error(f"Failed to initialize DirectoryManager: {e}", exc_info=True)
+
         logger.info("All managers instantiated and stored in app.state.")
 
         # Defer SearchManager initialization until after initial data loading completes

--- a/src/frontend/src/app.tsx
+++ b/src/frontend/src/app.tsx
@@ -85,6 +85,7 @@ import SettingsSearchView from './views/settings-search';
 import SettingsMcpView from './views/settings-mcp';
 import SettingsUiView from './views/settings-ui';
 import SettingsConnectorsView from './views/settings-connectors';
+import SettingsDirectoryView from './views/settings-directory';
 import SettingsSemanticModelsView from './views/settings-semantic-models';
 import SettingsCertificationLevelsView from './views/settings-certification-levels';
 
@@ -229,6 +230,7 @@ export default function App() {
                 <Route path="mcp" element={<SettingsMcpView />} />
                 <Route path="ui" element={<SettingsUiView />} />
                 <Route path="connectors" element={<SettingsConnectorsView />} />
+                <Route path="directory" element={<SettingsDirectoryView />} />
                 <Route path="semantic-models" element={<SettingsSemanticModelsView />} />
                 <Route path="certification-levels" element={<SettingsCertificationLevelsView />} />
                 <Route path="workflows" element={<Workflows />} />

--- a/src/frontend/src/components/common/assign-owner-dialog.tsx
+++ b/src/frontend/src/components/common/assign-owner-dialog.tsx
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Loader2 } from 'lucide-react';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
+import { PrincipalPicker } from '@/components/common/principal-picker';
 import type { OwnerObjectType } from '@/types/business-owner';
 import type { BusinessRoleRead } from '@/types/business-role';
 
@@ -94,18 +95,19 @@ export function AssignOwnerDialog({ open, onOpenChange, objectType, objectId, on
 
         <div className="grid gap-4 py-4">
           <div className="grid gap-2">
-            <Label htmlFor="owner-email">{t('assignDialog.emailLabel', { defaultValue: 'Email' })} *</Label>
-            <Input
+            <Label htmlFor="owner-email">{t('assignDialog.emailLabel', { defaultValue: 'User' })} *</Label>
+            <PrincipalPicker
               id="owner-email"
-              type="email"
+              accepts={['user']}
+              value={userEmail || null}
+              onChange={(next) => setUserEmail(next ?? '')}
               placeholder={t('assignDialog.emailPlaceholder', { defaultValue: 'user@example.com' })}
-              value={userEmail}
-              onChange={(e) => setUserEmail(e.target.value)}
+              aria-label="Owner user"
             />
           </div>
 
           <div className="grid gap-2">
-            <Label htmlFor="owner-name">{t('assignDialog.nameLabel', { defaultValue: 'Display Name' })}</Label>
+            <Label htmlFor="owner-name">{t('assignDialog.nameLabel', { defaultValue: 'Display Name (optional)' })}</Label>
             <Input
               id="owner-name"
               placeholder={t('assignDialog.namePlaceholder', { defaultValue: 'Jane Doe' })}

--- a/src/frontend/src/components/common/principal-picker.test.tsx
+++ b/src/frontend/src/components/common/principal-picker.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for PrincipalPicker.
+ *
+ * Scope: behaviour we can verify reliably in jsdom -- badges, manual
+ * entry, and the API call shape for configured-mode searches. The
+ * Radix Popover dropdown itself is exercised in Playwright E2E
+ * (tag-selector tests in this repo follow the same split for the same
+ * reason).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { renderWithProviders } from '@/test/utils';
+import { PrincipalPicker } from './principal-picker';
+import { useDirectoryStore } from '@/stores/directory-store';
+
+function setDirectoryStatus(configured: boolean) {
+  // Bypass the network call by seeding the store directly.
+  useDirectoryStore.setState({
+    status: configured
+      ? { configured: true, provider_type: 'entra', connection_name: 'graph' }
+      : { configured: false, provider_type: null, connection_name: null },
+    loaded: true,
+    degraded: false,
+    _inflight: null,
+  });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  // Default: status fetch returns unconfigured. Individual tests
+  // override this either by seeding the store or by overriding the
+  // mock.
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({ configured: false, provider_type: null, connection_name: null }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  );
+  global.fetch = fetchMock as unknown as typeof fetch;
+  // Reset the zustand store between tests.
+  useDirectoryStore.getState().reset();
+});
+
+afterEach(() => {
+  useDirectoryStore.getState().reset();
+});
+
+describe('PrincipalPicker — pre-existing values', () => {
+  it('renders a badge for each existing id without resolving against the directory', () => {
+    setDirectoryStatus(false);
+    renderWithProviders(
+      <PrincipalPicker multiple value={['alice@x.com', 'Producers']} onChange={() => {}} />,
+    );
+    const badges = screen.getAllByTestId('principal-badge');
+    expect(badges).toHaveLength(2);
+    expect(badges[0]).toHaveTextContent('alice@x.com');
+    expect(badges[1]).toHaveTextContent('Producers');
+    // No directory search was attempted for pre-existing values.
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('/api/directory/search'),
+      expect.anything(),
+    );
+  });
+
+  it('emits the remaining ids after X-removing a badge', async () => {
+    setDirectoryStatus(false);
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker multiple value={['alice@x.com', 'Producers']} onChange={onChange} />,
+    );
+    const aliceBadge = screen.getAllByTestId('principal-badge')[0];
+    const removeBtn = within(aliceBadge).getByRole('button', { name: /remove alice@x\.com/i });
+    await userEvent.click(removeBtn);
+    expect(onChange).toHaveBeenCalledWith(['Producers']);
+  });
+
+  it('does not render a remove button when disabled', () => {
+    setDirectoryStatus(false);
+    renderWithProviders(
+      <PrincipalPicker value="alice@x.com" onChange={() => {}} disabled />,
+    );
+    const badge = screen.getByTestId('principal-badge');
+    expect(within(badge).queryByRole('button')).toBeNull();
+  });
+});
+
+describe('PrincipalPicker — unconfigured mode (manual entry)', () => {
+  beforeEach(() => setDirectoryStatus(false));
+
+  it('Enter commits the typed value as a badge in single mode', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker value={null} onChange={onChange} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, 'alice@x.com{Enter}');
+    expect(onChange).toHaveBeenLastCalledWith('alice@x.com');
+  });
+
+  it('comma commits a value in multi mode and appends to existing selections', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker multiple value={['existing@x']} onChange={onChange} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, 'new@x,');
+    expect(onChange).toHaveBeenLastCalledWith(['existing@x', 'new@x']);
+  });
+
+  it('Tab commits a value', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker multiple value={[]} onChange={onChange} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, 'someone@y');
+    await userEvent.tab();
+    expect(onChange).toHaveBeenCalledWith(['someone@y']);
+  });
+
+  it('blur commits the buffered text', () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker multiple value={[]} onChange={onChange} />,
+    );
+    const input = screen.getByTestId('principal-picker-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'late@x' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(['late@x']);
+  });
+
+  it('ignores empty / whitespace-only entries', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker multiple value={[]} onChange={onChange} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, '   {Enter}');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate an already-selected value', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker multiple value={['alice@x.com']} onChange={onChange} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, 'alice@x.com{Enter}');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('PrincipalPicker — configured mode', () => {
+  beforeEach(() => {
+    setDirectoryStatus(true);
+    // Provide an empty result set; we only assert on the URL shape.
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.includes('/api/directory/search')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+  });
+
+  it('calls /api/directory/search with the typed query and accepts filter', async () => {
+    renderWithProviders(
+      <PrincipalPicker accepts={['user']} value={null} onChange={() => {}} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, 'ali');
+    // Debounce is 250ms; rely on the test framework's natural wait.
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((u) => u.includes('/api/directory/search'))).toBe(true);
+    });
+    const searchUrl = String(
+      fetchMock.mock.calls.find((c) => String(c[0]).includes('/api/directory/search'))![0],
+    );
+    expect(searchUrl).toContain('q=ali');
+    expect(searchUrl).toContain('types=user');
+    expect(searchUrl).not.toContain('types=group');
+  });
+
+  it('does not search for queries shorter than 2 chars', async () => {
+    renderWithProviders(
+      <PrincipalPicker value={null} onChange={() => {}} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, 'a');
+    // Give the debounce a moment to fire.
+    await new Promise((r) => setTimeout(r, 350));
+    const searches = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('/api/directory/search'),
+    );
+    expect(searches).toHaveLength(0);
+  });
+
+  it('passes both types when accepts is default', async () => {
+    renderWithProviders(
+      <PrincipalPicker value={null} onChange={() => {}} />,
+    );
+    const input = screen.getByTestId('principal-picker-input');
+    await userEvent.type(input, 'al');
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((c) => String(c[0]).includes('/api/directory/search')),
+      ).toBe(true);
+    });
+    const searchUrl = String(
+      fetchMock.mock.calls.find((c) => String(c[0]).includes('/api/directory/search'))![0],
+    );
+    // URLSearchParams encodes commas as %2C in some Node versions; check both.
+    expect(/types=user(,|%2C)group/.test(searchUrl)).toBe(true);
+  });
+
+  it('flips into manual-entry mode when search fails (graceful degradation)', async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.includes('/api/directory/search')) {
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    });
+    const onChange = vi.fn();
+    renderWithProviders(
+      <PrincipalPicker multiple value={[]} onChange={onChange} />,
+    );
+    // Type two chars to trigger the search, which will fail.
+    await userEvent.type(screen.getByTestId('principal-picker-input'), 'al');
+    await waitFor(() => {
+      expect(useDirectoryStore.getState().degraded).toBe(true);
+    });
+    // The picker has now re-rendered with the manual ManualInput
+    // (different component instance, fresh state). Type the full
+    // value and commit with Enter.
+    const manualInput = screen.getByTestId('principal-picker-input');
+    await userEvent.type(manualInput, 'alice@x.com{Enter}');
+    expect(onChange).toHaveBeenLastCalledWith(['alice@x.com']);
+  });
+});

--- a/src/frontend/src/components/common/principal-picker.tsx
+++ b/src/frontend/src/components/common/principal-picker.tsx
@@ -1,0 +1,693 @@
+/**
+ * Unified picker for directory principals (users + groups).
+ *
+ * One component, two runtime modes -- selected automatically from
+ * `useDirectoryStore().status`:
+ *
+ * - Configured: 2-char-debounced type-ahead against /api/directory/search
+ *   with two-line result rows (display name + sub_label), plus a
+ *   "Browse directory" dialog with type-filter chips.
+ * - Unconfigured: plain manual entry. Enter / Tab / comma turns the
+ *   typed value into a badge; clicking the badge reverts it to text.
+ *
+ * Pre-existing values render as plain badges with no error
+ * decoration in either mode, satisfying the plan's
+ * graceful-degradation rule.
+ *
+ * Component API: discriminated on `multiple` so callers get
+ * `string | null` or `string[]` typed correctly without casts.
+ */
+
+import {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Loader2, Search, Users, User, UserSquare, X } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { useDirectoryStore } from '@/stores/directory-store';
+import type { Principal, PrincipalType } from '@/types/directory';
+
+// ----- props ------------------------------------------------------------------
+
+type PrincipalKind = 'user' | 'group';
+
+interface CommonProps {
+  /** Which principal types to accept. Defaults to both. */
+  accepts?: PrincipalKind[];
+  /** Disables the entire control. */
+  disabled?: boolean;
+  /** Placeholder shown in the input when no selection exists. */
+  placeholder?: string;
+  /** Input id for label association. */
+  id?: string;
+  /** Optional aria-label when no surrounding <Label htmlFor=...> exists. */
+  'aria-label'?: string;
+  className?: string;
+}
+
+type SingleProps = CommonProps & {
+  multiple?: false;
+  value: string | null | undefined;
+  onChange: (next: string | null) => void;
+};
+
+type MultiProps = CommonProps & {
+  multiple: true;
+  value: string[];
+  onChange: (next: string[]) => void;
+};
+
+export type PrincipalPickerProps = SingleProps | MultiProps;
+
+// ----- helpers ----------------------------------------------------------------
+
+const DEFAULT_ACCEPTS: PrincipalKind[] = ['user', 'group'];
+
+const ICON_FOR_TYPE: Record<PrincipalType, typeof User> = {
+  user: User,
+  group: Users,
+  unknown: UserSquare,
+};
+
+function typeIcon(type: PrincipalType | undefined) {
+  const Icon = ICON_FOR_TYPE[type ?? 'unknown'];
+  return <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" aria-hidden />;
+}
+
+/** Debounce a single value; returns the latest value after `delay` ms of quiet. */
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(handle);
+  }, [value, delay]);
+  return debounced;
+}
+
+// ----- component --------------------------------------------------------------
+
+export function PrincipalPicker(props: PrincipalPickerProps) {
+  const {
+    accepts = DEFAULT_ACCEPTS,
+    disabled,
+    placeholder,
+    className,
+    multiple,
+  } = props as PrincipalPickerProps & { multiple?: boolean };
+  const inputId = useId();
+
+  const status = useDirectoryStore((s) => s.status);
+  const loaded = useDirectoryStore((s) => s.loaded);
+  const degraded = useDirectoryStore((s) => s.degraded);
+  const fetchStatus = useDirectoryStore((s) => s.fetchStatus);
+  const markDegraded = useDirectoryStore((s) => s.markDegraded);
+
+  useEffect(() => {
+    if (!loaded) {
+      void fetchStatus();
+    }
+  }, [loaded, fetchStatus]);
+
+  // Internal map of id -> Principal populated by recent picks so newly-added
+  // badges show the friendly display name with tooltip even though the
+  // underlying value is just the id string. Pre-existing values are NOT
+  // resolved against the directory -- they render as plain badges.
+  const [resolved, setResolved] = useState<Record<string, Principal>>({});
+  const remember = useCallback((p: Principal) => {
+    setResolved((prev) => (prev[p.id] ? prev : { ...prev, [p.id]: p }));
+  }, []);
+
+  // Normalise value to an array for the internal selection list.
+  // Wrapped in useMemo so the array identity is stable across renders
+  // when the underlying value hasn't changed -- otherwise callbacks
+  // that close over ``selectedIds`` would invalidate every render.
+  const rawValue = (props as PrincipalPickerProps).value;
+  const selectedIds: string[] = useMemo(
+    () => {
+      if (multiple) return (rawValue as string[] | undefined) ?? [];
+      const v = rawValue as string | null | undefined;
+      return v ? [v] : [];
+    },
+    [multiple, rawValue],
+  );
+
+  const emit = useCallback(
+    (next: string[]) => {
+      if (multiple) {
+        (props as MultiProps).onChange(next);
+      } else {
+        (props as SingleProps).onChange(next[0] ?? null);
+      }
+    },
+    [multiple, props],
+  );
+
+  const addPrincipal = useCallback(
+    (p: Principal) => {
+      if (selectedIds.includes(p.id)) return;
+      remember(p);
+      emit(multiple ? [...selectedIds, p.id] : [p.id]);
+    },
+    [selectedIds, multiple, emit, remember],
+  );
+
+  const addManual = useCallback(
+    (raw: string) => {
+      const trimmed = raw.trim();
+      if (!trimmed || selectedIds.includes(trimmed)) return;
+      emit(multiple ? [...selectedIds, trimmed] : [trimmed]);
+    },
+    [selectedIds, multiple, emit],
+  );
+
+  const removeId = useCallback(
+    (id: string) => {
+      emit(selectedIds.filter((x) => x !== id));
+    },
+    [selectedIds, emit],
+  );
+
+  const configured = !!status?.configured && !degraded;
+
+  // The dialog is only available in configured mode; we hoist its open
+  // state up here so the trigger button can sit beside the input.
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      <SelectionBadges
+        ids={selectedIds}
+        resolved={resolved}
+        disabled={disabled}
+        onRemove={removeId}
+      />
+      <div className="flex gap-1">
+        {configured ? (
+          <ConfiguredInput
+            id={props.id ?? inputId}
+            placeholder={placeholder}
+            disabled={disabled}
+            accepts={accepts}
+            selectedIds={selectedIds}
+            onPick={addPrincipal}
+            onSearchFail={markDegraded}
+            ariaLabel={props['aria-label']}
+          />
+        ) : (
+          <ManualInput
+            id={props.id ?? inputId}
+            placeholder={placeholder}
+            disabled={disabled}
+            onAdd={addManual}
+            ariaLabel={props['aria-label']}
+          />
+        )}
+        {configured && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            disabled={disabled}
+            onClick={() => setDialogOpen(true)}
+            title="Browse directory"
+            aria-label="Browse directory"
+          >
+            <Search className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+      {configured && (
+        <PrincipalPickerDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          accepts={accepts}
+          selectedIds={selectedIds}
+          onPick={(p) => {
+            addPrincipal(p);
+            if (!multiple) setDialogOpen(false);
+          }}
+          onSearchFail={markDegraded}
+        />
+      )}
+    </div>
+  );
+}
+
+// ----- selection badges -------------------------------------------------------
+
+interface SelectionBadgesProps {
+  ids: string[];
+  resolved: Record<string, Principal>;
+  disabled?: boolean;
+  onRemove: (id: string) => void;
+}
+
+function SelectionBadges({ ids, resolved, disabled, onRemove }: SelectionBadgesProps) {
+  if (ids.length === 0) return null;
+  return (
+    <TooltipProvider>
+      <div className="flex flex-wrap gap-1.5">
+        {ids.map((id) => {
+          const p = resolved[id];
+          const displayName = p?.display_name ?? id;
+          // Tooltip exposes the sub_label so users can confirm the
+          // underlying email / GUID. Falls back to the id itself for
+          // pre-existing values where we have no resolved Principal.
+          const tooltip = p?.sub_label ?? id;
+          const Icon = ICON_FOR_TYPE[p?.type ?? 'unknown'];
+          return (
+            <Tooltip key={id} delayDuration={200}>
+              <TooltipTrigger asChild>
+                <Badge
+                  variant="secondary"
+                  className="gap-1 pl-1.5 pr-1 font-normal"
+                  title={tooltip}
+                  data-testid="principal-badge"
+                >
+                  <Icon className="h-3 w-3 text-muted-foreground" aria-hidden />
+                  <span className="truncate max-w-[16rem]">{displayName}</span>
+                  {!disabled && (
+                    <button
+                      type="button"
+                      onClick={() => onRemove(id)}
+                      className="ml-0.5 rounded-sm opacity-70 hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+                      aria-label={`Remove ${displayName}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span className="text-xs">{tooltip}</span>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+// ----- configured-mode inline type-ahead --------------------------------------
+
+interface ConfiguredInputProps {
+  id: string;
+  placeholder?: string;
+  disabled?: boolean;
+  accepts: PrincipalKind[];
+  selectedIds: string[];
+  onPick: (p: Principal) => void;
+  onSearchFail: () => void;
+  ariaLabel?: string;
+}
+
+function ConfiguredInput({
+  id,
+  placeholder,
+  disabled,
+  accepts,
+  selectedIds,
+  onPick,
+  onSearchFail,
+  ariaLabel,
+}: ConfiguredInputProps) {
+  const [query, setQuery] = useState('');
+  // ``userClosed`` lets the user dismiss the dropdown (Esc / click
+  // outside) without us re-opening it on the next render. It's
+  // cleared whenever the query changes so a new keystroke re-opens
+  // the dropdown.
+  const [userClosed, setUserClosed] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debouncedQuery = useDebouncedValue(query, 250);
+  const { results, loading } = usePrincipalSearch({
+    query: debouncedQuery,
+    accepts,
+    enabled: !disabled,
+    onError: onSearchFail,
+  });
+
+  const visible = useMemo(
+    () => results.filter((p) => !selectedIds.includes(p.id)),
+    [results, selectedIds],
+  );
+
+  // Derived open state -- no effect needed. Once the debounced query
+  // is long enough and we have unfiltered matches, the popover opens;
+  // anything else hides it.
+  const popoverOpen =
+    !userClosed && debouncedQuery.trim().length >= 2 && visible.length > 0;
+
+  return (
+    <Popover
+      open={popoverOpen}
+      onOpenChange={(next) => {
+        if (!next) setUserClosed(true);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Input
+          id={id}
+          ref={inputRef}
+          type="text"
+          autoComplete="off"
+          value={query}
+          disabled={disabled}
+          placeholder={placeholder ?? 'Search directory…'}
+          aria-label={ariaLabel}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            // Any new keystroke is a fresh user intent to see results.
+            if (userClosed) setUserClosed(false);
+          }}
+          data-testid="principal-picker-input"
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-1"
+        align="start"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {loading ? (
+          <div className="flex items-center gap-2 px-2 py-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Searching…
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="px-2 py-2 text-sm text-muted-foreground">No matches.</div>
+        ) : (
+          <ul className="flex flex-col">
+            {visible.map((p) => (
+              <PrincipalRow
+                key={`${p.type}:${p.id}`}
+                principal={p}
+                onPick={() => {
+                  onPick(p);
+                  setQuery('');
+                  setUserClosed(false);
+                  inputRef.current?.focus();
+                }}
+              />
+            ))}
+          </ul>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ----- unconfigured-mode manual input -----------------------------------------
+
+interface ManualInputProps {
+  id: string;
+  placeholder?: string;
+  disabled?: boolean;
+  onAdd: (raw: string) => void;
+  ariaLabel?: string;
+}
+
+function ManualInput({ id, placeholder, disabled, onAdd, ariaLabel }: ManualInputProps) {
+  const [value, setValue] = useState('');
+
+  const commit = () => {
+    if (value.trim().length === 0) return;
+    onAdd(value);
+    setValue('');
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === 'Tab' || e.key === ',') {
+      if (value.trim().length === 0) return;
+      e.preventDefault();
+      commit();
+    }
+  };
+
+  return (
+    <Input
+      id={id}
+      type="text"
+      autoComplete="off"
+      value={value}
+      disabled={disabled}
+      placeholder={placeholder ?? 'Type and press Enter…'}
+      aria-label={ariaLabel}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={onKeyDown}
+      onBlur={commit}
+      data-testid="principal-picker-input"
+    />
+  );
+}
+
+// ----- shared row -------------------------------------------------------------
+
+interface PrincipalRowProps {
+  principal: Principal;
+  onPick: () => void;
+}
+
+function PrincipalRow({ principal, onPick }: PrincipalRowProps) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onPick}
+        className="w-full flex items-center gap-2 px-2 py-1.5 rounded-sm text-left hover:bg-accent focus:bg-accent focus:outline-none"
+        data-testid="principal-row"
+      >
+        {typeIcon(principal.type)}
+        <div className="flex flex-col min-w-0">
+          <span className="truncate text-sm font-medium">{principal.display_name}</span>
+          {principal.sub_label && (
+            <span className="truncate text-xs text-muted-foreground">{principal.sub_label}</span>
+          )}
+        </div>
+      </button>
+    </li>
+  );
+}
+
+// ----- popup dialog variant ---------------------------------------------------
+
+interface PrincipalPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accepts: PrincipalKind[];
+  selectedIds: string[];
+  onPick: (p: Principal) => void;
+  onSearchFail: () => void;
+}
+
+function PrincipalPickerDialog({
+  open,
+  onOpenChange,
+  accepts,
+  selectedIds,
+  onPick,
+  onSearchFail,
+}: PrincipalPickerDialogProps) {
+  const [filter, setFilter] = useState<PrincipalKind[]>(accepts);
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 250);
+  const { results, loading } = usePrincipalSearch({
+    query: debouncedQuery,
+    accepts: filter,
+    enabled: open,
+    onError: onSearchFail,
+  });
+
+  // Reset query and type filter whenever the dialog transitions to
+  // closed. Done in the onOpenChange handler (not an effect) to keep
+  // state writes out of effect bodies.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setQuery('');
+      setFilter(accepts);
+    }
+    onOpenChange(next);
+  };
+
+  const visible = results.filter((p) => !selectedIds.includes(p.id));
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Browse directory</DialogTitle>
+          <DialogDescription>Search users and groups from the configured provider.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          {accepts.length > 1 && (
+            <div className="flex gap-2" role="group" aria-label="Filter by type">
+              {accepts.map((kind) => {
+                const active = filter.includes(kind);
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => {
+                      // Always keep at least one filter active so the
+                      // user can't enter a state where no results are
+                      // possible.
+                      setFilter((prev) => {
+                        const without = prev.filter((k) => k !== kind);
+                        if (active && without.length > 0) return without;
+                        if (!active) return [...prev, kind];
+                        return prev;
+                      });
+                    }}
+                    className={cn(
+                      'px-2.5 py-1 rounded-full text-xs border',
+                      active
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'bg-background text-foreground border-input',
+                    )}
+                    data-testid={`type-chip-${kind}`}
+                  >
+                    {kind === 'user' ? 'Users' : 'Groups'}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          <Input
+            type="text"
+            autoComplete="off"
+            placeholder="Search…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            data-testid="principal-picker-dialog-input"
+          />
+          <div className="max-h-72 overflow-y-auto rounded-md border">
+            {loading ? (
+              <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Searching…
+              </div>
+            ) : debouncedQuery.trim().length < 2 ? (
+              <div className="px-3 py-2 text-sm text-muted-foreground">
+                Type at least 2 characters.
+              </div>
+            ) : visible.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-muted-foreground">No matches.</div>
+            ) : (
+              <ul className="flex flex-col p-1">
+                {visible.map((p) => (
+                  <PrincipalRow
+                    key={`${p.type}:${p.id}`}
+                    principal={p}
+                    onPick={() => onPick(p)}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ----- search hook ------------------------------------------------------------
+
+interface UsePrincipalSearchArgs {
+  query: string;
+  accepts: PrincipalKind[];
+  enabled: boolean;
+  onError: () => void;
+}
+
+function usePrincipalSearch({ query, accepts, enabled, onError }: UsePrincipalSearchArgs) {
+  // ``fetched`` is the most recent result set we successfully loaded
+  // from the server. We never clear it synchronously from the
+  // effect; instead the returned ``results`` derive from ``fetched``
+  // + the live query so consumers see an empty list whenever the
+  // query is below the 2-char threshold without us having to call
+  // setState in the effect body.
+  const [fetched, setFetched] = useState<Principal[]>([]);
+  const [loading, setLoading] = useState(false);
+  const errorReported = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const trimmed = query.trim();
+    if (trimmed.length < 2) return;
+    const controller = new AbortController();
+    const params = new URLSearchParams({
+      q: trimmed,
+      types: accepts.join(','),
+      limit: '20',
+    });
+    // setState wrapped in an inner async function to keep the
+    // effect body free of synchronous state writes (matches the
+    // pattern used elsewhere in this repo and satisfies the
+    // react-hooks/set-state-in-effect rule).
+    const run = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/directory/search?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = (await res.json()) as { results: Principal[] };
+        if (!controller.signal.aborted) {
+          setFetched(Array.isArray(body.results) ? body.results : []);
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setFetched([]);
+        if (!errorReported.current) {
+          errorReported.current = true;
+          console.warn('[PrincipalPicker] directory search failed, falling back to manual entry', err);
+          onError();
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+    void run();
+    return () => controller.abort();
+  }, [query, accepts.join(','), enabled, onError]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Derived: hide any stale ``fetched`` while the live query is below
+  // the threshold. Avoids clearing state inside the effect.
+  const trimmedNow = query.trim();
+  const results = trimmedNow.length < 2 ? [] : fetched;
+  return { results, loading };
+}
+
+export default PrincipalPicker;

--- a/src/frontend/src/components/settings/settings-layout.tsx
+++ b/src/frontend/src/components/settings/settings-layout.tsx
@@ -8,6 +8,7 @@ import {
   Plug2,
   GitBranch,
   Bot,
+  Contact,
   Network,
   Search,
   Briefcase,
@@ -66,6 +67,7 @@ const settingsNavGroups: SettingsNavGroup[] = [
     items: [
       { path: '/settings/git', labelKey: 'settings:tabs.git', defaultLabel: 'Git', icon: GitBranch },
       { path: '/settings/mcp', labelKey: 'settings:tabs.mcp', defaultLabel: 'MCP', icon: Bot },
+      { path: '/settings/directory', labelKey: 'settings:tabs.directory', defaultLabel: 'Directory', icon: Contact },
       { path: '/settings/semantic-models', labelKey: 'settings:tabs.rdfSources', defaultLabel: 'RDF Sources', icon: Network },
       { path: '/settings/search', labelKey: 'settings:tabs.search', defaultLabel: 'Search', icon: Search },
     ],

--- a/src/frontend/src/stores/directory-store.test.ts
+++ b/src/frontend/src/stores/directory-store.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the directory store.
+ *
+ * The store's one job is to ensure /api/directory/status is fetched
+ * at most once per page load and to expose the page-sticky
+ * ``degraded`` flag.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDirectoryStore } from './directory-store';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+  useDirectoryStore.getState().reset();
+});
+
+afterEach(() => {
+  useDirectoryStore.getState().reset();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('directory-store', () => {
+  it('fetchStatus populates status and sets loaded', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ configured: true, provider_type: 'entra', connection_name: 'graph' }),
+    );
+    await useDirectoryStore.getState().fetchStatus();
+    const s = useDirectoryStore.getState();
+    expect(s.loaded).toBe(true);
+    expect(s.status?.configured).toBe(true);
+    expect(s.status?.provider_type).toBe('entra');
+  });
+
+  it('fetchStatus is a no-op after loaded', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ configured: false, provider_type: null, connection_name: null }),
+    );
+    await useDirectoryStore.getState().fetchStatus();
+    await useDirectoryStore.getState().fetchStatus();
+    await useDirectoryStore.getState().fetchStatus();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent fetchStatus calls share a single in-flight request', async () => {
+    let resolveBody: (v: Response) => void = () => {};
+    fetchMock.mockReturnValue(new Promise<Response>((r) => (resolveBody = r)));
+    const p1 = useDirectoryStore.getState().fetchStatus();
+    const p2 = useDirectoryStore.getState().fetchStatus();
+    const p3 = useDirectoryStore.getState().fetchStatus();
+    resolveBody(jsonResponse({ configured: true, provider_type: 'entra', connection_name: 'graph' }));
+    await Promise.all([p1, p2, p3]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a not-configured status on fetch failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    await useDirectoryStore.getState().fetchStatus();
+    const s = useDirectoryStore.getState();
+    expect(s.loaded).toBe(true);
+    expect(s.status?.configured).toBe(false);
+  });
+
+  it('refresh re-fetches and clears the degraded flag', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ configured: true, provider_type: 'entra', connection_name: 'graph' }),
+    );
+    await useDirectoryStore.getState().fetchStatus();
+    useDirectoryStore.getState().markDegraded();
+    expect(useDirectoryStore.getState().degraded).toBe(true);
+    await useDirectoryStore.getState().refresh();
+    expect(useDirectoryStore.getState().degraded).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('markDegraded is session-sticky', () => {
+    useDirectoryStore.getState().markDegraded();
+    expect(useDirectoryStore.getState().degraded).toBe(true);
+    // Subsequent fetchStatus shouldn't unset it (only refresh does).
+    useDirectoryStore.setState({ loaded: false });
+    // Don't actually call fetch; just verify the flag persists.
+    expect(useDirectoryStore.getState().degraded).toBe(true);
+  });
+});

--- a/src/frontend/src/stores/directory-store.ts
+++ b/src/frontend/src/stores/directory-store.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared cache for the directory provider's wiring status.
+ *
+ * Every PrincipalPicker instance on a page consults this store so the
+ * GET /api/directory/status call happens at most once per page load
+ * regardless of how many pickers are mounted. Also tracks a
+ * "degraded" flag: if a live search call fails mid-session, pickers
+ * flip into manual-entry mode for the rest of the session and we
+ * remember that decision here so newly mounted pickers don't probe
+ * again.
+ */
+
+import { create } from 'zustand';
+
+import type { DirectoryStatus } from '@/types/directory';
+
+interface DirectoryState {
+  status: DirectoryStatus | null;
+  /** True once a fetch has resolved (success or failure). */
+  loaded: boolean;
+  /**
+   * Set by pickers when a search call fails after status said
+   * configured. Sticky for the lifetime of the page.
+   */
+  degraded: boolean;
+  /** In-flight promise so concurrent pickers share one network call. */
+  _inflight: Promise<void> | null;
+
+  fetchStatus: () => Promise<void>;
+  /** Force a re-fetch -- used by the Settings tab after Save. */
+  refresh: () => Promise<void>;
+  markDegraded: () => void;
+  reset: () => void;
+}
+
+async function loadStatus(): Promise<DirectoryStatus | null> {
+  try {
+    const res = await fetch('/api/directory/status');
+    if (!res.ok) {
+      return { configured: false, provider_type: null, connection_name: null };
+    }
+    return (await res.json()) as DirectoryStatus;
+  } catch {
+    return { configured: false, provider_type: null, connection_name: null };
+  }
+}
+
+export const useDirectoryStore = create<DirectoryState>((set, get) => ({
+  status: null,
+  loaded: false,
+  degraded: false,
+  _inflight: null,
+
+  fetchStatus: async () => {
+    const { loaded, _inflight } = get();
+    if (loaded) return;
+    if (_inflight) return _inflight;
+    const p = (async () => {
+      const status = await loadStatus();
+      set({ status, loaded: true, _inflight: null });
+    })();
+    set({ _inflight: p });
+    return p;
+  },
+
+  refresh: async () => {
+    const p = (async () => {
+      const status = await loadStatus();
+      // ``refresh`` is called after a successful Save -- reset the
+      // session-sticky ``degraded`` flag so the picker can probe again.
+      set({ status, loaded: true, degraded: false, _inflight: null });
+    })();
+    set({ _inflight: p });
+    return p;
+  },
+
+  markDegraded: () => set({ degraded: true }),
+
+  reset: () => set({ status: null, loaded: false, degraded: false, _inflight: null }),
+}));

--- a/src/frontend/src/types/directory.ts
+++ b/src/frontend/src/types/directory.ts
@@ -1,0 +1,63 @@
+/**
+ * TypeScript counterparts to the backend's Directory API models
+ * (see api/models/directory.py).
+ *
+ * The Directory layer is the generic abstraction over identity
+ * providers. v1 ships one concrete provider (Microsoft Entra ID via
+ * Microsoft Graph); these types stay provider-agnostic.
+ */
+
+export type PrincipalType = 'user' | 'group' | 'unknown';
+
+export interface Principal {
+  /** user | group | unknown */
+  type: PrincipalType;
+  /**
+   * Persisted identifier. UPN/email for users, displayName for groups.
+   * This is the value the picker emits and consumes -- NOT a GUID.
+   */
+  id: string;
+  display_name: string;
+  /**
+   * Secondary identifier shown on row two of search results and as
+   * tooltip on selected badges. Email/UPN for users, GUID for groups.
+   */
+  sub_label?: string | null;
+}
+
+export interface DirectoryStatus {
+  configured: boolean;
+  provider_type: string | null;
+  connection_name: string | null;
+}
+
+export interface DirectoryTestResult {
+  healthy: boolean;
+  error?: string | null;
+}
+
+export interface DirectorySearchResponse {
+  results: Principal[];
+}
+
+export interface DirectorySettingsUpdate {
+  provider_type?: string | null;
+  connection_name?: string | null;
+}
+
+export interface UcHttpConnection {
+  name: string;
+  connection_type: string;
+  comment?: string | null;
+  owner?: string | null;
+  created_at?: number | null;
+  updated_at?: number | null;
+}
+
+/**
+ * Supported provider types. ``entra`` is the only one enabled in v1;
+ * additional entries here will be rendered disabled in the Settings
+ * tab to telegraph the abstraction.
+ */
+export const DIRECTORY_PROVIDER_TYPES = ['entra'] as const;
+export type DirectoryProviderType = (typeof DIRECTORY_PROVIDER_TYPES)[number];

--- a/src/frontend/src/views/settings-directory.tsx
+++ b/src/frontend/src/views/settings-directory.tsx
@@ -1,0 +1,310 @@
+/**
+ * Settings → Integrations → Directory.
+ *
+ * Configures the Directory abstraction (PRD #335). v1 ships one
+ * concrete provider (Microsoft Entra ID via Microsoft Graph). The
+ * provider Select renders future providers visible-but-disabled so
+ * the abstraction is telegraphed to the user.
+ *
+ * All Graph traffic goes through a UC HTTP Connection so the app
+ * never holds a client secret or token cache. The Test button hits
+ * POST /api/directory/test which surfaces auth / connectivity errors.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, Plug2 } from 'lucide-react';
+
+import SettingsPageWrapper from '@/components/settings/settings-page-wrapper';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useApi } from '@/hooks/use-api';
+import { useToast } from '@/hooks/use-toast';
+import { useDirectoryStore } from '@/stores/directory-store';
+import type {
+  DirectorySettingsUpdate,
+  DirectoryStatus,
+  DirectoryTestResult,
+  UcHttpConnection,
+} from '@/types/directory';
+
+// Provider options. Only `entra` is enabled in v1; the others render
+// disabled so the abstraction is visible (matches the plan).
+const PROVIDER_OPTIONS: Array<{
+  value: string;
+  label: string;
+  disabled: boolean;
+  helpKey?: string;
+}> = [
+  { value: 'entra', label: 'Microsoft Entra ID', disabled: false, helpKey: 'entra' },
+  { value: 'okta', label: 'Okta (coming soon)', disabled: true },
+  { value: 'ping', label: 'Ping (coming soon)', disabled: true },
+];
+
+const ENTRA_HELP_LINES = [
+  ['Token URL', 'https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token'],
+  ['Base URL', 'https://graph.microsoft.com'],
+  ['Scope', 'https://graph.microsoft.com/.default'],
+  ['Grant type', 'client_credentials'],
+] as const;
+
+export default function SettingsDirectoryView() {
+  const { get, put, post } = useApi();
+  const { toast } = useToast();
+  const refreshStore = useDirectoryStore((s) => s.refresh);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [providerType, setProviderType] = useState<string>('');
+  const [connectionName, setConnectionName] = useState<string>('');
+  const [status, setStatus] = useState<DirectoryStatus | null>(null);
+  const [connections, setConnections] = useState<UcHttpConnection[]>([]);
+  const [connectionsLoading, setConnectionsLoading] = useState(false);
+
+  // Initial load
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [statusRes, connsRes] = await Promise.all([
+        get<DirectoryStatus>('/api/directory/status'),
+        (async () => {
+          setConnectionsLoading(true);
+          try {
+            return await get<UcHttpConnection[]>('/api/directory/uc-http-connections');
+          } finally {
+            if (!cancelled) setConnectionsLoading(false);
+          }
+        })(),
+      ]);
+      if (cancelled) return;
+      if (statusRes.data && !statusRes.error) {
+        setStatus(statusRes.data);
+        setProviderType(statusRes.data.provider_type ?? '');
+        setConnectionName(statusRes.data.connection_name ?? '');
+      }
+      if (connsRes.data && Array.isArray(connsRes.data)) {
+        setConnections(connsRes.data);
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [get]);
+
+  const dirty = useMemo(() => {
+    const persistedProvider = status?.provider_type ?? '';
+    const persistedConn = status?.connection_name ?? '';
+    return providerType !== persistedProvider || connectionName !== persistedConn;
+  }, [providerType, connectionName, status]);
+
+  const canSave = !saving && dirty;
+  const canTest = !!status?.configured && !testing && !dirty;
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const body: DirectorySettingsUpdate = {
+        provider_type: providerType || null,
+        connection_name: connectionName || null,
+      };
+      const res = await put<DirectoryStatus>('/api/directory/settings', body);
+      if (res.error) throw new Error(res.error);
+      setStatus(res.data);
+      // Re-pull status into the shared store so existing pickers pick
+      // up the change without a full page reload, and clear the
+      // session-sticky degraded flag.
+      await refreshStore();
+      toast({ title: 'Directory settings saved' });
+    } catch (err: any) {
+      toast({
+        variant: 'destructive',
+        title: 'Failed to save',
+        description: err.message ?? String(err),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    try {
+      const res = await post<DirectoryTestResult>('/api/directory/test', {});
+      if (res.error) throw new Error(res.error);
+      if (res.data.healthy) {
+        toast({ title: 'Directory test succeeded' });
+      } else {
+        toast({
+          variant: 'destructive',
+          title: 'Directory test failed',
+          description: res.data.error ?? 'Unknown error',
+        });
+      }
+    } catch (err: any) {
+      toast({
+        variant: 'destructive',
+        title: 'Directory test failed',
+        description: err.message ?? String(err),
+      });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleClear = async () => {
+    setSaving(true);
+    try {
+      const body: DirectorySettingsUpdate = { provider_type: null, connection_name: null };
+      const res = await put<DirectoryStatus>('/api/directory/settings', body);
+      if (res.error) throw new Error(res.error);
+      setStatus(res.data);
+      setProviderType('');
+      setConnectionName('');
+      await refreshStore();
+      toast({ title: 'Directory settings cleared' });
+    } catch (err: any) {
+      toast({
+        variant: 'destructive',
+        title: 'Failed to clear',
+        description: err.message ?? String(err),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <SettingsPageWrapper title="Directory">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        </div>
+      </SettingsPageWrapper>
+    );
+  }
+
+  return (
+    <SettingsPageWrapper title="Directory">
+      <div className="flex flex-col gap-6 max-w-2xl">
+        <p className="text-sm text-muted-foreground">
+          Connect an external identity provider so users and groups can be picked
+          from a live directory. All traffic flows through a Unity Catalog HTTP
+          Connection; the app never stores a client secret.
+        </p>
+
+        <div className="grid gap-2">
+          <Label htmlFor="directory-provider">Provider</Label>
+          <Select value={providerType} onValueChange={setProviderType} disabled={saving}>
+            <SelectTrigger id="directory-provider">
+              <SelectValue placeholder="Select a provider…" />
+            </SelectTrigger>
+            <SelectContent>
+              {PROVIDER_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value} disabled={opt.disabled}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="directory-connection">UC HTTP Connection</Label>
+          <Select
+            value={connectionName}
+            onValueChange={setConnectionName}
+            disabled={saving || connectionsLoading || connections.length === 0}
+          >
+            <SelectTrigger id="directory-connection">
+              <SelectValue
+                placeholder={
+                  connectionsLoading
+                    ? 'Loading connections…'
+                    : connections.length === 0
+                    ? 'No HTTP connections found'
+                    : 'Select a connection…'
+                }
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {connections.map((c) => (
+                <SelectItem key={c.name} value={c.name}>
+                  <div className="flex items-center gap-2">
+                    <Plug2 className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span>{c.name}</span>
+                    {c.comment && (
+                      <span className="text-xs text-muted-foreground">— {c.comment}</span>
+                    )}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {providerType === 'entra' && (
+          <Alert>
+            <AlertTitle>Entra ID connection setup</AlertTitle>
+            <AlertDescription>
+              <p className="mb-2 text-sm">
+                Create a Unity Catalog HTTP connection against Microsoft Graph with
+                client_credentials. The app&apos;s enterprise app must hold at least
+                <code className="mx-1">User.Read.All</code> and
+                <code className="mx-1">GroupMember.Read.All</code> (or
+                <code className="mx-1">Group.Read.All</code>) application scopes.
+              </p>
+              <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                {ENTRA_HELP_LINES.map(([k, v]) => (
+                  <div key={k} className="contents">
+                    <dt className="text-muted-foreground">{k}</dt>
+                    <dd>
+                      <code>{v}</code>
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex gap-2">
+          <Button onClick={handleSave} disabled={!canSave}>
+            {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Save
+          </Button>
+          <Button variant="outline" onClick={handleTest} disabled={!canTest}>
+            {testing && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Test connection
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={handleClear}
+            disabled={saving || (!status?.provider_type && !status?.connection_name)}
+          >
+            Clear
+          </Button>
+        </div>
+
+        {status && (
+          <p className="text-xs text-muted-foreground">
+            Status:{' '}
+            {status.configured ? (
+              <span className="text-foreground">Configured ({status.provider_type})</span>
+            ) : (
+              <span>Not configured</span>
+            )}
+          </p>
+        )}
+      </div>
+    </SettingsPageWrapper>
+  );
+}


### PR DESCRIPTION
Second of two PRs implementing Phase 1 of the directory-lookup-and-principal-picker plan (#375). **Stacked on #406** — base branch is `feat/directory-backend`, so the diff here is frontend-only. Will rebase onto `main` once #406 merges.

Source PRD: #335
Plan: #375
Backend PR: #406

## Summary
- **Settings → Integrations → Directory** tab: provider Select (Entra ID enabled, Okta/Ping rendered disabled so the abstraction is visible to operators), UC HTTP Connection dropdown fed from `/api/directory/uc-http-connections`, Save / Test / Clear buttons with success/destructive toast feedback, and a provider-specific help block for Entra with the four UC-connection fields plus required Graph application scopes.
- **`PrincipalPicker`** — single component, both modes (configured / unconfigured) and both UI variants (inline 2-char-debounced type-ahead + popup "Browse directory" dialog with type-filter chips) selected at runtime from the directory store. Two-line result rows (display name + sub_label), tooltip on selected badges exposing the underlying email/UPN/GUID, X-to-remove. Props are discriminated on `multiple` so single-pick callers get `string | null` typing and multi-pick callers get `string[]` typing without casts.
- **`directory-store` (Zustand)** — singleton cache for `/api/directory/status` so every picker on a page shares one network call, plus a session-sticky `degraded` flag flipped on the first search failure so subsequent pickers drop straight into manual mode without re-probing.
- **Assign Owner dialog** migrated to `PrincipalPicker(accepts=['user'])`. API payload (`user_email` + `user_name`) is unchanged — the change is purely UI.
- Sidebar entry under Settings → Integrations and `/settings/directory` route wired up.

## Architectural notes
- The picker emits and consumes only the persisted identifier string (UPN/email for users, displayName for groups). Existing storage shapes (`str` / `List[str]`) are preserved; no DB migration in v1.
- Pre-existing values render as plain badges with no error decoration regardless of provider availability. The picker does *not* re-resolve persisted ids against the directory.
- Graceful degradation: if `directory.status` says configured but a search call fails, the picker logs once (`console.warn`), flips into manual-entry mode for the rest of the session, and `directory-store.degraded` becomes sticky so newly-mounted pickers behave the same way.
- Future Phase-2+ migrations (Roles, Entitlements, Comments, etc.) reuse this same component with different `multiple` / `accepts` combinations — no per-call-site bespoke control.

## Test plan
- [x] Type-check clean: `yarn type-check` (Done in 17.93s)
- [x] Lint clean on new files (`npx eslint ...`): **0 errors**, only the repo-wide `err: any` catch-block warning pattern remains (matches existing files).
- [x] Frontend suite: `npx vitest run` → **550 passed, 6 skipped, 0 failed**.
- [x] New tests (19):
  - `principal-picker.test.tsx` (13): pre-existing values render as plain badges without re-resolving; X-remove emits remaining ids; disabled hides remove buttons; Enter/Tab/comma/blur commit in unconfigured mode; empty / duplicate inputs are no-ops; configured mode calls `/api/directory/search` with `q=` and `types=` honouring `accepts`; queries < 2 chars do not fire a request; failing search flips into manual-entry mode for the rest of the session.
  - `directory-store.test.ts` (6): `fetchStatus` populates state, dedupes concurrent calls into one in-flight request, no-ops once loaded, falls back to not-configured on network failure; `refresh` re-fetches and clears `degraded`; `markDegraded` is sticky.
- Radix Popover dropdown internals are deferred to Playwright E2E — the existing `tag-selector` tests in this repo follow the same split for the same reason (Radix Popover hangs in jsdom).
- [ ] Manual smoke test of the Settings tab + Assign Owner against a real workspace with an Entra UC connection (left for reviewer / follow-up).

## What's intentionally **not** here
- Migration of other principal-bearing fields (Roles, Entitlements, Comments, Teams, Reviews, MDM, etc.) — Phases 2–4 in the plan.
- A production second provider — abstraction is exercised by backend unit-test stub.