### PR TITLE
fix(test): add pytest-asyncio to dev env

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -30,6 +30,7 @@ python = "3.11"
 dependencies = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "pytest-asyncio>=0.23",
     "ruff>=0.8.0",
     "pre-commit>=3.0.0",
 ]
@@ -86,6 +87,7 @@ addopts = [
     "--import-mode=importlib",
     "-v",
 ]
+asyncio_mode = "strict"
 
 [tool.coverage.run]
 source = ["backend/src"]


### PR DESCRIPTION
## Summary
- 7 async tests in `backend/src/tests/unit/test_is_user_feature_admin.py` failed on `main` with `Failed: async def functions are not natively supported`. The hatch `dev` env in `src/pyproject.toml` didn't include `pytest-asyncio`, so `@pytest.mark.asyncio` was an unknown marker and pytest refused to run the async coroutines.
- Adds `pytest-asyncio>=0.23` to the `[tool.hatch.envs.dev]` dependencies and pins `asyncio_mode = \"strict\"` to match the existing explicit `@pytest.mark.asyncio` decorators on those tests.
- Failed run: https://github.com/databrickslabs/ontos/actions/runs/26221637174/job/77157850344

## Test plan
- [x] `hatch -e dev run pytest backend/src/tests/unit/test_is_user_feature_admin.py --no-cov -v` locally: 7 passed
- [ ] CI Backend Tests job green on this PR

This pull request and its description were written by Isaac.