### PR TITLE
fix(e2e): seed certification levels on fresh DB and route workflow-editor tests to a typed designer

### DIFF
--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -450,6 +450,23 @@ async def startup_event_handler(app: FastAPI):
         initialize_database() # Step 1: Setup Database
         logger.info("Database initialization sequence complete.")
 
+        # Step 1b: Seed reference data that the alembic data-migrations would
+        # have inserted but that `create_all()` cannot. On a fresh database
+        # init_db() takes the create_all() + stamp path (no `alembic upgrade`),
+        # so any rows seeded inside migrations (e.g. Bronze/Silver/Gold in
+        # a8_add_certification_levels_table.py) never get written. The
+        # seed_defaults() calls below are idempotent — they no-op if rows exist.
+        try:
+            from src.repositories.certification_levels_repository import certification_levels_repo
+
+            session_factory = get_session_factory()
+            with session_factory() as db_session:
+                certification_levels_repo.seed_defaults(db_session)
+                db_session.commit()
+            logger.info("Reference data seed step complete.")
+        except Exception as e:
+            logger.warning(f"Failed seeding reference data: {e}", exc_info=True)
+
         # Step 2: Initialize managers (requires ws_client to be set up if managers need it)
         # Create a temporary session for manager initializations that require DB access (like default namespace)
         # Note: Managers themselves should request sessions via DBSessionDep for their operational methods.

--- a/src/frontend/src/tests/workflow-editor-edges.spec.ts
+++ b/src/frontend/src/tests/workflow-editor-edges.spec.ts
@@ -17,7 +17,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 1. Workflow editor loads with step toolbar
   // -------------------------------------------------------------------------
   test('workflow editor loads with step toolbar and canvas', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
 
     // "Add Step" label in the toolbar panel
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
@@ -37,7 +37,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 2. Add nodes and verify auto-connection edge
   // -------------------------------------------------------------------------
   test('adding steps auto-creates connecting edges', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Start with just the trigger node
@@ -61,7 +61,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 3. Edge selection and visual feedback
   // -------------------------------------------------------------------------
   test('clicking an edge selects it and shows delete button', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Add two steps to get an edge between them
@@ -87,7 +87,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 4. Edge deletion via delete button
   // -------------------------------------------------------------------------
   test('clicking the delete button removes the edge', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Build a small graph: trigger → approval → notification
@@ -112,7 +112,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 5. Approval node has pass (green) and fail (red) source handles
   // -------------------------------------------------------------------------
   test('approval node exposes pass and fail handles', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Add an Approval step
@@ -132,7 +132,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 6. Drag from fail handle to create a fail edge
   // -------------------------------------------------------------------------
   test('drag from fail handle creates a fail-labeled edge', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Add Approval + two Notification nodes
@@ -189,7 +189,7 @@ test.describe('Workflow Editor — Edge Management', () => {
   // 7. Save workflow with connections — no errors
   // -------------------------------------------------------------------------
   test('save workflow with steps and connections succeeds', async ({ page }) => {
-    await page.goto('/workflows/new');
+    await page.goto('/workflows/new?type=process');
     await expect(page.getByText('Add Step')).toBeVisible({ timeout: 15_000 });
 
     // Fill in the workflow name (the inline Input with placeholder "Workflow name")


### PR DESCRIPTION
## Summary

Fixes the 10 E2E failures observed on `main` (and on every branch that rebases from it):

- 7 in `src/frontend/src/tests/workflow-editor-edges.spec.ts` — all timing out on `getByText('Add Step')`.
- 3 in `src/frontend/src/tests/lifecycle-certification-publication.spec.ts` — `certification levels API returns data`, `handle-certify approves certification`, and the `request-certify → handle-certify` flow test.

Two unrelated root causes, both producing element/data-not-found failures rather than logic bugs:

### 1. Workflow editor tests routed to the type-picker, not the canvas

#279 added a workflow-type chooser that gates the designer canvas: until the user picks `process` or `approval`, the **Add Step** toolbar is not rendered (`workflowType !== null` guard at `src/frontend/src/components/workflows/workflow-designer.tsx:1171`). The tests still navigate to `/workflows/new` without `?type=`, so they land on the picker and time out.

Fix: replace every `page.goto('/workflows/new')` with `page.goto('/workflows/new?type=process')`. The process palette already contains both buttons the tests click (`Request Approval`, `Notification`).

### 2. Certification levels never seeded on a fresh DB

`init_db()` takes the `create_all()` + alembic-`stamp` path when the DB is fresh — it does **not** run `alembic upgrade`. So the data inserts inside migration `a8_add_certification_levels_table.py` (Bronze/Silver/Gold) never execute, and the `certification_levels` table is created empty. That makes:

- `GET /api/certification-levels` return `[]` (test expects ≥3 with names `Bronze`/`Silver`/`Gold`).
- `POST /data-products/{id}/handle-certify` raise 404 at `data_product_routes.py:495` because the `get_by_order(db, certification_level)` lookup fails — and `404` is not in the test's accepted-status list.

The repository already exposes an idempotent `seed_defaults()` — it just was never called from startup. Invoke it from `startup_event_handler` as a new **Step 1b**, right after `initialize_database`. Wrapped in `try/except` so a seeding failure logs a warning but does not block startup, matching the pattern used elsewhere in the handler.

## Why not move seeding into the alembic migration?

The migration already seeds via `op.bulk_insert(...)` — it's correct, but it only runs when `alembic upgrade` is the path taken. On the `create_all()` path the migration body is bypassed entirely. Rather than diverging the two paths further, seeding it from startup keeps the source of truth on the repository and lets both bootstrap paths converge to the same state.

## Test plan

- [ ] `e2e-tests` job on this PR runs all 10 previously failing tests and they pass.
- [ ] `backend-tests` still passes (no behavioural change to existing routes).
- [ ] Manual: start backend with `APP_DB_DROP_ON_START=true`, then `curl http://localhost:8000/api/certification-levels` returns Bronze/Silver/Gold.
- [ ] Manual: open `/workflows/new` in the UI — type-picker still renders (regression check for #279).

This pull request and its description were written by Isaac.