### PR TITLE
perf(e2e): move demo-data load/clear to playwright global hooks

### DIFF
--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   timeout: 90_000,
   expect: { timeout: 10_000 },
   testDir: './src/tests',
+  globalSetup: './src/tests/global-setup.ts',
+  globalTeardown: './src/tests/global-teardown.ts',
   // Skip tests that depend on features not yet wired for CI (mock workspace client)
   testIgnore: process.env.CI ? [
     '**/contract-outputport-mapping*',

--- a/src/frontend/src/tests/global-setup.ts
+++ b/src/frontend/src/tests/global-setup.ts
@@ -1,0 +1,31 @@
+import { request, FullConfig } from '@playwright/test'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+
+/**
+ * Load demo data once before the entire Playwright run.
+ *
+ * Previously every spec ran loadDemoData in its own beforeAll, which meant
+ * ~9 full SQL replays per run against a shared backend. With workers=2 this
+ * is the dominant cost — most of the 20-minute job timeout went into
+ * re-seeding the same dataset between spec files. The endpoint itself is
+ * idempotent (ON CONFLICT DO NOTHING), so loading once at the start is
+ * sufficient; the per-spec helper now short-circuits when data is already
+ * present (see helpers/demo-data.ts).
+ */
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  const ctx = await request.newContext()
+  try {
+    const resp = await ctx.post(`${BACKEND_URL}/api/settings/demo-data/load`, {
+      timeout: 120_000,
+    })
+    if (!resp.ok()) {
+      const body = await resp.text()
+      throw new Error(`globalSetup: failed to load demo data (${resp.status()}): ${body}`)
+    }
+    // eslint-disable-next-line no-console
+    console.log('[globalSetup] demo data loaded')
+  } finally {
+    await ctx.dispose()
+  }
+}

--- a/src/frontend/src/tests/global-teardown.ts
+++ b/src/frontend/src/tests/global-teardown.ts
@@ -1,0 +1,38 @@
+import { request, FullConfig } from '@playwright/test'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+
+/**
+ * Clear demo data once after the entire Playwright run.
+ *
+ * Mirrors global-setup.ts. Failures here are logged but never thrown — the
+ * suite has already finished and we don't want teardown to flip a green run
+ * red. Local runs can also skip teardown so devs keep their seeded DB.
+ */
+export default async function globalTeardown(_config: FullConfig): Promise<void> {
+  if (!process.env.CI) {
+    // eslint-disable-next-line no-console
+    console.log('[globalTeardown] skipping clear (not in CI)')
+    return
+  }
+
+  const ctx = await request.newContext()
+  try {
+    const resp = await ctx.delete(`${BACKEND_URL}/api/settings/demo-data`, {
+      timeout: 60_000,
+    })
+    if (!resp.ok()) {
+      const body = await resp.text()
+      // eslint-disable-next-line no-console
+      console.warn(`[globalTeardown] clear failed (${resp.status()}): ${body}`)
+      return
+    }
+    // eslint-disable-next-line no-console
+    console.log('[globalTeardown] demo data cleared')
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[globalTeardown] clear errored:', err)
+  } finally {
+    await ctx.dispose()
+  }
+}

--- a/src/frontend/src/tests/helpers/demo-data.ts
+++ b/src/frontend/src/tests/helpers/demo-data.ts
@@ -2,22 +2,52 @@ import { APIRequestContext, Page } from '@playwright/test'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
+// Per-worker memo so a spec that survives a worker restart doesn't pay the
+// API-probe cost twice. Cross-worker dedup is handled by global-setup.ts.
+let presentInThisWorker = false
+
+async function isDemoDataPresent(request: APIRequestContext): Promise<boolean> {
+  if (presentInThisWorker) return true
+  try {
+    const resp = await request.get(`${BACKEND_URL}/api/data-products`, {
+      timeout: 10_000,
+    })
+    if (!resp.ok()) return false
+    const products = await resp.json()
+    const ok = Array.isArray(products) && products.length > 0
+    if (ok) presentInThisWorker = true
+    return ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Ensure demo data exists. Loads if absent; no-ops if global-setup or a prior
+ * spec already populated the DB. Specs can keep their existing
+ * `test.beforeAll(loadDemoData)` hooks — they're cheap after the first call.
+ */
 export async function loadDemoData(request: APIRequestContext) {
+  if (await isDemoDataPresent(request)) return { skipped: true }
+
   const resp = await request.post(`${BACKEND_URL}/api/settings/demo-data/load`)
   if (!resp.ok()) {
     const body = await resp.text()
     throw new Error(`Failed to load demo data (${resp.status()}): ${body}`)
   }
+  presentInThisWorker = true
   return resp.json()
 }
 
-export async function clearDemoData(request: APIRequestContext) {
-  const resp = await request.delete(`${BACKEND_URL}/api/settings/demo-data`)
-  if (!resp.ok()) {
-    const body = await resp.text()
-    throw new Error(`Failed to clear demo data (${resp.status()}): ${body}`)
-  }
-  return resp.json()
+/**
+ * No-op by design. End-of-run cleanup is owned by global-teardown.ts so
+ * specs don't repeatedly drop+reload the shared demo dataset between files.
+ * Kept exported so existing `test.afterAll(clearDemoData)` hooks compile;
+ * if a spec genuinely needs to clear mid-run, call the DELETE endpoint
+ * directly via the APIRequestContext.
+ */
+export async function clearDemoData(_request: APIRequestContext) {
+  return { skipped: true }
 }
 
 /**


### PR DESCRIPTION
## Summary

E2E was hitting the 20-min CI job timeout. The dominant cost was the per-spec `loadDemoData`/`clearDemoData` round-trip — 9 spec files each ran the full SQL-replay cycle against a shared backend, so with `workers=2` we were paying for ~9 full load+clear pairs per run.

This PR moves both calls to Playwright global hooks so the dataset is seeded once at the start of the run and cleared once at the end.

## Changes

- **`src/tests/global-setup.ts`** *(new)* — calls `POST /api/settings/demo-data/load` once before any worker starts. 120s timeout for the SQL replay.
- **`src/tests/global-teardown.ts`** *(new)* — calls `DELETE /api/settings/demo-data` once at the end. CI-only; local devs keep their seeded DB. Failures are logged, not thrown.
- **`src/tests/helpers/demo-data.ts`** — `loadDemoData` now probes `/api/data-products` first and no-ops when data is already present, with a per-worker module-level memo so the probe runs at most once per worker process. `clearDemoData` becomes a no-op so existing `test.afterAll(clearDemoData)` hooks compile and run without re-triggering the load cycle between files.
- **`playwright.config.ts`** — wires `globalSetup` and `globalTeardown`.

Spec files are intentionally untouched. The `test.beforeAll(loadDemoData)` / `test.afterAll(clearDemoData)` hooks in the 9 specs become cheap pass-throughs, which keeps the diff small and leaves the per-spec pattern available if a future test genuinely needs an explicit reset.

## Why not just bump workers to 4?

Workers and timeouts solve different problems. Adding workers without addressing the per-spec demo-data churn would have multiplied the concurrent load+clear hits against the same Postgres service container, trading hard timeouts for race-condition flakes. Once this lands, bumping `workers` is a real option — but for now `workers=2` is preserved.

## Test plan

- [ ] CI E2E job runs to completion under 20 minutes.
- [ ] First spec's `beforeAll` returns quickly (probe sees data already present from `globalSetup`).
- [ ] Local `yarn test:e2e` still works without `CI=1`; teardown is skipped locally.
- [ ] If `globalSetup` fails (e.g., backend not yet ready), the whole suite fails fast with a clear error rather than each spec failing on its own.

## Follow-ups

- Once we have confidence, the per-spec `beforeAll/afterAll` calls can be removed entirely (touches the 9 spec files but isn't required for this fix).
- If wall time is still high after this lands, `workers: 4` becomes a safer next step.

This pull request and its description were written by Isaac.