### PR TITLE
docs: correct repository URL to databrickslabs/ontos

### DIFF
--- a/.cursor/rules/01-expertise-and-principles.mdc
+++ b/.cursor/rules/01-expertise-and-principles.mdc
@@ -16,7 +16,7 @@ You are an expert in **Python, FastAPI, scalable API development, TypeScript, Re
 - Follow proper **naming conventions**:
   - For Python: use lowercase with underscores (e.g., `routers/user_routes.py`, `db_models/data_products.py`, `repositories/settings_repository.py`).
   - For TypeScript: use lowercase with dashes for directories and files (e.g., `components/auth-wizard`, `views/data-products.tsx`).
-- The project is ASF 2.0 licensed and open-source, hosted at https://github.com/larsgeorge/ontos-app
+- The project is ASF 2.0 licensed and open-source, hosted at https://github.com/databrickslabs/ontos
 
 ## Personal Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ You are an expert in **Python, FastAPI, scalable API development, TypeScript, Re
 - Follow proper **naming conventions**:
   - For Python: use lowercase with underscores (e.g., `routers/user_routes.py`, `db_models/data_products.py`, `repositories/settings_repository.py`).
   - For TypeScript: use lowercase with dashes for directories and files (e.g., `components/auth-wizard`, `views/data-products.tsx`).
-- The project is ASF 2.0 licensed and open-source, hosted at https://github.com/larsgeorge/ontos
+- The project is ASF 2.0 licensed and open-source, hosted at https://github.com/databrickslabs/ontos
 
 ## Personal Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Please be respectful and professional in all interactions. We're building a coll
    ```
 3. Add the upstream remote:
    ```bash
-   git remote add upstream https://github.com/larsgeorge/ontos.git
+   git remote add upstream https://github.com/databrickslabs/ontos.git
    ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Ontos is designed to run as a **Databricks App**:
 
 ```bash
 # Clone the repository
-git clone https://github.com/larsgeorge/ontos.git
+git clone https://github.com/databrickslabs/ontos.git
 cd ontos
 
 # Install frontend dependencies

--- a/docs/notes/podcast-narrative-ai-knowledge-systems.md
+++ b/docs/notes/podcast-narrative-ai-knowledge-systems.md
@@ -444,7 +444,7 @@ The fundamental insight is that data governance is ultimately about meaning. And
 
 ### Q: If listeners want to try Ontos, where do they start?
 
-**A:** "It's open source under Apache 2.0 at github.com/larsgeorge/ontos. Clone it, follow the Quick Start, enable demo mode to see sample data, and start exploring. The User Guide is comprehensive."
+**A:** "It's open source under Apache 2.0 at github.com/databrickslabs/ontos. Clone it, follow the Quick Start, enable demo mode to see sample data, and start exploring. The User Guide is comprehensive."
 
 ### Q: What existing technology inspired Ontos the most?
 

--- a/src/frontend/src/views/about.tsx
+++ b/src/frontend/src/views/about.tsx
@@ -169,7 +169,7 @@ export default function About() {
       <h2 className="text-3xl font-semibold mb-6">{t('about:learnMore')}</h2>
       <div className="flex flex-col md:flex-row gap-4">
         <Button asChild size="lg">
-          <a href="https://github.com/larsgeorge/ontos" target="_blank" rel="noopener noreferrer">
+          <a href="https://github.com/databrickslabs/ontos" target="_blank" rel="noopener noreferrer">
             <ExternalLink className="mr-2 h-5 w-5" /> {t('about:cta.github')}
           </a>
         </Button>

--- a/website/ontos/docs/contributing.md
+++ b/website/ontos/docs/contributing.md
@@ -35,7 +35,7 @@ Please be respectful and professional in all interactions. We're building a coll
    ```
 3. Add the upstream remote:
    ```bash
-   git remote add upstream https://github.com/larsgeorge/ontos.git
+   git remote add upstream https://github.com/databrickslabs/ontos.git
    ```
 
 ## Development Setup


### PR DESCRIPTION
## Summary

Several files still pointed at the older personal-fork URLs (`github.com/larsgeorge/ontos` and `github.com/larsgeorge/ontos-app`) instead of the canonical `https://github.com/databrickslabs/ontos`. This is a stale-reference fix only — no behavior changes.

Updated:

- `CLAUDE.md` — project attribution line.
- `.cursor/rules/01-expertise-and-principles.mdc` — same attribution for the Cursor rule (was `larsgeorge/ontos-app`).
- `README.md` — Quick Start `git clone` command.
- `CONTRIBUTING.md` — \`git remote add upstream\` command.
- `website/ontos/docs/contributing.md` — same upstream command in the doc-site copy.
- `docs/notes/podcast-narrative-ai-knowledge-systems.md` — Q&A line directing readers to the repo.
- `src/frontend/src/views/about.tsx` — the GitHub CTA button on the in-app About page (user-visible).

Intentionally **not** changed: `src/backend/src/owl/__init__.py` references `https://github.com/larsgeorge/ontobricks` — that's a different library (OntoBricks), legitimately on the personal account, and is correct provenance.

## Test plan

- [ ] About page in the running app shows the correct GitHub link.
- [ ] \`grep -rn 'larsgeorge/ontos' .\` returns no matches (verified locally).