### PR TITLE
docs(directory): ship sample principals CSV + contributor docs for file provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -484,6 +484,68 @@ yarn test:e2e
 - Use fixtures for common setup
 - Aim for >80% coverage on new code
 
+### Local Directory Provider (PrincipalPicker testing)
+
+Many surfaces in the app use the `PrincipalPicker` to resolve users and
+groups against the configured Directory provider (Roles, Entitlements,
+Reviews, Comments audience, Workflow Designer custom principals, Data
+Contract wizard owner/stakeholders, etc.). To exercise the configured
+code path locally without standing up an Entra ID tenant or a Lakebase
+table, use the bundled `file` provider against the sample CSV at
+`src/backend/src/data/principals.csv`.
+
+The CSV ships with three users (Alice / Bob / Carol) and three groups
+(Producers / Consumers / Admins) and matches the format the
+`FileProvider` expects:
+
+```csv
+type,id,display_name,sub_label
+user,alice@example.com,Alice Liddell,alice@example.com
+user,bob@example.com,Bob Builder,bob@example.com
+user,carol@example.com,Carol Carlsson,carol@example.com
+group,Producers,Data Producers,producers-guid
+group,Consumers,Data Consumers,consumers-guid
+group,Admins,Platform Admins,admins-guid
+```
+
+**Configure via the UI (recommended):**
+
+1. Start the dev servers (see [Development Setup](#development-setup)).
+2. Sign in as a user with `settings:READ_WRITE` permission.
+3. Navigate to **Settings → Integrations → Directory**.
+4. Pick **CSV file (test / demo)** as the Provider.
+5. Set **CSV file path** to the absolute path of the bundled file, e.g.
+   `/Users/you/code/ontos/src/backend/src/data/principals.csv`.
+6. Click **Save**, then **Test connection** — you should see a success
+   toast.
+
+**Configure via the backend directly** (e.g. in a test fixture or
+seed script):
+
+```python
+from src.repositories.app_settings_repository import app_settings_repo
+
+app_settings_repo.set_by_key(db, "DIRECTORY_PROVIDER_TYPE", "file")
+app_settings_repo.set_by_key(
+    db,
+    "DIRECTORY_FILE_PATH",
+    "/absolute/path/to/src/backend/src/data/principals.csv",
+)
+```
+
+**Verify it works:**
+
+- `GET /api/directory/status` → `{ "configured": true, "provider_type": "file", "file_path": "/…/principals.csv" }`
+- `GET /api/directory/search?q=ali&types=users` → returns Alice
+- In any picker (e.g. Assign Owner on a Data Product), type `al` —
+  the dropdown should show a two-line row with `Alice Liddell` and
+  `alice@example.com` underneath.
+
+The file is re-read whenever its `mtime` advances, so editing the CSV
+takes effect on the next picker query without a server restart. The
+sample file is checked in as a fixture — feel free to extend it
+locally, but please don't commit org-specific edits.
+
 ---
 
 ## License

--- a/src/backend/src/data/principals.csv
+++ b/src/backend/src/data/principals.csv
@@ -1,0 +1,7 @@
+type,id,display_name,sub_label
+user,alice@example.com,Alice Liddell,alice@example.com
+user,bob@example.com,Bob Builder,bob@example.com
+user,carol@example.com,Carol Carlsson,carol@example.com
+group,Producers,Data Producers,producers-guid
+group,Consumers,Data Consumers,consumers-guid
+group,Admins,Platform Admins,admins-guid


### PR DESCRIPTION
## Summary

Adds a bundled sample dataset and CONTRIBUTING.md instructions so contributors can exercise the Directory feature locally without needing an Entra ID tenant or a Lakebase table.

- `src/backend/src/data/principals.csv` — 3 users (Alice / Bob / Carol) + 3 groups (Producers / Consumers / Admins), in the exact column shape the `FileProvider` expects (`type,id,display_name,sub_label`).
- New **Local Directory Provider (PrincipalPicker testing)** subsection under CONTRIBUTING.md → Testing, covering:
  - The CSV format and what the fixture contains
  - UI-based configuration via Settings → Integrations → Directory (pick "CSV file (test / demo)" + absolute path → Save → Test)
  - Programmatic configuration via `app_settings_repo.set_by_key` for test fixtures / seed scripts
  - Verification steps (`GET /api/directory/status`, search, eyeball the picker dropdown)
  - Note that the provider re-reads on `mtime` change so editing the CSV is hot-reloaded

Builds on the Directory feature landed in #444 (Phases 2–4 + Lakebase/File providers). No code changes — fixture + docs only.

## Test plan

- [ ] Point Settings → Directory at the bundled CSV's absolute path, hit Test → success toast
- [ ] `GET /api/directory/search?q=ali&types=users` returns Alice
- [ ] In Assign Owner, type `al` → dropdown shows `Alice Liddell` / `alice@example.com`
- [ ] CONTRIBUTING.md renders cleanly on GitHub (table-of-contents anchors still resolve)