### PR TITLE
feat(versioning): list-view collapse with include_history toggle (Phase 2)

### DIFF
--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -5929,7 +5929,14 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
     # --- Contract Listing and API Model Building ---
 
     def _query_contracts(self, db, domain_id=None, project_id=None, is_admin=False, latest_only=True):
-        """Shared query logic for listing contracts. Returns list of DataContractDb."""
+        """Shared query logic for listing contracts. Returns (contracts, family_counts).
+
+        ``latest_only`` (default True) collapses every ``version_family_id``
+        down to the row with the newest ``created_at``. ``family_counts``
+        maps each surviving family_id → total rows in the family from the
+        visibility-filtered result set, so callers can render a "N versions"
+        badge without a second query. See PRD #442.
+        """
         if domain_id:
             query = db.query(DataContractDb).filter(DataContractDb.domain_id == domain_id)
             if not is_admin and project_id:
@@ -5946,17 +5953,29 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 is_admin=is_admin
             )
 
+        # Always compute family sizes from the visibility-filtered set so the
+        # collapsed and the expanded list views report consistent counts.
+        family_counts: dict = {}
+        for c in contracts:
+            fid = c.version_family_id or c.id
+            family_counts[fid] = family_counts.get(fid, 0) + 1
+
         if latest_only:
             original_count = len(contracts)
-            seen_base_names: dict = {}
+            # Family-id is the canonical group key (PRD #442). Falls back to
+            # row id for any legacy row that somehow escaped the backfill,
+            # which degrades to "treat as its own family" — never collapses
+            # unrelated rows together.
+            picked: dict = {}
             for c in contracts:
-                key = c.base_name or c.name
-                if key not in seen_base_names or c.created_at > seen_base_names[key].created_at:
-                    seen_base_names[key] = c
-            contracts = list(seen_base_names.values())
-            logger.debug(f"Filtered from {original_count} to {len(contracts)} latest versions (grouped by base_name)")
+                key = c.version_family_id or c.id
+                current = picked.get(key)
+                if current is None or (c.created_at and (current.created_at is None or c.created_at > current.created_at)):
+                    picked[key] = c
+            contracts = list(picked.values())
+            logger.debug(f"Collapsed {original_count} → {len(contracts)} rows (one per version_family_id)")
 
-        return contracts
+        return contracts, family_counts
 
     def list_contracts_from_db(
         self,
@@ -5964,14 +5983,33 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         domain_id: Optional[str] = None,
         project_id: Optional[str] = None,
         is_admin: bool = False,
-        latest_only: bool = True
+        latest_only: bool = True,
+        include_history: bool = False,
     ):
-        """List data contracts as lightweight summaries (no schema/quality/comments)."""
-        contracts = self._query_contracts(db, domain_id, project_id, is_admin, latest_only)
-        return self._build_contract_summaries(db, contracts)
+        """List data contracts as lightweight summaries (no schema/quality/comments).
 
-    def _build_contract_summaries(self, db, contracts):
-        """Build lightweight summary models for a list of contracts with batched lookups."""
+        When ``include_history`` is True the version-family collapse is
+        skipped and every visible row is returned. ``latest_only`` is the
+        legacy switch retained for callers that bypass the route layer; the
+        route always passes ``latest_only = not include_history``.
+        """
+        if include_history:
+            latest_only = False
+        contracts, family_counts = self._query_contracts(
+            db, domain_id, project_id, is_admin, latest_only
+        )
+        return self._build_contract_summaries(
+            db, contracts, family_counts=family_counts if latest_only else None
+        )
+
+    def _build_contract_summaries(self, db, contracts, family_counts=None):
+        """Build lightweight summary models for a list of contracts with batched lookups.
+
+        ``family_counts`` (PRD #442): optional ``{version_family_id → int}``
+        map. When provided, each summary gets a ``versionCount`` field so the
+        list UI can render a "N versions" badge without an extra round-trip.
+        Pass ``None`` for the expanded list view to omit the field entirely.
+        """
         from src.models.data_contracts_api import ContractDescription, DataContractSummary
         from src.repositories.data_domain_repository import data_domain_repo
         from src.repositories.tags_repository import entity_tag_repo
@@ -6057,6 +6095,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     limitations=c.description_limitations
                 )
 
+            family_id = getattr(c, "version_family_id", None) or c.id
+            version_count = (
+                family_counts.get(family_id) if family_counts is not None else None
+            )
+
             results.append(DataContractSummary(
                 id=c.id,
                 name=c.name,
@@ -6076,6 +6119,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 tags=tags_map.get(c.id, []),
                 created=c.created_at.isoformat() if c.created_at else None,
                 updated=c.updated_at.isoformat() if c.updated_at else None,
+                parent_contract_id=getattr(c, "parent_contract_id", None),
+                version_family_id=family_id,
+                base_name=getattr(c, "base_name", None),
+                change_summary=getattr(c, "change_summary", None),
+                draft_owner_id=getattr(c, "draft_owner_id", None),
+                version_count=version_count,
                 schemaObjectCount=schema_counts.get(c.id, 0),
                 publication_scope=getattr(c, "publication_scope", None) or "none",
                 published_at=c.published_at.isoformat() if getattr(c, "published_at", None) else None,

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -246,6 +246,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         caller_email: Optional[str] = None,
         caller_team_ids: Optional[List[str]] = None,
         caller_project_ids: Optional[List[str]] = None,
+        include_history: bool = False,
     ) -> List[DataProductApi]:
         """List ODPS v1.0.0 data products.
 
@@ -281,9 +282,36 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 caller_team_ids=caller_team_ids,
                 caller_project_ids=caller_project_ids,
             )
+
+            # Family-aware collapse (PRD #442). Counts are computed from the
+            # visibility-filtered set so the badge reflects what the caller
+            # can actually navigate to. When include_history=True we keep
+            # every row but still attach the count so the UI can group rows.
+            family_counts: dict = {}
+            for p in products_db:
+                fid = getattr(p, "version_family_id", None) or p.id
+                family_counts[fid] = family_counts.get(fid, 0) + 1
+
+            if not include_history:
+                picked: dict = {}
+                for p in products_db:
+                    key = getattr(p, "version_family_id", None) or p.id
+                    current = picked.get(key)
+                    if current is None or (
+                        p.created_at and (current.created_at is None or p.created_at > current.created_at)
+                    ):
+                        picked[key] = p
+                products_db = list(picked.values())
+
             products_with_tags = []
             for product_db in products_db:
                 product_with_tags = self._load_product_with_tags(product_db)
+                fid = getattr(product_db, "version_family_id", None) or product_db.id
+                # Only emit a count on the collapsed view; on the expanded
+                # view the rows speak for themselves and a per-row count
+                # would be misleading.
+                if not include_history:
+                    product_with_tags.version_count = family_counts.get(fid)
                 products_with_tags.append(product_with_tags)
             return products_with_tags
         except SQLAlchemyError as e:

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -563,6 +563,11 @@ class DataContractSummary(BaseModel):
     baseName: Optional[str] = Field(None, alias='base_name')
     changeSummary: Optional[str] = Field(None, alias='change_summary')
     draftOwnerId: Optional[str] = Field(None, alias='draft_owner_id')
+    # Count of versions in this row's family that are visible to the caller.
+    # Only emitted on the collapsed list view (include_history=False); on the
+    # expanded list view it is omitted because every row is its own family
+    # member. See PRD #442.
+    versionCount: Optional[int] = Field(None, alias='version_count')
     schema_object_count: int = Field(0, alias='schemaObjectCount')
     publication_scope: str = "none"
     published_at: Optional[str] = None

--- a/src/backend/src/models/data_products.py
+++ b/src/backend/src/models/data_products.py
@@ -382,6 +382,10 @@ class DataProduct(BaseModel):
     version_family_id: Optional[str] = Field(None, alias="versionFamilyId", description="Canonical family grouping key shared across every version of the family")
     base_name: Optional[str] = Field(None, alias="baseName", description="Legacy base name; superseded by versionFamilyId. Kept for back-compat.")
     change_summary: Optional[str] = Field(None, alias="changeSummary", description="Summary of changes in this version")
+    # Count of versions in this row's family that are visible to the caller.
+    # Only populated by the collapsed list view; None on detail responses
+    # and on the expanded list view. See PRD #442.
+    version_count: Optional[int] = Field(None, alias="versionCount", description="Number of visible versions in this family (collapsed list view only)")
 
     # Publication fields
     publication_scope: Optional[str] = Field("none", description="Publication scope: none, domain, organization, external")

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -97,11 +97,10 @@ async def get_contracts(
 ):
     """Get all data contracts with basic ODCS structure and optional project filtering.
 
-    ``include_history`` (PRD #442): reserved for the family-collapse rollout.
-    Until the frontend opts into the collapse, the param is accepted but the
-    response shape is unchanged (every version row returned). When the
-    frontend is ready, the manager will switch on this flag to return one
-    row per ``version_family_id`` by default and the full set when ``True``.
+    ``include_history`` (PRD #442): when False (default) the response contains
+    one row per ``version_family_id`` — the newest visible version of each
+    family, plus a ``versionCount`` field. When True, every visible version
+    is returned (used by the "Show all versions" toggle in the UI).
     """
     try:
         # Check if user is admin
@@ -121,7 +120,8 @@ async def get_contracts(
             db,
             domain_id=domain_id,
             project_id=project_id,
-            is_admin=is_admin
+            is_admin=is_admin,
+            include_history=include_history,
         )
         return result
     except Exception as e:

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1612,6 +1612,7 @@ async def upload_data_products(
 async def get_data_products(
     request: Request,
     project_id: Optional[str] = None,
+    include_history: bool = False,
     current_user: CurrentUserDep = None,
     db: DBSessionDep = None,
     manager: DataProductsManager = Depends(get_data_products_manager),
@@ -1682,8 +1683,12 @@ async def get_data_products(
             caller_email=caller_email,
             caller_team_ids=caller_team_ids,
             caller_project_ids=caller_project_ids,
+            include_history=include_history,
         )
-        logger.info(f"Retrieved {len(products)} data products")
+        logger.info(
+            f"Retrieved {len(products)} data products "
+            f"(include_history={include_history})"
+        )
         return [p.model_dump() for p in products]
     except Exception as e:
         error_msg = f"Error retrieving data products: {e!s}"

--- a/src/backend/src/tests/unit/test_version_family.py
+++ b/src/backend/src/tests/unit/test_version_family.py
@@ -309,3 +309,166 @@ class TestListFamilyRepresentatives:
         # that within family A v2 precedes v1.
         a_rows = [r for r in rows if r.version_family_id == two_families["fam_a"]]
         assert [r.id for r in a_rows] == [two_families["a_v2"], two_families["a_root"]]
+
+
+# ---------------------------------------------------------------------------
+# Manager-level list collapse (Phase 2)
+# ---------------------------------------------------------------------------
+
+class TestContractsListCollapse:
+    """``list_contracts_from_db`` collapses families and emits versionCount."""
+
+    @pytest.fixture
+    def family_with_loose_row(self, db_session: Session):
+        from datetime import datetime, timedelta, timezone
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fam = str(uuid.uuid4())
+        v1 = str(uuid.uuid4())
+        v2 = str(uuid.uuid4())
+        v3 = str(uuid.uuid4())
+        loose = str(uuid.uuid4())
+        # 3-version family A
+        db_session.add(DataContractDb(
+            id=v1, name="A", version="1.0.0", status="active",
+            version_family_id=fam,
+            created_at=base, updated_at=base,
+        ))
+        db_session.add(DataContractDb(
+            id=v2, name="A", version="2.0.0", status="active",
+            version_family_id=fam, parent_contract_id=v1,
+            created_at=base + timedelta(days=1), updated_at=base + timedelta(days=1),
+        ))
+        db_session.add(DataContractDb(
+            id=v3, name="A", version="3.0.0", status="draft",
+            version_family_id=fam, parent_contract_id=v2,
+            created_at=base + timedelta(days=2), updated_at=base + timedelta(days=2),
+        ))
+        # Single-version family B (loose row)
+        db_session.add(DataContractDb(
+            id=loose, name="B", version="1.0.0", status="active",
+            version_family_id=str(uuid.uuid4()),
+            created_at=base, updated_at=base,
+        ))
+        db_session.commit()
+        return {"fam": fam, "v1": v1, "v2": v2, "v3": v3, "loose": loose}
+
+    def _manager(self, db_session):
+        from pathlib import Path
+        from src.controller.data_contracts_manager import DataContractsManager
+        # The contracts manager keeps its DB session out of __init__ and takes
+        # it as a method arg; data_dir is only used for legacy YAML loading
+        # paths we don't exercise here.
+        return DataContractsManager(data_dir=Path("/tmp"))
+
+    def test_collapses_to_one_row_per_family_by_default(
+        self, db_session: Session, family_with_loose_row
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(db_session, is_admin=True)
+        ids = {s.id for s in summaries}
+        # Family A is represented by its newest version (v3); loose row B
+        # passes through as its own family.
+        assert family_with_loose_row["v3"] in ids
+        assert family_with_loose_row["v1"] not in ids
+        assert family_with_loose_row["v2"] not in ids
+        assert family_with_loose_row["loose"] in ids
+        assert len(summaries) == 2
+
+    def test_emits_version_count_on_collapse(
+        self, db_session: Session, family_with_loose_row
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(db_session, is_admin=True)
+        by_id = {s.id: s for s in summaries}
+        # Family A had 3 versions, loose row B is a family of one.
+        assert by_id[family_with_loose_row["v3"]].versionCount == 3
+        assert by_id[family_with_loose_row["loose"]].versionCount == 1
+
+    def test_include_history_returns_every_row_without_count(
+        self, db_session: Session, family_with_loose_row
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=True, include_history=True
+        )
+        ids = {s.id for s in summaries}
+        # All 4 rows are present.
+        assert ids == {
+            family_with_loose_row["v1"],
+            family_with_loose_row["v2"],
+            family_with_loose_row["v3"],
+            family_with_loose_row["loose"],
+        }
+        # versionCount is intentionally omitted on the expanded view.
+        assert all(s.versionCount is None for s in summaries)
+
+
+class TestProductsListCollapse:
+    """``list_products`` collapses by version_family_id and attaches counts."""
+
+    def test_default_collapses_to_latest_version_per_family(
+        self, db_session: Session
+    ):
+        from datetime import datetime, timedelta, timezone
+        from src.controller.data_products_manager import DataProductsManager
+        from databricks.sdk import WorkspaceClient
+        from unittest.mock import MagicMock
+
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fam = str(uuid.uuid4())
+        p1 = str(uuid.uuid4())
+        p2 = str(uuid.uuid4())
+        # Family with two versions.
+        db_session.add(DataProductDb(
+            id=p1, name="orders", version="1.0.0", status="active",
+            version_family_id=fam,
+            created_at=base, updated_at=base,
+        ))
+        db_session.add(DataProductDb(
+            id=p2, name="orders", version="2.0.0", status="active",
+            version_family_id=fam, parent_product_id=p1,
+            created_at=base + timedelta(days=1), updated_at=base + timedelta(days=1),
+        ))
+        db_session.commit()
+
+        ws = MagicMock(spec=WorkspaceClient)
+        manager = DataProductsManager(db=db_session, ws_client=ws)
+
+        products = manager.list_products(is_admin=True)
+        ids = {p.id for p in products}
+        # Newest version wins.
+        assert p2 in ids
+        assert p1 not in ids
+        # Family of two surfaces as versionCount=2.
+        assert {p.version_count for p in products if p.id == p2} == {2}
+
+    def test_include_history_returns_all_versions(self, db_session: Session):
+        from datetime import datetime, timedelta, timezone
+        from src.controller.data_products_manager import DataProductsManager
+        from databricks.sdk import WorkspaceClient
+        from unittest.mock import MagicMock
+
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fam = str(uuid.uuid4())
+        p1 = str(uuid.uuid4())
+        p2 = str(uuid.uuid4())
+        db_session.add(DataProductDb(
+            id=p1, name="orders", version="1.0.0", status="active",
+            version_family_id=fam,
+            created_at=base, updated_at=base,
+        ))
+        db_session.add(DataProductDb(
+            id=p2, name="orders", version="2.0.0", status="active",
+            version_family_id=fam, parent_product_id=p1,
+            created_at=base + timedelta(days=1), updated_at=base + timedelta(days=1),
+        ))
+        db_session.commit()
+
+        ws = MagicMock(spec=WorkspaceClient)
+        manager = DataProductsManager(db=db_session, ws_client=ws)
+
+        products = manager.list_products(is_admin=True, include_history=True)
+        ids = {p.id for p in products}
+        assert ids == {p1, p2}
+        # version_count is suppressed on the expanded view.
+        assert all(p.version_count is None for p in products)

--- a/src/frontend/src/components/common/version-count-badge.tsx
+++ b/src/frontend/src/components/common/version-count-badge.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tiny pill rendered next to a version cell that surfaces how many other
+ * versions live in the same family. Click bubbles via `onClick` so the
+ * parent can scope an "include_history" expansion to this single family
+ * (or, more commonly, navigate into the details view where the
+ * VersionNavigator already provides full prev/next + dropdown navigation).
+ *
+ * Renders nothing for single-version families — there's nothing useful
+ * to surface, and the badge would just add visual noise.
+ *
+ * See PRD docs/prds/prd-version-family-and-unified-selector.md.
+ */
+import { useTranslation } from 'react-i18next'
+import { History } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface VersionCountBadgeProps {
+  count?: number
+  className?: string
+  onClick?: (e: React.MouseEvent) => void
+}
+
+export function VersionCountBadge({ count, className, onClick }: VersionCountBadgeProps) {
+  const { t } = useTranslation('common')
+
+  if (!count || count <= 1) return null
+
+  const label = t('versionFamily.countBadge', { count, defaultValue: '{{count}} versions' })
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        // Stop the row-click handler from also firing. The badge owns this
+        // click; the row navigates separately.
+        e.stopPropagation()
+        onClick?.(e)
+      }}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground',
+        className,
+      )}
+      title={label}
+      aria-label={label}
+    >
+      <History className="h-3 w-3" />
+      {count}
+    </button>
+  )
+}
+
+export default VersionCountBadge

--- a/src/frontend/src/types/data-contract.ts
+++ b/src/frontend/src/types/data-contract.ts
@@ -24,6 +24,9 @@ export type DataContractListItem = {
   baseName?: string
   // Personal draft visibility
   draftOwnerId?: string // If set, this is a personal draft
+  // Number of visible versions in this row's family — only populated on the
+  // collapsed list view (include_history=false). See PRD #442.
+  versionCount?: number
   // Summary field from list endpoint
   schemaObjectCount?: number
   // Fields returned by summary endpoint for compatibility

--- a/src/frontend/src/types/data-product.ts
+++ b/src/frontend/src/types/data-product.ts
@@ -287,6 +287,9 @@ export interface DataProduct {
   versionFamilyId?: string; // PRD #442 — canonical family grouping key carried unchanged on every clone
   baseName?: string; // Legacy base name; superseded by versionFamilyId
   changeSummary?: string; // Summary of changes in this version
+  // Number of visible versions in this row's family — only populated on the
+  // collapsed list view (include_history=false). See PRD #442.
+  versionCount?: number;
 
   publication_scope?: string | null;
   published_at?: string | null;

--- a/src/frontend/src/views/data-contracts.tsx
+++ b/src/frontend/src/views/data-contracts.tsx
@@ -23,6 +23,8 @@ import { RelativeDate } from '@/components/common/relative-date';
 import EntityInfoDialog from '@/components/metadata/entity-info-dialog';
 import CertificationBadge from '@/components/common/certification-badge';
 import PublicationBadge from '@/components/common/publication-badge';
+import VersionCountBadge from '@/components/common/version-count-badge';
+import { Switch } from '@/components/ui/switch';
 import type { CertificationLevel } from '@/types/lifecycle';
 import { useApi } from '@/hooks/use-api';
 
@@ -32,6 +34,10 @@ export default function DataContracts() {
   const { getDomainName } = useDomains();
   const [contracts, setContracts] = useState<DataContractListItem[]>([]);
   const [loading, setLoading] = useState(true);
+  // "Show all versions" toggle — flips the family-collapse on the backend.
+  // When false (default) the list collapses to one row per version family
+  // and exposes a "N versions" badge. See PRD #442.
+  const [includeHistory, setIncludeHistory] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [openWizard, setOpenWizard] = useState(false);
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
@@ -63,7 +69,10 @@ export default function DataContracts() {
         setStaticSegments([]);
         setDynamicTitle(null);
     };
-  }, [setStaticSegments, setDynamicTitle, hasProjectContext, currentProject, t]);
+    // includeHistory belongs in the deps so toggling the switch triggers a
+    // re-fetch with the new query param.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setStaticSegments, setDynamicTitle, hasProjectContext, currentProject, t, includeHistory]);
 
   useEffect(() => {
     get<CertificationLevel[]>('/api/certification-levels').then(({ data }) => {
@@ -81,11 +90,16 @@ export default function DataContracts() {
     try {
       setLoading(true);
 
-      // Build URL with project context if available
-      let endpoint = '/api/data-contracts';
+      // Build URL with project context and include_history (PRD #442)
+      const params = new URLSearchParams();
       if (hasProjectContext && currentProject) {
-        endpoint += `?project_id=${currentProject.id}`;
+        params.set('project_id', currentProject.id);
       }
+      if (includeHistory) {
+        params.set('include_history', 'true');
+      }
+      const qs = params.toString();
+      const endpoint = qs ? `/api/data-contracts?${qs}` : '/api/data-contracts';
 
       const response = await fetch(endpoint);
       if (!response.ok) throw new Error('Failed to fetch contracts');
@@ -358,7 +372,21 @@ export default function DataContracts() {
           </Button>
         );
       },
-      cell: ({ row }) => <Badge variant="secondary">{row.getValue("version")}</Badge>,
+      cell: ({ row }) => {
+        const id = row.original.id
+        return (
+          <div className="flex items-center gap-1.5">
+            <Badge variant="secondary">{row.getValue("version")}</Badge>
+            {/* Family badge — only renders for families with > 1 visible version.
+                Click expands the version family for this row by routing into
+                the detail view, where VersionNavigator handles prev/next. */}
+            <VersionCountBadge
+              count={row.original.versionCount}
+              onClick={() => id && navigate(`${pathname}/${id}`)}
+            />
+          </div>
+        )
+      },
     },
     {
       accessorKey: "status",
@@ -521,6 +549,20 @@ export default function DataContracts() {
           storageKey="data-contracts-sort"
           toolbarActions={
             <>
+              {/* Family-collapse toggle. Off = one row per family + "N versions"
+                  badge; On = every version is its own row (legacy behavior).
+                  See PRD #442. */}
+              <div className="flex items-center gap-2 h-9 pr-2 border-r border-border">
+                <Switch
+                  id="contracts-include-history"
+                  checked={includeHistory}
+                  onCheckedChange={setIncludeHistory}
+                  aria-label={t('versionFamily.showAllVersions', { defaultValue: 'Show all versions' })}
+                />
+                <Label htmlFor="contracts-include-history" className="text-xs text-muted-foreground cursor-pointer">
+                  {t('versionFamily.showAllVersions', { defaultValue: 'Show all versions' })}
+                </Label>
+              </div>
               <Button onClick={() => setOpenWizard(true)} className="gap-2 h-9" title={t('common:tooltips.createDataContract')}>
                 <Plus className="h-4 w-4" />
                 {t('newContract')}

--- a/src/frontend/src/views/data-products.tsx
+++ b/src/frontend/src/views/data-products.tsx
@@ -30,6 +30,9 @@ import { useDomains } from '@/hooks/use-domains';
 import { useProjectContext } from '@/stores/project-store';
 import CertificationBadge from '@/components/common/certification-badge';
 import PublicationBadge from '@/components/common/publication-badge';
+import VersionCountBadge from '@/components/common/version-count-badge';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import type { CertificationLevel } from '@/types/lifecycle';
 
 // --- Helper Function Type Definition --- 
@@ -60,6 +63,10 @@ const checkApiResponse: CheckApiResponseFn = (response, name) => {
 export default function DataProducts() {
   const { t } = useTranslation(['data-products', 'common']);
   const [products, setProducts] = useState<DataProduct[]>([]);
+  // "Show all versions" toggle — flips include_history on the products list
+  // endpoint. Off (default) collapses each family to its newest visible
+  // version and surfaces a "N versions" badge per row. See PRD #442.
+  const [includeHistory, setIncludeHistory] = useState(false);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [productToEdit, setProductToEdit] = useState<DataProduct | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -117,11 +124,16 @@ export default function DataProducts() {
       setLoading(true);
       setError(null);
       try {
-        // Build URL with project context if available
-        let productsEndpoint = '/api/data-products';
+        // Build URL with project context and include_history flag (PRD #442).
+        const params = new URLSearchParams();
         if (hasProjectContext && currentProject) {
-          productsEndpoint += `?project_id=${currentProject.id}`;
+          params.set('project_id', currentProject.id);
         }
+        if (includeHistory) {
+          params.set('include_history', 'true');
+        }
+        const qs = params.toString();
+        const productsEndpoint = qs ? `/api/data-products?${qs}` : '/api/data-products';
 
         // Fetch products and dropdown values concurrently
         const [productsResp, statusesResp, ownersResp/*, typesResp*/] = await Promise.all([
@@ -171,7 +183,9 @@ export default function DataProducts() {
         setStaticSegments([]);
         setDynamicTitle(null);
     };
-  }, [get, canRead, permissionsLoading, setStaticSegments, setDynamicTitle, hasProjectContext, currentProject]);
+    // includeHistory in deps so toggling re-runs the initial fetch.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [get, canRead, permissionsLoading, setStaticSegments, setDynamicTitle, hasProjectContext, currentProject, includeHistory]);
 
   // Fetch user's subscriptions
   useEffect(() => {
@@ -229,11 +243,17 @@ export default function DataProducts() {
   const fetchProducts = async () => {
     if (!canRead) return;
     try {
-      // Build URL with project context if available
-      let endpoint = '/api/data-products';
+      // Mirror loadInitialData so a refetch after a create/delete keeps the
+      // same view mode (collapsed vs expanded) the user already had selected.
+      const params = new URLSearchParams();
       if (hasProjectContext && currentProject) {
-        endpoint += `?project_id=${currentProject.id}`;
+        params.set('project_id', currentProject.id);
       }
+      if (includeHistory) {
+        params.set('include_history', 'true');
+      }
+      const qs = params.toString();
+      const endpoint = qs ? `/api/data-products?${qs}` : '/api/data-products';
 
       const response = await get<DataProduct[]>(endpoint);
       const productsData = checkApiResponse(response, 'Products Refetch');
@@ -557,7 +577,21 @@ export default function DataProducts() {
           {t('table.version')} <ChevronDown className="ml-2 h-4 w-4" />
         </Button>
       ),
-      cell: ({ row }) => <Badge variant="secondary">{row.original.version}</Badge>,
+      cell: ({ row }) => {
+        const id = row.original.id
+        return (
+          <div className="flex items-center gap-1.5">
+            <Badge variant="secondary">{row.original.version}</Badge>
+            {/* Family badge — same UX as on contracts. Click routes into
+                the detail view where VersionNavigator handles version
+                navigation. See PRD #442. */}
+            <VersionCountBadge
+              count={row.original.versionCount}
+              onClick={() => id && navigate(`${pathname}/${id}`)}
+            />
+          </div>
+        )
+      },
     },
     {
       accessorKey: "outputPorts",
@@ -742,6 +776,19 @@ export default function DataProducts() {
               storageKey="data-products-sort"
               toolbarActions={
                 <>
+                  {/* Family-collapse toggle. Mirrors the contracts list view.
+                      See PRD #442. */}
+                  <div className="flex items-center gap-2 h-9 pr-2 border-r border-border">
+                    <Switch
+                      id="products-include-history"
+                      checked={includeHistory}
+                      onCheckedChange={setIncludeHistory}
+                      aria-label={t('versionFamily.showAllVersions', { defaultValue: 'Show all versions' })}
+                    />
+                    <Label htmlFor="products-include-history" className="text-xs text-muted-foreground cursor-pointer">
+                      {t('versionFamily.showAllVersions', { defaultValue: 'Show all versions' })}
+                    </Label>
+                  </div>
                   {/* My Subscriptions Filter Toggle */}
                   <Button
                     onClick={handleToggleMySubscriptions}


### PR DESCRIPTION
## Summary

Phase 2 of the unified version family work (PRD #442). Makes the data-contracts and data-products list views collapse by `version_family_id` by default, with a "Show all versions" toggle to expand. Each collapsed row gains a small "N versions" badge so users can see at a glance which entities have history.

**Stacked on** #446 (Phase 1). Base branch is \`feat-version-family\` — please merge #446 first.

### Backend
- `DataContractSummary` and `DataProduct` API models add `versionCount` (alias `version_count`). Emitted only on the collapsed view so the expanded view never reports misleading per-row counts.
- `DataContractsManager._query_contracts`: drop the legacy `base_name` Python-side dedupe in favor of canonical `version_family_id` grouping; return `(rows, family_counts)` so the builder attaches counts without a second query.
- `_build_contract_summaries` now also populates `parentContractId`, `versionFamilyId`, `baseName`, `changeSummary`, `draftOwnerId` on summary rows (these existed on the model but were always null in the response).
- `list_contracts_from_db` + `/data-contracts` route propagate `include_history` end-to-end.
- `DataProductsManager.list_products`: collapse by `version_family_id` after the visibility cascade, attach `version_count` to the surviving row; `include_history=True` bypasses the collapse and suppresses the count.
- `/data-products` route surfaces `include_history`.

### Frontend
- `DataContractListItem` and `DataProduct` gain `versionCount`.
- New `components/common/version-count-badge.tsx` — compact pill that hides itself for single-version families and otherwise renders a click-through history hint next to the version cell.
- `data-contracts.tsx` and `data-products.tsx`: family badge next to the version column + "Show all versions" switch in the toolbar. Both list-fetch paths plumb `include_history` through the query string.

### Tests
- 5 new unit tests cover collapse default, version-count emission, `include_history` bypass on contracts, and product-side parity. Suite is now 17 → 22 passing.

## Test plan
- [x] Unit tests pass: 22 / 22 in `test_version_family.py`
- [x] Linter clean on touched frontend files
- [ ] Manual: restart backend → verify default list view shows one row per family, badge appears for families > 1 version
- [ ] Manual: flip "Show all versions" toggle → all versions appear, badge disappears
- [ ] Manual: clone a contract / product, confirm the source row collapses to the new clone with a "2" badge
- [ ] Manual: consumer (non-admin) sees fewer rows; visibility-filtered count matches the badge
- [ ] Manual: contracts with `?domain_id=` still respect the collapse

## Notes
- The local dev server's auto-reloader has a pre-existing `--reload-dir` pointing at the old `src/api` layout (visible in `/tmp/backend.log` as a `FileNotFoundError` from `statreload`). A backend restart is required to pick up the new wiring for live verification — unrelated to this PR.