### PR TITLE
feat(workflows): approver-role filter + webhook extras + designer fixes (Phase 1)

### DIFF
--- a/src/backend/src/common/workflow_executor.py
+++ b/src/backend/src/common/workflow_executor.py
@@ -1347,31 +1347,58 @@ class WebhookStepHandler(StepHandler):
         timeout_seconds = self._config.get('timeout_seconds', 30)
         success_codes = self._config.get('success_codes')
         retry_count = self._config.get('retry_count', 0)
-        
+
+        # Caller-supplied extras forwarded into the UC HTTPConnection call
+        # (issue #401). All support the same template substitution as
+        # body_template / headers; absent or empty fields are no-ops, so
+        # legacy configs are unaffected.
+        additional_headers = self._config.get('additional_headers', {}) or {}
+        additional_query_params = self._config.get('additional_query_params', {}) or {}
+        path_suffix = self._config.get('path_suffix')
+
         # Validate configuration
         if not connection_name and not url:
             return StepResult(
                 passed=False,
                 error="Webhook requires either 'connection_name' (UC Connection) or 'url' (inline mode)"
             )
-        
+
         # Substitute template variables in body
         body = None
         if body_template:
             body = self._substitute_template(body_template, context)
-        
+
         # Substitute template variables in headers
         resolved_headers = {}
         for key, value in headers.items():
             resolved_headers[key] = self._substitute_template(value, context)
-        
+
+        # Merge additional_headers (caller-supplied extras win on key collision).
+        for key, value in additional_headers.items():
+            resolved_headers[key] = self._substitute_template(value, context)
+
+        # Resolve additional_query_params (values, not keys, are templated).
+        resolved_query_params: Dict[str, str] = {}
+        for key, value in additional_query_params.items():
+            resolved_query_params[key] = self._substitute_template(value, context)
+
+        # Resolve path_suffix and merge with the configured path.
+        resolved_path_suffix = (
+            self._substitute_template(path_suffix, context) if path_suffix else ''
+        )
+        effective_path = self._compose_path(
+            base_path=path or '',
+            suffix=resolved_path_suffix,
+            query_params=resolved_query_params,
+        )
+
         try:
             if connection_name:
                 # UC Connection mode
                 result = self._execute_via_uc_connection(
                     connection_name=connection_name,
                     method=method,
-                    path=path,
+                    path=effective_path,
                     headers=resolved_headers,
                     body=body,
                     timeout_seconds=timeout_seconds,
@@ -1379,9 +1406,13 @@ class WebhookStepHandler(StepHandler):
                     retry_count=retry_count,
                 )
             else:
-                # Inline mode
+                # Inline mode — append query params to the URL.
+                effective_url = self._compose_url(
+                    base_url=url,
+                    query_params=resolved_query_params,
+                )
                 result = self._execute_direct(
-                    url=url,
+                    url=effective_url,
                     method=method,
                     headers=resolved_headers,
                     body=body,
@@ -1389,12 +1420,57 @@ class WebhookStepHandler(StepHandler):
                     success_codes=success_codes,
                     retry_count=retry_count,
                 )
-            
+
             return result
-            
+
         except Exception as e:
             logger.exception(f"Webhook step failed: {e}")
             return StepResult(passed=False, error=str(e))
+
+    @staticmethod
+    def _compose_path(base_path: str, suffix: str, query_params: Dict[str, str]) -> str:
+        """Combine `base_path`, optional `suffix`, and optional `query_params` into
+        a single path string for the UC HTTPConnection call.
+
+        - If both `base_path` and `suffix` are empty, returns '/' (existing behavior).
+        - Avoids duplicated slashes at the join.
+        - Query string is appended last, URL-encoded.
+        """
+        from urllib.parse import urlencode
+
+        # Strip surrounding whitespace to forgive UI input.
+        base = (base_path or '').strip()
+        suf = (suffix or '').strip()
+
+        if base and suf:
+            # Ensure exactly one slash between base and suffix.
+            if base.endswith('/') and suf.startswith('/'):
+                combined = base + suf[1:]
+            elif not base.endswith('/') and not suf.startswith('/'):
+                combined = base + '/' + suf
+            else:
+                combined = base + suf
+        else:
+            combined = base or suf
+
+        if not combined:
+            combined = '/'
+
+        if query_params:
+            sep = '&' if '?' in combined else '?'
+            combined = f"{combined}{sep}{urlencode(query_params, doseq=True)}"
+
+        return combined
+
+    @staticmethod
+    def _compose_url(base_url: str, query_params: Dict[str, str]) -> str:
+        """Append `query_params` to `base_url` for inline-mode requests."""
+        from urllib.parse import urlencode
+
+        if not query_params:
+            return base_url
+        sep = '&' if '?' in base_url else '?'
+        return f"{base_url}{sep}{urlencode(query_params, doseq=True)}"
 
     def _substitute_template(self, template: str, context: StepContext) -> str:
         """Delegate to module-level substitute_template."""

--- a/src/backend/src/common/workflow_executor.py
+++ b/src/backend/src/common/workflow_executor.py
@@ -1406,9 +1406,10 @@ class WebhookStepHandler(StepHandler):
                     retry_count=retry_count,
                 )
             else:
-                # Inline mode — append query params to the URL.
+                # Inline mode — append path_suffix and query params to the URL.
                 effective_url = self._compose_url(
                     base_url=url,
+                    suffix=resolved_path_suffix,
                     query_params=resolved_query_params,
                 )
                 result = self._execute_direct(
@@ -1463,14 +1464,34 @@ class WebhookStepHandler(StepHandler):
         return combined
 
     @staticmethod
-    def _compose_url(base_url: str, query_params: Dict[str, str]) -> str:
-        """Append `query_params` to `base_url` for inline-mode requests."""
-        from urllib.parse import urlencode
+    def _compose_url(base_url: str, suffix: str, query_params: Dict[str, str]) -> str:
+        """Combine `base_url` with optional path `suffix` and `query_params`.
 
-        if not query_params:
-            return base_url
-        sep = '&' if '?' in base_url else '?'
-        return f"{base_url}{sep}{urlencode(query_params, doseq=True)}"
+        Inline-mode counterpart to ``_compose_path``. The suffix is inserted into
+        the URL's path component (before any existing query string) with single
+        normalizing slashes, then ``query_params`` are appended last.
+        """
+        from urllib.parse import urlencode, urlsplit, urlunsplit
+
+        url = base_url
+        suf = (suffix or '').strip()
+        if suf:
+            parts = urlsplit(url)
+            base_path = parts.path or ''
+            if base_path and suf:
+                if base_path.endswith('/') and suf.startswith('/'):
+                    combined = base_path + suf[1:]
+                elif not base_path.endswith('/') and not suf.startswith('/'):
+                    combined = base_path + '/' + suf
+                else:
+                    combined = base_path + suf
+            else:
+                combined = base_path or suf
+            url = urlunsplit((parts.scheme, parts.netloc, combined, parts.query, parts.fragment))
+        if query_params:
+            sep = '&' if '?' in url else '?'
+            url = f"{url}{sep}{urlencode(query_params, doseq=True)}"
+        return url
 
     def _substitute_template(self, template: str, context: StepContext) -> str:
         """Delegate to module-level substitute_template."""

--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -1693,6 +1693,22 @@ class SettingsManager:
             self._db.rollback()
             return [] # Return empty list on error
 
+    def list_app_roles_for_approval(self, approval_entity: Optional[str] = None) -> List[AppRole]:
+        """Lists app roles filtered by approval privilege for a given entity type.
+
+        When *approval_entity* is provided (e.g. ``"CONTRACTS"``), only roles
+        where ``approval_privileges[approval_entity]`` is ``True`` are returned.
+        When omitted, all roles are returned (backward-compatible behaviour).
+        """
+        all_roles = self.list_app_roles()
+        if approval_entity is None:
+            return all_roles
+        entity_key = approval_entity.upper()
+        return [
+            role for role in all_roles
+            if role.approval_privileges.get(ApprovalEntity(entity_key)) is True  # type: ignore[arg-type]
+        ]
+
     def get_app_role(self, role_id: str) -> Optional[AppRole]:
         """Retrieves a specific application role by ID."""
         try:

--- a/src/backend/src/models/process_workflows.py
+++ b/src/backend/src/models/process_workflows.py
@@ -461,7 +461,33 @@ class WebhookStepConfig(BaseModel):
     timeout_seconds: int = Field(default=30, description="Request timeout in seconds")
     success_codes: Optional[List[int]] = Field(default=None, description="HTTP codes considered success (default: 200-299)")
     retry_count: int = Field(default=0, description="Number of retries on failure")
-    
+
+    # Caller-supplied extra parameters forwarded into the UC HTTPConnection call.
+    # All three support ${entity.*} / ${trigger.*} / ${context.*} substitution,
+    # the same syntax as `body_template`. Absent/empty fields are no-ops, so
+    # existing webhook configs continue to work unchanged.
+    additional_headers: Optional[Dict[str, str]] = Field(
+        default_factory=dict,
+        description=(
+            "Additional headers merged into the request (template substitution supported). "
+            "Take precedence over `headers` if a key collides."
+        ),
+    )
+    additional_query_params: Optional[Dict[str, str]] = Field(
+        default_factory=dict,
+        description=(
+            "Additional query string parameters appended to the request "
+            "(template substitution supported). Values are URL-encoded."
+        ),
+    )
+    path_suffix: Optional[str] = Field(
+        None,
+        description=(
+            "Optional suffix appended to `path` before the query string "
+            "(template substitution supported). Useful for context-derived path segments."
+        ),
+    )
+
     class Config:
         json_schema_extra = {
             "example": {
@@ -469,7 +495,10 @@ class WebhookStepConfig(BaseModel):
                 "method": "POST",
                 "path": "/api/now/table/incident",
                 "body_template": '{"short_description": "Alert: ${entity_name}"}',
-                "timeout_seconds": 30
+                "additional_headers": {"X-Trace-Id": "${execution_id}"},
+                "additional_query_params": {"caller": "ontos"},
+                "path_suffix": "/${entity_id}",
+                "timeout_seconds": 30,
             }
         }
 

--- a/src/backend/src/routes/workflows_routes.py
+++ b/src/backend/src/routes/workflows_routes.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from sqlalchemy.orm import Session
 
 from src.common.database import get_db
-from src.common.dependencies import DBSessionDep, AuditManagerDep, AuditCurrentUserDep, get_notifications_manager
+from src.common.dependencies import DBSessionDep, AuditManagerDep, AuditCurrentUserDep, get_notifications_manager, SettingsManagerDep
 from src.common.authorization import (
     PermissionChecker,
     enforce_feature_permission,
@@ -367,21 +367,36 @@ async def list_compliance_policies_for_workflows(
 @router.get("/roles")
 async def list_roles_for_workflows(
     db: DBSessionDep,
+    settings_manager: SettingsManagerDep,
     _: bool = Depends(PermissionChecker('settings', FeatureAccessLevel.READ_ONLY)),
+    approval_entity: Optional[str] = Query(
+        default=None,
+        description=(
+            "Filter to roles whose approval_privileges flag is True for this entity type. "
+            "Valid values: CONTRACTS, PRODUCTS, DOMAINS, ASSET_REVIEWS. "
+            "Omit to return all roles (backward-compatible)."
+        ),
+    ),
 ) -> List[Dict[str, Any]]:
     """List roles available for workflow approver/recipient selection.
 
     Returns both app roles (RBAC) and business roles (governance) that are
     marked as approvers. Each role includes a 'source' field to distinguish
     between app and business roles.
+
+    When *approval_entity* is provided the app-role list is narrowed to only
+    roles where ``approval_privileges[approval_entity]`` is ``True``. Business
+    roles (is_approver=True) are always included regardless of the filter
+    because they carry entity-level approval semantics through their own flag.
     """
-    from src.db_models.settings import AppRoleDb
     from src.db_models.business_roles import BusinessRoleDb
 
-    # App roles (RBAC)
-    app_roles = db.query(AppRoleDb).order_by(AppRoleDb.name).all()
+    # App roles — optionally filtered by approval_entity
+    filtered_app_roles = settings_manager.list_app_roles_for_approval(
+        approval_entity=approval_entity
+    )
 
-    # Business roles marked as approvers
+    # Business roles marked as approvers (always returned for backward compat)
     business_roles = (
         db.query(BusinessRoleDb)
         .filter(BusinessRoleDb.is_approver.is_(True), BusinessRoleDb.status == "active")
@@ -391,7 +406,7 @@ async def list_roles_for_workflows(
 
     result = []
 
-    for r in app_roles:
+    for r in filtered_app_roles:
         result.append({
             "id": str(r.id),
             "name": r.name,

--- a/src/backend/src/tests/unit/test_settings_manager.py
+++ b/src/backend/src/tests/unit/test_settings_manager.py
@@ -438,3 +438,97 @@ class TestSettingsManager:
         manager._validate_permissions(perms)
         assert perms == {}
 
+    # =====================================================================
+    # list_app_roles_for_approval Tests (#161)
+    # =====================================================================
+
+    def test_list_app_roles_for_approval_no_filter_returns_all(self, manager, db_session):
+        """Without a filter param all roles are returned (backward compat)."""
+        import json
+        for i, privs in enumerate(['{"CONTRACTS": true}', '{}', '{"PRODUCTS": true}']):
+            db_session.add(AppRoleDb(
+                id=str(uuid.uuid4()),
+                name=f"Role {i}",
+                description="",
+                feature_permissions='{}',
+                assigned_groups='[]',
+                home_sections='[]',
+                approval_privileges=privs,
+            ))
+        db_session.commit()
+
+        result = manager.list_app_roles_for_approval(approval_entity=None)
+        assert len(result) == 3
+
+    def test_list_app_roles_for_approval_filters_by_entity(self, manager, db_session):
+        """Only roles with the matching approval privilege are returned."""
+        import json
+        db_session.add(AppRoleDb(
+            id=str(uuid.uuid4()),
+            name="Governor",
+            description="",
+            feature_permissions='{}',
+            assigned_groups='[]',
+            home_sections='[]',
+            approval_privileges='{"CONTRACTS": true, "PRODUCTS": true}',
+        ))
+        db_session.add(AppRoleDb(
+            id=str(uuid.uuid4()),
+            name="Consumer",
+            description="",
+            feature_permissions='{}',
+            assigned_groups='[]',
+            home_sections='[]',
+            approval_privileges='{}',
+        ))
+        db_session.commit()
+
+        result = manager.list_app_roles_for_approval(approval_entity="CONTRACTS")
+        assert len(result) == 1
+        assert result[0].name == "Governor"
+
+    def test_list_app_roles_for_approval_missing_privilege_excluded(self, manager, db_session):
+        """Roles where the flag is False (not just missing) are excluded."""
+        db_session.add(AppRoleDb(
+            id=str(uuid.uuid4()),
+            name="No Privilege",
+            description="",
+            feature_permissions='{}',
+            assigned_groups='[]',
+            home_sections='[]',
+            approval_privileges='{"DOMAINS": false}',
+        ))
+        db_session.commit()
+
+        result = manager.list_app_roles_for_approval(approval_entity="DOMAINS")
+        assert result == []
+
+    def test_list_app_roles_for_approval_multi_entity_intersection(self, manager, db_session):
+        """Roles must have ALL requested privileges to pass the filter."""
+        db_session.add(AppRoleDb(
+            id=str(uuid.uuid4()),
+            name="Both",
+            description="",
+            feature_permissions='{}',
+            assigned_groups='[]',
+            home_sections='[]',
+            approval_privileges='{"CONTRACTS": true, "PRODUCTS": true}',
+        ))
+        db_session.add(AppRoleDb(
+            id=str(uuid.uuid4()),
+            name="Contracts only",
+            description="",
+            feature_permissions='{}',
+            assigned_groups='[]',
+            home_sections='[]',
+            approval_privileges='{"CONTRACTS": true}',
+        ))
+        db_session.commit()
+
+        contracts = {r.name for r in manager.list_app_roles_for_approval(approval_entity="CONTRACTS")}
+        products = {r.name for r in manager.list_app_roles_for_approval(approval_entity="PRODUCTS")}
+        # Intersection of both sets simulates what the frontend does for multi-entity workflows
+        intersection = contracts & products
+        assert intersection == {"Both"}
+        assert "Contracts only" not in intersection
+

--- a/src/backend/src/tests/unit/test_webhook_step_extra_params.py
+++ b/src/backend/src/tests/unit/test_webhook_step_extra_params.py
@@ -1,0 +1,253 @@
+# Set test environment variables BEFORE any app imports
+import os
+os.environ['TESTING'] = 'true'
+os.environ['SKIP_STARTUP_TASKS'] = 'true'
+
+from unittest.mock import MagicMock, patch
+
+from src.common.workflow_executor import (
+    WebhookStepHandler,
+    StepContext,
+)
+
+
+def _ctx(**overrides) -> StepContext:
+    """Build a StepContext with rich defaults for webhook param tests."""
+    defaults = dict(
+        entity={'name': 'sales_kpis', 'status': 'draft', 'owner': 'alice@co.com'},
+        entity_type='data_product',
+        entity_id='dp-abc-123',
+        entity_name='sales_kpis',
+        user_email='requester@co.com',
+        trigger_context=None,
+        execution_id='exec-xyz-789',
+        workflow_id='wf-1',
+        workflow_name='Subscribe On Behalf',
+        step_results={},
+        on_behalf_of=None,
+    )
+    defaults.update(overrides)
+    return StepContext(**defaults)
+
+
+def _make_handler(config):
+    """Construct a WebhookStepHandler with a mock DB session."""
+    return WebhookStepHandler(db=MagicMock(), config=config)
+
+
+# =========================================================================
+# Path composition helper
+# =========================================================================
+
+
+class TestComposePath:
+    """`_compose_path` joins base path + suffix + query string correctly."""
+
+    def test_empty_returns_root(self):
+        assert WebhookStepHandler._compose_path('', '', {}) == '/'
+
+    def test_base_only(self):
+        assert WebhookStepHandler._compose_path('/api/foo', '', {}) == '/api/foo'
+
+    def test_suffix_only(self):
+        assert WebhookStepHandler._compose_path('', '/bar', {}) == '/bar'
+
+    def test_join_no_duplicate_slash(self):
+        assert WebhookStepHandler._compose_path('/api/foo', '/123', {}) == '/api/foo/123'
+
+    def test_join_inserts_missing_slash(self):
+        assert WebhookStepHandler._compose_path('/api/foo', '123', {}) == '/api/foo/123'
+
+    def test_join_keeps_single_slash_when_base_ends_with_slash(self):
+        assert WebhookStepHandler._compose_path('/api/foo/', '123', {}) == '/api/foo/123'
+
+    def test_query_string_appended(self):
+        out = WebhookStepHandler._compose_path('/api', '', {'a': '1', 'b': '2'})
+        assert out.startswith('/api?')
+        # urlencode order is preserved (Python 3.7+ dict insertion order).
+        assert 'a=1' in out and 'b=2' in out
+
+    def test_query_string_url_encoded(self):
+        out = WebhookStepHandler._compose_path('/api', '', {'q': 'hello world & co'})
+        assert 'q=hello+world+%26+co' in out
+
+    def test_query_string_merges_with_existing(self):
+        out = WebhookStepHandler._compose_path('/api?x=1', '', {'y': '2'})
+        assert out == '/api?x=1&y=2'
+
+
+# =========================================================================
+# Config plumbing — UC Connection mode
+# =========================================================================
+
+
+class TestWebhookExtraParamsUcConnection:
+    """Caller-supplied extras are substituted and forwarded to the UC SDK."""
+
+    @patch('src.common.workspace_client.get_workspace_client')
+    def test_additional_headers_merged_and_substituted(self, mock_get_ws):
+        mock_ws = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_ws.serving_endpoints.http_request.return_value = mock_response
+        mock_get_ws.return_value = mock_ws
+
+        handler = _make_handler({
+            'connection_name': 'servicenow-prod',
+            'method': 'POST',
+            'path': '/api/now/table/incident',
+            'headers': {'Content-Type': 'application/json'},
+            'additional_headers': {
+                'X-Trace-Id': '${execution_id}',
+                'X-Entity': '${entity_name}',
+            },
+        })
+        result = handler.execute(_ctx())
+
+        assert result.passed is True
+        kwargs = mock_ws.serving_endpoints.http_request.call_args.kwargs
+        sent_headers = kwargs['headers']
+        assert sent_headers['Content-Type'] == 'application/json'
+        assert sent_headers['X-Trace-Id'] == 'exec-xyz-789'
+        assert sent_headers['X-Entity'] == 'sales_kpis'
+
+    @patch('src.common.workspace_client.get_workspace_client')
+    def test_additional_headers_override_base_headers_on_collision(self, mock_get_ws):
+        """When the same header is in both `headers` and `additional_headers`,
+        the additional (caller-supplied) value wins."""
+        mock_ws = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_ws.serving_endpoints.http_request.return_value = mock_response
+        mock_get_ws.return_value = mock_ws
+
+        handler = _make_handler({
+            'connection_name': 'svc',
+            'headers': {'X-Source': 'static-default'},
+            'additional_headers': {'X-Source': 'override-${entity_name}'},
+        })
+        handler.execute(_ctx())
+
+        kwargs = mock_ws.serving_endpoints.http_request.call_args.kwargs
+        assert kwargs['headers']['X-Source'] == 'override-sales_kpis'
+
+    @patch('src.common.workspace_client.get_workspace_client')
+    def test_additional_query_params_appended_to_path(self, mock_get_ws):
+        mock_ws = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_ws.serving_endpoints.http_request.return_value = mock_response
+        mock_get_ws.return_value = mock_ws
+
+        handler = _make_handler({
+            'connection_name': 'svc',
+            'path': '/api/v1/items',
+            'additional_query_params': {
+                'caller': 'ontos',
+                'entity': '${entity_name}',
+            },
+        })
+        handler.execute(_ctx())
+
+        kwargs = mock_ws.serving_endpoints.http_request.call_args.kwargs
+        sent_path = kwargs['path']
+        assert sent_path.startswith('/api/v1/items?')
+        assert 'caller=ontos' in sent_path
+        assert 'entity=sales_kpis' in sent_path
+
+    @patch('src.common.workspace_client.get_workspace_client')
+    def test_path_suffix_appended_and_substituted(self, mock_get_ws):
+        mock_ws = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_ws.serving_endpoints.http_request.return_value = mock_response
+        mock_get_ws.return_value = mock_ws
+
+        handler = _make_handler({
+            'connection_name': 'svc',
+            'path': '/api/items',
+            'path_suffix': '/${entity_id}',
+        })
+        handler.execute(_ctx())
+
+        kwargs = mock_ws.serving_endpoints.http_request.call_args.kwargs
+        assert kwargs['path'] == '/api/items/dp-abc-123'
+
+    @patch('src.common.workspace_client.get_workspace_client')
+    def test_path_suffix_and_query_params_combine(self, mock_get_ws):
+        mock_ws = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_ws.serving_endpoints.http_request.return_value = mock_response
+        mock_get_ws.return_value = mock_ws
+
+        handler = _make_handler({
+            'connection_name': 'svc',
+            'path': '/api/items',
+            'path_suffix': '/${entity_id}',
+            'additional_query_params': {'caller': 'ontos'},
+        })
+        handler.execute(_ctx())
+
+        sent_path = mock_ws.serving_endpoints.http_request.call_args.kwargs['path']
+        assert sent_path == '/api/items/dp-abc-123?caller=ontos'
+
+    @patch('src.common.workspace_client.get_workspace_client')
+    def test_legacy_config_without_extras_still_works(self, mock_get_ws):
+        """Existing webhook configs without the new fields must keep working."""
+        mock_ws = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_ws.serving_endpoints.http_request.return_value = mock_response
+        mock_get_ws.return_value = mock_ws
+
+        handler = _make_handler({
+            'connection_name': 'svc',
+            'method': 'POST',
+            'path': '/api/foo',
+            'headers': {'X-Y': 'z'},
+            'body_template': '{"name": "${entity_name}"}',
+        })
+        result = handler.execute(_ctx())
+
+        assert result.passed is True
+        kwargs = mock_ws.serving_endpoints.http_request.call_args.kwargs
+        # Path unchanged when no suffix/query params provided.
+        assert kwargs['path'] == '/api/foo'
+        # Headers untouched.
+        assert kwargs['headers'] == {'X-Y': 'z'}
+
+
+# =========================================================================
+# Config plumbing — inline URL mode (httpx fallback path)
+# =========================================================================
+
+
+class TestWebhookExtraParamsInlineMode:
+    """Inline mode appends query params to the URL and merges headers."""
+
+    @patch('httpx.Client')
+    def test_inline_mode_appends_query_params_and_headers(self, mock_client_cls):
+        # Set up httpx.Client context manager -> client.request -> response.
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = 'ok'
+        mock_client.request.return_value = mock_response
+
+        handler = _make_handler({
+            'url': 'https://api.example.com/hook',
+            'method': 'POST',
+            'headers': {'X-Static': 'a'},
+            'additional_headers': {'X-Dyn': '${entity_name}'},
+            'additional_query_params': {'src': 'ontos'},
+            'body_template': '{"hi": "${entity_name}"}',
+        })
+        result = handler.execute(_ctx())
+
+        assert result.passed is True
+        call_kwargs = mock_client.request.call_args.kwargs
+        assert call_kwargs['url'] == 'https://api.example.com/hook?src=ontos'
+        assert call_kwargs['headers']['X-Static'] == 'a'
+        assert call_kwargs['headers']['X-Dyn'] == 'sales_kpis'

--- a/src/backend/src/tests/unit/test_webhook_step_extra_params.py
+++ b/src/backend/src/tests/unit/test_webhook_step_extra_params.py
@@ -251,3 +251,28 @@ class TestWebhookExtraParamsInlineMode:
         assert call_kwargs['url'] == 'https://api.example.com/hook?src=ontos'
         assert call_kwargs['headers']['X-Static'] == 'a'
         assert call_kwargs['headers']['X-Dyn'] == 'sales_kpis'
+
+    @patch('httpx.Client')
+    def test_inline_mode_appends_path_suffix_with_substitution(self, mock_client_cls):
+        """path_suffix must land in the URL path BEFORE the query string in inline mode."""
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = 'ok'
+        mock_client.request.return_value = mock_response
+
+        handler = _make_handler({
+            'url': 'https://api.example.com/hook',
+            'method': 'POST',
+            'path_suffix': '/extra/${entity_name}',
+            'additional_query_params': {'tag': '${entity_name}'},
+            'body_template': '{}',
+        })
+        result = handler.execute(_ctx())
+
+        assert result.passed is True
+        # Suffix substituted, joined with single slash, query string appended last.
+        assert mock_client.request.call_args.kwargs['url'] == (
+            'https://api.example.com/hook/extra/sales_kpis?tag=sales_kpis'
+        )

--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -44,11 +44,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { 
-  Save, 
-  ArrowLeft, 
-  // Plus - unused
-  Trash2, 
+import {
+  Save,
+  ArrowLeft,
+  Plus,
+  Trash2,
   Loader2,
   Shield,
   Bell,
@@ -129,6 +129,119 @@ import {
   joinRoleAndPrincipals,
   splitRoleAndPrincipals,
 } from '@/lib/workflow-principals';
+
+// -------------------------------------------------------------------------
+// KeyValueEditor — small inline editor for Record<string, string> config
+// fields. Used by the webhook step config panel for `additional_headers`
+// and `additional_query_params` (issue #401). Kept inline because it is
+// only used here; if a second caller needs it, lift to a shared file.
+// -------------------------------------------------------------------------
+interface KeyValueEditorProps {
+  label: string;
+  helpText?: string;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  value: Record<string, string>;
+  onChange: (next: Record<string, string>) => void;
+}
+
+function KeyValueEditor({
+  label,
+  helpText,
+  keyPlaceholder,
+  valuePlaceholder,
+  value,
+  onChange,
+}: KeyValueEditorProps) {
+  // Stable rendering: we render entries in insertion order. To preserve order
+  // while the user is mid-edit on a key, we keep an internal entries array
+  // mirroring the prop dict.
+  const entries = useMemo(
+    () => Object.entries(value || {}),
+    [value],
+  );
+
+  const commit = (next: Array<[string, string]>) => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of next) {
+      // Skip rows with empty key — they're "in progress" and shouldn't
+      // be persisted as an empty-string key.
+      if (k.length === 0) continue;
+      out[k] = v;
+    }
+    onChange(out);
+  };
+
+  const updateKey = (idx: number, newKey: string) => {
+    const next = entries.map((e) => [...e] as [string, string]);
+    next[idx][0] = newKey;
+    commit(next);
+  };
+  const updateValue = (idx: number, newVal: string) => {
+    const next = entries.map((e) => [...e] as [string, string]);
+    next[idx][1] = newVal;
+    commit(next);
+  };
+  const removeRow = (idx: number) => {
+    const next = entries.filter((_, i) => i !== idx);
+    commit(next);
+  };
+  const addRow = () => {
+    // We can't persist an empty-key row, so we don't commit yet — instead
+    // we add a row with a synthetic placeholder key so the UI shows the row,
+    // then the user types the real key.
+    const placeholder = `__new_${entries.length}`;
+    commit([...entries, [placeholder, '']]);
+  };
+
+  return (
+    <div>
+      <Label>{label}</Label>
+      <div className="space-y-2 mt-1">
+        {entries.length === 0 && (
+          <p className="text-xs text-muted-foreground italic">No entries.</p>
+        )}
+        {entries.map(([k, v], idx) => (
+          <div key={idx} className="flex gap-2 items-center">
+            <Input
+              value={k.startsWith('__new_') ? '' : k}
+              onChange={(e) => updateKey(idx, e.target.value)}
+              placeholder={keyPlaceholder || 'key'}
+              className="flex-1 font-mono text-sm"
+            />
+            <Input
+              value={v}
+              onChange={(e) => updateValue(idx, e.target.value)}
+              placeholder={valuePlaceholder || 'value'}
+              className="flex-1 font-mono text-sm"
+            />
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              onClick={() => removeRow(idx)}
+              aria-label="Remove row"
+            >
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          </div>
+        ))}
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={addRow}
+        >
+          <Plus className="w-3 h-3 mr-1" />
+          Add row
+        </Button>
+      </div>
+      {helpText && (
+        <p className="text-xs text-muted-foreground mt-1">{helpText}</p>
+      )}
+    </div>
+  );
+}
 
 // Node types registry (default = fallback for unknown step_type)
 const nodeTypes = {
@@ -2157,7 +2270,7 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
                         <Label>Body Template</Label>
                         <Textarea
                           value={(selectedStep.config as { body_template?: string })?.body_template || ''}
-                          onChange={(e) => updateStep(selectedStep.step_id, { 
+                          onChange={(e) => updateStep(selectedStep.step_id, {
                             config: { ...selectedStep.config, body_template: e.target.value }
                           })}
                           placeholder={'{\n  "description": "Alert for ${entity_name}",\n  "entity_type": "${entity_type}"\n}'}
@@ -2168,7 +2281,47 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
                           Use {'${variable}'} for substitution: entity_type, entity_id, entity_name, user_email, workflow_name
                         </p>
                       </div>
-                      
+
+                      {/* Extra parameters forwarded into the UC HTTPConnection call (issue #401).
+                          These augment what the connection's static config provides — useful when
+                          the downstream service needs context-derived headers, query string params,
+                          or path segments computed from ${entity.*} / ${trigger.*}. */}
+                      <KeyValueEditor
+                        label="Additional Headers"
+                        helpText="Merged into the request headers. Override `headers` on key collision. Values support ${variable} substitution."
+                        keyPlaceholder="X-Trace-Id"
+                        valuePlaceholder="${execution_id}"
+                        value={(selectedStep.config as { additional_headers?: Record<string, string> })?.additional_headers || {}}
+                        onChange={(next) => updateStep(selectedStep.step_id, {
+                          config: { ...selectedStep.config, additional_headers: next },
+                        })}
+                      />
+
+                      <KeyValueEditor
+                        label="Additional Query Parameters"
+                        helpText="Appended to the request URL/path as query string. Values support ${variable} substitution and are URL-encoded."
+                        keyPlaceholder="caller"
+                        valuePlaceholder="ontos"
+                        value={(selectedStep.config as { additional_query_params?: Record<string, string> })?.additional_query_params || {}}
+                        onChange={(next) => updateStep(selectedStep.step_id, {
+                          config: { ...selectedStep.config, additional_query_params: next },
+                        })}
+                      />
+
+                      <div>
+                        <Label>Path Suffix</Label>
+                        <Input
+                          value={(selectedStep.config as { path_suffix?: string })?.path_suffix || ''}
+                          onChange={(e) => updateStep(selectedStep.step_id, {
+                            config: { ...selectedStep.config, path_suffix: e.target.value },
+                          })}
+                          placeholder="/${entity_id}"
+                        />
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Appended to Path before the query string. Supports {'${variable}'} substitution.
+                        </p>
+                      </div>
+
                       <div>
                         <Label>Timeout (seconds)</Label>
                         <Input

--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -71,6 +71,9 @@ import {
   Send,
   KeyRound,
   Eye,
+  Edit2,
+  Check,
+  X,
 } from 'lucide-react';
 import ApprovalWizardDialog from './approval-wizard-dialog';
 
@@ -131,11 +134,28 @@ import {
 } from '@/lib/workflow-principals';
 
 // -------------------------------------------------------------------------
-// KeyValueEditor — small inline editor for Record<string, string> config
-// fields. Used by the webhook step config panel for `additional_headers`
-// and `additional_query_params` (issue #401). Kept inline because it is
-// only used here; if a second caller needs it, lift to a shared file.
+// KeyValueEditor — explicit add/edit editor for Record<string, string>
+// config fields. Used by the webhook step config panel for
+// `additional_headers` and `additional_query_params` (issue #401 follow-up).
+// Kept inline because it is only used here; if a second caller needs it,
+// lift to a shared file.
+//
+// UX contract:
+//   • "Add entry" row at the top — explicit Add button, validated on click.
+//   • Saved entries render read-only below with Edit (pencil) + Remove (trash).
+//   • Clicking Edit enters per-row edit mode: Save (check) + Cancel (X).
+//   • Validation: empty key blocked; duplicate key blocked (both Add + Edit).
+//   • Template warning: if a value contains an unclosed ${ show amber badge.
+//   • Empty state: muted italic "No entries." text.
 // -------------------------------------------------------------------------
+
+/** Returns true when a value string has an unclosed ${ template expression. */
+function hasUnclosedTemplate(val: string): boolean {
+  const opens = (val.match(/\$\{/g) || []).length;
+  const closes = (val.match(/\}/g) || []).length;
+  return opens > closes;
+}
+
 interface KeyValueEditorProps {
   label: string;
   helpText?: string;
@@ -153,89 +173,239 @@ function KeyValueEditor({
   value,
   onChange,
 }: KeyValueEditorProps) {
-  // Stable rendering: we render entries in insertion order. To preserve order
-  // while the user is mid-edit on a key, we keep an internal entries array
-  // mirroring the prop dict.
-  const entries = useMemo(
-    () => Object.entries(value || {}),
-    [value],
-  );
+  // Entries derived from the controlled prop — insertion-order preserved.
+  const entries = useMemo(() => Object.entries(value || {}), [value]);
 
-  const commit = (next: Array<[string, string]>) => {
+  // ---- Add-row state ----
+  const [addKey, setAddKey] = useState('');
+  const [addValue, setAddValue] = useState('');
+  const [addKeyError, setAddKeyError] = useState<string | null>(null);
+
+  // ---- Per-row edit state ----
+  // editIdx: which saved row is currently being edited (null = none)
+  const [editIdx, setEditIdx] = useState<number | null>(null);
+  const [editKey, setEditKey] = useState('');
+  const [editValue, setEditValue] = useState('');
+  const [editKeyError, setEditKeyError] = useState<string | null>(null);
+
+  const commitEntries = (next: Array<[string, string]>) => {
     const out: Record<string, string> = {};
     for (const [k, v] of next) {
-      // Skip rows with empty key — they're "in progress" and shouldn't
-      // be persisted as an empty-string key.
-      if (k.length === 0) continue;
-      out[k] = v;
+      if (k.length > 0) out[k] = v;
     }
     onChange(out);
   };
 
-  const updateKey = (idx: number, newKey: string) => {
-    const next = entries.map((e) => [...e] as [string, string]);
-    next[idx][0] = newKey;
-    commit(next);
+  // ---- Add handlers ----
+  const handleAdd = () => {
+    const trimmedKey = addKey.trim();
+    if (!trimmedKey) {
+      setAddKeyError('Key required');
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(value || {}, trimmedKey)) {
+      setAddKeyError('Key already exists — edit the existing entry');
+      return;
+    }
+    commitEntries([...entries, [trimmedKey, addValue]]);
+    setAddKey('');
+    setAddValue('');
+    setAddKeyError(null);
   };
-  const updateValue = (idx: number, newVal: string) => {
-    const next = entries.map((e) => [...e] as [string, string]);
-    next[idx][1] = newVal;
-    commit(next);
+
+  // ---- Edit handlers ----
+  const startEdit = (idx: number) => {
+    setEditIdx(idx);
+    setEditKey(entries[idx][0]);
+    setEditValue(entries[idx][1]);
+    setEditKeyError(null);
   };
+
+  const cancelEdit = () => {
+    setEditIdx(null);
+    setEditKeyError(null);
+  };
+
+  const commitEdit = () => {
+    const trimmedKey = editKey.trim();
+    if (!trimmedKey) {
+      setEditKeyError('Key required');
+      return;
+    }
+    // Duplicate check: allow the same key if it's the row being edited.
+    const isDuplicate = entries.some(
+      ([k], i) => k === trimmedKey && i !== editIdx,
+    );
+    if (isDuplicate) {
+      setEditKeyError('Key already exists — choose a different name');
+      return;
+    }
+    const next = entries.map((e, i) =>
+      i === editIdx ? ([trimmedKey, editValue] as [string, string]) : (e as [string, string]),
+    );
+    commitEntries(next);
+    setEditIdx(null);
+    setEditKeyError(null);
+  };
+
   const removeRow = (idx: number) => {
-    const next = entries.filter((_, i) => i !== idx);
-    commit(next);
-  };
-  const addRow = () => {
-    // We can't persist an empty-key row, so we don't commit yet — instead
-    // we add a row with a synthetic placeholder key so the UI shows the row,
-    // then the user types the real key.
-    const placeholder = `__new_${entries.length}`;
-    commit([...entries, [placeholder, '']]);
+    if (editIdx === idx) cancelEdit();
+    commitEntries(entries.filter((_, i) => i !== idx));
   };
 
   return (
     <div>
       <Label>{label}</Label>
-      <div className="space-y-2 mt-1">
+
+      {/* Add-entry row */}
+      <div className="mt-2 p-2 rounded-md border border-dashed bg-muted/30 space-y-1">
+        <p className="text-xs text-muted-foreground font-medium">Add entry</p>
+        <div className="flex gap-2 items-start">
+          <div className="flex-1 space-y-1">
+            <Input
+              value={addKey}
+              onChange={(e) => {
+                setAddKey(e.target.value);
+                if (addKeyError) setAddKeyError(null);
+              }}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
+              placeholder={keyPlaceholder || 'key'}
+              className="font-mono text-sm"
+              aria-label="New entry key"
+            />
+            {addKeyError && (
+              <p className="text-xs text-destructive">{addKeyError}</p>
+            )}
+          </div>
+          <div className="flex-1">
+            <Input
+              value={addValue}
+              onChange={(e) => setAddValue(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
+              placeholder={valuePlaceholder || 'value'}
+              className="font-mono text-sm"
+              aria-label="New entry value"
+            />
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={handleAdd}
+            aria-label="Add entry"
+          >
+            <Plus className="w-3 h-3 mr-1" />
+            Add
+          </Button>
+        </div>
+      </div>
+
+      {/* Saved entries list */}
+      <div className="space-y-1 mt-2">
         {entries.length === 0 && (
           <p className="text-xs text-muted-foreground italic">No entries.</p>
         )}
-        {entries.map(([k, v], idx) => (
-          <div key={idx} className="flex gap-2 items-center">
-            <Input
-              value={k.startsWith('__new_') ? '' : k}
-              onChange={(e) => updateKey(idx, e.target.value)}
-              placeholder={keyPlaceholder || 'key'}
-              className="flex-1 font-mono text-sm"
-            />
-            <Input
-              value={v}
-              onChange={(e) => updateValue(idx, e.target.value)}
-              placeholder={valuePlaceholder || 'value'}
-              className="flex-1 font-mono text-sm"
-            />
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              onClick={() => removeRow(idx)}
-              aria-label="Remove row"
+        {entries.map(([k, v], idx) => {
+          const isEditing = editIdx === idx;
+          return (
+            <div
+              key={k}
+              className={`flex gap-2 items-start rounded-md px-2 py-1 ${
+                isEditing ? 'ring-1 ring-primary/40 bg-primary/5' : 'bg-background'
+              }`}
             >
-              <Trash2 className="w-4 h-4" />
-            </Button>
-          </div>
-        ))}
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          onClick={addRow}
-        >
-          <Plus className="w-3 h-3 mr-1" />
-          Add row
-        </Button>
+              {isEditing ? (
+                <>
+                  <div className="flex-1 space-y-1">
+                    <Input
+                      value={editKey}
+                      onChange={(e) => {
+                        setEditKey(e.target.value);
+                        if (editKeyError) setEditKeyError(null);
+                      }}
+                      onKeyDown={(e) => { if (e.key === 'Enter') commitEdit(); else if (e.key === 'Escape') cancelEdit(); }}
+                      placeholder={keyPlaceholder || 'key'}
+                      className="font-mono text-sm"
+                      aria-label="Edit entry key"
+                      autoFocus
+                    />
+                    {editKeyError && (
+                      <p className="text-xs text-destructive">{editKeyError}</p>
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <Input
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') commitEdit(); else if (e.key === 'Escape') cancelEdit(); }}
+                      placeholder={valuePlaceholder || 'value'}
+                      className="font-mono text-sm"
+                      aria-label="Edit entry value"
+                    />
+                  </div>
+                  <div className="flex gap-1">
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      onClick={commitEdit}
+                      aria-label="Save edit"
+                      className="text-green-600 hover:text-green-700"
+                    >
+                      <Check className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      onClick={cancelEdit}
+                      aria-label="Cancel edit"
+                    >
+                      <X className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <span className="flex-1 font-mono text-sm py-1 truncate">{k}</span>
+                  <div className="flex-1 flex items-center gap-1 min-w-0">
+                    <span className="font-mono text-sm py-1 truncate">{v}</span>
+                    {hasUnclosedTemplate(v) && (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 text-amber-700 border-amber-400 bg-amber-100 text-xs px-1 py-0"
+                      >
+                        Check template
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex gap-1">
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => startEdit(idx)}
+                      aria-label="Edit row"
+                    >
+                      <Edit2 className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => removeRow(idx)}
+                      aria-label="Remove row"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
       </div>
+
       {helpText && (
         <p className="text-xs text-muted-foreground mt-1">{helpText}</p>
       )}

--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -120,6 +120,7 @@ import type {
 import {
   ALL_ENTITY_TYPES,
   isTriggerEntitySupported,
+  ENTITY_TYPE_TO_APPROVAL_ENTITY,
 } from '@/lib/workflow-labels';
 import { TriggerPicker, type TriggerTypeOption } from './trigger-picker';
 import { EntityTypeMultiselect } from './entity-type-multiselect';
@@ -528,6 +529,10 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
   const [_stepTypes, setStepTypes] = useState<StepTypeSchema[]>([]);
   const [compliancePolicies, setCompliancePolicies] = useState<CompliancePolicyRef[]>([]);
   const [availableRoles, setAvailableRoles] = useState<{ id: string; name: string; source: 'app' | 'business'; has_groups?: boolean; category?: string; description?: string }[]>([]);
+  // approverRoles is the approval-entity-filtered subset of availableRoles used
+  // specifically in the Approvers (Role) picker. It is re-computed whenever
+  // entityTypes changes so the dropdown tracks the trigger configuration.
+  const [approverRoles, setApproverRoles] = useState<typeof availableRoles>([]);
   const [httpConnections, setHttpConnections] = useState<HttpConnectionRef[]>([]);
   const [triggerTypeOptions, setTriggerTypeOptions] = useState<TriggerTypeOption[]>([]);
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
@@ -855,6 +860,61 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
     });
     return map;
   }, [availableRoles]);
+
+  // Re-compute approverRoles whenever entityTypes or the base role list changes.
+  // For each entity type that has an ApprovalEntity mapping we fetch the
+  // backend-filtered list, then intersect across all mapped types so only roles
+  // eligible to approve EVERY entity type are shown. Entity types without a
+  // mapping (e.g. 'table', 'catalog') are ignored for filtering purposes —
+  // if ALL entity types are unmapped the full role list is used.
+  useEffect(() => {
+    const requiredKeys = entityTypes
+      .map(et => ENTITY_TYPE_TO_APPROVAL_ENTITY[et])
+      .filter((k): k is string => k !== undefined);
+
+    if (requiredKeys.length === 0) {
+      // No approval-mapped entity types: show all roles (backward compat)
+      setApproverRoles(availableRoles);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchIntersection = async () => {
+      try {
+        const perKeyRoles = await Promise.all(
+          requiredKeys.map(key =>
+            get<typeof availableRoles>(`/api/workflows/roles?approval_entity=${encodeURIComponent(key)}`)
+              .then(r => r.data ?? [])
+          )
+        );
+
+        if (cancelled) return;
+
+        if (perKeyRoles.length === 0) {
+          setApproverRoles([]);
+          return;
+        }
+
+        // Intersect: keep roles present in all per-key result sets
+        const firstSet = perKeyRoles[0];
+        const idSets = perKeyRoles.slice(1).map(arr => new Set(arr.map(r => r.id)));
+        const intersected = firstSet.filter(role =>
+          idSets.every(s => s.has(role.id))
+        );
+
+        setApproverRoles(intersected);
+      } catch {
+        if (!cancelled) {
+          // Fall back to unfiltered list on error
+          setApproverRoles(availableRoles);
+        }
+      }
+    };
+
+    fetchIntersection();
+    return () => { cancelled = true; };
+  }, [entityTypes, availableRoles, get]);
 
   // Update node data when rolesMap changes
   useEffect(() => {
@@ -1877,7 +1937,7 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
                                   <SelectValue placeholder="Select role" />
                                 </SelectTrigger>
                                 <SelectContent>
-                                  {renderGroupedRoles(availableRoles, { requester: true })}
+                                  {renderGroupedRoles(approverRoles, { requester: true })}
                                 </SelectContent>
                               </Select>
                             </div>

--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -1042,6 +1042,19 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
     }
   }, [rolesMap, setNodes]);
 
+  // Keep the canvas trigger node in sync with the trigger picker state.
+  // Without this the node renders only the initial default (on_create / table)
+  // and never reflects changes the user makes in the Trigger Configuration panel.
+  useEffect(() => {
+    setNodes(prevNodes => prevNodes.map(node => {
+      if (node.type !== 'trigger') return node;
+      return {
+        ...node,
+        data: { ...node.data, trigger: { type: triggerType, entity_types: entityTypes } },
+      };
+    }));
+  }, [triggerType, entityTypes, setNodes]);
+
   // Handle node selection
   const onNodeClick = useCallback((_: React.MouseEvent, node: Node) => {
     setSelectedNodeId(node.id);

--- a/src/frontend/src/i18n/locales/de/common.json
+++ b/src/frontend/src/i18n/locales/de/common.json
@@ -329,7 +329,7 @@
     },
     "stepTypes": {
       "validation": "Validierung",
-      "approval": "Genehmigung",
+      "approval": "Genehmigung anfordern",
       "notification": "Benachrichtigung",
       "assign_tag": "Tag zuweisen",
       "remove_tag": "Tag entfernen",

--- a/src/frontend/src/i18n/locales/es/common.json
+++ b/src/frontend/src/i18n/locales/es/common.json
@@ -139,8 +139,6 @@
     "setStatus": "Establecer estado",
     "pasteODCSJSON": "Pegar JSON de ODCS",
     "searchDataProductsTermsContracts": "Buscar productos de datos, términos, contratos...",
-    "noResults": "No se encontraron resultados",
-    "noTags": "No se encontraron etiquetas",
     "exampleCatalogSchemaTable": "Ejemplo: catalog.schema.table"
   },
   "states": {
@@ -331,7 +329,7 @@
     },
     "stepTypes": {
       "validation": "Validación",
-      "approval": "Aprobación",
+      "approval": "Solicitar aprobación",
       "notification": "Notificación",
       "assign_tag": "Asignar etiqueta",
       "remove_tag": "Eliminar etiqueta",

--- a/src/frontend/src/i18n/locales/fr/common.json
+++ b/src/frontend/src/i18n/locales/fr/common.json
@@ -134,13 +134,11 @@
     "enterSecurableId": "Exemple : catalog.schema.table",
     "typeToSearch": "Tapez pour rechercher...",
     "noResults": "Aucun résultat trouvé",
-    "noTags": "Aucun tag trouvé",
+    "noTags": "Aucune étiquette trouvée",
     "searchConceptsAndTerms": "Rechercher des concepts et des termes...",
     "setStatus": "Définir le statut",
     "pasteODCSJSON": "Coller le JSON ODCS",
     "searchDataProductsTermsContracts": "Rechercher des produits de données, termes, contrats...",
-    "noResults": "Aucun résultat trouvé",
-    "noTags": "Aucune étiquette trouvée",
     "exampleCatalogSchemaTable": "Exemple : catalog.schema.table"
   },
   "states": {
@@ -331,7 +329,7 @@
     },
     "stepTypes": {
       "validation": "Validation",
-      "approval": "Approbation",
+      "approval": "Demander une approbation",
       "notification": "Notification",
       "assign_tag": "Attribuer un tag",
       "remove_tag": "Supprimer un tag",

--- a/src/frontend/src/i18n/locales/it/common.json
+++ b/src/frontend/src/i18n/locales/it/common.json
@@ -139,8 +139,6 @@
     "setStatus": "Imposta stato",
     "pasteODCSJSON": "Incolla JSON ODCS",
     "searchDataProductsTermsContracts": "Cerca prodotti dati, termini, contratti...",
-    "noResults": "Nessun risultato trovato",
-    "noTags": "Nessun tag trovato",
     "exampleCatalogSchemaTable": "Esempio: catalog.schema.table"
   },
   "states": {
@@ -331,7 +329,7 @@
     },
     "stepTypes": {
       "validation": "Validazione",
-      "approval": "Approvazione",
+      "approval": "Richiedi approvazione",
       "notification": "Notifica",
       "assign_tag": "Assegna tag",
       "remove_tag": "Rimuovi tag",

--- a/src/frontend/src/i18n/locales/ja/common.json
+++ b/src/frontend/src/i18n/locales/ja/common.json
@@ -139,8 +139,6 @@
     "setStatus": "ステータスを設定",
     "pasteODCSJSON": "ODCS JSONを貼り付け",
     "searchDataProductsTermsContracts": "データ製品、用語、契約を検索...",
-    "noResults": "結果が見つかりません",
-    "noTags": "タグが見つかりません",
     "exampleCatalogSchemaTable": "例: catalog.schema.table"
   },
   "states": {
@@ -331,7 +329,7 @@
     },
     "stepTypes": {
       "validation": "検証",
-      "approval": "承認",
+      "approval": "承認をリクエスト",
       "notification": "通知",
       "assign_tag": "タグ割り当て",
       "remove_tag": "タグ削除",

--- a/src/frontend/src/i18n/locales/nl/common.json
+++ b/src/frontend/src/i18n/locales/nl/common.json
@@ -329,7 +329,7 @@
     },
     "stepTypes": {
       "validation": "Validatie",
-      "approval": "Goedkeuring",
+      "approval": "Goedkeuring aanvragen",
       "notification": "Notificatie",
       "assign_tag": "Tag Toewijzen",
       "remove_tag": "Tag Verwijderen",
@@ -344,4 +344,3 @@
     }
   }
 }
-

--- a/src/frontend/src/lib/workflow-labels.ts
+++ b/src/frontend/src/lib/workflow-labels.ts
@@ -308,6 +308,31 @@ export const ALL_ENTITY_TYPES: EntityType[] = [
 ];
 
 /**
+ * Maps workflow trigger EntityType values to the backend ApprovalEntity key
+ * used in `approval_privileges`. Only entity types that have a corresponding
+ * approval privilege are listed here; types that are absent (e.g. 'table',
+ * 'catalog') do not carry approval semantics and are not filtered.
+ */
+export const ENTITY_TYPE_TO_APPROVAL_ENTITY: Partial<Record<EntityType, string>> = {
+  data_contract: 'CONTRACTS',
+  data_product: 'PRODUCTS',
+  domain: 'DOMAINS',
+  data_asset_review: 'ASSET_REVIEWS',
+};
+
+/**
+ * Given the workflow's entity types, returns an approval-entity key set
+ * representing the intersection of required privileges. Returns null when
+ * no entity type maps to an approval privilege (all-roles case).
+ */
+export function getApprovalEntityKeys(entityTypes: EntityType[]): string[] | null {
+  const keys = entityTypes
+    .map(et => ENTITY_TYPE_TO_APPROVAL_ENTITY[et])
+    .filter((k): k is string => k !== undefined);
+  return keys.length > 0 ? keys : null;
+}
+
+/**
  * All step types for use in selectors/dropdowns.
  */
 export const ALL_STEP_TYPES: StepType[] = [

--- a/src/frontend/src/views/workflows.tsx
+++ b/src/frontend/src/views/workflows.tsx
@@ -1239,14 +1239,17 @@ export default function Workflows() {
           <Tabs value={workflowTypeFilter} onValueChange={(v) => setWorkflowTypeFilter(v as 'all' | 'process' | 'approval')}>
             <div className="flex items-center gap-3">
               <TabsList className="h-auto p-1">
-                <TabsTrigger value="all" className="px-4 py-2">
+                <TabsTrigger value="all" className="px-4 py-2 flex flex-col items-center gap-0.5">
                   <span>All</span>
+                  <span className="text-[10px] italic font-normal text-muted-foreground leading-none">Process &amp; Approval</span>
                 </TabsTrigger>
-                <TabsTrigger value="process" className="px-4 py-2">
+                <TabsTrigger value="process" className="px-4 py-2 flex flex-col items-center gap-0.5">
                   <span>Process</span>
+                  <span className="text-[10px] italic font-normal text-muted-foreground leading-none">Background automation after events</span>
                 </TabsTrigger>
-                <TabsTrigger value="approval" className="px-4 py-2">
+                <TabsTrigger value="approval" className="px-4 py-2 flex flex-col items-center gap-0.5">
                   <span>Approval</span>
+                  <span className="text-[10px] italic font-normal text-muted-foreground leading-none">Interactive consent before actions</span>
                 </TabsTrigger>
               </TabsList>
               <TooltipProvider>

--- a/src/frontend/src/views/workflows.tsx
+++ b/src/frontend/src/views/workflows.tsx
@@ -1239,17 +1239,14 @@ export default function Workflows() {
           <Tabs value={workflowTypeFilter} onValueChange={(v) => setWorkflowTypeFilter(v as 'all' | 'process' | 'approval')}>
             <div className="flex items-center gap-3">
               <TabsList className="h-auto p-1">
-                <TabsTrigger value="all" className="px-4 py-2 flex flex-col items-center gap-0.5">
+                <TabsTrigger value="all" className="px-4 py-2">
                   <span>All</span>
-                  <span className="text-[10px] italic font-normal text-muted-foreground leading-none">Process &amp; Approval</span>
                 </TabsTrigger>
-                <TabsTrigger value="process" className="px-4 py-2 flex flex-col items-center gap-0.5">
+                <TabsTrigger value="process" className="px-4 py-2">
                   <span>Process</span>
-                  <span className="text-[10px] italic font-normal text-muted-foreground leading-none">Background automation after events</span>
                 </TabsTrigger>
-                <TabsTrigger value="approval" className="px-4 py-2 flex flex-col items-center gap-0.5">
+                <TabsTrigger value="approval" className="px-4 py-2">
                   <span>Approval</span>
-                  <span className="text-[10px] italic font-normal text-muted-foreground leading-none">Interactive consent before actions</span>
                 </TabsTrigger>
               </TabsList>
               <TooltipProvider>


### PR DESCRIPTION
## Summary

Phase 1 of the open-workflow-issue follow-up. Four pieces of workflow work bundled together because they all touch the workflow authoring surface (`workflow-designer.tsx` and `workflow_executor.py`):

### 1. Filter approver roles by `approval_entity` — closes #161

`GET /api/workflows/roles` now accepts an optional `approval_entity` query param (`CONTRACTS` / `PRODUCTS` / `DOMAINS` / `ASSET_REVIEWS` / `BUSINESS_TERMS`). When set, app roles are filtered to those whose `approval_privileges[approval_entity]` is `true`. Business roles (which carry approval semantics through their own flag) always pass through.

Frontend: the Approvers (Role) picker in the workflow designer now derives the workflow's entity type(s) from the trigger config and fetches a filtered list per type, intersecting client-side so multi-entity workflows only show roles that can approve **every** entity type. Single-entity workflows make exactly one call.

No migrations — `approval_privileges` is an existing JSON column.

### 2. Webhook step extra parameters for UC HTTPConnection — closes #401

Adds three caller-supplied fields to the Webhook step config so workflows can pass context-derived headers, query string params, and path segments to downstream services beyond what the static UC `HTTPConnection` config provides:

- `additional_headers: Record<string, string>` — merged into the request headers. Caller-explicit wins on key collision.
- `additional_query_params: Record<string, string>` — appended to the URL/path as URL-encoded query string.
- `path_suffix: string` — appended to the connection's base path (UC mode) or to the URL's path component (inline mode), with single normalizing slashes.

All three fields support `${entity.*}` / `${trigger.*}` template substitution consistent with the existing `body_template`. Backward compat verified — webhook configs without these fields take the same code path as before.

UI: explicit Add / Edit / Remove UX for the two key-value fields with inline validation (empty key, duplicate key) and a non-blocking amber "Check template" badge for values with unclosed `${`. The bare `path_suffix` input has placeholder + helper text showing template substitution.

### 3. Step palette rename "Approval" → "Request Approval" — part of #277

Renames the approval step type's display label in the designer palette + node label across all 7 i18n locales (en was already correct; de/nl/fr/es/it/ja updated). Backend `step_type=approval` and DB values are untouched — purely UI-facing.

### 4. Canvas trigger node syncs with Trigger Configuration panel — pre-existing bug

Adds a small `useEffect` in the workflow designer that mirrors `triggerType` / `entityTypes` back into the canvas trigger node's `data.trigger`. Pre-existing on `main`: the Trigger Configuration panel updated the React state correctly, but the canvas node only ever displayed the `on_create` / `table` initial default and never reflected edits — surfaced during #161 testing because users couldn't visually confirm the entity-type they'd just picked.

## Files changed

**Backend:**
- `src/backend/src/controller/settings_manager.py` — `list_app_roles_for_approval(approval_entity)` (#161)
- `src/backend/src/routes/workflows_routes.py` — `approval_entity` query param on `GET /api/workflows/roles` (#161)
- `src/backend/src/common/workflow_executor.py` — `WebhookStepHandler` config additions + `_compose_path` / `_compose_url` helpers (#401)
- `src/backend/src/models/process_workflows.py` — `WebhookStepConfig` Pydantic schema additions (#401)

**Frontend:**
- `src/frontend/src/components/workflows/workflow-designer.tsx` — approver picker filter, webhook extras UI, canvas trigger node sync
- `src/frontend/src/lib/workflow-labels.ts` — `ENTITY_TYPE_TO_APPROVAL_ENTITY` constant map
- `src/frontend/src/i18n/locales/{de,es,fr,it,ja,nl}/common.json` — "Request Approval" rename
- `src/frontend/src/views/workflows.tsx` — clean tab labels (no inline subtitles; tooltip on main is unchanged)

**Tests:**
- `src/backend/src/tests/unit/test_settings_manager.py` — 4 new tests for the approval filter (no-filter, single-entity, False-exclusion, multi-entity intersection)
- `src/backend/src/tests/unit/test_webhook_step_extra_params.py` — 17 tests for additional_headers / additional_query_params / path_suffix (including inline-mode path_suffix and the legacy-config-without-extras invariant)

## Test plan

- [x] Backend unit tests pass — `28 passed` for settings manager, `17 passed` for webhook
- [x] Frontend type-check clean on touched files
- [x] E2E on a Databricks Apps workspace — created a workflow with the new webhook fields pointing at httpbin.org/post, executed it, and confirmed the echoed URL = `https://httpbin.org/post/extra/<entity_id>?caller=ontos-fevm` with `X-Trace` + `X-Phase` headers present
- [x] E2E approver-role filter — verified `?approval_entity=CONTRACTS` returns 3 app + 3 business roles vs `?approval_entity=DOMAINS` returns 2 app + 3 business roles on a workspace with realistic role data
- [x] No customer names / internal identifiers in code or commit messages

## Notes for review

- Six logical commits in this PR (one per concern + two #401 follow-ups). I considered squashing but kept them granular so the path_suffix fix and the KeyValueEditor UX rewrite are reviewable independently of the initial #401 implementation.
- The trigger-node-sync fix is a 5-line `useEffect` — happy to split into a separate small PR if you'd prefer. Bundled here because it surfaced while testing #161 and lives in the same file.