### PR TITLE
feat(comments): role audience parity with workflows + project picker

### DIFF
--- a/src/backend/src/common/manager_dependencies.py
+++ b/src/backend/src/common/manager_dependencies.py
@@ -145,8 +145,17 @@ def get_metadata_manager(request: Request) -> MetadataManager:
 def get_comments_manager(request: Request) -> CommentsManager:
     manager = getattr(request.app.state, 'comments_manager', None)
     if not manager:
-        # Instantiate lazily and cache on app.state
-        manager = CommentsManager()
+        # Instantiate lazily and cache on app.state.
+        # Inject SettingsManager and AuthorizationManager so that list_comments
+        # can resolve viewer role IDs via the same group-membership + override
+        # logic that AuthorizationManager.get_user_effective_permissions uses
+        # (issue #326 — role audience parity with workflows).
+        settings_manager = getattr(request.app.state, 'settings_manager', None)
+        authorization_manager = getattr(request.app.state, 'authorization_manager', None)
+        manager = CommentsManager(
+            settings_manager=settings_manager,
+            authorization_manager=authorization_manager,
+        )
         setattr(request.app.state, 'comments_manager', manager)
         logger.info("Initialized CommentsManager and stored on app.state.comments_manager")
     return manager

--- a/src/backend/src/controller/authorization_manager.py
+++ b/src/backend/src/controller/authorization_manager.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 from collections import defaultdict
 
 from src.controller.settings_manager import SettingsManager
@@ -126,4 +126,48 @@ class AuthorizationManager:
         user_level = effective_permissions.get(feature_id, FeatureAccessLevel.NONE)
         has_perm = ACCESS_LEVEL_ORDER[user_level] >= ACCESS_LEVEL_ORDER[required_level]
         logger.debug(f"Permission check for feature '{feature_id}': Required='{required_level.value}', User has='{user_level.value}'. Granted: {has_perm}")
-        return has_perm 
+        return has_perm
+
+    def get_user_effective_role_ids(
+        self,
+        user_groups: Optional[List[str]],
+        applied_role_override_id: Optional[str] = None,
+    ) -> Set[str]:
+        """Return the set of AppRole UUIDs the viewer currently holds.
+
+        Resolution order (mirrors ``get_user_effective_permissions``):
+        1. If *applied_role_override_id* is set, the viewer is pinned to exactly
+           that one role (same as the impersonation override path).
+        2. Otherwise, every AppRole whose ``assigned_groups`` intersects the
+           viewer's *user_groups* is included (case-insensitive).
+
+        Args:
+            user_groups: Workspace/IdP groups for the viewing user.
+            applied_role_override_id: Optional role-ID override (from
+                ``SettingsManager.get_applied_role_override_for_user``).
+
+        Returns:
+            A (possibly empty) set of role-ID strings.
+        """
+        all_roles = self._settings_manager.list_app_roles()
+
+        if applied_role_override_id:
+            # Pin to the overridden role only
+            if any(str(r.id) == applied_role_override_id for r in all_roles):
+                return {applied_role_override_id}
+            logger.warning(
+                "get_user_effective_role_ids: applied override '%s' not found in roles list",
+                applied_role_override_id,
+            )
+            return set()
+
+        if not user_groups:
+            return set()
+
+        user_group_set = set(g.lower() for g in user_groups)
+        role_ids: Set[str] = set()
+        for role in all_roles:
+            role_groups = set(g.lower() for g in (role.assigned_groups or []))
+            if user_group_set.intersection(role_groups):
+                role_ids.add(str(role.id))
+        return role_ids

--- a/src/backend/src/controller/comments_manager.py
+++ b/src/backend/src/controller/comments_manager.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set
 import json
 
 from sqlalchemy.orm import Session
@@ -12,8 +12,15 @@ logger = get_logger(__name__)
 
 
 class CommentsManager:
-    def __init__(self, comments_repository: CommentsRepository = comments_repo):
+    def __init__(
+        self,
+        comments_repository: CommentsRepository = comments_repo,
+        settings_manager=None,
+        authorization_manager=None,
+    ):
         self._comments_repo = comments_repository
+        self._settings_manager = settings_manager
+        self._authorization_manager = authorization_manager
 
 
     def _convert_audience_from_json(self, comment_db) -> Optional[List[str]]:
@@ -51,6 +58,44 @@ class CommentsManager:
             "updated_at": comment_db.updated_at,
         }
         return Comment(**comment_data)
+
+    # ------------------------------------------------------------------
+    # Role-audience helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_viewer_role_ids(
+        self,
+        user_groups: Optional[List[str]],
+        applied_role_override_id: Optional[str] = None,
+    ) -> Set[str]:
+        """Return the set of AppRole UUIDs the viewer holds.
+
+        Delegates to ``AuthorizationManager.get_user_effective_role_ids`` when
+        the authorization manager is available; falls back to an empty set so
+        callers that don't inject the manager degrade gracefully (unfiltered
+        audience is already handled upstream).
+        """
+        if self._authorization_manager is None:
+            logger.debug("_resolve_viewer_role_ids: no authorization_manager; returning empty set")
+            return set()
+        try:
+            return self._authorization_manager.get_user_effective_role_ids(
+                user_groups, applied_role_override_id
+            )
+        except Exception:
+            logger.exception("_resolve_viewer_role_ids: unexpected error; returning empty set")
+            return set()
+
+    def _resolve_legacy_role_name_to_id(self, role_name: str) -> Optional[str]:
+        """Look up a role UUID by name for legacy ``role:<name>`` tokens."""
+        if self._settings_manager is None:
+            return None
+        try:
+            role = self._settings_manager.get_app_role_by_name(role_name)
+            return str(role.id) if role else None
+        except Exception:
+            logger.exception("_resolve_legacy_role_name_to_id: error resolving name '%s'", role_name)
+            return None
 
     def create_comment(
         self, 
@@ -94,20 +139,21 @@ class CommentsManager:
         return self._db_to_api_model(db_obj)
 
     def list_comments(
-        self, 
-        db: Session, 
-        *, 
-        entity_type: str, 
+        self,
+        db: Session,
+        *,
+        entity_type: str,
         entity_id: str,
         project_id: Optional[str] = None,
         user_groups: Optional[List[str]] = None,
         user_teams: Optional[List[str]] = None,
         user_app_role: Optional[str] = None,
         user_email: Optional[str] = None,
+        applied_role_override_id: Optional[str] = None,
         include_deleted: bool = False
     ) -> CommentListResponse:
         """List comments for an entity, filtered by project and user's audience visibility.
-        
+
         Args:
             db: Database session
             entity_type: Type of entity
@@ -115,26 +161,40 @@ class CommentsManager:
             project_id: Filter by project context
             user_groups: User's group memberships
             user_teams: User's team memberships (IDs)
-            user_app_role: User's app role name
+            user_app_role: User's app role name (legacy team-override path; kept for
+                backward-compat but superseded by group-derived role resolution)
             user_email: User's email (for direct targeting)
+            applied_role_override_id: UUID of the role the viewer has pinned via the
+                role-switcher (from SettingsManager.get_applied_role_override_for_user).
+                When set, this takes full precedence over group-derived roles.
             include_deleted: Include soft-deleted comments
         """
         logger.debug(f"Listing comments for {entity_type}:{entity_id}, project_id={project_id}")
-        
+
+        # Resolve the set of AppRole UUIDs this viewer holds, using the same
+        # group-membership + override logic that AuthorizationManager uses for
+        # feature-permission checks.
+        viewer_role_ids: Set[str] = self._resolve_viewer_role_ids(
+            user_groups, applied_role_override_id
+        )
+
         # Get all comments (for total count) - without project filter for admin view
         all_comments = self._comments_repo.list_for_entity(
-            db, 
-            entity_type=entity_type, 
+            db,
+            entity_type=entity_type,
             entity_id=entity_id,
             project_id=None,  # Get all for count
             user_groups=None,
             user_teams=None,
             user_app_role=None,
+            user_role_ids=None,
             include_deleted=include_deleted
         )
         total_count = len(all_comments)
-        
-        # Get visible comments filtered by project and audience
+
+        # Get visible comments filtered by project and audience.
+        # Pass both the legacy user_app_role (team-override name) and the new
+        # viewer_role_ids so the repository can match both token formats.
         visible_comments = self._comments_repo.list_for_entity(
             db,
             entity_type=entity_type,
@@ -143,26 +203,53 @@ class CommentsManager:
             user_groups=user_groups,
             user_teams=user_teams,
             user_app_role=user_app_role,
+            user_role_ids=viewer_role_ids if viewer_role_ids else None,
             include_deleted=include_deleted
         )
 
-        # Additionally include comments targeted directly to the user's email via audience token
-        if user_email:
+        # Additionally include comments targeted directly to the user's email via audience token,
+        # and role-tagged comments matched via legacy role:<name> tokens resolved to IDs.
+        if user_email or viewer_role_ids:
             try:
-                email_token = f"user:{user_email}"
+                already_visible_ids = {getattr(c, 'id', None) for c in visible_comments}
                 for c in all_comments:
-                    aud = getattr(c, 'audience', None)
-                    if aud and email_token in aud and c not in visible_comments:
-                        # Also check project_id matches
+                    if getattr(c, 'id', None) in already_visible_ids:
+                        continue
+                    aud_raw = getattr(c, 'audience', None)
+                    if not aud_raw:
+                        continue
+                    try:
+                        aud_tokens: List[str] = json.loads(aud_raw)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    matched = False
+
+                    # Direct email targeting
+                    if user_email and f"user:{user_email}" in aud_tokens:
+                        matched = True
+
+                    # Legacy role:<name> tokens — resolve name → UUID and compare
+                    if not matched and viewer_role_ids:
+                        for token in aud_tokens:
+                            if token.startswith("role:"):
+                                role_name = token[len("role:"):]
+                                resolved_id = self._resolve_legacy_role_name_to_id(role_name)
+                                if resolved_id and resolved_id in viewer_role_ids:
+                                    matched = True
+                                    break
+
+                    if matched:
+                        # Respect project_id scope
                         if project_id is None or c.project_id is None or c.project_id == project_id:
                             visible_comments.append(c)
             except Exception:
-                pass
+                logger.exception("list_comments: error during supplemental audience matching")
+
         visible_count = len(visible_comments)
-        
+
         # Convert to API models
         api_comments = [self._db_to_api_model(comment) for comment in visible_comments]
-        
+
         return CommentListResponse(
             comments=api_comments,
             total_count=total_count,

--- a/src/backend/src/repositories/comments_repository.py
+++ b/src/backend/src/repositories/comments_repository.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set
 import json
 
 from sqlalchemy.orm import Session
@@ -11,34 +11,40 @@ from src.models.comments import CommentCreate, CommentUpdate, CommentType as Api
 
 class CommentsRepository(CRUDBase[CommentDb, CommentCreate, CommentUpdate]):
     def list_for_entity(
-        self, 
-        db: Session, 
-        *, 
-        entity_type: str, 
-        entity_id: str, 
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
         project_id: Optional[str] = None,
         user_groups: Optional[List[str]] = None,
         user_teams: Optional[List[str]] = None,
         user_app_role: Optional[str] = None,
+        user_role_ids: Optional[Set[str]] = None,
         include_deleted: bool = False
     ) -> List[CommentDb]:
         """Get comments for a specific entity, filtered by project and audience visibility.
-        
+
         Args:
             db: Database session
             entity_type: Type of entity (data_domain, data_product, etc.)
             entity_id: ID of the entity
-            project_id: Filter by project ID. If provided, matches comments with this project_id or null (global)
+            project_id: Filter by project ID. If provided, matches comments with this
+                project_id or null (global)
             user_groups: List of user's group memberships
             user_teams: List of team IDs the user belongs to
-            user_app_role: The user's app role name
+            user_app_role: The user's app role *name* (legacy team-override path;
+                matches ``role:<name>`` tokens in stored audience JSON)
+            user_role_ids: Set of AppRole UUIDs the viewer holds (group-derived + any
+                applied override). Matches ``role_id:<uuid>`` tokens in stored audience
+                JSON. This is the authoritative path introduced in issue #326.
             include_deleted: Whether to include soft-deleted comments
         """
         query = db.query(CommentDb).filter(
-            CommentDb.entity_type == entity_type, 
+            CommentDb.entity_type == entity_type,
             CommentDb.entity_id == entity_id
         )
-        
+
         # Filter by project_id: match specific project or global (null) comments
         if project_id is not None:
             query = query.filter(
@@ -47,42 +53,57 @@ class CommentsRepository(CRUDBase[CommentDb, CommentCreate, CommentUpdate]):
                     CommentDb.project_id.is_(None)
                 )
             )
-        
+
         # Filter by status unless explicitly including deleted
         if not include_deleted:
             query = query.filter(CommentDb.status == CommentStatus.ACTIVE)
-        
+
         # Filter by audience if user info provided
-        if user_groups is not None or user_teams is not None or user_app_role is not None:
-            # Comments visible to user if:
+        has_audience_filter = (
+            user_groups is not None
+            or user_teams is not None
+            or user_app_role is not None
+            or user_role_ids is not None
+        )
+        if has_audience_filter:
+            # Comments are visible to the user if:
             # 1. audience is null (visible to all)
             # 2. audience contains at least one of user's groups (plain string)
             # 3. audience contains team:<team_id> matching user's teams
-            # 4. audience contains role:<role_name> matching user's app role
+            # 4. audience contains role:<role_name> matching user's app role (legacy)
+            # 5. audience contains role_id:<uuid> matching one of the user's effective
+            #    AppRole UUIDs (group-derived or override — introduced in issue #326)
             audience_conditions = [CommentDb.audience.is_(None)]
-            
+
             # Check plain group memberships
             if user_groups:
                 for group in user_groups:
                     audience_conditions.append(
                         CommentDb.audience.contains(f'"{group}"')
                     )
-            
+
             # Check team: prefixed tokens
             if user_teams:
                 for team_id in user_teams:
                     audience_conditions.append(
                         CommentDb.audience.contains(f'"team:{team_id}"')
                     )
-            
-            # Check role: prefixed token
+
+            # Check legacy role:<name> token (team-override path)
             if user_app_role:
                 audience_conditions.append(
                     CommentDb.audience.contains(f'"role:{user_app_role}"')
                 )
-            
+
+            # Check role_id:<uuid> tokens — the authoritative path for new comments
+            if user_role_ids:
+                for role_id in user_role_ids:
+                    audience_conditions.append(
+                        CommentDb.audience.contains(f'"role_id:{role_id}"')
+                    )
+
             query = query.filter(or_(*audience_conditions))
-        
+
         return query.order_by(CommentDb.created_at.desc()).all()
     
     def create_with_audience(

--- a/src/backend/src/routes/comments_routes.py
+++ b/src/backend/src/routes/comments_routes.py
@@ -9,7 +9,7 @@ from src.common.authorization import PermissionChecker, get_user_groups, is_user
 from src.common.config import get_settings, Settings
 from src.controller.comments_manager import CommentsManager
 from src.controller.change_log_manager import change_log_manager
-from src.common.manager_dependencies import get_comments_manager
+from src.common.manager_dependencies import get_comments_manager, get_settings_manager
 from src.models.comments import Comment, CommentCreate, CommentUpdate, CommentListResponse, RatingCreate, RatingAggregation
 from src.repositories.teams_repository import team_repo
 
@@ -112,20 +112,31 @@ async def list_comments(
     try:
         # Get user's groups for audience filtering
         user_groups = await get_user_groups(current_user.email)
-        
+
         # Get user's teams for team-based audience filtering
         user_teams = team_repo.get_teams_for_user(db, current_user.email, user_groups)
         user_team_ids = [team.id for team in user_teams]
-        
-        # Get user's app role for role-based audience filtering
+
+        # Legacy team-override role name (kept for backward-compat with role:<name> tokens)
         user_app_role = await get_user_team_role_overrides(current_user.email, user_groups, request=request)
-        
+
+        # Applied role-ID override (role-switcher / impersonation) — used for the
+        # group-derived role resolution path introduced in issue #326.
+        applied_role_override_id: Optional[str] = None
+        try:
+            settings_mgr = get_settings_manager(request)
+            applied_role_override_id = settings_mgr.get_applied_role_override_for_user(
+                current_user.email
+            )
+        except Exception:
+            logger.debug("list_comments: could not fetch applied role override; proceeding without it")
+
         # Only admins can see deleted comments
         if include_deleted:
             is_admin = is_user_admin(user_groups, get_settings())
             if not is_admin:
                 include_deleted = False
-        
+
         return manager.list_comments(
             db,
             entity_type=entity_type,
@@ -135,6 +146,7 @@ async def list_comments(
             user_teams=user_team_ids,
             user_app_role=user_app_role,
             user_email=current_user.email,
+            applied_role_override_id=applied_role_override_id,
             include_deleted=include_deleted
         )
     except HTTPException:
@@ -164,11 +176,20 @@ async def get_entity_timeline_count(
         # Get user's groups for audience filtering
         user_groups = await get_user_groups(current_user.email)
         is_admin = is_user_admin(user_groups, get_settings())
-        
+
         # Get user's teams and app role
         user_teams = team_repo.get_teams_for_user(db, current_user.email, user_groups)
         user_team_ids = [team.id for team in user_teams]
         user_app_role = await get_user_team_role_overrides(current_user.email, user_groups, request=request)
+
+        applied_role_override_id: Optional[str] = None
+        try:
+            settings_mgr = get_settings_manager(request)
+            applied_role_override_id = settings_mgr.get_applied_role_override_for_user(
+                current_user.email
+            )
+        except Exception:
+            logger.debug("get_entity_timeline_count: could not fetch applied role override")
 
         if filter_type in ("all", "comments"):
             # Get comments count
@@ -184,6 +205,7 @@ async def get_entity_timeline_count(
                 user_teams=user_team_ids,
                 user_app_role=user_app_role,
                 user_email=current_user.email,
+                applied_role_override_id=applied_role_override_id,
                 include_deleted=include_deleted
             )
             total_count += len(comments_response.comments)
@@ -227,21 +249,30 @@ async def get_entity_timeline(
     """Get a unified timeline of comments and change log entries for an entity."""
     try:
         timeline_entries = []
-        
+
         # Get user's groups for audience filtering
         user_groups = await get_user_groups(current_user.email)
         is_admin = is_user_admin(user_groups, get_settings())
-        
+
         # Get user's teams and app role
         user_teams = team_repo.get_teams_for_user(db, current_user.email, user_groups)
         user_team_ids = [team.id for team in user_teams]
         user_app_role = await get_user_team_role_overrides(current_user.email, user_groups, request=request)
-        
+
+        applied_role_override_id: Optional[str] = None
+        try:
+            settings_mgr = get_settings_manager(request)
+            applied_role_override_id = settings_mgr.get_applied_role_override_for_user(
+                current_user.email
+            )
+        except Exception:
+            logger.debug("get_entity_timeline: could not fetch applied role override")
+
         if filter_type in ("all", "comments"):
             # Get comments
             if include_deleted and not is_admin:
                 include_deleted = False
-                
+
             comments_response = manager.list_comments(
                 db,
                 entity_type=entity_type,
@@ -251,6 +282,7 @@ async def get_entity_timeline(
                 user_teams=user_team_ids,
                 user_app_role=user_app_role,
                 user_email=current_user.email,
+                applied_role_override_id=applied_role_override_id,
                 include_deleted=include_deleted
             )
             

--- a/src/backend/src/tests/unit/test_authorization_manager.py
+++ b/src/backend/src/tests/unit/test_authorization_manager.py
@@ -280,10 +280,119 @@ class TestAuthorizationManager:
             approval_privileges={},
         )
         mock_settings_manager.list_app_roles.return_value = [role_with_unknown]
-        
+
         result = manager.get_user_effective_permissions(["test"])
-        
+
         # Should process valid features and skip unknown ones
         assert result["data-products"] == FeatureAccessLevel.READ_WRITE
         assert "unknown-feature-xyz" not in result or result.get("unknown-feature-xyz") == FeatureAccessLevel.NONE
+
+
+# =============================================================================
+# Issue #326 — get_user_effective_role_ids
+# =============================================================================
+
+_ROLE_A_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_ROLE_B_ID = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+
+
+def _make_role(role_id: uuid.UUID, name: str, groups: list[str]) -> AppRole:
+    return AppRole(
+        id=role_id,
+        name=name,
+        description=None,
+        assigned_groups=groups,
+        feature_permissions={},
+        home_sections=[],
+        approval_privileges={},
+    )
+
+
+class TestGetUserEffectiveRoleIds:
+    """Tests for AuthorizationManager.get_user_effective_role_ids (issue #326)."""
+
+    @pytest.fixture
+    def mock_settings_manager(self):
+        return Mock()
+
+    @pytest.fixture
+    def manager(self, mock_settings_manager):
+        return AuthorizationManager(settings_manager=mock_settings_manager)
+
+    def test_group_derived_single_role(self, manager, mock_settings_manager):
+        """Viewer's group matches one role → that role's ID is returned."""
+        role = _make_role(_ROLE_A_ID, "Data Producer", ["data-producers"])
+        mock_settings_manager.list_app_roles.return_value = [role]
+
+        result = manager.get_user_effective_role_ids(["data-producers"])
+
+        assert result == {str(_ROLE_A_ID)}
+
+    def test_group_derived_multiple_roles(self, manager, mock_settings_manager):
+        """Viewer belongs to groups that match two roles → both IDs returned."""
+        role_a = _make_role(_ROLE_A_ID, "Data Producer", ["producers"])
+        role_b = _make_role(_ROLE_B_ID, "Data Steward", ["stewards"])
+        mock_settings_manager.list_app_roles.return_value = [role_a, role_b]
+
+        result = manager.get_user_effective_role_ids(["producers", "stewards"])
+
+        assert result == {str(_ROLE_A_ID), str(_ROLE_B_ID)}
+
+    def test_group_derived_no_match(self, manager, mock_settings_manager):
+        """Viewer's groups don't match any role → empty set."""
+        role = _make_role(_ROLE_A_ID, "Data Producer", ["producers"])
+        mock_settings_manager.list_app_roles.return_value = [role]
+
+        result = manager.get_user_effective_role_ids(["consumers"])
+
+        assert result == set()
+
+    def test_empty_groups(self, manager, mock_settings_manager):
+        """Empty group list → empty set."""
+        mock_settings_manager.list_app_roles.return_value = [
+            _make_role(_ROLE_A_ID, "Data Producer", ["producers"])
+        ]
+        result = manager.get_user_effective_role_ids([])
+        assert result == set()
+
+    def test_none_groups(self, manager, mock_settings_manager):
+        """None group list → empty set."""
+        mock_settings_manager.list_app_roles.return_value = [
+            _make_role(_ROLE_A_ID, "Data Producer", ["producers"])
+        ]
+        result = manager.get_user_effective_role_ids(None)
+        assert result == set()
+
+    def test_applied_override_pins_to_single_role(self, manager, mock_settings_manager):
+        """Applied role override → exactly that one role UUID is returned."""
+        role_a = _make_role(_ROLE_A_ID, "Data Producer", ["producers"])
+        role_b = _make_role(_ROLE_B_ID, "Data Steward", ["stewards"])
+        mock_settings_manager.list_app_roles.return_value = [role_a, role_b]
+
+        # Viewer has groups matching role_a but override pins to role_b
+        result = manager.get_user_effective_role_ids(
+            ["producers"], applied_role_override_id=str(_ROLE_B_ID)
+        )
+
+        assert result == {str(_ROLE_B_ID)}
+
+    def test_applied_override_unknown_id_returns_empty(self, manager, mock_settings_manager):
+        """Applied override ID not found in roles list → empty set."""
+        mock_settings_manager.list_app_roles.return_value = [
+            _make_role(_ROLE_A_ID, "Data Producer", ["producers"])
+        ]
+        unknown_id = str(uuid.uuid4())
+
+        result = manager.get_user_effective_role_ids(["producers"], unknown_id)
+
+        assert result == set()
+
+    def test_case_insensitive_group_matching(self, manager, mock_settings_manager):
+        """Group matching is case-insensitive (role has 'Producers', user has 'PRODUCERS')."""
+        role = _make_role(_ROLE_A_ID, "Data Producer", ["Producers"])
+        mock_settings_manager.list_app_roles.return_value = [role]
+
+        result = manager.get_user_effective_role_ids(["PRODUCERS"])
+
+        assert result == {str(_ROLE_A_ID)}
 

--- a/src/backend/src/tests/unit/test_comments_manager.py
+++ b/src/backend/src/tests/unit/test_comments_manager.py
@@ -4,7 +4,8 @@ Unit tests for CommentsManager
 import pytest
 import json
 from datetime import datetime
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
+from uuid import UUID
 from src.controller.comments_manager import CommentsManager
 from src.models.comments import CommentCreate, CommentUpdate, Comment
 from src.db_models.comments import CommentDb, CommentStatus
@@ -386,4 +387,249 @@ class TestCommentsManager:
         )
 
         assert result is False
+
+
+# =============================================================================
+# Issue #326 — role audience parity with workflows
+# =============================================================================
+
+ROLE_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+ROLE_UUID_2 = "11111111-2222-3333-4444-555555555555"
+COMMENT_UUID = "cccccccc-dddd-eeee-ffff-000000000001"
+
+
+def _make_comment_db(
+    comment_id: str = COMMENT_UUID,
+    audience_json: str | None = None,
+    project_id: str | None = None,
+) -> Mock:
+    """Build a minimal CommentDb mock."""
+    c = Mock(spec=CommentDb)
+    c.id = comment_id
+    c.entity_id = "e-1"
+    c.entity_type = "data_product"
+    c.title = "Test"
+    c.comment = "body"
+    c.audience = audience_json
+    c.project_id = project_id
+    c.status = CommentStatus.ACTIVE
+    c.comment_type = None
+    c.rating = None
+    c.created_by = "author@example.com"
+    c.updated_by = "author@example.com"
+    c.created_at = datetime(2024, 1, 1)
+    c.updated_at = datetime(2024, 1, 1)
+    return c
+
+
+class TestRoleAudienceParity:
+    """Tests for issue #326 – role_id:<uuid> and legacy role:<name> audience matching."""
+
+    @pytest.fixture
+    def mock_auth_manager(self):
+        m = Mock()
+        m.get_user_effective_role_ids.return_value = {ROLE_UUID}
+        return m
+
+    @pytest.fixture
+    def mock_settings_manager(self):
+        m = Mock()
+        # get_app_role_by_name returns a role whose id matches ROLE_UUID
+        role = Mock()
+        role.id = UUID(ROLE_UUID)
+        m.get_app_role_by_name.return_value = role
+        return m
+
+    @pytest.fixture
+    def mock_repo(self):
+        return Mock()
+
+    @pytest.fixture
+    def manager(self, mock_repo, mock_settings_manager, mock_auth_manager):
+        return CommentsManager(
+            comments_repository=mock_repo,
+            settings_manager=mock_settings_manager,
+            authorization_manager=mock_auth_manager,
+        )
+
+    # ------------------------------------------------------------------
+    # _resolve_viewer_role_ids
+    # ------------------------------------------------------------------
+
+    def test_resolve_viewer_role_ids_group_derived(self, manager, mock_auth_manager):
+        """Group membership resolves to a set of role UUIDs."""
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID}
+        result = manager._resolve_viewer_role_ids(["data-producers"], None)
+        assert result == {ROLE_UUID}
+        mock_auth_manager.get_user_effective_role_ids.assert_called_once_with(
+            ["data-producers"], None
+        )
+
+    def test_resolve_viewer_role_ids_override(self, manager, mock_auth_manager):
+        """Applied role override ID is passed through to auth_manager."""
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID_2}
+        result = manager._resolve_viewer_role_ids(["some-group"], ROLE_UUID_2)
+        assert result == {ROLE_UUID_2}
+        mock_auth_manager.get_user_effective_role_ids.assert_called_once_with(
+            ["some-group"], ROLE_UUID_2
+        )
+
+    def test_resolve_viewer_role_ids_no_auth_manager(self, mock_repo):
+        """Falls back to empty set when no auth manager is available."""
+        mgr = CommentsManager(comments_repository=mock_repo)
+        result = mgr._resolve_viewer_role_ids(["some-group"])
+        assert result == set()
+
+    # ------------------------------------------------------------------
+    # list_comments – role_id:<uuid> token matching (new format)
+    # ------------------------------------------------------------------
+
+    def test_list_comments_role_id_token_match(self, manager, mock_repo, mock_auth_manager):
+        """Comments tagged role_id:<uuid> are visible to a viewer who holds that role."""
+        comment = _make_comment_db(
+            audience_json=json.dumps([f"role_id:{ROLE_UUID}"])
+        )
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID}
+        # First call (all_comments), second call (visible)
+        mock_repo.list_for_entity.side_effect = [
+            [comment],
+            [comment],
+        ]
+
+        db = Mock()
+        result = manager.list_comments(
+            db, entity_type="data_product", entity_id="e-1",
+            user_groups=["data-producers"]
+        )
+
+        assert result.visible_count == 1
+        assert str(result.comments[0].id) == COMMENT_UUID
+
+    def test_list_comments_role_id_token_no_match(self, manager, mock_repo, mock_auth_manager):
+        """Comments tagged role_id:<uuid> are hidden when viewer doesn't hold that role."""
+        comment = _make_comment_db(
+            audience_json=json.dumps([f"role_id:{ROLE_UUID}"])
+        )
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID_2}  # different role
+        mock_repo.list_for_entity.side_effect = [
+            [comment],  # all comments
+            [],          # none visible (repo filters out mismatched role_id)
+        ]
+
+        db = Mock()
+        result = manager.list_comments(
+            db, entity_type="data_product", entity_id="e-1",
+            user_groups=["other-group"]
+        )
+
+        assert result.visible_count == 0
+
+    # ------------------------------------------------------------------
+    # list_comments – legacy role:<name> token matching
+    # ------------------------------------------------------------------
+
+    def test_list_comments_legacy_role_name_token_match(
+        self, manager, mock_repo, mock_auth_manager, mock_settings_manager
+    ):
+        """Legacy role:<name> tokens are resolved to UUIDs and matched."""
+        comment = _make_comment_db(
+            audience_json=json.dumps(["role:Data Producer"])
+        )
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID}
+        # Repo returns the comment in all_comments but NOT in visible (repo doesn't know
+        # about the name→id resolution; manager does the supplemental check).
+        mock_repo.list_for_entity.side_effect = [
+            [comment],  # all
+            [],          # visible (role:<name> not matched by repo directly)
+        ]
+        # settings_manager resolves "Data Producer" → role with id=ROLE_UUID
+        role = Mock()
+        role.id = UUID(ROLE_UUID)
+        mock_settings_manager.get_app_role_by_name.return_value = role
+
+        db = Mock()
+        result = manager.list_comments(
+            db, entity_type="data_product", entity_id="e-1",
+            user_groups=["data-producers"]
+        )
+
+        # Supplemental loop should add the comment
+        assert result.visible_count == 1
+        mock_settings_manager.get_app_role_by_name.assert_called_once_with("Data Producer")
+
+    def test_list_comments_legacy_role_name_token_no_match(
+        self, manager, mock_repo, mock_auth_manager, mock_settings_manager
+    ):
+        """Legacy role:<name> token is NOT matched when viewer holds a different role."""
+        comment = _make_comment_db(
+            audience_json=json.dumps(["role:Data Producer"])
+        )
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID_2}
+        mock_repo.list_for_entity.side_effect = [
+            [comment],
+            [],
+        ]
+        # Name resolves to ROLE_UUID, but viewer only holds ROLE_UUID_2
+        role = Mock()
+        role.id = UUID(ROLE_UUID)
+        mock_settings_manager.get_app_role_by_name.return_value = role
+
+        db = Mock()
+        result = manager.list_comments(
+            db, entity_type="data_product", entity_id="e-1",
+            user_groups=["consumers"]
+        )
+
+        assert result.visible_count == 0
+
+    # ------------------------------------------------------------------
+    # list_comments – override path
+    # ------------------------------------------------------------------
+
+    def test_list_comments_override_role_id_match(
+        self, manager, mock_repo, mock_auth_manager
+    ):
+        """Applied role_id override pins the viewer to exactly that role."""
+        comment = _make_comment_db(
+            audience_json=json.dumps([f"role_id:{ROLE_UUID}"])
+        )
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID}
+        mock_repo.list_for_entity.side_effect = [
+            [comment],
+            [comment],
+        ]
+
+        db = Mock()
+        result = manager.list_comments(
+            db, entity_type="data_product", entity_id="e-1",
+            applied_role_override_id=ROLE_UUID
+        )
+
+        assert result.visible_count == 1
+        mock_auth_manager.get_user_effective_role_ids.assert_called_once_with(
+            None, ROLE_UUID
+        )
+
+    # ------------------------------------------------------------------
+    # Ensure repo is called with user_role_ids kwarg
+    # ------------------------------------------------------------------
+
+    def test_list_comments_passes_role_ids_to_repo(
+        self, manager, mock_repo, mock_auth_manager
+    ):
+        """Manager passes resolved role_ids to the repository for SQL-level filtering."""
+        mock_auth_manager.get_user_effective_role_ids.return_value = {ROLE_UUID}
+        mock_repo.list_for_entity.return_value = []
+
+        db = Mock()
+        manager.list_comments(
+            db, entity_type="data_product", entity_id="e-1",
+            user_groups=["producers"]
+        )
+
+        # Second call is the visible-comments query; check user_role_ids was passed
+        calls = mock_repo.list_for_entity.call_args_list
+        assert len(calls) == 2
+        visible_call_kwargs = calls[1].kwargs
+        assert visible_call_kwargs.get("user_role_ids") == {ROLE_UUID}
 

--- a/src/frontend/src/components/comments/comment-sidebar.tsx
+++ b/src/frontend/src/components/comments/comment-sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { MessageSquare, Plus, Trash2, Edit, Send, Users, Filter, Clock, FileText, FolderOpen } from 'lucide-react';
+import { MessageSquare, Plus, Trash2, Edit, Send, Users, Filter, Clock, FileText, FolderOpen, Info } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
@@ -30,7 +30,19 @@ import { Separator } from '@/components/ui/separator';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { PrincipalPicker } from '@/components/common/principal-picker';
 import { buildAudienceTokens, parseAudienceTokens, resolveRoleTokenLabel } from '@/lib/audience';
-// Select components removed - unused
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 interface CommentFormData {
   title: string;
@@ -80,7 +92,13 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
 }) => {
   const { get, post, put, delete: deleteApi, loading } = useApi();
   const { toast } = useToast();
-  const { currentProject } = useProjectContext();
+  const { currentProject, availableProjects } = useProjectContext();
+
+  // Compute the "default" project_id for the composer: matches main-window context.
+  const defaultComposerProjectId = currentProject?.id ?? null;
+
+  // Local picker state: null = Global, string = project id.
+  const [composerProjectId, setComposerProjectId] = useState<string | null>(defaultComposerProjectId);
   
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -94,6 +112,11 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
     selectedRoles: [],
     selectedPrincipals: [],
   });
+
+  // Keep composer picker default in sync when the main-window project changes.
+  useEffect(() => {
+    setComposerProjectId(currentProject?.id ?? null);
+  }, [currentProject?.id]);
 
   // Ref for the ScrollArea viewport to control scrolling
   const scrollAreaRef = useRef<HTMLDivElement>(null);
@@ -254,7 +277,7 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
         title: formData.title || null,
         comment: formData.comment,
         audience: audienceTokens.length > 0 ? audienceTokens : null,
-        project_id: currentProject?.id || null,
+        project_id: composerProjectId,
       };
       
       const response = await post<Comment>(
@@ -279,6 +302,8 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
     
     // Reset form and refresh timeline
     setFormData({ title: '', comment: '', selectedTeams: [], selectedRoles: [], selectedPrincipals: [] });
+    // Reset project picker back to the main-window default (don't keep override sticky).
+    setComposerProjectId(currentProject?.id ?? null);
     setEditingComment(null);
     setIsFormOpen(false);
     await fetchTimeline();
@@ -404,6 +429,45 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
         />
       </div>
       
+      {/* Project scope picker — post-time only, does not affect the timeline list */}
+      {!editingComment && (
+        <div>
+          <div className="flex items-center gap-1 mb-1">
+            <Label htmlFor="composer-project">Post in project</Label>
+            {composerProjectId !== defaultComposerProjectId && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="w-3 h-3 text-amber-500 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="right" className="max-w-[220px]">
+                    You&apos;re posting under a different project than the main view. The timeline list is unaffected.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+          <Select
+            value={composerProjectId ?? '__global__'}
+            onValueChange={(val) => setComposerProjectId(val === '__global__' ? null : val)}
+          >
+            <SelectTrigger id="composer-project" className="mt-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__global__">Global (no project)</SelectItem>
+              {[...availableProjects]
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
       <div className="space-y-3">
         <div className="text-sm text-muted-foreground">
           Target specific teams or roles (optional). Leave empty for visibility to all project members.
@@ -535,7 +599,7 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
         )}
       </div>
     </form>
-  ), [formData, editingComment, loading, availableTeams, availableRoles, handleSubmit, resetForm]);
+  ), [formData, editingComment, loading, availableTeams, availableRoles, handleSubmit, resetForm, composerProjectId, defaultComposerProjectId, availableProjects]);
 
   const TimelineItem: React.FC<{ entry: TimelineEntry; canModify: boolean }> = ({ 
     entry, 

--- a/src/frontend/src/components/comments/comment-sidebar.tsx
+++ b/src/frontend/src/components/comments/comment-sidebar.tsx
@@ -29,7 +29,7 @@ import { RelativeDate } from '@/components/common/relative-date';
 import { Separator } from '@/components/ui/separator';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { PrincipalPicker } from '@/components/common/principal-picker';
-import { buildAudienceTokens, parseAudienceTokens } from '@/lib/audience';
+import { buildAudienceTokens, parseAudienceTokens, resolveRoleTokenLabel } from '@/lib/audience';
 // Select components removed - unused
 
 interface CommentFormData {
@@ -127,18 +127,21 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
     }
   }, [currentProject?.id, currentProject?.name, get]);
 
-  // Fetch available app roles
+  // Fetch available app roles from the same source that workflow designer uses
+  // (/api/workflows/roles returns {id, name, description, source, …}).
   const fetchRoles = useCallback(async () => {
-    console.debug('CommentSidebar: Fetching app roles');
-    const response = await get<AudienceRole[]>('/api/settings/roles/summary');
-    
+    console.debug('CommentSidebar: Fetching app roles from /api/workflows/roles');
+    const response = await get<AudienceRole[]>('/api/workflows/roles');
+
     if (response.error) {
       console.error('CommentSidebar: Failed to fetch roles:', response.error);
-      // Roles are less critical, just log the error
       setAvailableRoles([]);
     } else if (response.data) {
-      console.debug(`CommentSidebar: Loaded ${response.data.length} roles:`, response.data);
-      setAvailableRoles(response.data);
+      // Only show app-source roles in the audience picker (business roles are
+      // approver-scoped and not relevant for comment audience targeting).
+      const appRoles = response.data.filter((r) => !r.source || r.source === 'app');
+      console.debug(`CommentSidebar: Loaded ${appRoles.length} app roles`);
+      setAvailableRoles(appRoles);
     } else {
       console.warn('CommentSidebar: No role data returned');
       setAvailableRoles([]);
@@ -205,12 +208,15 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
       return;
     }
 
-    // Build audience array. ``team:`` / ``role:`` prefixes come from
-    // the checkbox lists; plain emails / group names come from the
-    // PrincipalPicker (Directory pick) and flow through unchanged.
+    // Build audience array. ``team:`` tokens come from the Teams
+    // checkbox list; ``role_id:<uuid>`` tokens come from the App Roles
+    // checkbox list (roles are stored by UUID — the canonical new
+    // format from issue #326); plain emails / group names come from the
+    // PrincipalPicker and flow through unchanged.
     const audienceTokens: string[] = buildAudienceTokens({
       teams: formData.selectedTeams,
-      roles: formData.selectedRoles,
+      roleIds: formData.selectedRoles, // selectedRoles holds UUIDs
+      legacyRoleNames: [],
       principals: formData.selectedPrincipals,
     });
 
@@ -314,17 +320,25 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
 
   const handleEdit = (comment: Comment) => {
     setEditingComment(comment);
-    
-    // Parse audience tokens. ``team:`` / ``role:`` go into the
-    // respective checkbox state; anything else is a Directory
-    // principal (plain email or group name) and rehydrates the
-    // PrincipalPicker.
-    const parsed = parseAudienceTokens(comment.audience);
+
+    // Build a name→id lookup from availableRoles so legacy ``role:<name>``
+    // tokens can be resolved to UUIDs and pre-select the right checkbox.
+    const rolesByName: Record<string, string> = {};
+    for (const r of availableRoles) {
+      if (r.name && r.id) rolesByName[r.name] = r.id;
+    }
+
+    // Parse audience tokens. ``team:`` go into selectedTeams; ``role_id:``
+    // and resolved ``role:<name>`` tokens go into selectedRoles (as UUIDs);
+    // unresolved legacy names stay in legacyRoleNames but are not surfaced
+    // in the picker (they are preserved at save time via buildAudienceTokens);
+    // everything else rehydrates the PrincipalPicker.
+    const parsed = parseAudienceTokens(comment.audience, rolesByName);
     setFormData({
       title: comment.title || '',
       comment: comment.comment,
       selectedTeams: parsed.teams,
-      selectedRoles: parsed.roles,
+      selectedRoles: parsed.roleIds,   // UUIDs for the checkbox list
       selectedPrincipals: parsed.principals,
     });
     setIsFormOpen(true);
@@ -431,32 +445,33 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
           </div>
         </div>
 
-        {/* Roles multi-select */}
+        {/* Roles multi-select — selection state tracks UUID (role.id) so that
+            the audience token is emitted as role_id:<uuid> on save. */}
         <div>
           <Label htmlFor="roles">App Roles</Label>
           <div className="mt-1 space-y-2">
             {availableRoles.map(role => (
-              <div key={role.name} className="flex items-center space-x-2">
+              <div key={role.id} className="flex items-center space-x-2">
                 <input
                   type="checkbox"
-                  id={`role-${role.name}`}
-                  checked={formData.selectedRoles.includes(role.name)}
+                  id={`role-${role.id}`}
+                  checked={formData.selectedRoles.includes(role.id)}
                   onChange={(e) => {
                     if (e.target.checked) {
-                      setFormData({ 
-                        ...formData, 
-                        selectedRoles: [...formData.selectedRoles, role.name] 
+                      setFormData({
+                        ...formData,
+                        selectedRoles: [...formData.selectedRoles, role.id],
                       });
                     } else {
-                      setFormData({ 
-                        ...formData, 
-                        selectedRoles: formData.selectedRoles.filter(name => name !== role.name) 
+                      setFormData({
+                        ...formData,
+                        selectedRoles: formData.selectedRoles.filter(id => id !== role.id),
                       });
                     }
                   }}
                   className="rounded"
                 />
-                <Label htmlFor={`role-${role.name}`} className="text-sm font-normal">
+                <Label htmlFor={`role-${role.id}`} className="text-sm font-normal">
                   {role.name}
                 </Label>
               </div>
@@ -496,11 +511,14 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
                 </Badge>
               ) : null;
             })}
-            {formData.selectedRoles.map(roleName => (
-              <Badge key={`role-${roleName}`} variant="outline" className="text-xs">
-                Role: {roleName}
-              </Badge>
-            ))}
+            {formData.selectedRoles.map(roleId => {
+              const role = availableRoles.find(r => r.id === roleId);
+              return (
+                <Badge key={`role-${roleId}`} variant="outline" className="text-xs">
+                  Role: {role?.name ?? roleId}
+                </Badge>
+              );
+            })}
           </div>
         )}
       </div>
@@ -621,34 +639,41 @@ const CommentSidebar: React.FC<CommentSidebarProps> = ({
 
         {entry.audience && entry.audience.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {entry.audience.map((token, idx) => {
-              // Parse audience tokens
-              if (token.startsWith('team:')) {
-                const teamId = token.substring(5);
-                const team = availableTeams.find(t => t.id === teamId);
-                return (
-                  <Badge key={`${token}-${idx}`} variant="secondary" className="text-xs">
-                    <Users className="w-3 h-3 mr-1" />
-                    Team: {team?.name || teamId}
-                  </Badge>
-                );
-              } else if (token.startsWith('role:')) {
-                const roleName = token.substring(5);
-                return (
-                  <Badge key={`${token}-${idx}`} variant="outline" className="text-xs">
-                    Role: {roleName}
-                  </Badge>
-                );
-              } else {
-                // Plain group token
+            {(() => {
+              // Build role lookup map once per render for O(1) badge resolution
+              const rolesById: Record<string, string> = {};
+              for (const r of availableRoles) {
+                if (r.id && r.name) rolesById[r.id] = r.name;
+              }
+              return entry.audience.map((token, idx) => {
+                if (token.startsWith('team:')) {
+                  const teamId = token.substring(5);
+                  const team = availableTeams.find(t => t.id === teamId);
+                  return (
+                    <Badge key={`${token}-${idx}`} variant="secondary" className="text-xs">
+                      <Users className="w-3 h-3 mr-1" />
+                      Team: {team?.name || teamId}
+                    </Badge>
+                  );
+                }
+                // Both role_id:<uuid> (new) and role:<name> (legacy) tokens
+                const roleLabel = resolveRoleTokenLabel(token, rolesById);
+                if (roleLabel !== null) {
+                  return (
+                    <Badge key={`${token}-${idx}`} variant="outline" className="text-xs">
+                      Role: {roleLabel}
+                    </Badge>
+                  );
+                }
+                // Plain principal (email, group name, or user: token)
                 return (
                   <Badge key={`${token}-${idx}`} variant="outline" className="text-xs">
                     <Users className="w-3 h-3 mr-1" />
                     {token}
                   </Badge>
                 );
-              }
-            })}
+              });
+            })()}
           </div>
         )}
 

--- a/src/frontend/src/lib/audience.test.ts
+++ b/src/frontend/src/lib/audience.test.ts
@@ -1,31 +1,47 @@
 /**
  * Tests for the audience-token round-trip used by the comment
- * composer. These cover the Phase-2 acceptance criterion:
- * "an audience containing a mix of users, groups, teams (team:*), and
- *  roles (role:*) round-trips correctly".
+ * composer. Covers:
+ *  - the original Phase-2 acceptance criterion: "an audience containing
+ *    a mix of users, groups, teams (team:*), and roles (role:*) round-trips
+ *    correctly"
+ *  - the issue #326 acceptance criterion: new tokens are emitted as
+ *    `role_id:<uuid>`; legacy `role:<name>` tokens still parse and
+ *    round-trip unchanged when no name→uuid lookup resolves them.
  */
 
 import { describe, expect, it } from 'vitest';
 
-import { buildAudienceTokens, parseAudienceTokens } from './audience';
+import { buildAudienceTokens, parseAudienceTokens, resolveRoleTokenLabel } from './audience';
 
 describe('parseAudienceTokens', () => {
-  it('splits team:, role:, and bare principal tokens', () => {
+  it('splits team:, role_id:, legacy role:, and bare principal tokens', () => {
     const parsed = parseAudienceTokens([
       'team:t-1',
-      'role:Admin',
+      'role_id:11111111-2222-3333-4444-555555555555',
+      'role:Admin', // legacy, no rolesByName provided → falls into legacyRoleNames
       'alice@x.com',
       'Data Producers',
     ]);
     expect(parsed.teams).toEqual(['t-1']);
-    expect(parsed.roles).toEqual(['Admin']);
+    expect(parsed.roleIds).toEqual(['11111111-2222-3333-4444-555555555555']);
+    expect(parsed.legacyRoleNames).toEqual(['Admin']);
     expect(parsed.principals).toEqual(['alice@x.com', 'Data Producers']);
   });
 
+  it('upgrades legacy role:<name> tokens to roleIds when rolesByName resolves them', () => {
+    const parsed = parseAudienceTokens(
+      ['role:Admin', 'role:Unknown'],
+      { Admin: 'admin-uuid' },
+    );
+    expect(parsed.roleIds).toEqual(['admin-uuid']);
+    expect(parsed.legacyRoleNames).toEqual(['Unknown']);
+  });
+
   it('returns empty arrays for null / undefined / empty input', () => {
-    expect(parseAudienceTokens(null)).toEqual({ teams: [], roles: [], principals: [] });
-    expect(parseAudienceTokens(undefined)).toEqual({ teams: [], roles: [], principals: [] });
-    expect(parseAudienceTokens([])).toEqual({ teams: [], roles: [], principals: [] });
+    const empty = { teams: [], roleIds: [], legacyRoleNames: [], principals: [] };
+    expect(parseAudienceTokens(null)).toEqual(empty);
+    expect(parseAudienceTokens(undefined)).toEqual(empty);
+    expect(parseAudienceTokens([])).toEqual(empty);
   });
 
   it('skips non-string and empty tokens', () => {
@@ -41,39 +57,71 @@ describe('parseAudienceTokens', () => {
   });
 
   it('treats prefix-only tokens as the empty id behind the prefix', () => {
-    const parsed = parseAudienceTokens(['team:', 'role:']);
-    // Empty ids are preserved -- the caller decides whether to filter.
+    const parsed = parseAudienceTokens(['team:', 'role_id:', 'role:']);
+    // Empty ids are preserved — the caller decides whether to filter.
     expect(parsed.teams).toEqual(['']);
-    expect(parsed.roles).toEqual(['']);
+    expect(parsed.roleIds).toEqual(['']);
+    expect(parsed.legacyRoleNames).toEqual(['']);
     expect(parsed.principals).toEqual([]);
   });
 });
 
 describe('buildAudienceTokens', () => {
-  it('emits team: / role: prefixes for checkbox selections, principals bare', () => {
+  it('emits team:, role_id: (canonical), legacy role: (preserved), and bare principals', () => {
     const tokens = buildAudienceTokens({
       teams: ['t-1', 't-2'],
-      roles: ['Admin'],
+      roleIds: ['admin-uuid'],
+      legacyRoleNames: ['LegacyName'],
       principals: ['alice@x.com', 'Data Producers'],
     });
     expect(tokens).toEqual([
       'team:t-1',
       'team:t-2',
-      'role:Admin',
+      'role_id:admin-uuid',
+      'role:LegacyName',
       'alice@x.com',
       'Data Producers',
     ]);
   });
 
-  it('round-trips a mixed audience without loss', () => {
+  it('round-trips a mixed audience without loss (no legacy)', () => {
     const original = [
       'team:t-7',
-      'role:Reviewer',
+      'role_id:reviewer-uuid',
       'bob@x.com',
       'Engineering',
     ];
     const parsed = parseAudienceTokens(original);
     const rebuilt = buildAudienceTokens(parsed);
     expect(rebuilt).toEqual(original);
+  });
+
+  it('preserves legacy role:<name> tokens unchanged on round-trip (no rolesByName)', () => {
+    const original = ['role:Admin', 'role:DataSteward', 'alice@x.com'];
+    const parsed = parseAudienceTokens(original);
+    const rebuilt = buildAudienceTokens(parsed);
+    expect(rebuilt).toEqual(original);
+  });
+});
+
+describe('resolveRoleTokenLabel', () => {
+  const rolesById = { 'admin-uuid': 'Admin', 'steward-uuid': 'Data Steward' };
+
+  it('resolves role_id:<uuid> tokens via the lookup map', () => {
+    expect(resolveRoleTokenLabel('role_id:admin-uuid', rolesById)).toBe('Admin');
+  });
+
+  it('falls back to a truncated label when the uuid is unknown', () => {
+    const label = resolveRoleTokenLabel('role_id:deadbeef-1234-5678-9abc-defabcdef012', rolesById);
+    expect(label).toBe('Role (deadbeef…)');
+  });
+
+  it('returns the bare name for legacy role:<name> tokens', () => {
+    expect(resolveRoleTokenLabel('role:LegacyAdmin', rolesById)).toBe('LegacyAdmin');
+  });
+
+  it('returns null for non-role tokens', () => {
+    expect(resolveRoleTokenLabel('team:t-1', rolesById)).toBeNull();
+    expect(resolveRoleTokenLabel('alice@x.com', rolesById)).toBeNull();
   });
 });

--- a/src/frontend/src/lib/audience.ts
+++ b/src/frontend/src/lib/audience.ts
@@ -2,38 +2,74 @@
  * Audience token helpers for the comment composer.
  *
  * Audience tokens flow on the wire as a single ``string[]`` mixing
- * three shapes:
+ * four shapes:
  *
  * - ``team:<team-id>`` — selected from the Teams checkbox list.
- * - ``role:<role-name>`` — selected from the App Roles checkbox list.
+ * - ``role_id:<uuid>`` — NEW canonical format (issue #326). Role selected
+ *   via the App Roles checkbox list in the composer; persisted on save.
+ * - ``role:<role-name>`` — LEGACY format still present in existing rows.
+ *   Parsed on read and hydrated back into the role picker by resolving
+ *   the name against the available roles list. Not emitted by the
+ *   composer on save (round-trip identity is preserved on edit — legacy
+ *   tokens are only rewritten when the user explicitly changes the
+ *   audience selection).
  * - anything else — a Directory principal (plain user email/UPN or
  *   plain group display name) picked via the PrincipalPicker.
  *
  * These helpers keep the round-trip (compose -> store -> edit) honest
- * across the three shapes and are pure functions so they can be unit
+ * across the four shapes and are pure functions so they can be unit
  * tested without rendering Radix UI.
  */
 
 export interface ParsedAudience {
   teams: string[];
-  roles: string[];
+  /**
+   * Role UUIDs (from ``role_id:<uuid>`` tokens) or legacy role names
+   * (from ``role:<name>`` tokens). The caller must distinguish using
+   * ``legacyRoleNames`` if it needs to resolve names to IDs.
+   */
+  roleIds: string[];
+  /** Legacy ``role:<name>`` tokens that could not be resolved to a UUID. */
+  legacyRoleNames: string[];
   principals: string[];
 }
 
 const TEAM_PREFIX = 'team:';
-const ROLE_PREFIX = 'role:';
+const ROLE_ID_PREFIX = 'role_id:';
+const LEGACY_ROLE_PREFIX = 'role:';
 
+/**
+ * Parse a raw audience token array into its four constituent parts.
+ *
+ * @param audience - raw audience token list from the API
+ * @param rolesByName - optional lookup map from role name → UUID, used to
+ *   upgrade ``role:<name>`` tokens to ``roleIds`` when the name resolves.
+ */
 export function parseAudienceTokens(
   audience: string[] | null | undefined,
+  rolesByName?: Record<string, string>,
 ): ParsedAudience {
-  const out: ParsedAudience = { teams: [], roles: [], principals: [] };
+  const out: ParsedAudience = {
+    teams: [],
+    roleIds: [],
+    legacyRoleNames: [],
+    principals: [],
+  };
   if (!audience) return out;
   for (const token of audience) {
     if (typeof token !== 'string' || token.length === 0) continue;
     if (token.startsWith(TEAM_PREFIX)) {
       out.teams.push(token.slice(TEAM_PREFIX.length));
-    } else if (token.startsWith(ROLE_PREFIX)) {
-      out.roles.push(token.slice(ROLE_PREFIX.length));
+    } else if (token.startsWith(ROLE_ID_PREFIX)) {
+      out.roleIds.push(token.slice(ROLE_ID_PREFIX.length));
+    } else if (token.startsWith(LEGACY_ROLE_PREFIX)) {
+      const name = token.slice(LEGACY_ROLE_PREFIX.length);
+      const resolvedId = rolesByName?.[name];
+      if (resolvedId) {
+        out.roleIds.push(resolvedId);
+      } else {
+        out.legacyRoleNames.push(name);
+      }
     } else {
       out.principals.push(token);
     }
@@ -41,10 +77,41 @@ export function parseAudienceTokens(
   return out;
 }
 
+/**
+ * Build a token array from the parsed audience parts.
+ *
+ * Roles are always emitted as ``role_id:<uuid>`` — the canonical format.
+ * Legacy role names are passed through unchanged to preserve round-trip
+ * identity for rows that were not re-saved by the user.
+ */
 export function buildAudienceTokens(parsed: ParsedAudience): string[] {
   return [
     ...parsed.teams.map((t) => `${TEAM_PREFIX}${t}`),
-    ...parsed.roles.map((r) => `${ROLE_PREFIX}${r}`),
+    ...parsed.roleIds.map((id) => `${ROLE_ID_PREFIX}${id}`),
+    // Preserve legacy tokens that could not be resolved to a UUID
+    ...parsed.legacyRoleNames.map((n) => `${LEGACY_ROLE_PREFIX}${n}`),
     ...parsed.principals,
   ];
+}
+
+/**
+ * Resolve a ``role_id:<uuid>`` or ``role:<name>`` token to a human-readable
+ * display name.
+ *
+ * @param token - raw audience token string
+ * @param rolesById - map from role UUID → display name
+ * @returns display name, or ``null`` if the token is not a role token
+ */
+export function resolveRoleTokenLabel(
+  token: string,
+  rolesById: Record<string, string>,
+): string | null {
+  if (token.startsWith(ROLE_ID_PREFIX)) {
+    const uuid = token.slice(ROLE_ID_PREFIX.length);
+    return rolesById[uuid] ?? `Role (${uuid.slice(0, 8)}…)`;
+  }
+  if (token.startsWith(LEGACY_ROLE_PREFIX)) {
+    return token.slice(LEGACY_ROLE_PREFIX.length);
+  }
+  return null;
 }

--- a/src/frontend/src/types/comments.ts
+++ b/src/frontend/src/types/comments.ts
@@ -71,8 +71,16 @@ export interface AudienceTeam {
   name: string;
 }
 
+/**
+ * App role as returned by /api/workflows/roles.
+ * ``id`` is the UUID string used for ``role_id:<uuid>`` audience tokens.
+ * ``source`` distinguishes "app" (RBAC) from "business" roles.
+ */
 export interface AudienceRole {
+  id: string;
   name: string;
+  description?: string | null;
+  source?: 'app' | 'business' | string;
 }
 
 // Rating-related types


### PR DESCRIPTION
## Summary

Phase 1 of the open-comments-issue follow-up. Two pieces of comment-composer work that both touch the comment composer + role/audience flow, bundled together for review:

### 1. Comment role-audience parity with workflows — closes #326

Brings the comment audience role-matching to parity with how the Workflows feature resolves roles. Today comments match audience tokens against the *team override* path; this PR switches the resolution to the **group-membership-derived effective roles + role override** logic that `AuthorizationManager.get_user_effective_permissions` already uses for workflows.

- **List endpoint**: matches comments tagged with `role_id:<uuid>` against the viewer's group-derived effective roles + any active role override. Legacy `role:<name>` tokens still match (resolved via `get_app_role_by_name` against the same role set).
- **Create / update**: persists new role audience tokens as `role_id:<uuid>` (UUID-stable). Legacy `role:<name>` tokens are never rewritten on edit — round-trip identity preserved.
- **Frontend picker source**: switched from `/api/settings/roles/summary` to `/api/workflows/roles` (filtered to `source === 'app'` — business roles intentionally excluded from comment audiences for parity with the workflow approver picker).
- **Sidebar + timeline hydration**: picker hydrates from both `role_id:<uuid>` and legacy `role:<name>` tokens losslessly; timeline rendering uses a `resolveRoleTokenLabel` helper that falls back gracefully for unknown legacy tokens.

No migrations — the audience JSON column is unchanged; only the token format inside it.

### 2. Post-time project picker in the comment composer — follow-up to #326

Adds a "Post in project" `Select` dropdown to the composer above the audience section. Lets the user explicitly choose which project a new comment belongs to instead of inheriting the main-window's `currentProject` silently.

- **Default**: the main-window's `currentProject?.id` if set, else "Global" (`project_id=null`).
- **Override visual**: when the picker value diverges from the main-window context, an amber `Info` icon appears with a tooltip ("You're posting under a different project than the main view. The timeline list is unaffected.").
- **Reset after submit**: the picker resets to the main-window default after a successful post so the override doesn't accidentally stick across multiple comments.
- **Edit path**: hidden during edits (the backend PUT endpoint doesn't accept `project_id` changes).
- **Timeline list scope unchanged** — this is post-time only. The list still follows the main-window context, consistent with the rest of the app.

No new fetch hooks added — `availableProjects` was already loaded in the Zustand store by `ProjectChooser` on mount.

## Files changed

**Backend:**
- `src/backend/src/controller/authorization_manager.py` — `get_user_effective_role_ids()` (mirrors existing permission logic, returns `Set[str]` of role UUIDs)
- `src/backend/src/controller/comments_manager.py` — `list_comments` threads `applied_role_override_id`; `_resolve_viewer_role_ids` delegates to auth manager; supplemental Python loop matches legacy `role:<name>` tokens
- `src/backend/src/repositories/comments_repository.py` — `list_for_entity` accepts `user_role_ids: Optional[Set[str]]`; SQL `contains('"role_id:<uuid>"')` clauses
- `src/backend/src/routes/comments_routes.py` — list / timeline endpoints fetch `applied_role_override_id` from SettingsManager and thread it through
- `src/backend/src/common/manager_dependencies.py` — `get_comments_manager` injects `settings_manager` + `authorization_manager` from `app.state`

**Frontend:**
- `src/frontend/src/components/comments/comment-sidebar.tsx` — picker source swap, project picker, role audience token round-trip
- `src/frontend/src/lib/audience.ts` — full rewrite: `parseAudienceTokens` handles `role_id:` + legacy `role:` tokens; `buildAudienceTokens` emits `role_id:<uuid>`; new `resolveRoleTokenLabel` helper
- `src/frontend/src/types/comments.ts` — `AudienceRole.id` made required; `description` + `source` added

**Tests:**
- `src/backend/src/tests/unit/test_authorization_manager.py` — `TestGetUserEffectiveRoleIds` (8 tests)
- `src/backend/src/tests/unit/test_comments_manager.py` — `TestRoleAudienceParity` (9 tests, includes legacy-token-still-matches)

## Test plan

- [x] 17 new backend tests pass
- [x] Frontend type-check clean on touched files
- [x] E2E on a Databricks Apps workspace — verified the picker source is `/api/workflows/roles` (only `source === 'app'` roles); new comments persist as `role_id:<uuid>` tokens; legacy `role:<name>` token still matches in the list endpoint for the same viewer's effective roles
- [x] Project picker E2E — defaults to the main-window project, override badge appears when changed, resets after submit, hidden during edit
- [x] No customer names / internal identifiers in code or commit messages

## Notes for review

- Two logical commits (parity + project picker follow-up).
- Pre-existing `TestCommentsManager` tests remain quarantined (`collect_ignore`) — pre-existing bit-rot, not introduced by this PR. The new `TestRoleAudienceParity` class in the same file runs cleanly in isolation.
- Backend PUT endpoint for comments doesn't accept `project_id` updates today — the project picker is intentionally hidden during edits.