### PR TITLE
feat: consolidate Team and Ownership model

### DIFF
--- a/docs/prds/prd-consolidate-team-and-ownership.md
+++ b/docs/prds/prd-consolidate-team-and-ownership.md
@@ -1,0 +1,184 @@
+# PRD: Consolidate Team and Ownership Model
+
+## Concept Model
+
+Four governance primitives are involved in this consolidation. Disambiguating them is a prerequisite for the UI cleanup:
+
+- **Principals** — users or groups, backed by manual entries or the Directory feature. The atomic identity unit referenced by all other constructs.
+- **Projects** — group work into distinct units; define visibility/accessibility of entities by principals. Optional — entities without a project default to visible to all principals.
+- **Teams** — a set of principals with optional role overrides (e.g., a Data Engineer working as a Data Steward for objects assigned to that team). Teams are optional — entities without a team can only be modified by the owner and admins directly. Teams can also be populated from the original ODCS/ODPS record during import.
+- **Owners** — a polymorphic list of principals with a business role assigned to an entity. Owners can be assigned manually by the owner/admin, copied (even partially) from the Team to the entity, or imported from the original ODCS/ODPS owners/team information.
+
+These are distinct from the ODCS/ODPS "team" section in a contract/product YAML, which is an imported metadata array of contacts — not the Ontos Team governance entity.
+
+## Problem Statement
+
+Data Products and Data Contracts currently surface "who is responsible" through three independent, uncoordinated mechanisms:
+
+1. **Contacts** (sidebar card) — filters the ODCS/ODPS `team.members` for owner-type roles and displays them as quick-reference contacts.
+2. **ODCS/ODPS Team** section (main content) — the imported `team.members` array, editable, with roles like "owner", "data steward", "contributor".
+3. **Ownership Panel** (main content) — reads from the polymorphic `business_owners` table, supports role assignment, lifecycle tracking (assigned_at, removed_at, history), and works across all entity types.
+
+Additionally, the metadata grid labels the assigned **Ontos Team** as "Owner:" — which conflicts with the Ownership Panel that tracks actual business owners. The tooltip says "Team ID: ..." and the link navigates to `/teams/:id`, yet the label says "Owner", creating confusion.
+
+These surfaces are fully decoupled: you can have Alice in the ODCS/ODPS Team section but Carol/Frank/Eva as Business Owners, while the "Owner:" label in the header points to a completely different Ontos Team entity. Users must mentally reconcile three separate concepts.
+
+When exporting to ODCS/ODPS YAML, only the imported Team section is written — any ownership changes made via the Ownership Panel are lost.
+
+## Solution
+
+Make **Business Owners** (the `business_owners` table) the single authoritative source for "who is responsible for this entity." The ODCS/ODPS Team data is preserved as read-only import provenance. A unified "People & Ownership" card replaces the separate Team and Ownership Panel sections. On YAML export, active Business Owners are merged into the Team section for standards compliance.
+
+The sidebar Contacts card switches to pulling from Business Owners instead of Team members, ensuring consistency between the quick-reference and the detailed view.
+
+## User Stories
+
+### Label and layout clarity
+
+1. As a Data Steward, I want the metadata grid to label the assigned Ontos Team as "Team" (not "Owner"), so that I do not confuse the team assignment with individual business owners.
+2. As a Data Steward, I want to see the Project and Team assignments together in the metadata grid, so that I understand the governance context (who manages it + what scope it belongs to) at a glance.
+
+### Ownership consolidation
+
+3. As a Data Producer, I want a single, unambiguous list of who owns and manages my Data Product, so that I do not need to reconcile two separate panels (ODCS/ODPS Team vs Owners).
+4. As a Data Consumer, I want the sidebar Contacts to always reflect the current authoritative owners, so that I know who to reach out to without checking multiple sections.
+5. As a Data Steward, I want to assign owners with lifecycle tracking (assigned date, removal date, removal reason, history), so that I have a full audit trail of ownership changes over time.
+6. As a Data Steward, I want to see who was imported from an ODCS/ODPS YAML Team section, so that I retain provenance of the original contract/product metadata.
+7. As a Data Steward, I want a one-click "Import as Owners" action that converts imported ODCS/ODPS Team members into Business Owner records, so that I do not have to re-enter the same people manually.
+8. As a Data Steward, I want to copy selected Ontos Team members to the Owners panel, so that I can bootstrap ownership from the assigned team without re-entering each person.
+9. As a Data Producer, I want the YAML export to include my current Business Owners merged into the Team section, so that downstream consumers of the YAML see up-to-date ownership without manual synchronization.
+10. As a Data Producer, I want ODCS/ODPS Team members from the original YAML who are NOT current Business Owners to still appear in the exported Team section, so that contributor-level team members are not lost.
+11. As a Data Steward importing an existing ODCS contract YAML, I want the Team section to be stored verbatim as read-only provenance, so that round-trip fidelity is preserved.
+12. As a Data Producer, I want to see the imported ODCS/ODPS Team data collapsed by default with a member count, so that it does not clutter the interface when I primarily work with the Owners section.
+13. As an Admin, I want ownership roles (Data Owner, Technical Owner, Business Sponsor, etc.) to be consistent across Data Products, Data Contracts, and all other entity types, so that reporting on ownership is uniform.
+14. As a Data Consumer viewing the sidebar, I want to see owner-role contacts (Data Owner, Technical Owner, Business Sponsor) pulled from Business Owners, so that I always see the authoritative responsible parties.
+15. As a Data Consumer, I want a fallback to ODCS/ODPS Team members if no Business Owners exist yet (e.g., freshly imported contract), so that Contacts is never empty when people are known.
+16. As a Data Steward, I want the "Import as Owners" flow to suggest role mappings (e.g., ODCS role "owner" maps to Business Role "Data Owner"), so that I can review and confirm before committing.
+17. As a Data Producer, I want to still be able to view and expand the original imported ODCS/ODPS Team data, so that I can reference who was originally specified in the external YAML.
+18. As an Admin, I want the ODCS/ODPS Team section to become read-only after consolidation, so that there is no ambiguity about which list to edit.
+
+## Implementation Decisions
+
+### Label cleanup
+
+**Rename "Owner:" to "Team:" in the metadata grid:**
+- The metadata grid currently displays `owner_team_name` under the label "Owner:" — this is misleading because it refers to the Ontos Team entity, not a business owner person.
+- Change the label to "Team:" on both Data Contract and Data Product detail pages.
+- Both already navigate to `/teams/:id` and show tooltip "Team ID: ..." — only the label text needs updating.
+
+**Group Project and Team together in the metadata grid:**
+- Currently Project and Team (labeled "Owner:") are separated by other fields (Domain, Tenant, etc.).
+- Move them adjacent to each other so the governance context (Team + Project) is visible as a pair.
+- Suggested order in the metadata grid row: Domain, Team, Project (or Team and Project on the same line).
+
+### Source of truth
+
+- `business_owners` table (polymorphic, with `object_type` + `object_id`) is the single authoritative source for ownership across all entity types.
+- The ODCS/ODPS Team (`data_contract_team` table / `product.team.members` JSON) is preserved as-is but becomes read-only in the UI. It serves as import provenance.
+- The Ontos Team entity (`teams` table, referenced via `owner_team_id`) remains the governance team assignment — it controls access/permissions and provides a pool of principals that can be copied to the Owners panel.
+
+### Unified "People & Ownership" card
+
+- Replaces the separate ODCS/ODPS Team section and OwnershipPanel with a single card.
+- Top section: "Owners" — the current OwnershipPanel functionality (assign, remove, history toggle). Owners can be assigned manually, copied from the Ontos Team, or imported from the ODCS/ODPS data.
+- Bottom section: "Imported Contacts (from ODCS/ODPS)" — read-only, collapsed by default showing member count. Expandable to see all original ODCS/ODPS Team members with their roles. This preserves provenance of imported YAML data.
+- "Import as Owners" button in the Imported Contacts section: creates Business Owner records from ODCS/ODPS Team members with a role-mapping confirmation dialog.
+- "Copy from Team" action in the Owners section: allows copying selected members from the assigned Ontos Team into the Owners panel with role selection.
+
+### Sidebar Contacts changes
+
+- Pulls from `business_owners` (active records with owner-type role IDs) instead of `team.members`.
+- Fallback chain: (1) active Business Owners, (2) ODCS/ODPS `team.members` filtered by owner-type roles, (3) Ontos Team name as last resort. This ensures Contacts is never empty when people are known, regardless of migration status.
+
+### YAML export merge strategy
+
+- Start with original `team.members` as base.
+- For each active Business Owner: check if a matching Team member exists (by email/username). If yes, update the role. If no, add as new Team member.
+- Team members not present in Business Owners are preserved (they may be contributors).
+- Mapping from BusinessRole name to ODCS/ODPS role string is maintained in a configuration map.
+
+### Import behavior
+
+- On YAML import, ODCS/ODPS Team data is stored verbatim (no change from today).
+- No automatic creation of Business Owner records. The user is shown the Imported Contacts section with an "Import as Owners" button.
+- The role-mapping dialog shows a table: ODCS/ODPS member username/name, their role, suggested Business Role, with ability to override or skip individual members.
+- Separately, when an Ontos Team is assigned to the entity, the user can "Copy from Team" to create Owner records from Team members — this is a distinct action from importing ODCS/ODPS contacts.
+
+### ODCS/ODPS Team editability
+
+- The ODCS/ODPS Team section (now labeled "Imported Contacts") becomes read-only in the UI after this change.
+- The "Add Member" and edit/delete buttons are removed from this section.
+- All people-management goes through the Owners section (Assign Owner / Remove Owner / Copy from Team).
+- The underlying `data_contract_team` / `product.team` data is still writable via API for programmatic use (e.g., YAML import), but the UI does not expose editing.
+
+### Terminology disambiguation
+
+To avoid confusion between the Ontos Team entity and the ODCS/ODPS team metadata:
+- The metadata grid field is labeled **"Team:"** (links to the Ontos Team entity page)
+- The collapsed provenance section is labeled **"Imported Contacts (from ODCS/ODPS)"** (not "Team")
+- The "Import from Team" button (which copies Ontos Team members into ODCS/ODPS data) is renamed or removed — its functionality is superseded by "Copy from Team" which creates Owners directly
+- API and code comments distinguish: `owner_team_id` (Ontos Team FK), `data_contract_team` (ODCS imported contacts), `business_owners` (authoritative owners)
+
+### Scope
+
+- Applies to Data Products and Data Contracts initially (the two entity types that have both Team and Owners today).
+- Other entity types (glossaries, datasets, etc.) already only have OwnershipPanel — no change needed for them.
+
+### Backend endpoints
+
+- New endpoint: `POST /api/business-owners/import-from-team` — accepts `object_type`, `object_id`, and a list of `{username, suggested_role_id}` mappings. Creates Business Owner records in bulk. Works for both ODCS/ODPS team imports and Ontos Team member copies.
+- Existing YAML export endpoints gain merge logic: when serializing Team for YAML output, merge active Business Owners into the team array.
+
+## Testing Decisions
+
+### What makes a good test
+
+Tests verify externally observable behavior through public interfaces. They should not test wiring between components but rather the end-to-end effect of a user action (e.g., "after importing team as owners, the GET owners endpoint returns the imported members with correct roles").
+
+### Modules to test
+
+- **Import-from-team endpoint**: POST with valid/invalid mappings, duplicate detection, role resolution.
+- **YAML export merge logic**: various scenarios (no owners, owners matching team, owners not in team, team members not in owners).
+- **Sidebar contacts API behavior**: returns Business Owners when they exist, falls back to Team members when they don't.
+- **OwnershipPanel component**: renders owners section, renders collapsed imported team, expand/collapse behavior, import dialog interaction.
+
+### Prior art
+
+- `test_business_owners_routes.py` — existing Business Owners endpoint tests.
+- `test_data_contracts_routes.py` — contract CRUD and team member tests.
+- Ownership panel component tests (if they exist).
+
+## Out of Scope
+
+- **Deleting the ODCS/ODPS Team data model or tables.** The `data_contract_team` table and `product.team` JSON field remain for backward compatibility and YAML round-trip fidelity.
+- **Changing the Ontos Team or Project entities.** Teams and Projects are unaffected structurally — only the UI label ("Owner:" → "Team:") and layout (grouping with Project) change.
+- **Automatic bidirectional sync.** Changes to Owners do NOT auto-update the stored ODCS/ODPS Team data (only export merges them). Changes to ODCS/ODPS Team (via API/import) do NOT auto-create Owners.
+- **Migration of existing data.** Existing ODCS/ODPS Team members are not automatically converted to Business Owners. Users migrate on their own schedule via the "Import as Owners" button.
+- **Owner-type role taxonomy changes.** The existing Business Roles (Data Owner, Technical Owner, Business Sponsor) are used as-is. Adding new roles is a separate concern.
+- **Other entity types beyond Data Products and Data Contracts.** Glossaries, datasets, etc., already only use OwnershipPanel.
+- **Removing the `owner_team_id` / `owner_team_name` field.** This stays as the Team assignment (now labeled "Team:" instead of "Owner:").
+
+## Further Notes
+
+### Relationship to existing features
+
+- **OwnershipPanel** (`src/frontend/src/components/common/ownership-panel.tsx`): Extended with an optional "Imported Contacts" sub-section and "Copy from Team" action rather than replaced.
+- **Business Owners API** (`/api/business-owners/`): Gains a new bulk-import endpoint.
+- **Data Contract YAML export** (`data_contracts_manager.py`): Export logic enhanced with merge step.
+- **Data Product YAML export** (if applicable): Same merge logic.
+- **Ontos Teams** (`/api/teams`): Unchanged structurally. The only change is the UI label from "Owner:" to "Team:" in the metadata grid.
+- **Projects** (`/api/projects`): Unchanged structurally. Only the layout position in the metadata grid changes (moved adjacent to Team).
+
+### Migration path
+
+- The UI change is non-breaking: existing ODCS/ODPS Team data remains visible (just read-only and collapsed under "Imported Contacts").
+- Users see a clear prompt to "Import as Owners" when viewing entities with imported contacts but no Business Owners.
+- No forced migration — entities can remain in the "imported contacts only" state indefinitely, with Contacts falling back to ODCS/ODPS team members.
+- The "Owner:" → "Team:" label rename is purely cosmetic and requires no data migration.
+
+### Resolved decisions
+
+- **No banner/toast for "Import as Owners"** — the action remains manual via the collapsible section. Users discover it organically.
+- **No bulk migration tool** — migration happens per-entity at the user's pace.
+- **Yes — sidebar fallback indicator** — when the Contacts card shows imported ODPS/ODCS team members (tier 2) or team-name-only (tier 3), a subtle muted description appears below the title (e.g., "From imported data" / "Team assignment only") so users know these are provisional, not confirmed business owners.
+- **Remove old "Import from Team" button** — the button that copied Ontos Team members into the ODCS/ODPS team array is removed since that section is now read-only. The "Copy from Team" action in the Owners panel (which creates Business Owner records) remains as the correct flow for assigning team principals as owners.

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -840,6 +840,50 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             "skipped": skipped,
         }
 
+    # Role mapping from Business Role names to ODCS/ODPS team role strings
+    BUSINESS_ROLE_TO_TEAM_ROLE = {
+        "data owner": "owner",
+        "technical owner": "technical steward",
+        "business sponsor": "business steward",
+    }
+
+    def _merge_business_owners_into_team(
+        self, members_list: list, db_session, object_type: str, object_id: str
+    ) -> list:
+        """Merge active Business Owners into the team members list for YAML export.
+        Deduplicates by (username/email, role). Owners take precedence over existing members."""
+        from src.repositories.business_owners_repository import business_owner_repo
+
+        try:
+            active_owners = business_owner_repo.get_for_object(
+                db_session, object_type=object_type, object_id=object_id, active_only=True
+            )
+        except Exception:
+            return members_list
+
+        if not active_owners:
+            return members_list
+
+        existing_keys = {
+            (m.get('username', '').lower(), m.get('role', '').lower())
+            for m in members_list
+        }
+
+        for owner in active_owners:
+            role_name = owner.role.name if owner.role else 'owner'
+            team_role = self.BUSINESS_ROLE_TO_TEAM_ROLE.get(role_name.lower(), role_name.lower())
+            username = owner.user_email
+            key = (username.lower(), team_role.lower())
+
+            if key not in existing_keys:
+                member_dict = {'role': team_role, 'username': username}
+                if owner.user_name:
+                    member_dict['name'] = owner.user_name
+                members_list.append(member_dict)
+                existing_keys.add(key)
+
+        return members_list
+
     def build_odcs_from_db(self, db_obj: DataContractDb, db_session=None) -> Dict[str, Any]:
         odcs: Dict[str, Any] = {
             'id': db_obj.id,
@@ -1325,8 +1369,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             odcs['schema'] = schema
             
         # Build team (version-aware: Team object for v3.1.0+, plain array for v3.0.x)
+        # Merge active Business Owners into the exported team array for YAML fidelity
+        members_list = []
         if hasattr(db_obj, 'team') and db_obj.team:
-            members_list = []
             for member in db_obj.team:
                 member_dict = {
                     'role': member.role,
@@ -1346,6 +1391,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     member_dict['description'] = member.description
                 members_list.append(member_dict)
 
+        if db_session:
+            members_list = self._merge_business_owners_into_team(
+                members_list, db_session, 'data_contract', str(db_obj.id)
+            )
+
+        if members_list:
             api_version = db_obj.api_version or 'v3.1.0'
             tm = getattr(db_obj, 'team_metadata', None)
             if api_version >= 'v3.1.0' and tm:

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2874,6 +2874,50 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             "datasets": datasets_out,
         }
 
+    # Role mapping from Business Role names to ODPS team role strings
+    BUSINESS_ROLE_TO_TEAM_ROLE = {
+        "data owner": "owner",
+        "technical owner": "technical steward",
+        "business sponsor": "business steward",
+    }
+
+    def _merge_business_owners_into_team(
+        self, members_list: list, db_session, object_type: str, object_id: str
+    ) -> list:
+        """Merge active Business Owners into the team members list for YAML export.
+        Deduplicates by (username/email, role). Owners take precedence over existing members."""
+        from src.repositories.business_owners_repository import business_owner_repo
+
+        try:
+            active_owners = business_owner_repo.get_for_object(
+                db_session, object_type=object_type, object_id=object_id, active_only=True
+            )
+        except Exception:
+            return members_list
+
+        if not active_owners:
+            return members_list
+
+        existing_keys = {
+            (m.get('username', '').lower(), m.get('role', '').lower())
+            for m in members_list
+        }
+
+        for owner in active_owners:
+            role_name = owner.role.name if owner.role else 'owner'
+            team_role = self.BUSINESS_ROLE_TO_TEAM_ROLE.get(role_name.lower(), role_name.lower())
+            username = owner.user_email
+            key = (username.lower(), team_role.lower())
+
+            if key not in existing_keys:
+                member_dict = {'role': team_role, 'username': username}
+                if owner.user_name:
+                    member_dict['name'] = owner.user_name
+                members_list.append(member_dict)
+                existing_keys.add(key)
+
+        return members_list
+
     def build_odps_export(
         self,
         product_id: str,
@@ -2944,16 +2988,24 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 for s in product.support_channels
             ]
 
+        # Build team members from ODPS data, then merge active Business Owners
+        team_members = []
         if product.team and product.team.members:
-            odps["team"] = {
-                "name": product.team.name,
-                "members": [
-                    {k: v for k, v in {
-                        "username": m.username, "role": m.role,
-                    }.items() if v}
-                    for m in product.team.members
-                ],
-            }
+            team_members = [
+                {k: v for k, v in {
+                    "username": m.username, "role": m.role,
+                    "name": getattr(m, 'name', None),
+                }.items() if v}
+                for m in product.team.members
+            ]
+        team_members = self._merge_business_owners_into_team(
+            team_members, session, 'data_product', product_id
+        )
+        if team_members:
+            team_name = product.team.name if product.team else None
+            odps["team"] = {"members": team_members}
+            if team_name:
+                odps["team"]["name"] = team_name
 
         if product.custom_properties:
             odps["customProperties"] = [

--- a/src/backend/src/models/business_owners.py
+++ b/src/backend/src/models/business_owners.py
@@ -63,3 +63,26 @@ class BusinessOwnerHistory(BaseModel):
     object_id: str
     current_owners: List[BusinessOwnerRead] = Field(default_factory=list)
     previous_owners: List[BusinessOwnerRead] = Field(default_factory=list)
+
+
+# --- Bulk Import Models ---
+
+class ImportTeamMemberMapping(BaseModel):
+    """Single team member to import as a business owner."""
+    username: str = Field(..., description="Username/email from the ODCS/ODPS team or Ontos Team member")
+    name: Optional[str] = Field(None, description="Display name (optional)")
+    role_id: UUID = Field(..., description="Business role ID to assign")
+
+
+class ImportFromTeamRequest(BaseModel):
+    """Bulk import request: create Business Owner records from team members."""
+    object_type: OwnerObjectType = Field(..., description="Type of the target object")
+    object_id: str = Field(..., description="ID of the target object")
+    members: List[ImportTeamMemberMapping] = Field(..., min_length=1, description="Team members to import as owners")
+
+
+class ImportFromTeamResponse(BaseModel):
+    """Result of bulk import."""
+    created: int = Field(0, description="Number of new owner records created")
+    skipped: int = Field(0, description="Number skipped (already assigned)")
+    errors: List[str] = Field(default_factory=list, description="Any error messages")

--- a/src/backend/src/routes/business_owners_routes.py
+++ b/src/backend/src/routes/business_owners_routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query, Request
 from src.models.business_owners import (
     BusinessOwnerCreate, BusinessOwnerUpdate, BusinessOwnerRead,
     BusinessOwnerRemove, BusinessOwnerHistory,
+    ImportFromTeamRequest, ImportFromTeamResponse,
 )
 from src.controller.business_owners_manager import business_owners_manager
 from src.common.authorization import PermissionChecker
@@ -259,6 +260,65 @@ def remove_owner(
             ip_address=request.client.host if request.client else None,
             feature=FEATURE_ID, action="REMOVE_OWNER", success=success, details=details,
         )
+
+
+# --- Bulk Import from Team ---
+
+@router.post(
+    "/import-from-team",
+    response_model=ImportFromTeamResponse,
+    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE))],
+)
+def import_from_team(
+    request: Request,
+    body: ImportFromTeamRequest,
+    db: DBSessionDep,
+    audit_manager: AuditManagerDep,
+    current_user: AuditCurrentUserDep,
+    manager=Depends(get_business_owners_manager),
+):
+    """Bulk-import team members as business owners.
+
+    Accepts a list of username/role mappings and creates Business Owner records.
+    Skips members who are already active owners on the target object.
+    Works for both ODCS/ODPS imported team members and Ontos Team members.
+    """
+    created = 0
+    skipped = 0
+    errors: List[str] = []
+
+    for member in body.members:
+        try:
+            owner_in = BusinessOwnerCreate(
+                object_type=body.object_type,
+                object_id=body.object_id,
+                user_email=member.username,
+                user_name=member.name,
+                role_id=member.role_id,
+            )
+            manager.assign_owner(db=db, owner_in=owner_in, current_user_id=current_user.email)
+            created += 1
+        except ConflictError:
+            skipped += 1
+        except NotFoundError as e:
+            errors.append(f"{member.username}: {str(e)}")
+        except Exception as e:
+            logger.warning("Failed to import team member %s: %s", member.username, str(e))
+            errors.append(f"{member.username}: {str(e)}")
+
+    audit_manager.log_action(
+        db=db, username=current_user.username,
+        ip_address=request.client.host if request.client else None,
+        feature=FEATURE_ID, action="IMPORT_FROM_TEAM", success=True,
+        details={
+            "object": f"{body.object_type}:{body.object_id}",
+            "created": created,
+            "skipped": skipped,
+            "errors": errors,
+        },
+    )
+
+    return ImportFromTeamResponse(created=created, skipped=skipped, errors=errors)
 
 
 # --- Current user's ownerships (on separate prefix) ---

--- a/src/frontend/src/components/common/ownership-panel.tsx
+++ b/src/frontend/src/components/common/ownership-panel.tsx
@@ -1,17 +1,24 @@
 /**
  * Reusable ownership panel for embedding in detail pages.
  * Shows current and (optionally) previous owners for any object type.
+ * Optionally shows imported ODCS/ODPS contacts as read-only provenance.
  * Self-contained: manages assign and remove dialogs internally.
  *
  * Usage:
  *   <OwnershipPanel objectType="data_product" objectId={product.id} canAssign />
+ *   <OwnershipPanel
+ *     objectType="data_contract" objectId={contract.id} canAssign
+ *     importedContacts={contract.team}
+ *     importedContactsLabel="Imported Contacts"
+ *   />
  */
 import { useState, useEffect, useCallback } from 'react';
-import { Users2, History, UserPlus, Loader2, Trash2 } from 'lucide-react';
+import { Users2, History, UserPlus, Loader2, Trash2, ChevronDown, ChevronRight, Import, Copy } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { RelativeDate } from '@/components/common/relative-date';
 import { AssignOwnerDialog } from '@/components/common/assign-owner-dialog';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
@@ -22,6 +29,16 @@ import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from 'react-i18next';
 import type { BusinessOwnerRead, OwnerObjectType } from '@/types/business-owner';
 
+export interface ImportedContact {
+  username?: string;
+  name?: string;
+  email?: string;
+  role?: string;
+  description?: string;
+  dateIn?: string;
+  dateOut?: string;
+}
+
 interface OwnershipPanelProps {
   objectType: OwnerObjectType;
   objectId: string;
@@ -29,16 +46,42 @@ interface OwnershipPanelProps {
   canAssign?: boolean;
   /** Optional CSS class name */
   className?: string;
+  /** Imported ODCS/ODPS team contacts to display as read-only provenance */
+  importedContacts?: ImportedContact[];
+  /** Label for the imported contacts section */
+  importedContactsLabel?: string;
+  /** Callback when user clicks "Import as Owners" on the imported contacts */
+  onImportAsOwners?: (contacts: ImportedContact[]) => void;
+  /** Ontos Team ID for "Copy from Team" functionality */
+  ownerTeamId?: string;
+  /** Ontos Team name for display */
+  ownerTeamName?: string;
 }
 
-export function OwnershipPanel({ objectType, objectId, canAssign = false, className }: OwnershipPanelProps) {
+export function OwnershipPanel({
+  objectType,
+  objectId,
+  canAssign = false,
+  className,
+  importedContacts,
+  importedContactsLabel = 'Imported Contacts',
+  onImportAsOwners,
+  ownerTeamId,
+  ownerTeamName,
+}: OwnershipPanelProps) {
   const [currentOwners, setCurrentOwners] = useState<BusinessOwnerRead[]>([]);
   const [previousOwners, setPreviousOwners] = useState<BusinessOwnerRead[]>([]);
   const [showHistory, setShowHistory] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [importedOpen, setImportedOpen] = useState(false);
 
   // Assign dialog state
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
+
+  // Copy from Team dialog state
+  const [copyFromTeamOpen, setCopyFromTeamOpen] = useState(false);
+  const [teamMembers, setTeamMembers] = useState<Array<{ id: string; member_identifier: string; member_type: string; member_name?: string }>>([]);
+  const [teamMembersLoading, setTeamMembersLoading] = useState(false);
 
   // Remove dialog state
   const [removeTarget, setRemoveTarget] = useState<BusinessOwnerRead | null>(null);
@@ -72,6 +115,22 @@ export function OwnershipPanel({ objectType, objectId, canAssign = false, classN
     if (objectId) fetchOwners();
   }, [objectId, fetchOwners]);
 
+  useEffect(() => {
+    if (!copyFromTeamOpen || !ownerTeamId) return;
+    (async () => {
+      setTeamMembersLoading(true);
+      try {
+        const res = await apiGet<Array<{ id: string; member_identifier: string; member_type: string; member_name?: string }>>(
+          `/api/teams/${ownerTeamId}/members`
+        );
+        if (!res.error && Array.isArray(res.data)) {
+          setTeamMembers(res.data);
+        }
+      } catch { /* best effort */ }
+      finally { setTeamMembersLoading(false); }
+    })();
+  }, [copyFromTeamOpen, ownerTeamId, apiGet]);
+
   const handleRemove = async () => {
     if (!removeTarget) return;
     setIsRemoving(true);
@@ -91,6 +150,8 @@ export function OwnershipPanel({ objectType, objectId, canAssign = false, classN
     }
   };
 
+  const hasImportedContacts = importedContacts && importedContacts.length > 0;
+
   return (
     <>
       <Card className={className}>
@@ -105,6 +166,17 @@ export function OwnershipPanel({ objectType, objectId, canAssign = false, classN
                 <Button variant="ghost" size="sm" onClick={() => setShowHistory(!showHistory)}>
                   <History className="h-4 w-4 mr-1" />
                   {t('panel.history')}
+                </Button>
+              )}
+              {canAssign && ownerTeamId && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCopyFromTeamOpen(true)}
+                  title={ownerTeamName ? `Copy members from ${ownerTeamName}` : 'Copy from assigned team'}
+                >
+                  <Copy className="h-4 w-4 mr-1" />
+                  Copy from Team
                 </Button>
               )}
               {canAssign && (
@@ -188,6 +260,52 @@ export function OwnershipPanel({ objectType, objectId, canAssign = false, classN
               )}
             </div>
           )}
+
+          {/* Imported Contacts (from ODCS/ODPS) - read-only, collapsible */}
+          {hasImportedContacts && (
+            <>
+              <Separator className="my-4" />
+              <Collapsible open={importedOpen} onOpenChange={setImportedOpen}>
+                <div className="flex items-center justify-between">
+                  <CollapsibleTrigger asChild>
+                    <Button variant="ghost" size="sm" className="p-0 h-auto hover:bg-transparent">
+                      {importedOpen ? (
+                        <ChevronDown className="h-4 w-4 mr-1" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 mr-1" />
+                      )}
+                      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                        {importedContactsLabel} ({importedContacts!.length})
+                      </span>
+                    </Button>
+                  </CollapsibleTrigger>
+                  {canAssign && onImportAsOwners && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 text-xs"
+                      onClick={() => onImportAsOwners(importedContacts!)}
+                    >
+                      <Import className="h-3.5 w-3.5 mr-1" />
+                      Import as Owners
+                    </Button>
+                  )}
+                </div>
+                <CollapsibleContent className="mt-2">
+                  <div className="space-y-2">
+                    {importedContacts!.map((contact, idx) => (
+                      <div key={idx} className="flex items-center gap-2 text-sm">
+                        <span className="font-medium">{contact.name || contact.username || contact.email || 'Unknown'}</span>
+                        <Badge variant="outline" className="text-xs">
+                          {contact.role || 'member'}
+                        </Badge>
+                      </div>
+                    ))}
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            </>
+          )}
         </CardContent>
       </Card>
 
@@ -224,6 +342,64 @@ export function OwnershipPanel({ objectType, objectId, canAssign = false, classN
             <Button variant="destructive" onClick={handleRemove} disabled={isRemoving}>
               {isRemoving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               {t('removeDialog.remove')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Copy from Team Dialog */}
+      <Dialog open={copyFromTeamOpen} onOpenChange={setCopyFromTeamOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>Copy from Team{ownerTeamName ? `: ${ownerTeamName}` : ''}</DialogTitle>
+            <DialogDescription>
+              Select team members to add as business owners. They will be assigned via the "Assign Owner" flow where you can choose a role.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-4 max-h-[300px] overflow-y-auto">
+            {teamMembersLoading ? (
+              <div className="flex items-center justify-center py-4">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : teamMembers.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-4">No team members found.</p>
+            ) : (
+              <div className="space-y-2">
+                {teamMembers.map((member) => {
+                  const alreadyOwner = currentOwners.some(
+                    (o) => o.user_email.toLowerCase() === member.member_identifier.toLowerCase()
+                  );
+                  return (
+                    <div key={member.id} className="flex items-center justify-between p-2 border rounded-lg">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="text-xs">{member.member_type}</Badge>
+                        <span className="text-sm">{member.member_name || member.member_identifier}</span>
+                      </div>
+                      {alreadyOwner ? (
+                        <Badge variant="secondary" className="text-xs">Already owner</Badge>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() => {
+                            setCopyFromTeamOpen(false);
+                            setAssignDialogOpen(true);
+                          }}
+                        >
+                          <UserPlus className="h-3.5 w-3.5 mr-1" />
+                          Assign
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCopyFromTeamOpen(false)}>
+              Close
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/frontend/src/views/data-contract-details.tsx
+++ b/src/frontend/src/views/data-contract-details.tsx
@@ -44,7 +44,6 @@ import CreateFromContractDialog from '@/components/data-products/create-from-con
 import DqxSchemaSelectDialog from '@/components/data-contracts/dqx-schema-select-dialog'
 import DqxSuggestionsDialog from '@/components/data-contracts/dqx-suggestions-dialog'
 import AuthoritativeDefinitionFormDialog from '@/components/data-contracts/authoritative-definition-form-dialog'
-import ImportTeamMembersDialog from '@/components/data-contracts/import-team-members-dialog'
 import LinkProductToContractDialog from '@/components/data-contracts/link-product-to-contract-dialog'
 import VersioningRecommendationDialog from '@/components/common/versioning-recommendation-dialog'
 import CustomPropertyFormDialog from '@/components/data-contracts/custom-property-form-dialog'
@@ -270,7 +269,6 @@ export default function DataContractDetails() {
   const [isCreateProductDialogOpen, setIsCreateProductDialogOpen] = useState(false)
 
   // Team import state
-  const [isImportTeamMembersOpen, setIsImportTeamMembersOpen] = useState(false)
 
   // Team metadata (ODCS v3.1.0)
   const [, setTeamMetadata] = useState<{ name?: string; description?: string }>({})
@@ -1538,36 +1536,6 @@ export default function DataContractDetails() {
     fetchProfileRuns()
   }
 
-  const handleImportTeamMembers = async (members: TeamMember[]) => {
-    if (!contract) return
-    
-    try {
-      // Append to existing team array
-      const updatedTeam = [...(contract.team || []), ...members]
-      
-      // Store team assignment metadata in customProperties
-      const customProps = contract.customProperties || {}
-      const now = new Date().toISOString()
-      
-      await updateContract({
-        team: updatedTeam,
-        customProperties: {
-          ...customProps,
-          assignedTeamId: contract.owner_team_id,
-          assignedTeamName: contract.owner_team_name,
-          assignedTeamDate: now
-        }
-      }, false)  // Suppress generic toast, show custom one below
-      
-      toast({
-        title: 'Team Members Imported',
-        description: `Successfully imported ${members.length} team ${members.length === 1 ? 'member' : 'members'} to the contract.`
-      })
-    } catch (e) {
-      // Error already handled by updateContract
-      throw e
-    }
-  }
 
   const handleSaveTeamMetadata = async () => {
     if (!contractId) return
@@ -1871,17 +1839,10 @@ export default function DataContractDetails() {
                 )}
               </div>
             )}
-            {/* Hide Tenant if empty in minimal mode */}
-            {(viewMode !== 'minimal' || contract.tenant) && (
-              <div className="flex items-center gap-2">
-                <Label className="text-xs text-muted-foreground min-w-[4rem]">Tenant:</Label>
-                <span className="text-xs text-muted-foreground truncate">{contract.tenant || t('common:states.notAssigned')}</span>
-              </div>
-            )}
-            {/* Hide Owner if empty in minimal mode */}
+            {/* Hide Team if empty in minimal mode */}
             {(viewMode !== 'minimal' || (contract.owner_team_id && contract.owner_team_name)) && (
               <div className="flex items-center gap-2">
-                <Label className="text-xs text-muted-foreground min-w-[4rem]">Owner:</Label>
+                <Label className="text-xs text-muted-foreground min-w-[4rem]">Team:</Label>
                 {contract.owner_team_id && contract.owner_team_name ? (
                   <span
                     className="text-xs cursor-pointer text-primary hover:underline truncate"
@@ -1893,6 +1854,13 @@ export default function DataContractDetails() {
                 ) : (
                   <span className="text-xs text-muted-foreground">{t('common:states.notAssigned')}</span>
                 )}
+              </div>
+            )}
+            {/* Hide Tenant if empty in minimal mode */}
+            {(viewMode !== 'minimal' || contract.tenant) && (
+              <div className="flex items-center gap-2">
+                <Label className="text-xs text-muted-foreground min-w-[4rem]">Tenant:</Label>
+                <span className="text-xs text-muted-foreground truncate">{contract.tenant || t('common:states.notAssigned')}</span>
               </div>
             )}
             <div className="flex items-center gap-2">
@@ -2665,84 +2633,33 @@ export default function DataContractDetails() {
       </Card>
       )}
 
-      {/* Team & Roles Section */}
-      {shouldShowSection('team-members') && (
+      {/* ODCS Team Metadata (read-only provenance) */}
+      {shouldShowSection('team-members') && (contract.team?.length || teamMetaName || teamMetaDesc) && (
         <Card>
           <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle className="text-xl">Team Members ({contract.team?.length || 0})</CardTitle>
-              <CardDescription>Team responsible for this contract</CardDescription>
-            </div>
-            <div className="flex gap-2">
-              {(() => {
-                console.log('[DEBUG] Rendering Team Members buttons:', {
-                  owner_team_id: contract.owner_team_id,
-                  owner_team_name: contract.owner_team_name,
-                  hasOwnerTeamId: !!contract.owner_team_id,
-                  shouldShowButton: !!contract.owner_team_id
-                })
-                return null
-              })()}
-              {canEditInPlace && contract.owner_team_id && (
-                <Button 
-                  size="sm" 
-                  variant="outline"
-                  onClick={() => setIsImportTeamMembersOpen(true)}
-                  disabled={!contract.owner_team_name}
-                  title={contract.owner_team_name ? `Import members from ${contract.owner_team_name}` : 'No team assigned'}
-                >
-                  <Plus className="h-4 w-4 mr-1.5" />
-                  Import from Team
-                </Button>
-              )}
-              {canEditInPlace && (
-                <Button size="sm" onClick={() => { setEditingTeamMemberIndex(null); setIsTeamMemberFormOpen(true); }}>
-                  <Plus className="h-4 w-4 mr-1.5" />
-                  Add Member
-                </Button>
-              )}
+              <CardTitle className="text-xl">ODCS Team Metadata</CardTitle>
+              <CardDescription>Read-only provenance from imported contract YAML. Manage ownership via the Owners panel above.</CardDescription>
             </div>
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Team metadata (ODCS v3.1.0) */}
-          <div className="grid grid-cols-2 gap-4 border rounded-lg p-4 bg-muted/30">
-            <div className="space-y-1">
-              <Label className="text-xs text-muted-foreground">Team Name</Label>
-              {canEditInPlace ? (
-                <Input
-                  value={teamMetaName}
-                  onChange={(e) => { setTeamMetaName(e.target.value); setTeamMetaDirty(true) }}
-                  placeholder="e.g. Data Engineering"
-                  className="h-8"
-                />
-              ) : (
+          {(teamMetaName || teamMetaDesc) && (
+            <div className="grid grid-cols-2 gap-4 border rounded-lg p-4 bg-muted/30">
+              <div className="space-y-1">
+                <Label className="text-xs text-muted-foreground">Team Name</Label>
                 <p className="text-sm">{teamMetaName || '—'}</p>
-              )}
-            </div>
-            <div className="space-y-1">
-              <Label className="text-xs text-muted-foreground">Team Description</Label>
-              {canEditInPlace ? (
-                <Textarea
-                  value={teamMetaDesc}
-                  onChange={(e) => { setTeamMetaDesc(e.target.value); setTeamMetaDirty(true) }}
-                  placeholder="Brief description of the team"
-                  className="min-h-[32px] resize-none"
-                  rows={1}
-                />
-              ) : (
-                <p className="text-sm">{teamMetaDesc || '—'}</p>
-              )}
-            </div>
-            {canEditInPlace && teamMetaDirty && (
-              <div className="col-span-2 flex justify-end">
-                <Button size="sm" onClick={handleSaveTeamMetadata}>Save Team Info</Button>
               </div>
-            )}
-          </div>
+              <div className="space-y-1">
+                <Label className="text-xs text-muted-foreground">Team Description</Label>
+                <p className="text-sm">{teamMetaDesc || '—'}</p>
+              </div>
+            </div>
+          )}
 
-          {/* Team members list */}
+          {/* Team members list (read-only) */}
           {contract.team && contract.team.length > 0 ? (
             <div className="space-y-2">
               {contract.team.map((member, idx) => (
@@ -2751,21 +2668,11 @@ export default function DataContractDetails() {
                     <Badge variant="outline">{member.role}</Badge>
                     <span className="text-sm">{member.name || member.username || member.email}</span>
                   </div>
-                  {canEditInPlace && (
-                    <div className="flex gap-2">
-                      <Button size="sm" variant="ghost" onClick={() => { setEditingTeamMemberIndex(idx); setIsTeamMemberFormOpen(true); }}>
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button size="sm" variant="ghost" onClick={() => handleDeleteTeamMember(idx)} className="text-destructive hover:text-destructive">
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  )}
                 </div>
               ))}
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground text-center py-8">No team members defined. Click "Add Member" to add one.</p>
+            <p className="text-sm text-muted-foreground text-center py-4">No imported team members.</p>
           )}
         </CardContent>
       </Card>
@@ -3075,9 +2982,26 @@ export default function DataContractDetails() {
       </Card>
       )}
 
-      {/* Ownership Panel */}
+      {/* Ownership Panel (with imported ODCS contacts) */}
       {shouldShowSection('metadata-panel') && contract.id && (
-        <OwnershipPanel objectType="data_contract" objectId={contract.id} canAssign={canEditInPlace} className="mb-6" />
+        <OwnershipPanel
+          objectType="data_contract"
+          objectId={contract.id}
+          canAssign={canEditInPlace}
+          className="mb-6"
+          importedContacts={contract.team?.map((m) => ({
+            username: m.username,
+            name: m.name,
+            email: m.email,
+            role: m.role,
+            description: m.description,
+            dateIn: m.dateIn,
+            dateOut: m.dateOut,
+          }))}
+          importedContactsLabel="Imported Contacts"
+          ownerTeamId={contract.owner_team_id}
+          ownerTeamName={contract.owner_team_name}
+        />
       )}
 
       {/* Entity Relationships Panel */}
@@ -3256,18 +3180,6 @@ export default function DataContractDetails() {
         level="property"
       />
 
-      {/* Import Team Members Dialog */}
-      {contract?.owner_team_id && (
-        <ImportTeamMembersDialog
-          isOpen={isImportTeamMembersOpen}
-          onOpenChange={setIsImportTeamMembersOpen}
-          entityId={contractId!}
-          entityType="contract"
-          teamId={contract.owner_team_id}
-          teamName={contract.owner_team_name || contract.owner_team_id}
-          onImport={handleImportTeamMembers}
-        />
-      )}
 
       {/* Link Product to Contract Dialog */}
       <LinkProductToContractDialog

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -9,7 +9,6 @@ import ManagementPortFormDialog from '@/components/data-products/management-port
 import TeamMemberFormDialog from '@/components/data-products/team-member-form-dialog';
 import SupportChannelFormDialog from '@/components/data-products/support-channel-form-dialog';
 import ImportExportDialog from '@/components/data-products/import-export-dialog';
-import ImportTeamMembersDialog from '@/components/data-contracts/import-team-members-dialog';
 import { useApi } from '@/hooks/use-api';
 import { useApprovalWizardTrigger } from '@/hooks/use-approval-wizard-trigger';
 import { Button } from '@/components/ui/button';
@@ -463,6 +462,7 @@ export default function DataProductDetails() {
   const [product, setProduct] = useState<DataProduct | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [sidebarOwners, setSidebarOwners] = useState<Array<{ user_name?: string | null; user_email: string; role_name?: string | null }>>([]);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isVersionDialogOpen, setIsVersionDialogOpen] = useState(false);
   const [iriDialogOpen, setIriDialogOpen] = useState(false);
@@ -481,7 +481,6 @@ export default function DataProductDetails() {
   const [isTeamMemberDialogOpen, setIsTeamMemberDialogOpen] = useState(false);
   const [isSupportChannelDialogOpen, setIsSupportChannelDialogOpen] = useState(false);
   const [isImportExportDialogOpen, setIsImportExportDialogOpen] = useState(false);
-  const [isImportTeamMembersOpen, setIsImportTeamMembersOpen] = useState(false);
 
   // Editing state for nested entities
   const [editingInputPortIndex, setEditingInputPortIndex] = useState<number | null>(null);
@@ -702,6 +701,20 @@ export default function DataProductDetails() {
       setDynamicTitle(null);
     };
   }, [productId, canRead, permissionsLoading]);
+
+  useEffect(() => {
+    if (!productId) return;
+    (async () => {
+      try {
+        const res = await get<Array<{ user_name?: string | null; user_email: string; role_name?: string | null; is_active: boolean }>>(
+          `/api/business-owners/by-object/data_product/${productId}?active_only=true`
+        );
+        if (!res.error && Array.isArray(res.data)) {
+          setSidebarOwners(res.data.filter((o) => o.is_active));
+        }
+      } catch { /* sidebar contacts are best-effort */ }
+    })();
+  }, [productId, get]);
 
   const handleEdit = () => {
     if (!canWrite) {
@@ -1158,71 +1171,6 @@ export default function DataProductDetails() {
     }
   };
 
-  const handleImportTeamMembers = async (members: TeamMember[]) => {
-    if (!productId || !product) return;
-    
-    try {
-      // Append imported members to existing team members
-      const existingMembers = product.team?.members || [];
-      const updatedMembers = [...existingMembers, ...members];
-      const updatedTeam = { ...product.team, members: updatedMembers };
-      
-      // Convert tags from objects to strings (tag FQNs) if needed
-      const tags = Array.isArray(product.tags) 
-        ? product.tags.map((tag: any) => typeof tag === 'string' ? tag : (tag.tag_fqn || tag.tagFQN))
-        : [];
-      
-      // Store team assignment metadata in customProperties
-      const teamMetadata = {
-        property: 'assigned_team',
-        value: JSON.stringify({
-          team_id: product.owner_team_id,
-          team_name: product.owner_team_name,
-          assigned_at: new Date().toISOString(),
-          member_count: members.length
-        }),
-        description: 'App team assignment metadata'
-      };
-      
-      const existingCustomProps = product.customProperties || [];
-      const updatedCustomProps = [
-        ...existingCustomProps.filter((p: any) => p.property !== 'assigned_team'),
-        teamMetadata
-      ];
-      
-      const res = await fetch(`/api/data-products/${productId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ 
-          ...product, 
-          team: updatedTeam, 
-          customProperties: updatedCustomProps,
-          tags // Use converted tags
-        }),
-      });
-      
-      if (!res.ok) {
-        const errorText = await res.text().catch(() => '');
-        throw new Error(`Failed to import team members (${res.status}): ${errorText}`);
-      }
-      
-      await fetchProductDetails();
-      setIsImportTeamMembersOpen(false);
-      
-      toast({
-        title: 'Team Members Imported',
-        description: `Successfully imported ${members.length} team member(s) from ${product.owner_team_name}`,
-      });
-    } catch (error) {
-      console.error('Failed to import team members:', error);
-      toast({
-        title: 'Import Failed',
-        description: error instanceof Error ? error.message : 'Failed to import team members',
-        variant: 'destructive',
-      });
-      throw error;
-    }
-  };
 
   const handleAddSupportChannel = async (channel: Support) => {
     if (!productId || !product) return;
@@ -1659,15 +1607,9 @@ export default function DataProductDetails() {
                   )}
                 </div>
               )}
-              {(viewMode !== 'minimal' || product.tenant) && (
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[4rem]">Tenant:</Label>
-                  <span className="text-xs text-muted-foreground truncate">{product.tenant || t('common:states.notAssigned')}</span>
-                </div>
-              )}
               {(viewMode !== 'minimal' || (product.owner_team_id && product.owner_team_name)) && (
                 <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground min-w-[4rem]">Owner:</Label>
+                  <Label className="text-xs text-muted-foreground min-w-[4rem]">Team:</Label>
                   {product.owner_team_id && product.owner_team_name ? (
                     <span
                       className="text-xs cursor-pointer text-primary hover:underline truncate"
@@ -1679,6 +1621,12 @@ export default function DataProductDetails() {
                   ) : (
                     <span className="text-xs text-muted-foreground">{t('common:states.notAssigned')}</span>
                   )}
+                </div>
+              )}
+              {(viewMode !== 'minimal' || product.tenant) && (
+                <div className="flex items-center gap-2">
+                  <Label className="text-xs text-muted-foreground min-w-[4rem]">Tenant:</Label>
+                  <span className="text-xs text-muted-foreground truncate">{product.tenant || t('common:states.notAssigned')}</span>
                 </div>
               )}
               {viewMode !== 'minimal' && (
@@ -1735,17 +1683,50 @@ export default function DataProductDetails() {
         {/* Sidebar: Contacts + Quality */}
         <div className="space-y-4">
           {/* Contacts */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium">Contacts</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {(() => {
-                const contacts = product.team?.members?.filter(
-                  (m) => m.role && ['owner', 'data owner', 'data steward', 'steward'].includes(m.role.toLowerCase())
-                );
-                if (contacts && contacts.length > 0) {
-                  return contacts.map((member, idx) => (
+          {(() => {
+            // Determine contact source for fallback indicator
+            const ownerContacts = product.team?.members?.filter(
+              (m) => m.role && ['owner', 'data owner', 'data steward', 'steward'].includes(m.role.toLowerCase())
+            );
+            const contactSource = sidebarOwners.length > 0
+              ? 'owners'
+              : (ownerContacts && ownerContacts.length > 0)
+                ? 'imported'
+                : product.owner_team_name
+                  ? 'team_only'
+                  : 'none';
+
+            return (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-medium">Contacts</CardTitle>
+                  {contactSource === 'imported' && (
+                    <p className="text-[11px] text-muted-foreground italic">From imported data</p>
+                  )}
+                  {contactSource === 'team_only' && (
+                    <p className="text-[11px] text-muted-foreground italic">Team assignment only</p>
+                  )}
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {contactSource === 'owners' && sidebarOwners.map((owner, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <Avatar className="h-8 w-8">
+                        <AvatarFallback className="text-xs bg-primary/10 text-primary">
+                          {(owner.user_name || owner.user_email || '?')
+                            .split(/[\s.@]+/)
+                            .filter(Boolean)
+                            .slice(0, 2)
+                            .map((p) => p[0].toUpperCase())
+                            .join('')}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium truncate">{owner.user_name || owner.user_email}</div>
+                        <div className="text-xs text-muted-foreground">{owner.role_name || 'Owner'}</div>
+                      </div>
+                    </div>
+                  ))}
+                  {contactSource === 'imported' && ownerContacts!.map((member, idx) => (
                     <div key={idx} className="flex items-center gap-2">
                       <Avatar className="h-8 w-8">
                         <AvatarFallback className="text-xs bg-primary/10 text-primary">
@@ -1762,27 +1743,27 @@ export default function DataProductDetails() {
                         <div className="text-xs text-muted-foreground">{member.role}</div>
                       </div>
                     </div>
-                  ));
-                }
-                if (product.owner_team_name) {
-                  return (
+                  ))}
+                  {contactSource === 'team_only' && (
                     <div className="flex items-center gap-2">
                       <Avatar className="h-8 w-8">
                         <AvatarFallback className="text-xs bg-primary/10 text-primary">
-                          {product.owner_team_name.split(/\s+/).slice(0, 2).map((p) => p[0].toUpperCase()).join('')}
+                          {product.owner_team_name!.split(/\s+/).slice(0, 2).map((p) => p[0].toUpperCase()).join('')}
                         </AvatarFallback>
                       </Avatar>
                       <div className="min-w-0">
                         <div className="text-sm font-medium truncate">{product.owner_team_name}</div>
-                        <div className="text-xs text-muted-foreground">Owner Team</div>
+                        <div className="text-xs text-muted-foreground">Team</div>
                       </div>
                     </div>
-                  );
-                }
-                return <span className="text-xs text-muted-foreground">No contacts assigned</span>;
-              })()}
-            </CardContent>
-          </Card>
+                  )}
+                  {contactSource === 'none' && (
+                    <span className="text-xs text-muted-foreground">No contacts assigned</span>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })()}
 
           <LifecycleSummaryPanel
             status={(product.status || 'draft').toLowerCase()}
@@ -2101,69 +2082,24 @@ export default function DataProductDetails() {
       </Card>
       )}
 
-      {/* Team Section */}
-      {shouldShowSection('team') && (
+      {/* ODPS Team Metadata (read-only provenance) */}
+      {shouldShowSection('team') && product.team?.members && product.team.members.length > 0 && (
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
-            <span>Team ({product.team?.members?.length || 0} members)</span>
-            <div className="flex gap-2">
-              {canWrite && product.owner_team_id && (
-                <Button 
-                  size="sm" 
-                  variant="outline"
-                  onClick={() => setIsImportTeamMembersOpen(true)}
-                >
-                  <Download className="mr-2 h-4 w-4" />
-                  Import from Team
-                </Button>
-              )}
-              {canModify && (
-                <Button size="sm" onClick={() => setIsTeamMemberDialogOpen(true)}>
-                  <Plus className="mr-2 h-4 w-4" />
-                  Add Member
-                </Button>
-              )}
-            </div>
+            <span>ODPS Team Metadata ({product.team.members.length} members)</span>
           </CardTitle>
+          <p className="text-sm text-muted-foreground">Read-only provenance from imported product YAML. Manage ownership via the Owners panel above.</p>
         </CardHeader>
         <CardContent>
-          {product.team?.members && product.team.members.length > 0 ? (
-            <div className="space-y-2">
-              {product.team.members.map((member, idx) => (
-                <div key={idx} className="flex items-center justify-between p-3 border rounded-lg">
-                  <div className="flex items-center gap-3">
-                    <Badge variant="outline">{member.role || 'Member'}</Badge>
-                    <span className="text-sm">{member.name || member.username}</span>
-                  </div>
-                  {canModify && (
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => {
-                          setEditingTeamMemberIndex(idx);
-                          setIsTeamMemberDialogOpen(true);
-                        }}
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => handleDeleteTeamMember(idx)}
-                        className="text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">No team members defined</p>
-          )}
+          <div className="space-y-2">
+            {product.team.members.map((member, idx) => (
+              <div key={idx} className="flex items-center gap-3 p-3 border rounded-lg">
+                <Badge variant="outline">{member.role || 'Member'}</Badge>
+                <span className="text-sm">{member.name || member.username}</span>
+              </div>
+            ))}
+          </div>
         </CardContent>
       </Card>
       )}
@@ -2268,9 +2204,23 @@ export default function DataProductDetails() {
         />
       )}
 
-      {/* Ownership Panel */}
+      {/* Ownership Panel (with imported ODPS contacts) */}
       {shouldShowSection('ownership') && (
-        <OwnershipPanel objectType="data_product" objectId={productId!} canAssign={canModify} className="mb-6" />
+        <OwnershipPanel
+          objectType="data_product"
+          objectId={productId!}
+          canAssign={canModify}
+          className="mb-6"
+          importedContacts={product.team?.members?.map((m) => ({
+            username: m.username,
+            name: m.name,
+            role: m.role,
+            description: m.description,
+          }))}
+          importedContactsLabel="Imported Contacts"
+          ownerTeamId={product.owner_team_id}
+          ownerTeamName={product.owner_team_name}
+        />
       )}
 
       {/* Entity Relationships Panel (tree-based with drill-down) */}
@@ -2439,18 +2389,6 @@ export default function DataProductDetails() {
         currentProduct={product}
       />
 
-      {/* Import Team Members Dialog */}
-      {product.owner_team_id && (
-        <ImportTeamMembersDialog
-          isOpen={isImportTeamMembersOpen}
-          onOpenChange={setIsImportTeamMembersOpen}
-          entityId={productId!}
-          entityType="product"
-          teamId={product.owner_team_id}
-          teamName={product.owner_team_name || product.owner_team_id}
-          onImport={handleImportTeamMembers}
-        />
-      )}
 
       {/* Link Contract to Port Dialog */}
       <LinkContractToPortDialog


### PR DESCRIPTION
## Summary

- Consolidates the disparate "people" surfaces (ODCS/ODPS Team, Ontos Team entity, Business Owners) into a single authoritative Owners panel with read-only provenance for imported data
- Renames misleading "Owner:" label to "Team:" in metadata grid and groups it with Project
- Merges active Business Owners into YAML export team section for standards compliance
- Adds sidebar fallback indicator and removes dead "Import from Team" flow

## Changes

### Frontend
- **OwnershipPanel**: Extended with "Imported Contacts" collapsible section, "Copy from Team" dialog
- **data-product-details.tsx**: Sidebar Contacts fallback indicator, removed old import flow
- **data-contract-details.tsx**: Read-only ODCS Team Metadata section, removed old import flow
- Both detail pages: "Owner:" → "Team:" label rename, Project/Team grouping

### Backend
- **business_owners_routes.py**: New `POST /api/business-owners/import-from-team` endpoint
- **data_contracts_manager.py**: YAML export merges Business Owners into team section
- **data_products_manager.py**: Same merge logic for ODPS export

### Docs
- PRD with resolved design decisions: `docs/prds/prd-consolidate-team-and-ownership.md`

## Test plan

- [x] Verified via Playwright: "Team:" label on both pages
- [x] Verified: "Copy from Team" dialog opens and lists team members
- [x] Verified: Imported Contacts section expands with correct layout
- [x] Verified: Sidebar shows "From imported data" indicator on fallback
- [x] Verified: ODCS export includes merged Business Owners in team section
- [ ] Backend unit tests for import-from-team endpoint
- [ ] Backend unit tests for export merge dedup logic

Closes #431