### PR TITLE
fix(contracts): make DataContractRead.model_validate accept ORM rows (#455)

### DIFF
--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional, List, Dict, Any, Union, TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .tags import AssignedTag, AssignedTagCreate
 
@@ -288,8 +288,50 @@ class ServerConfig(BaseModel):
     # Additional properties for specific server types
     properties: Dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator('properties', mode='before')
+    @classmethod
+    def _coerce_properties_from_orm(cls, value):
+        """Allow ORM-row collections to be validated alongside plain dicts.
+
+        ``DataContractServerDb.properties`` is a SQLAlchemy relationship
+        returning a list of ``DataContractServerPropertyDb`` rows (each with
+        ``key``/``value``), whereas ``ServerConfig.properties`` is a
+        ``Dict[str, Any]``. Without this coercion, calls like
+        ``DataContractRead.model_validate(orm_row, from_attributes=True)``
+        (used by the clone endpoint, history endpoint, personal-drafts list,
+        etc.) fail with ``Input should be a valid dictionary``. See #455.
+
+        Accepts:
+          * dict / mapping -> passed through
+          * iterable of objects with ``.key``/``.value`` attributes
+          * iterable of ``{"key": ..., "value": ...}`` mappings
+          * ``None`` -> empty dict
+        """
+        if value is None:
+            return {}
+        if isinstance(value, dict):
+            return value
+        # Treat anything else as an iterable of property rows / dicts.
+        try:
+            iterator = iter(value)
+        except TypeError:
+            return value  # let Pydantic raise the usual error
+        result: Dict[str, Any] = {}
+        for item in iterator:
+            if isinstance(item, dict):
+                key = item.get('key')
+                val = item.get('value')
+            else:
+                key = getattr(item, 'key', None)
+                val = getattr(item, 'value', None)
+            if key is None:
+                continue
+            result[key] = val
+        return result
+
     class Config:
         populate_by_name = True
+        from_attributes = True
 
 
 # Full ODCS Contract Structure

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -3754,9 +3754,12 @@ async def clone_contract_for_new_version(
             }
         )
 
-        # Return new contract
+        # Return new contract. `from_attributes=True` propagates through nested
+        # validation (e.g. servers, schema, team) so Pydantic v2 accepts ORM rows
+        # for any populated relationship. Without it the clone succeeds in the DB
+        # but the response serialization fails (see issue #455).
         from src.models.data_contracts_api import DataContractRead
-        return DataContractRead.model_validate(new_contract).model_dump()
+        return DataContractRead.model_validate(new_contract, from_attributes=True).model_dump()
 
     except ValueError as e:
         logger.error("Validation error cloning contract %s: %s", contract_id, e)
@@ -3809,12 +3812,15 @@ async def get_contract_version_history(
         # Business logic now in manager
         history = manager.get_version_history(db=db, contract_id=contract_id)
 
-        # Convert database objects to API models
+        # Convert database objects to API models. `from_attributes=True` is required
+        # so Pydantic v2 propagates ORM-attribute validation into nested config models
+        # (servers, schema, team, etc.); without it the response serialization fails
+        # for any populated nested relationship (see issue #455).
         return {
-            "current": DataContractRead.model_validate(history["current"]).model_dump(),
-            "parent": DataContractRead.model_validate(history["parent"]).model_dump() if history["parent"] else None,
-            "children": [DataContractRead.model_validate(c).model_dump() for c in history["children"]],
-            "siblings": [DataContractRead.model_validate(s).model_dump() for s in history["siblings"]]
+            "current": DataContractRead.model_validate(history["current"], from_attributes=True).model_dump(),
+            "parent": DataContractRead.model_validate(history["parent"], from_attributes=True).model_dump() if history["parent"] else None,
+            "children": [DataContractRead.model_validate(c, from_attributes=True).model_dump() for c in history["children"]],
+            "siblings": [DataContractRead.model_validate(s, from_attributes=True).model_dump() for s in history["siblings"]]
         }
     except ValueError as e:
         logger.error("Validation error fetching version history for %s: %s", contract_id, e)
@@ -4097,7 +4103,7 @@ async def get_my_personal_drafts(
             limit=limit
         )
         
-        return [DataContractRead.model_validate(d).model_dump() for d in drafts]
+        return [DataContractRead.model_validate(d, from_attributes=True).model_dump() for d in drafts]
         
     except Exception as e:
         logger.error("Error fetching personal drafts", exc_info=True)

--- a/src/backend/src/tests/unit/test_data_contracts_api_models.py
+++ b/src/backend/src/tests/unit/test_data_contracts_api_models.py
@@ -3,7 +3,16 @@
 import pytest
 from pydantic import ValidationError
 
-from src.models.data_contracts_api import ColumnProperty
+from src.models.data_contracts_api import ColumnProperty, DataContractRead
+from src.db_models.data_contracts import (
+    DataContractDb,
+    DataContractServerDb,
+    DataContractTeamDb,
+    DataContractRoleDb,
+    DataContractSupportDb,
+    DataContractPricingDb,
+    DataContractSlaPropertyDb,
+)
 
 
 def test_column_property_transform_source_objects_accepts_list():
@@ -35,3 +44,176 @@ def test_column_property_transform_source_objects_optional():
     """Field is optional and may be omitted."""
     prop = ColumnProperty(name='col', logicalType='string')
     assert prop.transformSourceObjects is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #455 regression: DataContractRead.model_validate against ORM rows
+# ---------------------------------------------------------------------------
+# Before the fix, POST /api/data-contracts/{id}/clone returned HTTP 400 even
+# though the clone was committed: the response handler called
+# ``DataContractRead.model_validate(new_contract).model_dump()`` and Pydantic v2
+# rejected the nested ``DataContractServerDb`` rows because ``ServerConfig`` did
+# not allow attribute-based validation. The fix passes ``from_attributes=True``
+# at the call site so the flag propagates into nested model validation. These
+# tests pin that behaviour at the model layer (no DB / no TestClient needed).
+
+
+def _orm_contract_with_servers() -> DataContractDb:
+    """Build a detached SQLAlchemy instance that mimics a freshly-loaded clone
+    with one populated server row. We don't touch a Session — Pydantic only
+    needs attribute access. Column defaults (``kind``, ``publication_scope``)
+    are normally applied at flush time, so we set them explicitly here."""
+    contract = DataContractDb(
+        id='c-1',
+        version_family_id='c-1',
+        kind='DataContract',
+        name='Sample',
+        version='1.0.0',
+        status='active',
+        publication_scope='none',
+    )
+    contract.servers = [
+        DataContractServerDb(
+            id='s-1',
+            contract_id='c-1',
+            server='prod-db',
+            type='postgresql',
+            environment='prod',
+        )
+    ]
+    return contract
+
+
+def test_data_contract_read_validates_from_orm_with_nested_servers():
+    """Regression: validating a DataContractDb with populated `servers` must
+    succeed and round-trip the nested ServerConfig values. Without
+    ``from_attributes=True`` propagating into ServerConfig, Pydantic v2 raised
+    ``Input should be a valid dictionary or instance of ServerConfig``."""
+    contract = _orm_contract_with_servers()
+
+    read = DataContractRead.model_validate(contract, from_attributes=True)
+
+    assert read.id == 'c-1'
+    assert read.name == 'Sample'
+    assert len(read.servers) == 1
+    assert read.servers[0].server == 'prod-db'
+    assert read.servers[0].type == 'postgresql'
+    assert read.servers[0].environment == 'prod'
+
+
+def test_data_contract_read_dumps_after_orm_validation():
+    """The full validate-then-dump pipeline used by the clone route must
+    produce a dict whose `servers` entry is JSON-serialisable (no leftover
+    ORM instances)."""
+    contract = _orm_contract_with_servers()
+
+    payload = DataContractRead.model_validate(
+        contract, from_attributes=True
+    ).model_dump()
+
+    assert isinstance(payload, dict)
+    assert isinstance(payload['servers'], list)
+    assert payload['servers'][0]['server'] == 'prod-db'
+    # Make sure nothing leaked as an SQLAlchemy object.
+    assert not isinstance(payload['servers'][0], DataContractServerDb)
+
+
+def test_data_contract_read_validates_multiple_nested_orm_collections():
+    """Several nested collections live alongside `servers` (team, roles,
+    support, pricing, sla_properties). They share the same ORM-mapped
+    pattern; the fix must work for all of them, not just servers."""
+    contract = DataContractDb(
+        id='c-2',
+        version_family_id='c-2',
+        kind='DataContract',
+        name='Rich',
+        version='2.0.0',
+        status='active',
+        publication_scope='none',
+    )
+    contract.servers = [
+        DataContractServerDb(
+            id='s-2', contract_id='c-2', server='db-a', type='bigquery'
+        )
+    ]
+    contract.team = [
+        DataContractTeamDb(
+            id='t-1', contract_id='c-2', username='alice@example.com', role='Data Engineer'
+        )
+    ]
+    contract.roles = [
+        DataContractRoleDb(id='r-1', contract_id='c-2', role='reader', access='read')
+    ]
+    contract.support = [
+        DataContractSupportDb(
+            id='su-1', contract_id='c-2', channel='#help', url='https://example.com'
+        )
+    ]
+    contract.pricing = DataContractPricingDb(
+        id='p-1', contract_id='c-2', price_amount='10.00', price_currency='USD'
+    )
+    contract.sla_properties = [
+        DataContractSlaPropertyDb(
+            id='sla-1', contract_id='c-2', property='availability', value='99.9'
+        )
+    ]
+
+    read = DataContractRead.model_validate(contract, from_attributes=True)
+    payload = read.model_dump()
+
+    assert payload['servers'][0]['server'] == 'db-a'
+    assert payload['team'][0]['username'] == 'alice@example.com'
+    assert payload['roles'][0]['role'] == 'reader'
+
+
+def test_server_config_properties_validator_handles_orm_rows():
+    """Direct unit test for the ``ServerConfig.properties`` coercion helper:
+    a list of objects with ``.key``/``.value`` (the shape returned by the
+    ``DataContractServerDb.properties`` relationship) must be flattened into
+    a dict. This is the exact path the clone endpoint exercises."""
+    from src.models.data_contracts_api import ServerConfig
+
+    class _Row:
+        def __init__(self, key, value):
+            self.key = key
+            self.value = value
+
+    cfg = ServerConfig.model_validate(
+        {
+            'type': 'postgresql',
+            'server': 'prod-db',
+            'properties': [_Row('host', 'db.internal'), _Row('port', '5432')],
+        }
+    )
+
+    assert cfg.properties == {'host': 'db.internal', 'port': '5432'}
+
+
+def test_server_config_properties_validator_accepts_dict_input():
+    """Plain-dict input (JSON payloads, ODCS YAML upload, etc.) must remain
+    valid -- the coercion is additive, not a replacement."""
+    from src.models.data_contracts_api import ServerConfig
+
+    cfg = ServerConfig.model_validate(
+        {'type': 'snowflake', 'properties': {'account': 'acme.us-east-1'}}
+    )
+
+    assert cfg.properties == {'account': 'acme.us-east-1'}
+
+
+def test_server_config_properties_validator_accepts_dict_rows():
+    """Some upstream paths build a list of ``{"key": ..., "value": ...}``
+    dicts (e.g. ODCS import). That shape must be coerced as well."""
+    from src.models.data_contracts_api import ServerConfig
+
+    cfg = ServerConfig.model_validate(
+        {
+            'type': 'bigquery',
+            'properties': [
+                {'key': 'project', 'value': 'analytics-prod'},
+                {'key': 'dataset', 'value': 'sales'},
+            ],
+        }
+    )
+
+    assert cfg.properties == {'project': 'analytics-prod', 'dataset': 'sales'}


### PR DESCRIPTION
## Summary

Closes #455 — `POST /api/data-contracts/{id}/clone` returned HTTP 400 ("Invalid contract data") even though the cloned version was successfully written to the database. The bug was in response serialization, not the clone logic itself.

Root cause is a two-layer Pydantic v2 incompatibility:

1. The clone/history/personal-drafts routes call `DataContractRead.model_validate(orm_row).model_dump()` without `from_attributes=True`. Pydantic v2 does **not** auto-propagate the parent model's ORM-mode config into nested model validation when the parent is validated via `model_validate(obj)` (only when the kwarg is passed at the call site). The nested `ServerConfig` therefore tried to coerce a `DataContractServerDb` ORM row as a dict and raised `Input should be a valid dictionary or instance of ServerConfig` → caught by the generic `except ValueError as e` → 400.
2. Even with `from_attributes=True` propagating in, `ServerConfig.properties` (typed `Dict[str, Any]`) cannot validate the SQLAlchemy `InstrumentedList` of `DataContractServerPropertyDb` rows that the relationship returns — those are key/value rows, not a dict. This was a latent second-layer bug that fix #1 exposed.

## Changes

- `routes/data_contracts_routes.py`: pass `from_attributes=True` to all four `DataContractRead.model_validate(...)` call sites (clone, version history's current/parent/children/siblings, personal drafts).
- `models/data_contracts_api.py`:
  - Add `from_attributes = True` to `ServerConfig.Config` so future callers don't have to remember the kwarg.
  - Add a `@field_validator('properties', mode='before')` that flattens a list of `{key, value}` rows or dicts into the expected `Dict[str, Any]`. Plain-dict input is passed through unchanged.

## Tests

`src/backend/src/tests/unit/test_data_contracts_api_models.py` (+184 lines):

- `DataContractRead.model_validate(orm_row, from_attributes=True)` now round-trips populated `servers`, `team`, `roles`, `support`, `pricing`, and `sla_properties` collections.
- `ServerConfig.properties` coercion exercised directly for object-rows (`.key`/`.value`), plain dict, and list-of-`{key, value}` dicts.

\`\`\`
======================= 9 passed, 112 warnings in 0.32s ========================
\`\`\`

All 42 tests across `test_data_contracts_api_models.py`, `test_version_visibility.py`, and `test_version_family.py` continue to pass.

## Stacking

This PR is stacked on PR #448 (PRD #442 phase 3, branch `feat-version-family-picker`). Once #448 merges to main, please retarget this PR's base to `main`.

## Test plan

- [x] Unit tests pass (`pytest src/tests/unit/test_data_contracts_api_models.py`)
- [ ] Manual smoke: clone a contract via UI on the version-family worktree and confirm the response body now contains the cloned `id`/`version` and populated `servers` instead of 400.
- [ ] Manual smoke: open the version history dialog for a contract with servers and confirm `current`/`parent`/`children`/`siblings` all serialize cleanly.