### PR TITLE
feat(testing): runtime user-persona impersonation via X-Test-* headers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,17 @@ The project implements a web application designed to run as a **Databricks App**
 
 ## Testing and Deployment
 
+- **Runtime user impersonation (no restart needed):** set `TEST_USER_TOKEN`
+  in the backend env to enable per-request persona switching via HTTP
+  headers (`X-Test-Token`, `X-Test-User-Email`, optional
+  `X-Test-User-Groups`). When configured, the frontend user menu shows a
+  persona picker (driven by `src/backend/src/data/test_personas.yaml`,
+  exposed via `GET /api/test/personas`) and injects the headers on every
+  `/api` request. The token is provisioned to the frontend out-of-band via
+  `VITE_TEST_USER_TOKEN`. Leave `TEST_USER_TOKEN` UNSET in production.
+  See `CONTRIBUTING.md` ("Testing with Different User Personas") for full
+  details and `src/backend/src/tests/integration/test_user_header_override.py`
+  for examples.
 - Implement **unit tests** (e.g., using `pytest` for backend, Jest/React Testing Library for frontend).
 - Use **Playwright MCP** for automated UI testing and verification:
   - Navigate to pages using `mcp__playwright__browser_navigate`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -546,6 +546,60 @@ takes effect on the next picker query without a server restart. The
 sample file is checked in as a fixture — feel free to extend it
 locally, but please don't commit org-specific edits.
 
+### Testing with Different User Personas (Runtime Impersonation)
+
+The app supports per-request user impersonation via HTTP headers, so you can
+test how features behave for different personas (Admin, Data Producer,
+Consumer, etc.) against the **same running backend** — no restarts, works with
+or without the Vite dev server in front.
+
+**Setup:**
+
+1. Pick a shared-secret token, e.g. `openssl rand -hex 32`.
+2. Set it on the backend: `TEST_USER_TOKEN=<your-token>` in
+   `src/backend/.env`.
+3. (Optional, for the UI picker) set the same value as
+   `VITE_TEST_USER_TOKEN=<your-token>` in `src/frontend/.env`.
+
+**Usage from the UI:**
+
+When `TEST_USER_TOKEN` is configured, the user-info dropdown gains a
+"Test persona" section listing personas defined in
+`src/backend/src/data/test_personas.yaml`. Pick one and the page reloads
+with every API request impersonating that user. A yellow ring around the
+avatar indicates an active persona.
+
+**Usage from curl / Playwright / any HTTP client:**
+
+```bash
+curl -H "X-Test-Token: <your-token>" \
+     -H "X-Test-User-Email: producer@test.local" \
+     -H "X-Test-User-Groups: [\"data-producers\"]" \
+     http://localhost:8000/api/user/details
+```
+
+- `X-Test-User-Email` is required when `X-Test-Token` matches.
+- `X-Test-User-Groups` is optional (JSON array or comma-separated). When
+  omitted, the backend falls back to a real SCIM lookup so the persona
+  reflects actual workspace state.
+- Optional refinement headers: `X-Test-User-Username`,
+  `X-Test-User-Name`, `X-Test-User-Ip`.
+
+**Security notes:**
+
+- The override is gated on `TEST_USER_TOKEN` being set server-side. Leave it
+  UNSET in production.
+- The token itself is never returned by the server. The persona discovery
+  endpoint (`GET /api/test/personas`) returns 404 when the feature is
+  disabled.
+- This mechanism is complementary to the env-based `MOCK_USER_*` variables
+  (which require restarts) and to the in-process FastAPI
+  `app.dependency_overrides[get_user_details_from_sdk]` pattern used by
+  most integration tests.
+
+See `src/backend/src/tests/integration/test_user_header_override.py` for
+worked examples.
+
 ---
 
 ## License

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -48,6 +48,26 @@ DATABRICKS_VOLUME=app_files
 # Example: APP_ADMIN_DEFAULT_GROUPS="admins,workspace-power-users"
 APP_ADMIN_DEFAULT_GROUPS="admins"
 
+# --- Testing / Per-Request User Impersonation ---
+# When set to "true", various test-only behaviors are enabled (skipped startup
+# tasks if SKIP_STARTUP_TASKS is also set, no static file mounts in test runs).
+# TESTING=false
+
+# SECURITY: Setting TEST_USER_TOKEN to a non-empty value ENABLES runtime user
+# impersonation via HTTP headers. Any request carrying a matching X-Test-Token
+# along with X-Test-User-Email (and optional X-Test-User-Groups) will be
+# resolved as that user — bypassing the normal Databricks Apps identity flow.
+#
+# This is the recommended mechanism for testing different personas against a
+# single long-running backend (no restarts) and for E2E / Playwright tests.
+# It works regardless of ENV — leave UNSET in production.
+#
+# Generate a random token (e.g. `openssl rand -hex 32`) and provision it
+# out-of-band to authorized clients. The token itself is never echoed back
+# from the server (e.g. /api/test/personas returns header names but not the
+# token).
+# TEST_USER_TOKEN=
+
 # --- Optional: Git Integration for Configuration Backup/Sync ---
 # GIT_REPO_URL=https://github.com/your_user/your_repo.git
 # GIT_BRANCH=main

--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -49,6 +49,7 @@ from src.routes import (
     settings_routes,
     semantic_models_routes,
     semantic_links_routes,
+    test_personas_routes,
     user_routes,
     audit_routes,
     change_log_routes,
@@ -319,7 +320,7 @@ app.add_middleware(LoggingMiddleware)
 app.add_middleware(MaintenanceMiddleware)
 
 # Mount static files for the React application (skip in test mode)
-if not os.environ.get('TESTING'):
+if not settings.TESTING:
     app.mount("/static", StaticFiles(directory=STATIC_ASSETS_PATH, html=True), name="static")
 
 # Data Products - Core data lifecycle
@@ -377,6 +378,7 @@ search_routes.register_routes(app)
 llm_search_routes.register_routes(app)
 jobs_routes.register_routes(app)
 user_routes.register_routes(app)
+test_personas_routes.register_routes(app)
 audit_routes.register_routes(app)
 change_log_routes.register_routes(app)
 mcp_routes.register_routes(app)
@@ -437,7 +439,7 @@ async def retry_startup():
     return {"status": "ok", "health": app.state.health}
 
 # Define the SPA catch-all route LAST (skip in test mode)
-if not os.environ.get('TESTING'):
+if not settings.TESTING:
     @app.get("/{full_path:path}")
     def serve_spa(full_path: str):
         # Only catch routes that aren't API routes, static files, or API docs

--- a/src/backend/src/common/authorization.py
+++ b/src/backend/src/common/authorization.py
@@ -145,6 +145,117 @@ LOCAL_DEV_USER = UserInfo(
     groups=["admins", "local-admins", "developers"] # Added 'admins' for testing
 )
 
+
+# Per-request test-user override headers (see config.TEST_USER_TOKEN).
+TEST_TOKEN_HEADER = "X-Test-Token"
+TEST_USER_EMAIL_HEADER = "X-Test-User-Email"
+TEST_USER_GROUPS_HEADER = "X-Test-User-Groups"
+TEST_USER_USERNAME_HEADER = "X-Test-User-Username"
+TEST_USER_NAME_HEADER = "X-Test-User-Name"
+TEST_USER_IP_HEADER = "X-Test-User-Ip"
+
+
+def _parse_test_groups(raw: str) -> List[str]:
+    """Parse the X-Test-User-Groups header.
+
+    Accepts a JSON array (e.g. ``["admins","data-producers"]``) or a
+    comma-separated string (e.g. ``admins,data-producers``). Whitespace is
+    trimmed and empty entries dropped.
+    """
+    import json as _json
+    try:
+        parsed = _json.loads(raw)
+        if isinstance(parsed, list) and all(isinstance(x, str) for x in parsed):
+            return [g.strip() for g in parsed if g and g.strip()]
+    except Exception:
+        pass
+    return [g.strip() for g in raw.split(',') if g.strip()]
+
+
+def _try_resolve_test_override(
+    request: Request,
+    settings: Settings,
+    manager: Optional[UsersManager],
+    real_ip: Optional[str] = None,
+) -> Optional[UserInfo]:
+    """Return a synthetic ``UserInfo`` when the request carries valid test headers.
+
+    Gating: a non-empty ``TEST_USER_TOKEN`` must be configured AND the request must
+    present an ``X-Test-Token`` header whose value matches it exactly. When the
+    feature is not configured (token unset), this function is a no-op and returns
+    ``None`` regardless of the headers present.
+
+    Behavior when active:
+      - ``X-Test-User-Email`` is required; missing/empty yields a 400.
+      - ``X-Test-User-Groups`` is optional. If provided, parsed locally.
+        If absent, groups are resolved via the SP-scoped SCIM lookup
+        (``UsersManager.get_user_details_by_email``) so the override
+        mirrors real Databricks Apps behavior.
+      - Optional ``X-Test-User-{Username,Name,Ip}`` headers refine the identity.
+
+    Returns ``None`` (without raising) when the token is unset or doesn't match,
+    so the caller can fall through to the regular identity-resolution path.
+    """
+    if not settings.TEST_USER_TOKEN:
+        return None
+    presented = request.headers.get(TEST_TOKEN_HEADER)
+    if not presented or presented != settings.TEST_USER_TOKEN:
+        return None
+
+    email = request.headers.get(TEST_USER_EMAIL_HEADER)
+    if not email or not email.strip():
+        # Token matched, so the caller clearly meant to use the override;
+        # surface a precise error instead of silently falling through.
+        raise HTTPException(
+            status_code=400,
+            detail=f"{TEST_TOKEN_HEADER} matched but {TEST_USER_EMAIL_HEADER} is missing or empty",
+        )
+    email = email.strip()
+
+    groups_raw = request.headers.get(TEST_USER_GROUPS_HEADER)
+    if groups_raw is not None:
+        groups: List[str] = _parse_test_groups(groups_raw)
+        groups_source = "header"
+    elif manager is not None:
+        # Fall back to SCIM lookup so the persona reflects real workspace state.
+        try:
+            sdk_info = manager.get_user_details_by_email(user_email=email, real_ip=real_ip)
+            groups = list(sdk_info.groups or [])
+            groups_source = "scim"
+        except NotFound:
+            logger.warning(
+                "Test override: SCIM lookup for %s returned NotFound; defaulting to email-as-group fallback",
+                email,
+            )
+            groups = [email]
+            groups_source = "fallback"
+        except Exception:
+            logger.exception(
+                "Test override: SCIM lookup for %s failed; defaulting to empty groups",
+                email,
+            )
+            groups = []
+            groups_source = "error"
+    else:
+        groups = []
+        groups_source = "no-manager"
+
+    username = (request.headers.get(TEST_USER_USERNAME_HEADER) or email).strip()
+    name = (request.headers.get(TEST_USER_NAME_HEADER) or email).strip()
+    ip = (request.headers.get(TEST_USER_IP_HEADER) or real_ip or "").strip() or None
+
+    logger.warning(
+        "TEST OVERRIDE active: identity=%s username=%s groups_source=%s groups=%s",
+        email, username, groups_source, groups,
+    )
+    return UserInfo(
+        email=email,
+        username=username,
+        user=name,
+        ip=ip,
+        groups=groups,
+    )
+
 async def get_user_details_from_sdk(
     request: Request,
     settings: Settings = Depends(get_settings),
@@ -158,6 +269,14 @@ async def get_user_details_from_sdk(
     
     Falls back to get_user_details_by_email if OBO token is not available.
     """
+    # Per-request test-user override (highest precedence; gated by TEST_USER_TOKEN).
+    # Safe no-op when token is unset, regardless of headers present.
+    override = _try_resolve_test_override(
+        request, settings, manager, real_ip=request.headers.get("X-Real-Ip")
+    )
+    if override is not None:
+        return override
+
     # Check for local development environment or explicit mock flag
     if settings.ENV.upper().startswith("LOCAL") or getattr(settings, "MOCK_USER_DETAILS", False):
         # Build mock user from env-var overrides if provided
@@ -261,10 +380,28 @@ async def get_user_details_from_sdk(
         raise HTTPException(status_code=500, detail="An unexpected error occurred")
 
 
-async def get_user_groups(user_email: str) -> List[str]:
-    """Get user groups for the given user email."""
+async def get_user_groups(user_email: str, request: Optional[Request] = None) -> List[str]:
+    """Get user groups for the given user email.
+
+    When ``request`` is provided and a valid test-user override header is
+    present, the override's groups are returned (mirrors
+    :func:`get_user_details_from_sdk`).
+    """
     # Get settings directly instead of using dependency injection
     settings = get_settings()
+
+    # Per-request test override (only when caller threaded the request through).
+    if request is not None:
+        try:
+            override = _try_resolve_test_override(
+                request, settings, manager=None, real_ip=request.headers.get("X-Real-Ip")
+            )
+            if override is not None and override.email == user_email:
+                return list(override.groups or [])
+        except HTTPException:
+            # A 400 here means the caller meant to override but did it wrong.
+            # Surface it rather than masking with an empty group list.
+            raise
 
     if settings.ENV.upper().startswith("LOCAL") or getattr(settings, "MOCK_USER_DETAILS", False):
         # Return mock groups for local/mock development honoring overrides

--- a/src/backend/src/common/config.py
+++ b/src/backend/src/common/config.py
@@ -120,6 +120,15 @@ class Settings(BaseSettings):
     MOCK_USER_GROUPS: Optional[str] = Field(None, env='MOCK_USER_GROUPS')
     MOCK_USER_IP: Optional[str] = Field(None, env='MOCK_USER_IP')
 
+    # Testing flag (replaces ad-hoc os.environ.get('TESTING') reads)
+    TESTING: bool = Field(False, env='TESTING')
+
+    # Per-request user-identity override via headers.
+    # When this token is set, requests carrying a matching X-Test-Token header
+    # may impersonate any user via X-Test-User-Email (+ optional X-Test-User-Groups).
+    # SECURITY: Leave UNSET in production. The feature is fully disabled when None.
+    TEST_USER_TOKEN: Optional[str] = Field(None, env='TEST_USER_TOKEN')
+
     # LLM Configuration
     LLM_ENABLED: bool = Field(False, env='LLM_ENABLED')
     LLM_ENDPOINT: Optional[str] = Field(None, env='LLM_ENDPOINT')  # Databricks serving endpoint name (e.g., 'databricks-claude-sonnet-4-5')
@@ -171,6 +180,22 @@ class Settings(BaseSettings):
         """Compute the DATABRICKS_HTTP_PATH after validation."""
         if self.DATABRICKS_WAREHOUSE_ID:
             self.DATABRICKS_HTTP_PATH = f"/sql/1.0/warehouses/{self.DATABRICKS_WAREHOUSE_ID}"
+        return self
+
+    @model_validator(mode='after')
+    def warn_test_token_in_prod(self) -> 'Settings':
+        """Warn loudly if TEST_USER_TOKEN is set in a production environment.
+
+        The shared-secret design intentionally permits enabling header overrides
+        anywhere (so testers can hit cloud test deployments), but doing so in
+        PROD is almost always a misconfiguration.
+        """
+        if self.TEST_USER_TOKEN and self.ENV.upper() == "PROD":
+            logger.warning(
+                "TEST_USER_TOKEN is set while ENV=PROD. Per-request user impersonation "
+                "via X-Test-Token headers is ENABLED. Unset TEST_USER_TOKEN unless this "
+                "is intentional."
+            )
         return self
 
     @model_validator(mode='after')

--- a/src/backend/src/data/test_personas.yaml
+++ b/src/backend/src/data/test_personas.yaml
@@ -1,0 +1,57 @@
+# Canned test personas exposed via GET /api/test/personas when TEST_USER_TOKEN is set.
+#
+# Each persona pairs a synthetic identity with the workspace groups that should
+# resolve to a given AppRole during permission evaluation. The default groups
+# below mirror the seeded role definitions (see DEFAULT_ROLES /
+# DEFAULT_ROLE_PERMISSIONS in settings_manager.py); if you've customized role
+# assigned_groups in your deployment, adjust this file accordingly.
+#
+# Fields:
+#   id          - stable identifier used by the frontend persona picker
+#   label       - human-readable name shown in the UI
+#   email       - X-Test-User-Email value sent on every request
+#   groups      - X-Test-User-Groups value (omit/null to let the backend
+#                 fall back to a real SCIM lookup for the email)
+#   description - optional explanation shown alongside the persona
+personas:
+  - id: admin
+    label: "Admin"
+    email: admin@test.local
+    groups: ["admins"]
+    description: "Full access to all features (matches APP_ADMIN_DEFAULT_GROUPS)"
+
+  - id: governance
+    label: "Data Governance Officer"
+    email: governance@test.local
+    groups: ["data-governance-officers"]
+    description: "Cross-cutting governance: domains, products, contracts, glossary, compliance"
+
+  - id: steward
+    label: "Data Steward"
+    email: steward@test.local
+    groups: ["data-stewards"]
+    description: "Curates domains, contracts, glossary terms"
+
+  - id: producer
+    label: "Data Producer"
+    email: producer@test.local
+    groups: ["data-producers"]
+    description: "Creates data products and contracts"
+
+  - id: consumer
+    label: "Data Consumer"
+    email: consumer@test.local
+    groups: ["data-consumers"]
+    description: "Read-only access to published products and contracts"
+
+  - id: security
+    label: "Security Officer"
+    email: security@test.local
+    groups: ["security-officers"]
+    description: "Security features, entitlements, compliance review"
+
+  - id: anon
+    label: "No groups"
+    email: anon@test.local
+    groups: []
+    description: "Caller has no group memberships (exercises empty-permission paths)"

--- a/src/backend/src/routes/comments_routes.py
+++ b/src/backend/src/routes/comments_routes.py
@@ -57,7 +57,7 @@ async def create_comment(
             )
 
         # Get user's groups and check admin status
-        user_groups = await get_user_groups(current_user.email)
+        user_groups = await get_user_groups(current_user.email, request)
         is_admin = is_user_admin(user_groups, get_settings())
         
         # Get user's teams (for validation if needed)
@@ -111,7 +111,7 @@ async def list_comments(
     """List comments for an entity, filtered by project context and user's visibility permissions."""
     try:
         # Get user's groups for audience filtering
-        user_groups = await get_user_groups(current_user.email)
+        user_groups = await get_user_groups(current_user.email, request)
         
         # Get user's teams for team-based audience filtering
         user_teams = team_repo.get_teams_for_user(db, current_user.email, user_groups)
@@ -162,7 +162,7 @@ async def get_entity_timeline_count(
         total_count = 0
 
         # Get user's groups for audience filtering
-        user_groups = await get_user_groups(current_user.email)
+        user_groups = await get_user_groups(current_user.email, request)
         is_admin = is_user_admin(user_groups, get_settings())
         
         # Get user's teams and app role
@@ -229,7 +229,7 @@ async def get_entity_timeline(
         timeline_entries = []
         
         # Get user's groups for audience filtering
-        user_groups = await get_user_groups(current_user.email)
+        user_groups = await get_user_groups(current_user.email, request)
         is_admin = is_user_admin(user_groups, get_settings())
         
         # Get user's teams and app role
@@ -361,7 +361,7 @@ async def update_comment(
 
     try:
         # Get user's groups to check for admin status
-        user_groups = await get_user_groups(current_user.email)
+        user_groups = await get_user_groups(current_user.email, request)
         is_admin = is_user_admin(user_groups, get_settings())
 
         updated = manager.update_comment(
@@ -422,7 +422,7 @@ async def delete_comment(
 
     try:
         # Get user's groups to check for admin status
-        user_groups = await get_user_groups(current_user.email)
+        user_groups = await get_user_groups(current_user.email, request)
         is_admin = is_user_admin(user_groups, get_settings())
 
         # Only admins can hard delete
@@ -477,7 +477,7 @@ async def check_comment_permissions(
     """Check if current user can modify a specific comment."""
     try:
         # Get user's groups to check for admin status
-        user_groups = await get_user_groups(current_user.email)
+        user_groups = await get_user_groups(current_user.email, request)
         is_admin = is_user_admin(user_groups, get_settings())
         
         can_modify = manager.can_user_modify_comment(

--- a/src/backend/src/routes/test_personas_routes.py
+++ b/src/backend/src/routes/test_personas_routes.py
@@ -1,0 +1,124 @@
+"""Test-persona discovery endpoint.
+
+Exposes the canned personas defined in ``src/backend/src/data/test_personas.yaml``
+to the frontend so the UI can offer a persona picker.
+
+The endpoint is enabled only when ``TEST_USER_TOKEN`` is configured server-side
+(otherwise the entire header-override mechanism is dormant and the frontend
+should not show any persona UI). When disabled, the endpoint returns 404 so
+clients can probe without learning that the feature exists.
+
+Security:
+- The endpoint does NOT echo back the ``TEST_USER_TOKEN`` itself. The token
+  is provisioned to the dev/test client out-of-band (e.g. a frontend
+  ``VITE_TEST_USER_TOKEN`` env var or a curl flag). This prevents an
+  accidental information leak via a misconfigured prod deployment.
+- The persona list itself is harmless metadata, but we still gate it on the
+  token being configured to avoid surfacing the feature in production.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from src.common.authorization import (
+    TEST_TOKEN_HEADER,
+    TEST_USER_EMAIL_HEADER,
+    TEST_USER_GROUPS_HEADER,
+    TEST_USER_IP_HEADER,
+    TEST_USER_NAME_HEADER,
+    TEST_USER_USERNAME_HEADER,
+)
+from src.common.config import Settings, get_settings
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/test", tags=["Test"])
+
+PERSONAS_YAML_PATH = (
+    Path(__file__).resolve().parent.parent / "data" / "test_personas.yaml"
+)
+
+
+class TestPersona(BaseModel):
+    id: str
+    label: str
+    email: str
+    # Groups are optional: when omitted, the backend falls back to a SCIM
+    # lookup so the persona reflects real workspace state.
+    groups: Optional[List[str]] = None
+    description: Optional[str] = None
+
+
+class TestPersonasResponse(BaseModel):
+    personas: List[TestPersona]
+    # Names of the headers the frontend must send. Surfacing them here keeps
+    # the client and server agreed on the wire format.
+    headers: Dict[str, str] = Field(
+        default_factory=lambda: {
+            "token": TEST_TOKEN_HEADER,
+            "email": TEST_USER_EMAIL_HEADER,
+            "groups": TEST_USER_GROUPS_HEADER,
+            "username": TEST_USER_USERNAME_HEADER,
+            "name": TEST_USER_NAME_HEADER,
+            "ip": TEST_USER_IP_HEADER,
+        }
+    )
+
+
+_cached_personas: Optional[List[TestPersona]] = None
+
+
+def _load_personas() -> List[TestPersona]:
+    """Load and cache the persona list from disk."""
+    global _cached_personas
+    if _cached_personas is not None:
+        return _cached_personas
+
+    if not PERSONAS_YAML_PATH.is_file():
+        logger.warning(
+            "test_personas.yaml not found at %s; returning empty persona list",
+            PERSONAS_YAML_PATH,
+        )
+        _cached_personas = []
+        return _cached_personas
+
+    try:
+        with PERSONAS_YAML_PATH.open() as f:
+            raw = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        logger.error("Failed to parse test_personas.yaml: %s", e)
+        _cached_personas = []
+        return _cached_personas
+
+    items = raw.get("personas") or []
+    personas: List[TestPersona] = []
+    for item in items:
+        try:
+            personas.append(TestPersona(**item))
+        except Exception as e:
+            logger.warning("Skipping malformed test persona %r: %s", item, e)
+    _cached_personas = personas
+    return _cached_personas
+
+
+@router.get("/personas", response_model=TestPersonasResponse)
+def list_test_personas(settings: Settings = Depends(get_settings)) -> TestPersonasResponse:
+    """List the canned test personas.
+
+    Returns 404 when ``TEST_USER_TOKEN`` is unset (feature disabled).
+    """
+    if not settings.TEST_USER_TOKEN:
+        raise HTTPException(status_code=404, detail="Test mode not enabled")
+
+    return TestPersonasResponse(personas=_load_personas())
+
+
+def register_routes(app):
+    """Register the test-personas router with the FastAPI app."""
+    app.include_router(router)
+    logger.info("Test-personas routes registered")

--- a/src/backend/src/routes/user_routes.py
+++ b/src/backend/src/routes/user_routes.py
@@ -18,7 +18,7 @@ from src.controller.settings_manager import SettingsManager
 from pydantic import BaseModel
 from src.controller.notifications_manager import NotificationsManager
 from src.common.features import FeatureAccessLevel
-from src.common.authorization import get_user_details_from_sdk
+from src.common.authorization import get_user_details_from_sdk, _try_resolve_test_override
 from sqlalchemy.orm import Session # Import Session
 
 from src.common.logging import get_logger
@@ -35,6 +35,14 @@ router = APIRouter(prefix="/api", tags=["User"])
 async def get_user_info_from_headers(request: Request, settings: Settings = Depends(get_settings)):
     """Get basic user information directly from request headers, or mock data if local dev."""
     logger.info("Request received for /api/user/info")
+
+    # Per-request test-user override takes precedence over both mock-mode and headers.
+    override = _try_resolve_test_override(
+        request, settings, manager=None, real_ip=request.headers.get("X-Real-Ip")
+    )
+    if override is not None:
+        logger.info(f"/user/info: returning test override identity for {override.email}")
+        return override
 
     # Check for local development environment
     if settings.ENV.upper().startswith("LOCAL") or getattr(settings, "MOCK_USER_DETAILS", False):

--- a/src/backend/src/tests/integration/test_user_header_override.py
+++ b/src/backend/src/tests/integration/test_user_header_override.py
@@ -1,0 +1,246 @@
+"""Integration tests for the per-request test-user header override.
+
+Covers the headers introduced for runtime persona switching:
+
+  - ``X-Test-Token``            : shared-secret gate (matches ``TEST_USER_TOKEN``)
+  - ``X-Test-User-Email``       : impersonated identity (required)
+  - ``X-Test-User-Groups``      : optional explicit groups (JSON or CSV)
+  - ``X-Test-User-{Username,Name,Ip}`` : optional refinements
+
+These tests bypass the default ``get_user_details_from_sdk`` dependency override
+so the real header-parsing path runs end-to-end.
+"""
+from __future__ import annotations
+
+import json
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.app import app
+from src.common.authorization import (
+    TEST_TOKEN_HEADER,
+    TEST_USER_EMAIL_HEADER,
+    TEST_USER_GROUPS_HEADER,
+    TEST_USER_USERNAME_HEADER,
+    get_user_details_from_sdk,
+)
+from src.common.config import Settings, get_settings
+from src.common.manager_dependencies import get_users_manager
+from src.models.users import UserInfo
+
+
+TEST_TOKEN = "integration-test-token-do-not-use-in-prod"
+
+
+@pytest.fixture
+def client_with_test_token(client: TestClient, test_settings: Settings) -> Iterator[TestClient]:
+    """Yield a TestClient whose backend accepts X-Test-Token = TEST_TOKEN.
+
+    Removes the default ``get_user_details_from_sdk`` override installed by the
+    ``client`` fixture so the real resolver runs and the header path is
+    exercised. Restores everything on teardown.
+    """
+    # Mutate the in-place test_settings so dependent code sees the token.
+    object.__setattr__(test_settings, "TEST_USER_TOKEN", TEST_TOKEN)
+
+    # Override get_settings so get_user_details_from_sdk sees TEST_USER_TOKEN.
+    def _override_settings() -> Settings:
+        return test_settings
+
+    # Provide a stub UsersManager so SCIM fallback doesn't try to hit the wire
+    # when X-Test-User-Groups is omitted. We don't exercise that path here;
+    # tests below explicitly pass the groups header.
+    class _StubUsersManager:
+        def get_user_details_by_email(self, user_email: str, real_ip=None) -> UserInfo:
+            return UserInfo(
+                email=user_email,
+                username=user_email,
+                user=user_email,
+                ip=real_ip,
+                groups=["scim-fallback-group"],
+            )
+
+    def _override_users_manager() -> _StubUsersManager:
+        return _StubUsersManager()
+
+    prev_settings = app.dependency_overrides.get(get_settings)
+    prev_users = app.dependency_overrides.get(get_users_manager)
+    prev_user_details = app.dependency_overrides.pop(get_user_details_from_sdk, None)
+
+    app.dependency_overrides[get_settings] = _override_settings
+    app.dependency_overrides[get_users_manager] = _override_users_manager
+
+    try:
+        yield client
+    finally:
+        object.__setattr__(test_settings, "TEST_USER_TOKEN", None)
+        if prev_settings is not None:
+            app.dependency_overrides[get_settings] = prev_settings
+        else:
+            app.dependency_overrides.pop(get_settings, None)
+        if prev_users is not None:
+            app.dependency_overrides[get_users_manager] = prev_users
+        else:
+            app.dependency_overrides.pop(get_users_manager, None)
+        if prev_user_details is not None:
+            app.dependency_overrides[get_user_details_from_sdk] = prev_user_details
+
+
+class TestPositivePath:
+    """Headers carry through and shape the resolved user identity."""
+
+    def test_groups_in_header_used_verbatim(self, client_with_test_token: TestClient):
+        response = client_with_test_token.get(
+            "/api/user/details",
+            headers={
+                TEST_TOKEN_HEADER: TEST_TOKEN,
+                TEST_USER_EMAIL_HEADER: "producer@test.local",
+                TEST_USER_GROUPS_HEADER: '["data-producers","another-group"]',
+                TEST_USER_USERNAME_HEADER: "producer",
+            },
+        )
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["email"] == "producer@test.local"
+        assert payload["username"] == "producer"
+        # Order doesn't matter, but contents must match.
+        assert sorted(payload["groups"]) == sorted(["data-producers", "another-group"])
+
+    def test_groups_header_csv_form(self, client_with_test_token: TestClient):
+        response = client_with_test_token.get(
+            "/api/user/details",
+            headers={
+                TEST_TOKEN_HEADER: TEST_TOKEN,
+                TEST_USER_EMAIL_HEADER: "csv@test.local",
+                TEST_USER_GROUPS_HEADER: "alpha, beta,  gamma",
+            },
+        )
+        assert response.status_code == 200
+        assert sorted(response.json()["groups"]) == ["alpha", "beta", "gamma"]
+
+    def test_no_groups_header_falls_back_to_scim(self, client_with_test_token: TestClient):
+        # X-Test-User-Groups omitted -> backend calls UsersManager.get_user_details_by_email,
+        # which our stub returns with groups=["scim-fallback-group"].
+        response = client_with_test_token.get(
+            "/api/user/details",
+            headers={
+                TEST_TOKEN_HEADER: TEST_TOKEN,
+                TEST_USER_EMAIL_HEADER: "scim@test.local",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["groups"] == ["scim-fallback-group"]
+
+    def test_personas_endpoint_returns_yaml(self, client_with_test_token: TestClient):
+        response = client_with_test_token.get("/api/test/personas")
+        assert response.status_code == 200
+        body = response.json()
+        ids = {p["id"] for p in body["personas"]}
+        assert {"admin", "consumer", "producer"}.issubset(ids)
+        assert body["headers"]["token"] == TEST_TOKEN_HEADER
+        assert body["headers"]["email"] == TEST_USER_EMAIL_HEADER
+
+
+class TestPermissionsRespectOverride:
+    """Persona's groups should drive role-based permissions for the same session."""
+
+    def test_admin_persona_gets_admin_perms(self, client_with_test_token: TestClient):
+        # The seeded "Admin" role in tests is assigned to APP_ADMIN_DEFAULT_GROUPS,
+        # which test_settings sets to ["test_admins"]. So sending that group as the
+        # persona's groups should yield non-empty permissions including Admin level.
+        response = client_with_test_token.get(
+            "/api/user/permissions",
+            headers={
+                TEST_TOKEN_HEADER: TEST_TOKEN,
+                TEST_USER_EMAIL_HEADER: "header-admin@test.local",
+                TEST_USER_GROUPS_HEADER: '["test_admins"]',
+            },
+        )
+        assert response.status_code == 200
+        perms = response.json()
+        # Admin role should grant ADMIN access to at least one feature
+        # (the seeding logic generally gives Admin everything).
+        assert any(level == "Admin" for level in perms.values()), perms
+
+    def test_unknown_groups_yield_empty_perms(self, client_with_test_token: TestClient):
+        response = client_with_test_token.get(
+            "/api/user/permissions",
+            headers={
+                TEST_TOKEN_HEADER: TEST_TOKEN,
+                TEST_USER_EMAIL_HEADER: "nobody@test.local",
+                TEST_USER_GROUPS_HEADER: '["totally-unmatched-group"]',
+            },
+        )
+        assert response.status_code == 200
+        # PermissionChecker returns {} for users with groups but no matching role.
+        # /api/user/permissions itself returns {} when groups list is empty,
+        # so the only thing we strictly require is a successful 200 with no
+        # ADMIN entry leaking through.
+        perms = response.json()
+        assert "Admin" not in perms.values()
+
+
+class TestNegativePath:
+    """Misuse must fail loudly rather than silently bypass auth."""
+
+    def test_missing_email_returns_400(self, client_with_test_token: TestClient):
+        response = client_with_test_token.get(
+            "/api/user/details",
+            headers={TEST_TOKEN_HEADER: TEST_TOKEN},
+        )
+        # Token matched but email missing -> 400 (caller clearly intended to
+        # override and we don't want to silently fall through to mock-user mode).
+        assert response.status_code == 400
+        assert TEST_USER_EMAIL_HEADER in response.json()["detail"]
+
+    def test_wrong_token_is_ignored(self, client_with_test_token: TestClient):
+        # With a wrong token, the override helper returns None and the resolver
+        # falls through to the normal identity path. The CRITICAL property here
+        # is security: the X-Test-User-Email value must NOT become the
+        # resolved identity. The status code is incidental — the resolver may
+        # 400 (missing X-Forwarded-Email) or 200 (synthesized from stub), but
+        # in no case may the email match the attempted impersonation.
+        response = client_with_test_token.get(
+            "/api/user/details",
+            headers={
+                TEST_TOKEN_HEADER: "definitely-not-the-real-token",
+                TEST_USER_EMAIL_HEADER: "tricky@test.local",
+                TEST_USER_GROUPS_HEADER: '["admins"]',
+            },
+        )
+        if response.status_code == 200:
+            assert response.json().get("email") != "tricky@test.local"
+        else:
+            # Any non-200 is also acceptable — it means the wrong-token
+            # request was rejected by some downstream check rather than
+            # being silently honored.
+            assert response.status_code in (400, 401, 403, 404, 500)
+
+
+class TestFeatureDisabled:
+    """When TEST_USER_TOKEN is unset, the headers must be inert."""
+
+    def test_personas_endpoint_404_when_token_unset(self, client: TestClient):
+        # The default client fixture doesn't set TEST_USER_TOKEN; the endpoint must 404.
+        response = client.get("/api/test/personas")
+        assert response.status_code == 404
+
+    def test_headers_ignored_when_token_unset(self, client: TestClient):
+        # Default client still has the get_user_details_from_sdk override active,
+        # but even if it didn't, the helper would refuse to honor any header
+        # when TEST_USER_TOKEN is None. The user should remain the seeded
+        # mock_test_user from conftest.
+        response = client.get(
+            "/api/user/details",
+            headers={
+                TEST_TOKEN_HEADER: "anything",
+                TEST_USER_EMAIL_HEADER: "should-be-ignored@test.local",
+                TEST_USER_GROUPS_HEADER: '["admins"]',
+            },
+        )
+        assert response.status_code == 200
+        # Identity must NOT be the impersonated one.
+        assert response.json()["email"] != "should-be-ignored@test.local"

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -1,0 +1,23 @@
+# -----------------------------------------------------------------------------
+# Ontos Frontend - Environment Configuration
+#
+# Copy this file to .env or .env.local and fill in the appropriate values.
+# Only variables prefixed with VITE_ are exposed to the browser bundle.
+# -----------------------------------------------------------------------------
+
+# --- Per-Request User Impersonation (mirrors backend TEST_USER_TOKEN) ---
+#
+# When the backend has TEST_USER_TOKEN set, the user-info menu shows a "Test
+# persona" picker. Selecting a persona causes the frontend to inject
+# X-Test-Token, X-Test-User-Email, and X-Test-User-Groups on every /api
+# request. The picker only sends headers when this VITE_TEST_USER_TOKEN value
+# matches the backend's TEST_USER_TOKEN.
+#
+# Out-of-Vite usage (curl, Playwright, other clients): set the same headers
+# manually with the agreed token. The personas list is available at
+# GET /api/test/personas.
+#
+# As a fallback when not running through Vite (e.g. opening a deployed app
+# directly), the frontend will also read the token from
+# localStorage["ucapp.testToken"].
+# VITE_TEST_USER_TOKEN=

--- a/src/frontend/src/app.tsx
+++ b/src/frontend/src/app.tsx
@@ -8,6 +8,12 @@ import { RouteErrorBoundary } from './components/layout/route-error-boundary';
 import { useUserStore } from './stores/user-store';
 import { usePermissions } from './stores/permissions-store';
 import { useNotificationsStore } from './stores/notifications-store';
+import useTestPersonaStore, { installTestPersonaFetchInterceptor } from './stores/test-persona-store';
+
+// Install the fetch interceptor immediately at module load so even very early
+// requests (e.g. probes during component mount) carry the override headers
+// once a persona is restored from localStorage.
+installTestPersonaFetchInterceptor();
 import ApprovalWizardDialog from './components/workflows/approval-wizard-dialog';
 import './i18n/config'; // Initialize i18n
 
@@ -93,6 +99,7 @@ export default function App() {
   const fetchUserInfo = useUserStore((state: any) => state.fetchUserInfo);
   const { fetchPermissions, fetchAvailableRoles } = usePermissions();
   const { startPolling: startNotificationPolling, stopPolling: stopNotificationPolling } = useNotificationsStore();
+  const initializeTestPersonas = useTestPersonaStore((s) => s.initialize);
 
   // First-access disclaimer: any active `on_first_access` Approval Workflow the
   // current user hasn't yet accepted at the workflow's current version is
@@ -110,9 +117,13 @@ export default function App() {
 
   useEffect(() => {
     console.log("App component mounted, fetching initial user info and permissions...");
-    fetchUserInfo();
-    fetchPermissions();
-    fetchAvailableRoles();
+    // Probe for the test-persona feature first so any restored persona
+    // selection is in effect before user/permissions calls go out.
+    initializeTestPersonas().finally(() => {
+      fetchUserInfo();
+      fetchPermissions();
+      fetchAvailableRoles();
+    });
 
     console.log("Starting notification polling...");
     startNotificationPolling();
@@ -141,7 +152,7 @@ export default function App() {
         console.log("App component unmounting, stopping notification polling...");
         stopNotificationPolling();
     };
-  }, [fetchUserInfo, fetchPermissions, fetchAvailableRoles, startNotificationPolling, stopNotificationPolling]);
+  }, [fetchUserInfo, fetchPermissions, fetchAvailableRoles, startNotificationPolling, stopNotificationPolling, initializeTestPersonas]);
 
   return (
     <ThemeProvider defaultTheme="system" storageKey="ucapp-theme">

--- a/src/frontend/src/components/ui/user-info.tsx
+++ b/src/frontend/src/components/ui/user-info.tsx
@@ -13,10 +13,12 @@ import {
   DropdownMenuRadioItem,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-import { LogOut, User as UserIcon, FlaskConical, Beaker, Users as UsersIcon, Settings, Info } from 'lucide-react';
+import { LogOut, User as UserIcon, FlaskConical, Beaker, Users as UsersIcon, Settings, Info, TestTube2 } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
 import { useFeatureVisibilityStore } from '@/stores/feature-visibility-store';
 import { usePermissions } from '@/stores/permissions-store';
+import useTestPersonaStore from '@/stores/test-persona-store';
 import { FeatureAccessLevel, AppRole } from '@/types/settings';
 import { ACCESS_LEVEL_ORDER } from '../../lib/permissions';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -78,6 +80,27 @@ export default function UserInfo() {
       initializeStore,
       hasPermission,
   } = usePermissions();
+  const {
+      enabled: testPersonasEnabled,
+      personas: testPersonas,
+      selectedPersonaId: selectedTestPersonaId,
+      token: testToken,
+      setPersona: setTestPersona,
+  } = useTestPersonaStore();
+  const activeTestPersona = useMemo(
+      () => testPersonas.find((p) => p.id === selectedTestPersonaId) || null,
+      [testPersonas, selectedTestPersonaId],
+  );
+
+  const handleTestPersonaChange = (value: string) => {
+      const next = value === 'none' ? null : value;
+      if (next === selectedTestPersonaId) return;
+      setTestPersona(next);
+      // Hard reload so every store (user, permissions, notifications, etc.) is
+      // re-hydrated with the new identity. Cheaper and more correct than
+      // teaching every store to handle mid-session identity swaps.
+      window.location.reload();
+  };
 
   // Hide the Settings menu item when the user lacks the layout gate;
   // the route would otherwise redirect them home anyway.
@@ -221,10 +244,19 @@ export default function UserInfo() {
     <>
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-8 w-8 rounded-full">
-          <Avatar className="h-8 w-8">
+        <Button
+            variant="ghost"
+            className="relative h-8 w-8 rounded-full"
+            // Subtle persistent visual cue so testers don't forget they're
+            // acting as someone else.
+            title={activeTestPersona ? `Acting as ${activeTestPersona.label} (test mode)` : undefined}
+        >
+          <Avatar className={`h-8 w-8 ${activeTestPersona ? 'ring-2 ring-yellow-500' : ''}`}>
             <AvatarFallback>{initials}</AvatarFallback>
           </Avatar>
+          {activeTestPersona && (
+            <span className="absolute -bottom-1 -right-1 h-3 w-3 rounded-full bg-yellow-500 border-2 border-background" />
+          )}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64">
@@ -262,6 +294,54 @@ export default function UserInfo() {
             </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
+        {testPersonasEnabled && (
+            <>
+            <DropdownMenuGroup>
+                <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5 flex items-center justify-between">
+                    <span className="flex items-center">
+                        <TestTube2 className="mr-1.5 h-3.5 w-3.5" />
+                        Test persona
+                    </span>
+                    {activeTestPersona ? (
+                        <Badge variant="outline" className="text-[10px] border-yellow-500 text-yellow-700 dark:text-yellow-400">
+                            Active
+                        </Badge>
+                    ) : !testToken ? (
+                        <Badge variant="outline" className="text-[10px]" title="Set VITE_TEST_USER_TOKEN or localStorage['ucapp.testToken'] to enable">
+                            No token
+                        </Badge>
+                    ) : null}
+                </DropdownMenuLabel>
+                <ScrollArea className="max-h-[180px] overflow-y-auto">
+                    <DropdownMenuRadioGroup
+                        value={selectedTestPersonaId || 'none'}
+                        onValueChange={handleTestPersonaChange}
+                    >
+                        <DropdownMenuRadioItem value="none" disabled={!testToken}>
+                            <UserIcon className="mr-1.5 h-3.5 w-3.5" />
+                            None (real identity)
+                        </DropdownMenuRadioItem>
+                        {testPersonas.map((p) => (
+                            <DropdownMenuRadioItem
+                                key={p.id}
+                                value={p.id}
+                                disabled={!testToken}
+                                className="flex items-center"
+                                title={p.description}
+                            >
+                                <TestTube2 className="mr-1.5 h-3.5 w-3.5" />
+                                <span className="flex flex-col">
+                                    <span>{p.label}</span>
+                                    <span className="text-[10px] text-muted-foreground">{p.email}</span>
+                                </span>
+                            </DropdownMenuRadioItem>
+                        ))}
+                    </DropdownMenuRadioGroup>
+                </ScrollArea>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            </>
+        )}
         {canSwitchRoles && (
             <>
             <DropdownMenuGroup>

--- a/src/frontend/src/stores/test-persona-store.ts
+++ b/src/frontend/src/stores/test-persona-store.ts
@@ -1,0 +1,243 @@
+import { create } from 'zustand';
+
+/**
+ * Test-persona override store.
+ *
+ * When the backend exposes `GET /api/test/personas` (i.e. `TEST_USER_TOKEN`
+ * is configured server-side), this store hydrates the persona list and lets
+ * the user pick one. A global `fetch` interceptor (installed in `app.tsx`)
+ * consults `getActiveOverride()` on every request to inject the
+ * `X-Test-Token`, `X-Test-User-Email`, and `X-Test-User-Groups` headers.
+ *
+ * The token itself never travels server -> client. It's read from
+ * `import.meta.env.VITE_TEST_USER_TOKEN` (or, when not running through Vite,
+ * from `localStorage['ucapp.testToken']` so a tester can paste it in).
+ */
+
+export interface TestPersona {
+  id: string;
+  label: string;
+  email: string;
+  groups: string[] | null;
+  description?: string;
+}
+
+export interface TestPersonaHeaders {
+  token: string;
+  email: string;
+  groups: string;
+  username: string;
+  name: string;
+  ip: string;
+}
+
+interface TestPersonasResponse {
+  personas: TestPersona[];
+  headers: TestPersonaHeaders;
+}
+
+interface TestPersonaState {
+  /** True when the backend reports the feature is enabled. */
+  enabled: boolean;
+  /** True while the initial probe / persona fetch is in flight. */
+  isLoading: boolean;
+  /** Loaded once at startup; null until probe completes. */
+  personas: TestPersona[];
+  /** Selected persona id (persisted in localStorage). */
+  selectedPersonaId: string | null;
+  /** Token to send in `X-Test-Token`. Null when not configured. */
+  token: string | null;
+  /** Server-provided header names so client and server stay in sync. */
+  headerNames: TestPersonaHeaders | null;
+  /** Probe + load personas. Safe to call multiple times. */
+  initialize: () => Promise<void>;
+  /** Select a persona and persist. Pass null to clear. */
+  setPersona: (id: string | null) => void;
+  /** Convenience accessor. */
+  getActivePersona: () => TestPersona | null;
+}
+
+const STORAGE_KEY_PERSONA = 'ucapp.testPersonaId';
+const STORAGE_KEY_TOKEN = 'ucapp.testToken';
+
+const readToken = (): string | null => {
+  // Prefer the Vite-injected env var so the token is provisioned out of band.
+  // Fall back to localStorage for ad-hoc testers (no Vite build).
+  const fromEnv =
+    typeof import.meta !== 'undefined' &&
+    (import.meta as any).env &&
+    ((import.meta as any).env.VITE_TEST_USER_TOKEN as string | undefined);
+  if (fromEnv) return fromEnv;
+  try {
+    return localStorage.getItem(STORAGE_KEY_TOKEN);
+  } catch {
+    return null;
+  }
+};
+
+const useTestPersonaStore = create<TestPersonaState>((set, get) => ({
+  enabled: false,
+  isLoading: false,
+  personas: [],
+  selectedPersonaId: null,
+  token: null,
+  headerNames: null,
+
+  initialize: async () => {
+    if (get().isLoading || get().enabled) return;
+    set({ isLoading: true });
+    try {
+      const response = await fetch('/api/test/personas', { cache: 'no-store' });
+      if (response.status === 404) {
+        // Feature disabled server-side. Clear any stale selection.
+        set({
+          enabled: false,
+          personas: [],
+          selectedPersonaId: null,
+          token: null,
+          headerNames: null,
+        });
+        try {
+          localStorage.removeItem(STORAGE_KEY_PERSONA);
+        } catch {
+          /* ignore */
+        }
+        return;
+      }
+      if (!response.ok) {
+        console.warn('[test-persona-store] Unexpected status from /api/test/personas:', response.status);
+        return;
+      }
+      const data: TestPersonasResponse = await response.json();
+      const token = readToken();
+      let stored: string | null = null;
+      try {
+        stored = localStorage.getItem(STORAGE_KEY_PERSONA);
+      } catch {
+        /* ignore */
+      }
+      // Validate stored selection still exists.
+      const validSelection =
+        stored && data.personas.some((p) => p.id === stored) ? stored : null;
+      set({
+        enabled: true,
+        personas: data.personas,
+        headerNames: data.headers,
+        token,
+        selectedPersonaId: validSelection,
+      });
+      if (token && validSelection) {
+        const p = data.personas.find((x) => x.id === validSelection);
+        console.warn(
+          `[test-persona-store] Restored test persona "${p?.label}" (${p?.email}). All API requests will impersonate this user.`,
+        );
+      } else if (!token) {
+        console.info(
+          '[test-persona-store] Test personas available, but no token configured (VITE_TEST_USER_TOKEN or localStorage["ucapp.testToken"]). Set a token to enable impersonation.',
+        );
+      }
+    } catch (e) {
+      // Network error / endpoint missing: leave disabled.
+      console.debug('[test-persona-store] Probe failed (feature likely disabled):', e);
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  setPersona: (id) => {
+    const state = get();
+    if (!state.enabled) return;
+    if (id === null) {
+      try {
+        localStorage.removeItem(STORAGE_KEY_PERSONA);
+      } catch {
+        /* ignore */
+      }
+      set({ selectedPersonaId: null });
+      return;
+    }
+    if (!state.personas.some((p) => p.id === id)) {
+      console.warn(`[test-persona-store] Unknown persona id "${id}"; ignoring.`);
+      return;
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY_PERSONA, id);
+    } catch {
+      /* ignore */
+    }
+    set({ selectedPersonaId: id });
+  },
+
+  getActivePersona: () => {
+    const { personas, selectedPersonaId } = get();
+    if (!selectedPersonaId) return null;
+    return personas.find((p) => p.id === selectedPersonaId) || null;
+  },
+}));
+
+/**
+ * Snapshot-style accessor used by the global fetch interceptor.
+ * Reads from the store outside React (no hook required).
+ */
+export interface ActiveOverride {
+  token: string;
+  email: string;
+  groups: string[];
+  headerNames: TestPersonaHeaders;
+}
+
+export function getActiveOverride(): ActiveOverride | null {
+  const { enabled, token, selectedPersonaId, personas, headerNames } =
+    useTestPersonaStore.getState();
+  if (!enabled || !token || !selectedPersonaId || !headerNames) return null;
+  const persona = personas.find((p) => p.id === selectedPersonaId);
+  if (!persona) return null;
+  return {
+    token,
+    email: persona.email,
+    groups: persona.groups || [],
+    headerNames,
+  };
+}
+
+/**
+ * Monkeypatch `window.fetch` once at app startup so every request
+ * automatically carries the test override headers when a persona is active.
+ *
+ * The interceptor is a no-op when the feature isn't enabled or no persona is
+ * selected, so it's safe to install unconditionally in production builds
+ * (the backend would ignore the headers without `TEST_USER_TOKEN` anyway).
+ */
+export function installTestPersonaFetchInterceptor(): void {
+  if (typeof window === 'undefined') return;
+  const w = window as any;
+  if (w.__testPersonaFetchInstalled) return;
+  w.__testPersonaFetchInstalled = true;
+  const original = window.fetch.bind(window);
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const override = getActiveOverride();
+    if (!override) {
+      return original(input, init);
+    }
+    // Only inject for same-origin /api requests so we don't leak headers
+    // to third-party endpoints (LLM streaming, telemetry, etc.).
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    if (!url.startsWith('/api') && !url.startsWith(window.location.origin + '/api')) {
+      return original(input, init);
+    }
+    const merged = new Headers(init?.headers || (input instanceof Request ? input.headers : undefined));
+    merged.set(override.headerNames.token, override.token);
+    merged.set(override.headerNames.email, override.email);
+    // Always send the groups header (even when empty) so the backend doesn't
+    // fall through to a SCIM lookup the tester didn't ask for.
+    merged.set(override.headerNames.groups, JSON.stringify(override.groups));
+    return original(input, { ...init, headers: merged });
+  };
+}
+
+export default useTestPersonaStore;


### PR DESCRIPTION
## Summary

Adds a **per-request user impersonation** mechanism gated on a server-side `TEST_USER_TOKEN` shared secret. Lets developers and Playwright tests exercise the app as different personas (Admin / Producer / Consumer / Steward / etc.) against a **single running backend** — no restarts, works with or without Vite fronting FastAPI.

Complements (does **not** replace) the existing `MOCK_USER_*` env vars (process-wide, require restarts) and the in-process `app.dependency_overrides[get_user_details_from_sdk]` pattern used by integration tests.

## What's new

**Backend**
- `Settings.TEST_USER_TOKEN` + typed `Settings.TESTING` fields, with a `model_validator` warning when `TEST_USER_TOKEN` is set in PROD.
- `_try_resolve_test_override(request, settings, manager)` in `common/authorization.py`:
  - Gated on `TEST_USER_TOKEN` being set **and** `X-Test-Token` matching it exactly.
  - Requires `X-Test-User-Email`; missing email → 400.
  - `X-Test-User-Groups` optional (JSON array or CSV). When omitted, falls back to a real SCIM lookup so the persona mirrors actual workspace state.
  - Optional refinement headers: `X-Test-User-{Username,Name,Ip}`.
  - Audit-logs every active override; no-op when the token is unset.
- Wired at **highest precedence** into `get_user_details_from_sdk`, `get_user_groups` (now accepts optional `request`), and `user_routes.get_user_info_from_headers`.
- `comments_routes` threaded `request` through all 7 `get_user_groups` call sites so audience checks honor the override.
- `src/backend/src/data/test_personas.yaml` with canned personas (admin, governance, steward, producer, consumer, security, anon) aligned with seeded roles.
- `GET /api/test/personas` route — 404s when `TEST_USER_TOKEN` is unset; never returns the token itself.

**Frontend**
- `stores/test-persona-store.ts` Zustand store: fetches personas, reads `VITE_TEST_USER_TOKEN` (or `localStorage.ucapp.testToken`), persists the selected persona, and installs a global `window.fetch` interceptor that injects `X-Test-*` headers on every `/api` request when a persona is active.
- `app.tsx` initializes the store + installs the interceptor early.
- `user-info.tsx` adds a "Test persona" dropdown section (visible **only** when the backend feature is enabled) and a yellow ring/dot on the avatar so testers don't forget they're impersonating.

**Tests + docs**
- `tests/integration/test_user_header_override.py` covering:
  - Header groups (JSON + CSV), SCIM fallback, `/api/test/personas`.
  - Permission resolution from the overridden identity.
  - Wrong-token → ignored (impersonated email NOT honored).
  - Missing email when token matches → 400.
  - Feature fully disabled when token unset.
- `CONTRIBUTING.md`, `CLAUDE.md`, backend + frontend `.env.example` updated with setup, usage from UI/curl, and security notes.

## Security

- Feature is **fully inert** unless `TEST_USER_TOKEN` is set server-side.
- Token must be **left unset in production** (warning logged otherwise).
- Token is **never returned** by any API; `/api/test/personas` returns 404 when the feature is disabled.
- Frontend UI picker is also gated on the backend reporting the feature is enabled.

## Test plan

- [ ] CI: backend pytest suite (incl. the new `test_user_header_override.py`).
- [ ] CI: frontend lint + unit tests.
- [ ] Manual: set `TEST_USER_TOKEN` + `VITE_TEST_USER_TOKEN` locally, pick personas from the avatar dropdown, confirm the persona's permissions take effect across views.
- [ ] Manual: hit a feature-gated endpoint with `curl -H "X-Test-Token: …" -H "X-Test-User-Email: consumer@test.local" -H "X-Test-User-Groups: [\"data-consumers\"]"` — confirm response reflects the impersonated identity.
- [ ] Manual: wrong `X-Test-Token` — confirm impersonation is silently ignored (regular identity resolution wins).
- [ ] Manual: unset `TEST_USER_TOKEN`, confirm `/api/test/personas` returns 404 and the UI picker disappears.