### PR TITLE
ci: lint pull-request titles against Conventional Commits

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -18,7 +18,7 @@ jobs:
     name: validate title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,52 @@
+name: pr-title-lint
+
+# Enforce Conventional Commits format on pull-request titles. Squash-merge
+# uses the PR title as the commit message, so a well-formed PR title becomes
+# a well-formed commit, which is what downstream changelog / release-please
+# tooling parses. The accepted vocabulary mirrors the type table in
+# CONTRIBUTING.md ("Commit Guidelines" -> "Types").
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: validate title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in sync with CONTRIBUTING.md > Commit Guidelines > Types.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Scopes are optional; CONTRIBUTING.md lists a recommended set but
+          # does not enforce it. Leaving requireScope unset preserves that.
+          requireScope: false
+          # Description (the part after the colon) must start with a
+          # lowercase letter -- matches the existing 95% of merged PRs and
+          # rejects things like "feat: Add foo" or "Feature/ontos approval".
+          subjectPattern: ^[a-z].+$
+          subjectPatternError: |
+            The subject of the PR title (the part after the colon) must
+            start with a lowercase letter and be non-empty.
+
+            Got: "{subject}"
+            Title: "{title}"
+
+            Example: feat(contracts): add ODCS v3.1.0 schema export


### PR DESCRIPTION
## Summary

Adds a lightweight CI check that lints PR titles against Conventional Commits, using [`amannn/action-semantic-pull-request@v5`](https://github.com/amannn/action-semantic-pull-request).

- Accepted types mirror the table in [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) > Commit Guidelines > Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
- Subject (post-colon) must start with a lowercase letter — matches the existing 95% of merged PRs and rejects legacy strays like `Feature/ontos approval workflows ux`.
- Scope is optional. CONTRIBUTING.md lists a recommended set but does not enforce it; the workflow preserves that.

## Why

PR titles become squash-merge commit messages. Keeping them strictly Conventional Commits means the commit log stays clean for any future release-please / semantic-release / conventional-changelog tooling. This codifies what's already documented in `CONTRIBUTING.md` and practiced by contributors today; the workflow just prevents drift.

Pairs with the recently-completed issue-title normalization. After both changes:
- **Issues:** `[Type]: Sentence-case description` (human-readable, mixed audience)
- **PRs / commits:** `type(scope): description` (machine-parseable, drives changelog tooling)

These are intentionally different conventions for different artifacts.

## Files

- `.github/workflows/pr-title-lint.yml` — the new workflow. Runs on `pull_request: [opened, edited, synchronize, reopened]`, read-only permissions.

## Test plan

- [ ] CI passes on this PR (the PR title itself conforms, so the check should be green).
- [ ] Open a throwaway draft PR with an intentionally bad title (e.g. `Add cool thing`) and verify the check fails with a helpful error.
- [ ] Edit a PR title from non-conforming to conforming and verify the check re-runs and passes.