### PR TITLE
feat(roles): seed default group bindings to match test personas

### DIFF
--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -37,14 +37,39 @@ ROLES_YAML_PATH = Path(__file__).parent.parent / 'data' / 'settings.yaml'
 
 # --- Default Role Definitions --- 
 
-# Define default roles structure
+# Define default roles structure.
+# Non-Admin roles ship with `assigned_groups` that match the personas in
+# src/backend/src/data/test_personas.yaml, so the runtime impersonation flow
+# (TEST_USER_TOKEN) lands users in the matching role out of the box. Admin's
+# groups still come from APP_ADMIN_DEFAULT_GROUPS so production deployments
+# keep full control of who gets admin without depending on this default list.
 DEFAULT_ROLES = [
     {"name": "Admin", "description": "Default role: Admin"},
-    {"name": "Data Governance Officer", "description": "Default role: Data Governance Officer"},
-    {"name": "Data Steward", "description": "Default role: Data Steward"},
-    {"name": "Data Consumer", "description": "Default role: Data Consumer"},
-    {"name": "Data Producer", "description": "Default role: Data Producer"},
-    {"name": "Security Officer", "description": "Default role: Security Officer"},
+    {
+        "name": "Data Governance Officer",
+        "description": "Default role: Data Governance Officer",
+        "assigned_groups": ["data-governance-officers"],
+    },
+    {
+        "name": "Data Steward",
+        "description": "Default role: Data Steward",
+        "assigned_groups": ["data-stewards"],
+    },
+    {
+        "name": "Data Consumer",
+        "description": "Default role: Data Consumer",
+        "assigned_groups": ["data-consumers"],
+    },
+    {
+        "name": "Data Producer",
+        "description": "Default role: Data Producer",
+        "assigned_groups": ["data-producers"],
+    },
+    {
+        "name": "Security Officer",
+        "description": "Default role: Security Officer",
+        "assigned_groups": ["security-officers"],
+    },
 ]
 
 # Define desired default permissions for non-Admin roles
@@ -490,6 +515,12 @@ class SettingsManager:
                                 'name': name,
                                 'description': role_def.get('description'),
                             }
+                            # Propagate group bindings declared on the in-code defaults
+                            # (e.g. data-producers -> Data Producer) so the generated
+                            # YAML matches the canned test personas out of the box.
+                            default_groups = role_def.get('assigned_groups')
+                            if default_groups:
+                                base['assigned_groups'] = list(default_groups)
                             # Only include non-admin explicit permissions; admin will be expanded at runtime
                             if name != 'Admin':
                                 base['feature_permissions'] = {

--- a/src/backend/src/data/settings.yaml
+++ b/src/backend/src/data/settings.yaml
@@ -24,6 +24,12 @@ roles:
 
   - name: Data Governance Officer
     description: "Default role: Data Governance Officer"
+    # Default group binding. Matches the persona of the same id in
+    # src/backend/src/data/test_personas.yaml so runtime impersonation
+    # (TEST_USER_TOKEN flow) lands users in this role out of the box.
+    # Override in production via the Settings UI or a custom settings.yaml.
+    assigned_groups:
+      - data-governance-officers
     feature_permissions:
       data-domains: Admin
       data-products: Admin
@@ -62,6 +68,8 @@ roles:
 
   - name: Data Steward
     description: "Default role: Data Steward"
+    assigned_groups:
+      - data-stewards
     feature_permissions:
       data-domains: Read/Write
       data-products: Read/Write
@@ -95,6 +103,8 @@ roles:
 
   - name: Data Consumer
     description: "Default role: Data Consumer"
+    assigned_groups:
+      - data-consumers
     feature_permissions:
       data-domains: Read-only
       data-products: Read-only
@@ -111,6 +121,8 @@ roles:
 
   - name: Data Producer
     description: "Default role: Data Producer"
+    assigned_groups:
+      - data-producers
     feature_permissions:
       data-domains: Read-only
       data-products: Read/Write
@@ -138,6 +150,8 @@ roles:
 
   - name: Security Officer
     description: "Default role: Security Officer"
+    assigned_groups:
+      - security-officers
     feature_permissions:
       security-features: Admin
       entitlements: Admin


### PR DESCRIPTION
## Summary

Follow-up to #459 (runtime test-user impersonation). Until now only the **Admin** role shipped with a default `assigned_groups` binding (driven by `APP_ADMIN_DEFAULT_GROUPS`). All other seeded roles were created with empty `assigned_groups`, so the runtime persona override would correctly impersonate the persona's *identity* but resolve to **zero permissions** — making the feature useless out of the box for anything except the Admin persona.

This patch bakes the conventional group names into both seed sources so every persona in `src/backend/src/data/test_personas.yaml` lands in the matching role on first run.

## Bindings added

| Role | `assigned_groups` |
|---|---|
| Data Governance Officer | `data-governance-officers` |
| Data Steward | `data-stewards` |
| Data Producer | `data-producers` |
| Data Consumer | `data-consumers` |
| Security Officer | `security-officers` |

Group names match the personas in `test_personas.yaml` and the labels in the Test Persona dropdown.

## Sources touched

- `src/backend/src/data/settings.yaml` — the authoritative seed YAML.
- `DEFAULT_ROLES` in `src/backend/src/controller/settings_manager.py` — the in-code fallback used when the YAML is missing. Also updated the `generated_roles` codepath that writes the YAML on first run, so a fresh deployment without `settings.yaml` also gets the bindings.

## Why Admin is intentionally NOT touched

Admin's `assigned_groups` continue to come from `APP_ADMIN_DEFAULT_GROUPS`. Hardcoding it here would risk granting admin to whatever happens to be set on someone's local workspace by name collision. Production deployments keep explicit control via env var.

## Migration

Existing deployments already have role records persisted to the database and **will not** be affected by this change (the seed only fires when records are missing). To pick up the new bindings on an existing install:

- **Recommended:** Settings → Roles → edit each role → add the corresponding group from the table above.
- **Or:** delete the affected role rows so they get re-seeded on next start.

## Test plan

- [ ] Fresh install (empty DB, no `settings.yaml`): role records pick up the new groups.
- [ ] Fresh install (with shipped `settings.yaml`): role records pick up the new groups.
- [ ] Existing install: role records remain unchanged (verifies we're not destructive).
- [ ] With `TEST_USER_TOKEN` set: pick "Data Producer" from the Test Persona dropdown -> `/api/user/permissions` returns Producer's permission map (non-empty), not `None` across the board.