### PR TITLE
feat(marketplace): add data quality badge to product tiles

### DIFF
--- a/src/frontend/src/components/home/marketplace-view.tsx
+++ b/src/frontend/src/components/home/marketplace-view.tsx
@@ -22,6 +22,7 @@ import ApprovalWizardDialog from '@/components/workflows/approval-wizard-dialog'
 import { useApprovalWizardTrigger } from '@/hooks/use-approval-wizard-trigger';
 import { DataDomainMiniGraph } from '@/components/data-domains/data-domain-mini-graph';
 import { RatingBadge } from '@/components/ratings';
+import { QualityBadge } from '@/components/quality/quality-badge';
 import CertificationBadge from '@/components/common/certification-badge';
 import PublicationBadge from '@/components/common/publication-badge';
 import { PUBLICATION_SCOPE_LABELS, type CertificationLevel } from '@/types/lifecycle';
@@ -448,6 +449,14 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
               <RatingBadge
                 entityType="data_product"
                 entityId={product.id}
+                size="sm"
+              />
+            )}
+            {product.id && (
+              <QualityBadge
+                entityType="data_product"
+                entityId={product.id}
+                productAggregation
                 size="sm"
               />
             )}

--- a/src/frontend/src/components/quality/quality-badge.tsx
+++ b/src/frontend/src/components/quality/quality-badge.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { useApi } from '@/hooks/use-api';
+import { scoreColor, type EntityKind, type QualitySummary } from '@/types/quality';
+
+export interface QualityBadgeProps {
+  /** Entity type (data_product, data_contract, asset, ...) */
+  entityType: EntityKind;
+  /** Entity ID */
+  entityId: string;
+  /** When true, uses the product aggregation endpoint (rolls up child contracts). */
+  productAggregation?: boolean;
+  /** Size variant */
+  size?: 'sm' | 'md';
+  /** Additional class names */
+  className?: string;
+  /** Click handler (optional) */
+  onClick?: (e: React.MouseEvent) => void;
+}
+
+/**
+ * QualityBadge - Compact inline data-quality indicator for cards.
+ *
+ * Fetches the quality summary for the given entity and renders a small
+ * color-coded percentage chip. Returns null when there are no measurements,
+ * so cards stay clean for entities without quality data.
+ */
+export function QualityBadge({
+  entityType,
+  entityId,
+  productAggregation,
+  size = 'sm',
+  className,
+  onClick,
+}: QualityBadgeProps) {
+  const { get } = useApi();
+  const [summary, setSummary] = useState<QualitySummary | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!entityType || !entityId) return;
+    let cancelled = false;
+
+    const url = productAggregation
+      ? `/api/data-products/${entityId}/quality-summary`
+      : `/api/entities/${entityType}/${entityId}/quality-items/summary`;
+
+    const fetchSummary = async () => {
+      try {
+        const response = await get<QualitySummary>(url);
+        if (cancelled) return;
+        if (!response.error && response.data) {
+          setSummary(response.data);
+        }
+      } catch {
+        // Silent fail - quality info is not critical for card render.
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    };
+
+    fetchSummary();
+    return () => {
+      cancelled = true;
+    };
+  }, [entityType, entityId, productAggregation, get]);
+
+  if (!loaded || !summary || summary.items_count === 0) {
+    return null;
+  }
+
+  const pct = summary.overall_score_percent;
+  const color = scoreColor(pct);
+
+  const gaugePx = size === 'sm' ? 14 : 16;
+  const innerPx = gaugePx - 4;
+  const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
+
+  const measuredAtLabel = summary.measured_at
+    ? `\nLast measured ${new Date(summary.measured_at).toLocaleString()}`
+    : '';
+
+  // Tint background lightly based on score band so the chip reads at a glance.
+  const bandBg =
+    pct >= 90
+      ? 'bg-green-50 dark:bg-green-950/30 hover:bg-green-100 dark:hover:bg-green-900/40'
+      : pct >= 70
+        ? 'bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100 dark:hover:bg-amber-900/40'
+        : 'bg-red-50 dark:bg-red-950/30 hover:bg-red-100 dark:hover:bg-red-900/40';
+
+  // Mini conic-gradient gauge — mirrors the large gauge in EntityQualityPanel.
+  const gaugeStyle: React.CSSProperties = {
+    width: gaugePx,
+    height: gaugePx,
+    borderRadius: '50%',
+    background: `conic-gradient(${color} 0% ${pct}%, hsl(var(--muted-foreground) / 0.25) ${pct}% 100%)`,
+    flexShrink: 0,
+  };
+  const gaugeInnerStyle: React.CSSProperties = {
+    width: innerPx,
+    height: innerPx,
+    borderRadius: '50%',
+    background: 'hsl(var(--background))',
+  };
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full leading-none',
+        bandBg,
+        onClick && 'cursor-pointer transition-colors',
+        className,
+      )}
+      onClick={onClick}
+      title={`Data Quality: ${pct.toFixed(1)}% (${summary.items_count} measurement${summary.items_count === 1 ? '' : 's'})${measuredAtLabel}`}
+    >
+      <span style={gaugeStyle} aria-hidden>
+        <span style={gaugeInnerStyle} className="block m-[2px]" />
+      </span>
+      <span
+        className={cn(textSize, 'font-semibold tabular-nums leading-none')}
+        style={{ color }}
+      >
+        {pct.toFixed(0)}%
+      </span>
+    </div>
+  );
+}
+
+export default QualityBadge;

--- a/src/frontend/src/components/ratings/rating-badge.tsx
+++ b/src/frontend/src/components/ratings/rating-badge.tsx
@@ -60,30 +60,29 @@ export function RatingBadge({
     return null;
   }
 
-  const sizeClasses = size === 'sm' 
-    ? 'h-3 w-3 text-[10px]' 
-    : 'h-3.5 w-3.5 text-xs';
+  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
+  const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
 
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-50 dark:bg-amber-950/30',
-        onClick && 'cursor-pointer hover:bg-amber-100 dark:hover:bg-amber-900/40 transition-colors',
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full leading-none bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100 dark:hover:bg-amber-900/40',
+        onClick && 'cursor-pointer transition-colors',
         className
       )}
       onClick={onClick}
       title={`${rating.average_rating.toFixed(1)} out of 5 stars (${rating.total_ratings} ratings)`}
     >
-      <Star className={cn(sizeClasses, 'fill-amber-400 text-amber-400')} />
+      <Star className={cn(iconSize, 'shrink-0 fill-amber-400 text-amber-400')} />
       <span className={cn(
-        sizeClasses,
-        'font-medium text-amber-700 dark:text-amber-300 tabular-nums'
+        textSize,
+        'font-semibold tabular-nums leading-none text-amber-700 dark:text-amber-300'
       )}>
         {rating.average_rating.toFixed(1)}
       </span>
       <span className={cn(
-        sizeClasses,
-        'text-amber-600/70 dark:text-amber-400/70 ml-1.5'
+        textSize,
+        'tabular-nums leading-none text-amber-600/70 dark:text-amber-400/70'
       )}>
         ({rating.total_ratings})
       </span>


### PR DESCRIPTION
## Summary

Adds a compact Data Quality chip to marketplace product tiles, mirroring the existing Rating chip. The badge fetches each product's aggregated quality summary and **only renders when measurements exist**, so tiles for products without quality data look unchanged.

## Changes

- **New `QualityBadge` component** (`src/frontend/src/components/quality/quality-badge.tsx`)
  - Props: `entityType`, `entityId`, `productAggregation?`, `size?`, `className?`, `onClick?`
  - Fetches from `/api/data-products/{id}/quality-summary` (when `productAggregation`) or `/api/entities/{type}/{id}/quality-items/summary` otherwise
  - Renders `null` when `items_count === 0` — satisfies the "only show when results are present" requirement
  - Visual: mini conic-gradient gauge ring filled to the score percentage (same visual language as the main gauge in `EntityQualityPanel`) plus color-coded percentage text
  - Score-band tint: `bg-green-50` (≥ 90), `bg-amber-50` (≥ 70), `bg-red-50` (< 70), consistent with `scoreColor()` from `types/quality.ts`
  - Tooltip surfaces full score, measurement count, and last-measured timestamp
- **Wired into `marketplace-view.tsx`** `renderProductCard`, next to the existing `RatingBadge`, with `productAggregation` so contract-level scores roll up.
- **Aligned `RatingBadge` sizing** (`gap-1.5 px-2`, `text-xs`, `h-3.5 w-3.5` icon) so the rating and quality pills sit consistently in the chip row.

## Visual

Before: thin `Gauge` icon at `h-3 w-3` that visually clipped at small sizes.

After: a proper mini-gauge ring showing the score proportionally — e.g. `67%` in red with a 67%-filled red arc on a `bg-red-50` pill, matching the rating chip's footprint.

## Forward compatibility

The badge is generic on `entityType`, so when the multi-entity marketplace (PRD: `docs/prds/prd-marketplace-multi-entity.md`) lands, the same component can be dropped into contract/asset tiles with `entityType="data_contract"` or `entityType="asset"` (no `productAggregation`). Both backend summary endpoints already exist.

## Out of scope

- No backend changes (endpoints already exist).
- No changes to the quality panel or its CRUD UI.
- No home-discovery-section changes (it does not render the marketplace card).
- No new i18n keys — tooltip uses an inline string; can be lifted to `home.json` if requested.

## Test plan

- [x] Verified via Playwright on `/marketplace`: only the POS Transaction Stream tile (the one with a quality measurement) shows the chip; all others omit it.
- [x] Confirmed band coloring at 67% renders red ring + red text on `bg-red-50` pill.
- [x] Confirmed tooltip reads `Data Quality: 67.0% (1 measurement) — Last measured ...`.
- [x] Confirmed rating and quality chips render at the same height after the `RatingBadge` size update.
- [x] No lints introduced.