### PR TITLE
fix(frontend): handle DB-down in dev + fix root layout horizontal overflow

### DIFF
--- a/src/frontend/src/components/layout/layout.tsx
+++ b/src/frontend/src/components/layout/layout.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, Sparkles } from 'lucide-react';
+import { AlertTriangle, DatabaseZap, Sparkles } from 'lucide-react';
 import { Sidebar } from './sidebar';
 import { Header } from './header';
 import { Breadcrumbs } from '@/components/ui/breadcrumbs';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useLayoutStore } from '@/stores/layout-store';
 import { useCopilotStore } from '@/stores/copilot-store';
@@ -17,6 +18,8 @@ interface HealthState {
   db_error: string | null;
 }
 
+const HEALTH_POLL_INTERVAL_MS = 30_000;
+
 interface LayoutProps {
   children: React.ReactNode;
 }
@@ -28,40 +31,150 @@ export default function Layout({ children }: LayoutProps) {
   const isCopilotOpen = useCopilotStore((s) => s.isOpen);
   const { togglePanel } = useCopilotStore((s) => s.actions);
   const [health, setHealth] = useState<HealthState | null>(null);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [retryError, setRetryError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetch('/api/health')
-      .then((r) => r.json())
-      .then(setHealth)
-      .catch(() => {});
+  const refreshHealth = useCallback(async (): Promise<HealthState | null> => {
+    try {
+      const r = await fetch('/api/health');
+      const h = (await r.json()) as HealthState;
+      setHealth(h);
+      return h;
+    } catch {
+      return null;
+    }
   }, []);
 
-  const showWarning = health && (!health.ws_ok || (health.warnings && health.warnings.length > 0));
+  useEffect(() => {
+    refreshHealth();
+  }, [refreshHealth]);
+
+  // Auto-poll while the DB is down so recovery is hands-free in dev too
+  // (in prod, the FastAPI catch-all serves MAINTENANCE_HTML, which has its
+  // own setInterval; this covers the Vite dev case where the SPA shell
+  // boots before the middleware can intercept).
+  useEffect(() => {
+    if (!health || health.db_ok) return;
+    const id = setInterval(() => {
+      refreshHealth();
+    }, HEALTH_POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [health, refreshHealth]);
+
+  const handleRetry = useCallback(async () => {
+    setIsRetrying(true);
+    setRetryError(null);
+    try {
+      const r = await fetch('/api/health/retry', { method: 'POST' });
+      const d = await r.json().catch(() => ({}));
+      if (r.ok) {
+        // Hard reload so permissions store, managers, search index, etc.
+        // are re-fetched cleanly after recovery.
+        window.location.reload();
+        return;
+      }
+      setRetryError(d?.detail || 'Retry failed');
+      await refreshHealth();
+    } catch (e) {
+      setRetryError(e instanceof Error ? e.message : 'Network error');
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [refreshHealth]);
+
+  const isDbDown = !!health && !health.db_ok;
+  // Suppress the soft warning banner when the DB is down: startup short-circuits
+  // before initialize_managers runs, so ws_ok stays false even though the real
+  // problem is the DB. Showing both would be misleading.
+  const showWarning =
+    !!health &&
+    !isDbDown &&
+    (!health.ws_ok || (health.warnings && health.warnings.length > 0));
 
   return (
-    <div className="flex min-h-screen bg-background">
+    <div className="min-h-screen bg-background">
       <Sidebar isCollapsed={isSidebarCollapsed} />
+      {/* Sidebar/copilot offsets use padding (not margin) so the column
+          stays at 100vw and never overflows horizontally. The Sidebar is
+          position:fixed and contributes no flex/inline width. */}
       <div className={cn(
-        "flex flex-col flex-1 transition-all duration-300 ease-in-out",
-        isSidebarCollapsed ? "ml-[56px]" : "ml-[240px]",
-        isCopilotOpen && "mr-[400px]"
+        "flex flex-col min-h-screen min-w-0 transition-[padding] duration-300 ease-in-out",
+        isSidebarCollapsed ? "pl-[56px]" : "pl-[240px]",
+        isCopilotOpen && "pr-[400px]"
       )}>
         <Header onToggleSidebar={toggleSidebar} isSidebarCollapsed={isSidebarCollapsed} />
+        {/* Alerts wrapped in padded containers (not mx-6 on the Alert itself):
+            shadcn Alert is `w-full`, so mx-6 would expand it past the
+            parent and overflow horizontally by the margin width. */}
+        {isDbDown && (
+          <div className="px-6 pt-4">
+            <Alert variant="destructive">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Database unavailable</AlertTitle>
+              <AlertDescription className="space-y-2">
+                <p>
+                  The application cannot reach its metadata database. Most features will
+                  return errors until the connection is restored.
+                </p>
+                {health?.db_error && (
+                  <pre className="text-xs whitespace-pre-wrap break-words bg-muted/40 rounded p-2 max-h-32 overflow-auto">
+                    {health.db_error}
+                  </pre>
+                )}
+                <div className="flex items-center gap-2 pt-1 flex-wrap">
+                  <Button size="sm" onClick={handleRetry} disabled={isRetrying}>
+                    {isRetrying ? 'Retrying…' : 'Retry connection'}
+                  </Button>
+                  {retryError && (
+                    <span className="text-xs text-destructive">{retryError}</span>
+                  )}
+                  <span className="text-xs text-muted-foreground ml-auto">
+                    Auto-retrying every {HEALTH_POLL_INTERVAL_MS / 1000} seconds
+                  </span>
+                </div>
+              </AlertDescription>
+            </Alert>
+          </div>
+        )}
         {showWarning && (
-          <Alert variant="destructive" className="mx-6 mt-4">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertTitle>System Warning</AlertTitle>
-            <AlertDescription>
-              {!health.ws_ok && (
-                <p>Databricks workspace connection failed. Some features may be unavailable.</p>
-              )}
-              {health.warnings?.map((w, i) => <p key={i}>{w}</p>)}
-            </AlertDescription>
-          </Alert>
+          <div className="px-6 pt-4">
+            <Alert variant="destructive">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>System Warning</AlertTitle>
+              <AlertDescription>
+                {!health.ws_ok && (
+                  <p>Databricks workspace connection failed. Some features may be unavailable.</p>
+                )}
+                {health.warnings?.map((w, i) => <p key={i}>{w}</p>)}
+              </AlertDescription>
+            </Alert>
+          </div>
         )}
         <main className="flex-1 overflow-y-auto p-6">
-          <Breadcrumbs className="mb-6" />
-          {children}
+          {isDbDown ? (
+            // Don't render the routed page when the DB is down: most views
+            // immediately fetch /api/* which 503s, producing noisy half-broken
+            // UI (empty lists, inline error toasts, "HTTP error! status: 503").
+            // Show a neutral placeholder instead — the banner above is the
+            // single source of truth and offers the retry path.
+            <div className="flex flex-col items-center justify-center text-center py-24 text-muted-foreground">
+              <DatabaseZap className="h-12 w-12 mb-4 opacity-60" />
+              <h2 className="text-lg font-medium text-foreground mb-1">
+                Application paused
+              </h2>
+              <p className="text-sm max-w-md">
+                The metadata database is unreachable, so navigation and data
+                views are disabled to avoid showing inconsistent state. Use
+                <span className="font-medium"> Retry connection </span>
+                above (or wait for the next auto-retry) to resume.
+              </p>
+            </div>
+          ) : (
+            <>
+              <Breadcrumbs className="mb-6" />
+              {children}
+            </>
+          )}
         </main>
       </div>
 


### PR DESCRIPTION
## Summary

Two fixes that compound on the same symptom — when Postgres is unreachable at backend startup, the dev UI showed a misleading warning and a broken half-rendered page, and the whole root layout was overflowing the viewport horizontally.

### Why DB-down was mishandled in dev

The backend already supports a maintenance/retry flow: when \`initialize_database\` fails, \`startup_event\` flips \`app.state.health[\"db_ok\"] = False\` and returns, and \`MaintenanceMiddleware\` serves \`MAINTENANCE_HTML\` (with a Retry button + 30s auto-poll) on every non-\`/api/health\` request. In **prod** that works because FastAPI's catch-all serves \`index.html\` and the middleware intercepts it.

In **dev** that path never engages: Vite serves \`index.html\` directly on \`:3000\`, only \`/api/*\` is proxied to \`:8000\`. So the SPA boots normally, then every page-level \`useEffect\` fires \`/api/*\` calls that 503, and \`layout.tsx\` only checked \`!ws_ok\` for its system warning banner — which is misleadingly false here because \`initialize_managers\` never ran, leaving \`ws_ok\` at its default \`False\` even though the real problem is the DB.

### Why the layout was overflowing

Latent bug, surfaced by the new full-width banner: root container was \`display: flex\` with a \`position: fixed\` Sidebar and an inner column with \`flex-1 + ml-[56|240px]\`. Sidebar contributes nothing to flex sizing, so \`flex-1\` made the column 100vw wide and the margin pushed it past the right edge by the sidebar width. The \`Alert\` component is hardcoded \`w-full\`, and \`mx-6\` on a \`w-full\` element overflows by the margin width (CSS \`width:100%\` ignores own margins) — adding another 24px of spill. Both bugs coexisted; only the alert one was newly visible.

## Changes (single file: \`src/frontend/src/components/layout/layout.tsx\`)

- **New \"Database unavailable\" alert** when \`health.db_ok === false\`: shows \`db_error\`, offers a Retry button (\`POST /api/health/retry\`, hard-reload on success), and auto-polls \`/api/health\` every 30s while down.
- **Suppress the soft \"System Warning\"** when DB is down so we don't lie about the workspace connection.
- **Replace \`children\` + \`Breadcrumbs\`** with a neutral \"Application paused\" placeholder while DB is down, so per-view \`fetch\`es don't fire and render half-broken UI.
- **Root container**: \`flex\` → block; sidebar/copilot offsets switched from margins to padding (\`pl-[56|240px]\`, \`pr-[400px]\`) so the column stays at 100vw.
- **Alerts**: wrap in \`px-6 pt-4\` containers instead of \`mx-6\` directly on the \`w-full\` \`Alert\`. Same visual, no overflow.
- **\`<pre>\`**: \`overflow-y-auto\` → \`overflow-auto\` so a single very long error line clips horizontally.

## Test plan

- [x] Verified with Playwright: \`document.documentElement.scrollWidth === clientWidth\` (1440/1440, \`hasHorizontalScroll: false\`) at 1440x900. Was 1464/1440 before.
- [x] Visual: alert sits inside viewport with proper right margin, \"Application paused\" placeholder centered, no spill behind the Ask Ontos tab.
- [x] Lint clean.
- [ ] Stop Postgres → load app → confirm \"Database unavailable\" banner with the actual \`db_error\` text.
- [ ] Start Postgres → click **Retry connection** → page reloads into the normal app.
- [ ] Wait for the 30s auto-poll instead of clicking Retry → same result.
- [ ] Prod parity check: deploy to a Databricks App with Postgres down and confirm \`MAINTENANCE_HTML\` is still served by the FastAPI catch-all (unchanged backend behavior).
- [ ] Toggle copilot open with DB up → confirm the \`pr-[400px]\` reserve actually reserves space (this was previously also overflowing).