### PR TITLE
feat(ontology): async generation with DB-persisted run history

### DIFF
--- a/src/backend/alembic/versions/g2_add_ontology_generation_runs.py
+++ b/src/backend/alembic/versions/g2_add_ontology_generation_runs.py
@@ -1,7 +1,7 @@
 """add_ontology_generation_runs
 
 Revision ID: g2_ontology_gen_runs
-Revises: f1_merge_aa9_e2
+Revises: j1_add_version_family_id
 Create Date: 2026-05-28
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSON
 
 revision: str = 'g2_ontology_gen_runs'
-down_revision: Union[str, None] = 'i1_workflow_version'
+down_revision: Union[str, None] = 'j1_add_version_family_id'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/backend/alembic/versions/g2_add_ontology_generation_runs.py
+++ b/src/backend/alembic/versions/g2_add_ontology_generation_runs.py
@@ -1,0 +1,50 @@
+"""add_ontology_generation_runs
+
+Revision ID: g2_ontology_gen_runs
+Revises: f1_merge_aa9_e2
+Create Date: 2026-05-28
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSON
+
+revision: str = 'g2_ontology_gen_runs'
+down_revision: Union[str, None] = 'i1_workflow_version'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'ontology_generation_runs',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('user_id', sa.String(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False, server_default='pending'),
+        sa.Column('progress_message', sa.String(), nullable=True),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column('connection_id', sa.String(), nullable=True),
+        sa.Column('connection_name', sa.String(), nullable=True),
+        sa.Column('selected_paths', JSON(), nullable=True),
+        sa.Column('guidelines', sa.Text(), nullable=True),
+        sa.Column('base_uri', sa.String(), nullable=True),
+        sa.Column('options', JSON(), nullable=True),
+        sa.Column('steps', JSON(), nullable=True),
+        sa.Column('result', JSON(), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('completed_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_ontology_generation_runs_user_id', 'ontology_generation_runs', ['user_id'])
+    op.create_index('ix_ontology_runs_user_status', 'ontology_generation_runs', ['user_id', 'status'])
+    op.create_index('ix_ontology_runs_user_created', 'ontology_generation_runs', ['user_id', 'created_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_ontology_runs_user_created', table_name='ontology_generation_runs')
+    op.drop_index('ix_ontology_runs_user_status', table_name='ontology_generation_runs')
+    op.drop_index('ix_ontology_generation_runs_user_id', table_name='ontology_generation_runs')
+    op.drop_table('ontology_generation_runs')

--- a/src/backend/src/controller/ontology_generator_manager.py
+++ b/src/backend/src/controller/ontology_generator_manager.py
@@ -14,9 +14,14 @@ The agent loop:
 
 import json
 import re
+import threading
 import time
+import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
 
 from src.common.config import Settings
 from src.common.logging import get_logger
@@ -190,11 +195,16 @@ TOOL_HANDLERS = {
 # Manager
 # =====================================================================
 
+MAX_CONCURRENT_RUNS_PER_USER = 3
+
+
 class OntologyGeneratorManager:
     """Generates OWL ontologies from metadata using an LLM agent loop."""
 
     def __init__(self, settings: Settings):
         self._settings = settings
+        self._cancel_events: Dict[str, threading.Event] = {}
+        self._lock = threading.Lock()
 
     def _get_openai_client(self, user_token: Optional[str] = None):
         """Create an OpenAI client via the shared factory.
@@ -376,6 +386,7 @@ class OntologyGeneratorManager:
         selected_tables: Optional[List[str]] = None,
         on_step: Optional[Callable[[str], None]] = None,
         user_token: Optional[str] = None,
+        cancel_event: Optional[threading.Event] = None,
     ) -> AgentResult:
         """Run the ontology-generation agent.
 
@@ -444,6 +455,11 @@ class OntologyGeneratorManager:
         tools_supported = True
 
         for iteration in range(MAX_ITERATIONS):
+            if cancel_event and cancel_event.is_set():
+                result.error = "Generation cancelled by user"
+                logger.info("Agent cancelled before iteration %d", iteration + 1)
+                return result
+
             logger.info("Iteration %d/%d — %d messages", iteration + 1, MAX_ITERATIONS, len(messages))
             notify(f"Agent thinking… (step {iteration + 1})")
 
@@ -581,3 +597,229 @@ class OntologyGeneratorManager:
         result.error = f"Agent reached maximum iterations ({MAX_ITERATIONS}) without producing output"
         logger.error("Agent failed: %s", result.error)
         return result
+
+    # ------------------------------------------------------------------
+    # Async run management
+    # ------------------------------------------------------------------
+
+    def start_run(
+        self,
+        db: Session,
+        user_id: str,
+        metadata: dict,
+        *,
+        guidelines: str = "",
+        options: Optional[dict] = None,
+        base_uri: str = "http://ontos.example.org/ontology#",
+        user_token: Optional[str] = None,
+        connection_id: Optional[str] = None,
+        connection_name: Optional[str] = None,
+        selected_paths: Optional[List[str]] = None,
+    ) -> str:
+        """Create a DB-persisted run and execute generation in a background thread.
+
+        Returns the run_id immediately.  Raises ValueError if the user has
+        hit the concurrent-run cap.
+        """
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+
+        running = ontology_generation_runs_repo.count_running_for_user(db, user_id)
+        if running >= MAX_CONCURRENT_RUNS_PER_USER:
+            raise ValueError(
+                f"Concurrent run limit reached ({MAX_CONCURRENT_RUNS_PER_USER}). "
+                "Wait for a running generation to finish or cancel one."
+            )
+
+        run_id = str(uuid.uuid4())
+        options = options or {}
+
+        ontology_generation_runs_repo.create(
+            db,
+            run_id=run_id,
+            user_id=user_id,
+            connection_id=connection_id,
+            connection_name=connection_name,
+            selected_paths=selected_paths,
+            guidelines=guidelines,
+            base_uri=base_uri,
+            options=options,
+            steps=[],
+        )
+        db.commit()
+
+        cancel_event = threading.Event()
+        with self._lock:
+            self._cancel_events[run_id] = cancel_event
+
+        thread = threading.Thread(
+            target=self._run_generation,
+            args=(run_id, metadata, guidelines, options, base_uri, user_token, cancel_event),
+            daemon=True,
+        )
+        thread.start()
+        logger.info("Started background generation run %s for user %s", run_id, user_id)
+        return run_id
+
+    def _run_generation(
+        self,
+        run_id: str,
+        metadata: dict,
+        guidelines: str,
+        options: dict,
+        base_uri: str,
+        user_token: Optional[str],
+        cancel_event: threading.Event,
+    ) -> None:
+        """Background thread body — runs generate_ontology and persists results."""
+        from src.common.database import get_session_factory
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+
+        SessionLocal = get_session_factory()
+        db = SessionLocal()
+
+        accumulated_steps: List[dict] = []
+
+        def on_step(msg: str):
+            accumulated_steps.append({
+                "step_type": "progress",
+                "content": msg,
+                "tool_name": "",
+                "duration_ms": 0,
+            })
+            try:
+                ontology_generation_runs_repo.update_steps(db, run_id, accumulated_steps, progress_message=msg)
+                db.commit()
+            except Exception:
+                db.rollback()
+
+        try:
+            ontology_generation_runs_repo.update_status(db, run_id, 'running', progress_message='Starting…')
+            db.commit()
+
+            result = self.generate_ontology(
+                metadata=metadata,
+                guidelines=guidelines,
+                options=options,
+                base_uri=base_uri,
+                user_token=user_token,
+                on_step=on_step,
+                cancel_event=cancel_event,
+            )
+
+            if cancel_event.is_set():
+                ontology_generation_runs_repo.update_status(
+                    db, run_id, 'cancelled',
+                    progress_message='Cancelled',
+                    error=result.error or 'Cancelled by user',
+                    completed_at=datetime.now(timezone.utc),
+                )
+                db.commit()
+                return
+
+            final_steps = [
+                {"step_type": s.step_type, "content": s.content, "tool_name": s.tool_name, "duration_ms": s.duration_ms}
+                for s in result.steps
+            ]
+
+            if result.success:
+                result_dict = self._agent_result_to_response_dict(result)
+                run = ontology_generation_runs_repo.get(db, run_id)
+                if run:
+                    run.steps = final_steps
+                    run.result = result_dict
+                    run.status = 'completed'
+                    run.progress_message = 'Completed'
+                    run.completed_at = datetime.now(timezone.utc)
+                    db.commit()
+            else:
+                ontology_generation_runs_repo.update_steps(db, run_id, final_steps, progress_message='Failed')
+                ontology_generation_runs_repo.update_status(
+                    db, run_id, 'failed',
+                    error=result.error,
+                    completed_at=datetime.now(timezone.utc),
+                )
+                db.commit()
+
+        except Exception as exc:
+            logger.exception("Background generation run %s failed with exception", run_id)
+            try:
+                ontology_generation_runs_repo.update_status(
+                    db, run_id, 'failed',
+                    error=str(exc),
+                    completed_at=datetime.now(timezone.utc),
+                )
+                db.commit()
+            except Exception:
+                db.rollback()
+        finally:
+            db.close()
+            with self._lock:
+                self._cancel_events.pop(run_id, None)
+
+    def cancel_run(self, run_id: str) -> bool:
+        """Signal a running generation to stop.  Returns True if the cancel
+        event was set (i.e. the run was active in this process)."""
+        with self._lock:
+            event = self._cancel_events.get(run_id)
+        if event:
+            event.set()
+            return True
+        return False
+
+    @staticmethod
+    def get_run(db: Session, run_id: str):
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+        return ontology_generation_runs_repo.get(db, run_id)
+
+    @staticmethod
+    def get_run_for_user(db: Session, run_id: str, user_id: str):
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+        return ontology_generation_runs_repo.get_for_user(db, run_id, user_id)
+
+    @staticmethod
+    def list_runs(db: Session, user_id: str, *, limit: int = 50):
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+        return ontology_generation_runs_repo.list_for_user(db, user_id, limit=limit)
+
+    @staticmethod
+    def list_all_runs(db: Session, *, limit: int = 50):
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+        return ontology_generation_runs_repo.list_all(db, limit=limit)
+
+    @staticmethod
+    def delete_run(db: Session, run_id: str) -> bool:
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+        return ontology_generation_runs_repo.delete(db, run_id)
+
+    @staticmethod
+    def _agent_result_to_response_dict(result: AgentResult) -> dict:
+        """Convert AgentResult to the GenerateOntologyResponse-compatible dict
+        that is stored in the DB ``result`` JSON column."""
+        from src.models.ontology_generator import (
+            OntologyClassResponse,
+            OntologyPropertyResponse,
+            OntologyInfoResponse,
+            AgentStepResponse,
+        )
+        return {
+            "success": result.success,
+            "owl_content": result.owl_content,
+            "classes": [OntologyClassResponse(**c).model_dump() for c in result.classes],
+            "properties": [OntologyPropertyResponse(**p).model_dump() for p in result.properties],
+            "ontology_info": (
+                OntologyInfoResponse(**result.ontology_info).model_dump()
+                if result.ontology_info else {}
+            ),
+            "constraints": result.constraints,
+            "axioms": result.axioms,
+            "steps": [
+                AgentStepResponse(
+                    step_type=s.step_type, content=s.content,
+                    tool_name=s.tool_name, duration_ms=s.duration_ms,
+                ).model_dump()
+                for s in result.steps
+            ],
+            "iterations": result.iterations,
+            "error": result.error,
+            "usage": result.usage,
+        }

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -1811,7 +1811,8 @@ class SemanticModelsManager:
                 f"urn:taxonomy:{taxonomy_name}",
                 f"urn:semantic-model:{taxonomy_name}",
                 f"urn:schema:{taxonomy_name}",
-                f"urn:glossary:{taxonomy_name}"
+                f"urn:glossary:{taxonomy_name}",
+                f"urn:ontology:{taxonomy_name}",
             ]
             for context in self._graph.contexts():
                 if hasattr(context, 'identifier') and str(context.identifier) in target_contexts:

--- a/src/backend/src/db_models/__init__.py
+++ b/src/backend/src/db_models/__init__.py
@@ -43,4 +43,5 @@ from . import certification_levels
 from . import workflow_configurations
 from . import workflow_installations
 from . import workflow_job_runs
+from . import ontology_generation_runs
 

--- a/src/backend/src/db_models/ontology_generation_runs.py
+++ b/src/backend/src/db_models/ontology_generation_runs.py
@@ -1,0 +1,50 @@
+"""
+Ontology Generation Run Database Model
+
+Persists async ontology generation runs so they survive server restarts.
+"""
+
+from sqlalchemy import Column, String, DateTime, Text, func, Index
+from sqlalchemy.dialects.postgresql import JSON
+from uuid import uuid4
+
+from src.common.database import Base
+
+
+class OntologyGenerationRunDb(Base):
+    """Tracks an async ontology generation run."""
+    __tablename__ = 'ontology_generation_runs'
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    user_id = Column(String, nullable=False, index=True)
+
+    # pending | running | completed | failed | cancelled
+    status = Column(String, nullable=False, default='pending')
+    progress_message = Column(String, nullable=True)
+    error = Column(Text, nullable=True)
+
+    # Run parameters
+    connection_id = Column(String, nullable=True)
+    connection_name = Column(String, nullable=True)
+    selected_paths = Column(JSON, nullable=True)
+    guidelines = Column(Text, nullable=True)
+    base_uri = Column(String, nullable=True)
+    options = Column(JSON, nullable=True)
+
+    # Live-updated agent steps (JSON array of step dicts)
+    steps = Column(JSON, nullable=True)
+
+    # Full result blob (GenerateOntologyResponse as dict) — set on completion
+    result = Column(JSON, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index('ix_ontology_runs_user_status', 'user_id', 'status'),
+        Index('ix_ontology_runs_user_created', 'user_id', 'created_at'),
+    )
+
+    def __repr__(self):
+        return f"<OntologyGenerationRunDb(id='{self.id}', user='{self.user_id}', status='{self.status}')>"

--- a/src/backend/src/models/ontology_generator.py
+++ b/src/backend/src/models/ontology_generator.py
@@ -1,5 +1,7 @@
 """Pydantic models for the ontology generator API."""
 
+from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -115,3 +117,59 @@ class SaveToCollectionResponse(BaseModel):
     collection_iri: str = ""
     triples_imported: int = 0
     error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Async generation run models
+# ---------------------------------------------------------------------------
+
+class GenerationRunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class RunParams(BaseModel):
+    """Summarised parameters stored with each run."""
+    connection_id: Optional[str] = None
+    connection_name: Optional[str] = None
+    path_count: int = 0
+    guidelines: str = ""
+    base_uri: str = ""
+    options: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StartRunResponse(BaseModel):
+    run_id: str
+    status: GenerationRunStatus
+
+
+class GenerationRunSummary(BaseModel):
+    run_id: str
+    status: GenerationRunStatus
+    progress_message: Optional[str] = None
+    error: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    params: RunParams = Field(default_factory=RunParams)
+    step_count: int = 0
+
+
+class GenerationRunDetail(BaseModel):
+    run_id: str
+    status: GenerationRunStatus
+    progress_message: Optional[str] = None
+    error: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    params: RunParams = Field(default_factory=RunParams)
+    steps: List[AgentStepResponse] = Field(default_factory=list)
+    result: Optional[GenerateOntologyResponse] = None
+
+
+class RunListResponse(BaseModel):
+    runs: List[GenerationRunSummary] = Field(default_factory=list)

--- a/src/backend/src/repositories/ontology_generation_runs_repository.py
+++ b/src/backend/src/repositories/ontology_generation_runs_repository.py
@@ -1,0 +1,122 @@
+"""
+Repository for ontology generation run CRUD operations.
+"""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.db_models.ontology_generation_runs import OntologyGenerationRunDb
+
+logger = get_logger(__name__)
+
+
+class OntologyGenerationRunsRepository:
+
+    def get(self, db: Session, run_id: str) -> Optional[OntologyGenerationRunDb]:
+        return db.query(OntologyGenerationRunDb).filter(
+            OntologyGenerationRunDb.id == run_id,
+        ).first()
+
+    def get_for_user(self, db: Session, run_id: str, user_id: str) -> Optional[OntologyGenerationRunDb]:
+        return db.query(OntologyGenerationRunDb).filter(
+            OntologyGenerationRunDb.id == run_id,
+            OntologyGenerationRunDb.user_id == user_id,
+        ).first()
+
+    def list_for_user(
+        self, db: Session, user_id: str, *, limit: int = 50, skip: int = 0
+    ) -> List[OntologyGenerationRunDb]:
+        return (
+            db.query(OntologyGenerationRunDb)
+            .filter(OntologyGenerationRunDb.user_id == user_id)
+            .order_by(desc(OntologyGenerationRunDb.created_at))
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def list_all(
+        self, db: Session, *, limit: int = 50, skip: int = 0
+    ) -> List[OntologyGenerationRunDb]:
+        return (
+            db.query(OntologyGenerationRunDb)
+            .order_by(desc(OntologyGenerationRunDb.created_at))
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def count_running_for_user(self, db: Session, user_id: str) -> int:
+        return (
+            db.query(OntologyGenerationRunDb)
+            .filter(
+                OntologyGenerationRunDb.user_id == user_id,
+                OntologyGenerationRunDb.status.in_(('pending', 'running')),
+            )
+            .count()
+        )
+
+    def create(self, db: Session, *, run_id: str, user_id: str, **kwargs) -> OntologyGenerationRunDb:
+        run = OntologyGenerationRunDb(id=run_id, user_id=user_id, status='pending', **kwargs)
+        db.add(run)
+        db.flush()
+        db.refresh(run)
+        return run
+
+    def update_status(
+        self,
+        db: Session,
+        run_id: str,
+        status: str,
+        *,
+        progress_message: Optional[str] = None,
+        error: Optional[str] = None,
+        completed_at: Optional[datetime] = None,
+    ) -> Optional[OntologyGenerationRunDb]:
+        run = self.get(db, run_id)
+        if not run:
+            return None
+        run.status = status
+        if progress_message is not None:
+            run.progress_message = progress_message
+        if error is not None:
+            run.error = error
+        if completed_at is not None:
+            run.completed_at = completed_at
+        db.flush()
+        return run
+
+    def update_steps(
+        self, db: Session, run_id: str, steps: list, progress_message: Optional[str] = None
+    ) -> None:
+        run = self.get(db, run_id)
+        if not run:
+            return
+        run.steps = steps
+        if progress_message is not None:
+            run.progress_message = progress_message
+        db.flush()
+
+    def set_result(self, db: Session, run_id: str, result: dict) -> None:
+        run = self.get(db, run_id)
+        if not run:
+            return
+        run.result = result
+        run.status = 'completed'
+        run.completed_at = datetime.now(timezone.utc)
+        db.flush()
+
+    def delete(self, db: Session, run_id: str) -> bool:
+        run = self.get(db, run_id)
+        if not run:
+            return False
+        db.delete(run)
+        db.flush()
+        return True
+
+
+ontology_generation_runs_repo = OntologyGenerationRunsRepository()

--- a/src/backend/src/routes/ontology_generator_routes.py
+++ b/src/backend/src/routes/ontology_generator_routes.py
@@ -1,8 +1,8 @@
 """API routes for LLM-based ontology generation.
 
-Accepts table metadata and guidelines, runs an agentic LLM loop to
-produce an OWL ontology in Turtle format, and returns the parsed
-classes, properties, constraints, and axioms.
+Both POST /generate and POST /generate-from-connection are async: they
+return HTTP 202 with a run_id immediately, and the actual LLM work runs
+in a background thread.  Clients poll GET /runs/{run_id} for progress.
 """
 
 from typing import List, Optional
@@ -10,19 +10,25 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from src.controller.ontology_generator_manager import AgentResult, OntologyGeneratorManager
+from src.controller.ontology_generator_manager import OntologyGeneratorManager
 from src.models.ontology_generator import (
     AgentStepResponse,
     GenerateFromConnectionRequest,
     GenerateOntologyRequest,
     GenerateOntologyResponse,
+    GenerationRunDetail,
+    GenerationRunStatus,
+    GenerationRunSummary,
     OntologyClassResponse,
     OntologyInfoResponse,
     OntologyPropertyResponse,
+    RunListResponse,
+    RunParams,
     SaveToCollectionRequest,
     SaveToCollectionResponse,
+    StartRunResponse,
 )
-from src.common.authorization import PermissionChecker
+from src.common.authorization import PermissionChecker, is_user_feature_admin
 from src.common.features import FeatureAccessLevel
 from src.common.dependencies import (
     DBSessionDep,
@@ -48,39 +54,76 @@ def _get_user_token(request: Request) -> Optional[str]:
     return request.headers.get("x-forwarded-access-token")
 
 
-def _build_response(result: AgentResult) -> GenerateOntologyResponse:
-    """Convert an ``AgentResult`` to the API response model."""
-    return GenerateOntologyResponse(
-        success=result.success,
-        owl_content=result.owl_content,
-        classes=[OntologyClassResponse(**c) for c in result.classes],
-        properties=[OntologyPropertyResponse(**p) for p in result.properties],
-        ontology_info=(
-            OntologyInfoResponse(**result.ontology_info)
-            if result.ontology_info
-            else OntologyInfoResponse()
-        ),
-        constraints=result.constraints,
-        axioms=result.axioms,
-        steps=[
-            AgentStepResponse(
-                step_type=s.step_type,
-                content=s.content,
-                tool_name=s.tool_name,
-                duration_ms=s.duration_ms,
-            )
-            for s in result.steps
-        ],
-        iterations=result.iterations,
-        error=result.error,
-        usage=result.usage,
+# ------------------------------------------------------------------
+# Helpers to convert DB rows to response models
+# ------------------------------------------------------------------
+
+def _run_to_params(run) -> RunParams:
+    return RunParams(
+        connection_id=run.connection_id,
+        connection_name=run.connection_name,
+        path_count=len(run.selected_paths) if run.selected_paths else 0,
+        guidelines=(run.guidelines or "")[:200],
+        base_uri=run.base_uri or "",
+        options=run.options or {},
     )
 
 
+def _run_to_summary(run) -> GenerationRunSummary:
+    return GenerationRunSummary(
+        run_id=run.id,
+        status=GenerationRunStatus(run.status),
+        progress_message=run.progress_message,
+        error=run.error,
+        created_at=run.created_at,
+        updated_at=run.updated_at,
+        completed_at=run.completed_at,
+        params=_run_to_params(run),
+        step_count=len(run.steps) if run.steps else 0,
+    )
+
+
+def _run_to_detail(run) -> GenerationRunDetail:
+    steps = []
+    if run.steps:
+        for s in run.steps:
+            steps.append(AgentStepResponse(
+                step_type=s.get("step_type", ""),
+                content=s.get("content", ""),
+                tool_name=s.get("tool_name", ""),
+                duration_ms=s.get("duration_ms", 0),
+            ))
+
+    result_model = None
+    if run.result:
+        try:
+            result_model = GenerateOntologyResponse(**run.result)
+        except Exception:
+            logger.warning("Failed to parse stored result for run %s", run.id)
+
+    return GenerationRunDetail(
+        run_id=run.id,
+        status=GenerationRunStatus(run.status),
+        progress_message=run.progress_message,
+        error=run.error,
+        created_at=run.created_at,
+        updated_at=run.updated_at,
+        completed_at=run.completed_at,
+        params=_run_to_params(run),
+        steps=steps,
+        result=result_model,
+    )
+
+
+# ------------------------------------------------------------------
+# Async generation endpoints
+# ------------------------------------------------------------------
+
 @router.post(
     "/generate",
-    response_model=GenerateOntologyResponse,
-    summary="Generate an OWL ontology from table metadata using an LLM agent",
+    response_model=StartRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start async OWL ontology generation from table metadata",
     dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE))],
 )
 def generate_ontology(
@@ -91,7 +134,7 @@ def generate_ontology(
     current_user: AuditCurrentUserDep = None,
     manager: OntologyGeneratorManagerDep = None,
 ):
-    """Run the ontology-generation agent and return structured results."""
+    """Kick off an async ontology generation run and return the run_id."""
     success = False
     details = {
         "table_count": len(body.metadata.tables),
@@ -101,38 +144,34 @@ def generate_ontology(
 
     try:
         metadata_dict = {"tables": [t.model_dump() for t in body.metadata.tables]}
-
         options = {
             "includeDataProperties": body.include_data_properties,
             "includeRelationships": body.include_relationships,
             "includeInheritance": body.include_inheritance,
         }
 
-        result = manager.generate_ontology(
+        run_id = manager.start_run(
+            db=db,
+            user_id=current_user.email or current_user.username or "unknown",
             metadata=metadata_dict,
             guidelines=body.guidelines,
             options=options,
             base_uri=body.base_uri,
-            selected_tables=body.selected_tables,
             user_token=_get_user_token(request),
         )
 
-        success = result.success
-        details["iterations"] = result.iterations
-        details["classes_count"] = len(result.classes)
-        details["properties_count"] = len(result.properties)
-        details["owl_content_length"] = len(result.owl_content)
-        if result.error:
-            details["error"] = result.error
+        success = True
+        details["run_id"] = run_id
+        return StartRunResponse(run_id=run_id, status=GenerationRunStatus.PENDING)
 
-        return _build_response(result)
-
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(e))
     except Exception as e:
-        logger.exception("Failed to generate ontology")
+        logger.exception("Failed to start ontology generation run")
         details["exception"] = {"type": type(e).__name__, "message": str(e)}
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ontology generation failed: {e}",
+            detail=f"Failed to start generation: {e}",
         )
     finally:
         audit_manager.log_action(
@@ -140,7 +179,7 @@ def generate_ontology(
             username=current_user.username,
             ip_address=request.client.host if request.client else None,
             feature=FEATURE_ID,
-            action="GENERATE_ONTOLOGY",
+            action="START_ONTOLOGY_GENERATION",
             success=success,
             details=details,
         )
@@ -148,8 +187,9 @@ def generate_ontology(
 
 @router.post(
     "/generate-from-connection",
-    response_model=GenerateOntologyResponse,
-    summary="Generate an OWL ontology from a connection's selected tables",
+    response_model=StartRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start async OWL ontology generation from a connection",
     dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE))],
 )
 def generate_from_connection(
@@ -160,7 +200,7 @@ def generate_from_connection(
     current_user: AuditCurrentUserDep = None,
     manager: OntologyGeneratorManagerDep = None,
 ):
-    """Fetch table metadata via a connection, then generate an OWL ontology."""
+    """Resolve table metadata from a connection, then start an async generation run."""
     success = False
     details = {
         "connection_id": body.connection_id,
@@ -196,29 +236,36 @@ def generate_from_connection(
             "includeInheritance": body.include_inheritance,
         }
 
-        result = manager.generate_ontology(
+        connection = conn_mgr.get_connection(UUID(body.connection_id))
+        conn_name = connection.name if connection else body.connection_id
+
+        run_id = manager.start_run(
+            db=db,
+            user_id=current_user.email or current_user.username or "unknown",
             metadata={"tables": tables_metadata},
             guidelines=body.guidelines,
             options=options,
             base_uri=body.base_uri,
             user_token=_get_user_token(request),
+            connection_id=body.connection_id,
+            connection_name=conn_name,
+            selected_paths=body.selected_paths,
         )
 
-        success = result.success
-        details["iterations"] = result.iterations
-        details["classes_count"] = len(result.classes)
-        details["properties_count"] = len(result.properties)
+        success = True
+        details["run_id"] = run_id
+        return StartRunResponse(run_id=run_id, status=GenerationRunStatus.PENDING)
 
-        return _build_response(result)
-
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Failed to generate ontology from connection")
+        logger.exception("Failed to start ontology generation from connection")
         details["exception"] = {"type": type(e).__name__, "message": str(e)}
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ontology generation failed: {e}",
+            detail=f"Failed to start generation: {e}",
         )
     finally:
         audit_manager.log_action(
@@ -226,11 +273,119 @@ def generate_from_connection(
             username=current_user.username,
             ip_address=request.client.host if request.client else None,
             feature=FEATURE_ID,
-            action="GENERATE_ONTOLOGY_FROM_CONNECTION",
+            action="START_ONTOLOGY_GENERATION_FROM_CONNECTION",
             success=success,
             details=details,
         )
 
+
+# ------------------------------------------------------------------
+# Run management endpoints
+# ------------------------------------------------------------------
+
+@router.get(
+    "/runs",
+    response_model=RunListResponse,
+    summary="List recent ontology generation runs",
+    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+async def list_runs(
+    request: Request,
+    db: DBSessionDep = None,
+    current_user: AuditCurrentUserDep = None,
+    manager: OntologyGeneratorManagerDep = None,
+    limit: int = 50,
+):
+    user_id = current_user.email or current_user.username or "unknown"
+    is_admin = await is_user_feature_admin(
+        current_user.email, current_user.groups, FEATURE_ID, request,
+    )
+
+    if is_admin:
+        rows = manager.list_all_runs(db, limit=limit)
+    else:
+        rows = manager.list_runs(db, user_id, limit=limit)
+
+    return RunListResponse(runs=[_run_to_summary(r) for r in rows])
+
+
+@router.get(
+    "/runs/{run_id}",
+    response_model=GenerationRunDetail,
+    summary="Get full details of a generation run",
+    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+async def get_run(
+    run_id: str,
+    request: Request,
+    db: DBSessionDep = None,
+    current_user: AuditCurrentUserDep = None,
+    manager: OntologyGeneratorManagerDep = None,
+):
+    user_id = current_user.email or current_user.username or "unknown"
+    is_admin = await is_user_feature_admin(
+        current_user.email, current_user.groups, FEATURE_ID, request,
+    )
+
+    if is_admin:
+        run = manager.get_run(db, run_id)
+    else:
+        run = manager.get_run_for_user(db, run_id, user_id)
+
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Refresh to pick up latest background-thread updates
+    db.refresh(run)
+    return _run_to_detail(run)
+
+
+@router.delete(
+    "/runs/{run_id}",
+    summary="Cancel a running generation or delete a finished run",
+    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE))],
+)
+async def delete_run(
+    run_id: str,
+    request: Request,
+    db: DBSessionDep = None,
+    current_user: AuditCurrentUserDep = None,
+    manager: OntologyGeneratorManagerDep = None,
+):
+    user_id = current_user.email or current_user.username or "unknown"
+    is_admin = await is_user_feature_admin(
+        current_user.email, current_user.groups, FEATURE_ID, request,
+    )
+
+    if is_admin:
+        run = manager.get_run(db, run_id)
+    else:
+        run = manager.get_run_for_user(db, run_id, user_id)
+
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    if run.status in ('pending', 'running'):
+        manager.cancel_run(run_id)
+        from src.repositories.ontology_generation_runs_repository import ontology_generation_runs_repo
+        from datetime import datetime, timezone as tz
+        ontology_generation_runs_repo.update_status(
+            db, run_id, 'cancelled',
+            progress_message='Cancelled',
+            error='Cancelled by user',
+            completed_at=datetime.now(tz.utc),
+        )
+        db.commit()
+        return {"detail": "Run cancelled", "run_id": run_id}
+
+    manager.delete_run(db, run_id)
+    db.commit()
+    return {"detail": "Run deleted", "run_id": run_id}
+
+
+# ------------------------------------------------------------------
+# Save to collection (unchanged — synchronous)
+# ------------------------------------------------------------------
 
 @router.post(
     "/save-to-collection",

--- a/src/frontend/src/views/ontology-generator.tsx
+++ b/src/frontend/src/views/ontology-generator.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Wand2, Loader2, Copy, Download, Save } from 'lucide-react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Wand2, Loader2, Copy, Download, Save, XCircle, Clock, CheckCircle2, AlertCircle, History, ChevronDown, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -26,6 +26,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
@@ -33,25 +34,7 @@ import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
 import type { Connection } from '@/types/connections';
 import SchemaBrowser from '@/components/schema-importer/schema-browser';
 
-interface OntologyClass {
-  uri: string;
-  name: string;
-  label: string;
-  comment: string;
-  emoji: string;
-  parent: string;
-  dataProperties: { name: string; label: string; uri: string }[];
-}
-
-interface OntologyProperty {
-  uri: string;
-  name: string;
-  label: string;
-  comment: string;
-  type: string;
-  domain: string;
-  range: string;
-}
+// -- Types --
 
 interface AgentStep {
   step_type: string;
@@ -63,8 +46,8 @@ interface AgentStep {
 interface GenerateResponse {
   success: boolean;
   owl_content: string;
-  classes: OntologyClass[];
-  properties: OntologyProperty[];
+  classes: { uri: string; name: string; label: string; comment: string; emoji: string; parent: string; dataProperties: { name: string; label: string; uri: string }[] }[];
+  properties: { uri: string; name: string; label: string; comment: string; type: string; domain: string; range: string }[];
   ontology_info: { uri: string; label: string; comment: string; namespace: string };
   constraints: Record<string, unknown>[];
   axioms: Record<string, unknown>[];
@@ -74,8 +57,44 @@ interface GenerateResponse {
   usage: { prompt_tokens: number; completion_tokens: number };
 }
 
+interface RunParams {
+  connection_id?: string;
+  connection_name?: string;
+  path_count: number;
+  guidelines: string;
+  base_uri: string;
+  options: Record<string, unknown>;
+}
+
+interface RunSummary {
+  run_id: string;
+  status: string;
+  progress_message?: string;
+  error?: string;
+  created_at?: string;
+  updated_at?: string;
+  completed_at?: string;
+  params: RunParams;
+  step_count: number;
+}
+
+interface RunDetail extends Omit<RunSummary, 'step_count'> {
+  steps: AgentStep[];
+  result?: GenerateResponse;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+const STATUS_CONFIG: Record<string, { icon: typeof Loader2; variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
+  pending: { icon: Clock, variant: 'outline', label: 'Pending' },
+  running: { icon: Loader2, variant: 'default', label: 'Running' },
+  completed: { icon: CheckCircle2, variant: 'secondary', label: 'Completed' },
+  failed: { icon: AlertCircle, variant: 'destructive', label: 'Failed' },
+  cancelled: { icon: XCircle, variant: 'outline', label: 'Cancelled' },
+};
+
 export default function OntologyGeneratorView() {
-  const { get: apiGet, post } = useApi();
+  const { get: apiGet, post, delete: apiDelete } = useApi();
   const { toast } = useToast();
   const setStaticSegments = useBreadcrumbStore((s) => s.setStaticSegments);
   const setDynamicTitle = useBreadcrumbStore((s) => s.setDynamicTitle);
@@ -93,14 +112,25 @@ export default function OntologyGeneratorView() {
   const [includeRelationships, setIncludeRelationships] = useState(true);
   const [includeInheritance, setIncludeInheritance] = useState(true);
 
-  const [isGenerating, setIsGenerating] = useState(false);
+  // Async run state
+  const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [result, setResult] = useState<GenerateResponse | null>(null);
+  const [liveSteps, setLiveSteps] = useState<AgentStep[]>([]);
+  const [progressMessage, setProgressMessage] = useState<string | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const selectedRunIdRef = useRef<string | null>(null);
 
   // Save to collection
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
   const [collectionName, setCollectionName] = useState('');
   const [collectionDescription, setCollectionDescription] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+
+  // Recent runs panel visibility
+  const [showRecentRuns, setShowRecentRuns] = useState(false);
 
   useEffect(() => {
     setStaticSegments([]);
@@ -111,6 +141,8 @@ export default function OntologyGeneratorView() {
     };
   }, [setStaticSegments, setDynamicTitle]);
 
+  // -- Connections --
+
   const fetchConnections = useCallback(async () => {
     setIsLoadingConnections(true);
     try {
@@ -118,9 +150,7 @@ export default function OntologyGeneratorView() {
       if (resp.data) {
         const enabled = resp.data.filter((c) => c.enabled);
         setConnections(enabled);
-        if (enabled.length === 1) {
-          setSelectedConnectionId(enabled[0].id);
-        }
+        if (enabled.length === 1) setSelectedConnectionId(enabled[0].id);
       }
     } catch (err) {
       console.error('Failed to fetch connections:', err);
@@ -129,27 +159,116 @@ export default function OntologyGeneratorView() {
     }
   }, [apiGet]);
 
+  useEffect(() => { fetchConnections(); }, [fetchConnections]);
+
+  // -- Runs list fetch --
+
+  const fetchRuns = useCallback(async () => {
+    try {
+      const resp = await apiGet<{ runs: RunSummary[] }>('/api/ontology/runs?limit=20');
+      if (resp.data?.runs) {
+        setRuns(resp.data.runs);
+        // If there's a running run and we're not already polling, resume
+        const running = resp.data.runs.find((r) => r.status === 'running' || r.status === 'pending');
+        if (running && !activeRunId) {
+          setActiveRunId(running.run_id);
+          setProgressMessage(running.progress_message || null);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to fetch runs:', err);
+    }
+  }, [apiGet, activeRunId]);
+
+  useEffect(() => { fetchRuns(); }, [fetchRuns]);
+
+  // -- Polling for active run --
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
+
+  const pollRun = useCallback(async (runId: string) => {
+    try {
+      const resp = await apiGet<RunDetail>(`/api/ontology/runs/${runId}`);
+      if (!resp.data) return;
+
+      const run = resp.data;
+      setProgressMessage(run.progress_message || null);
+
+      // Only update the detail pane if the user is viewing this run (or no run selected)
+      const viewing = selectedRunIdRef.current;
+      const isViewingActiveRun = !viewing || viewing === runId;
+
+      if (isViewingActiveRun) {
+        setLiveSteps(run.steps || []);
+      }
+
+      if (run.status === 'completed') {
+        stopPolling();
+        setActiveRunId(null);
+        if (run.result && isViewingActiveRun) {
+          setResult(run.result);
+          setSelectedRunId(runId);
+          selectedRunIdRef.current = runId;
+        }
+        toast({
+          title: 'Ontology generated',
+          description: run.result
+            ? `${run.result.classes.length} classes, ${run.result.properties.length} properties.`
+            : 'Generation completed.',
+        });
+        fetchRuns();
+      } else if (run.status === 'failed' || run.status === 'cancelled') {
+        stopPolling();
+        setActiveRunId(null);
+        toast({
+          title: run.status === 'cancelled' ? 'Generation cancelled' : 'Generation failed',
+          description: run.error || 'Unknown error',
+          variant: 'destructive',
+        });
+        fetchRuns();
+      }
+    } catch (err) {
+      console.error('Poll error:', err);
+    }
+  }, [apiGet, stopPolling, toast, fetchRuns]);
+
   useEffect(() => {
-    fetchConnections();
-  }, [fetchConnections]);
+    if (!activeRunId) return;
+    pollRun(activeRunId);
+    pollingRef.current = setInterval(() => pollRun(activeRunId), POLL_INTERVAL_MS);
+    return stopPolling;
+  }, [activeRunId, pollRun, stopPolling]);
+
+  // Cleanup on unmount
+  useEffect(() => stopPolling, [stopPolling]);
+
+  // -- Generate --
 
   const handleConnectionChange = (id: string) => {
     setSelectedConnectionId(id);
     setSelectedPaths(new Set());
-    setResult(null);
   };
 
   const selectedConnection = connections.find((c) => c.id === selectedConnectionId);
-  const canGenerate = selectedPaths.size > 0 && !isGenerating;
+  const isRunning = !!activeRunId;
+  const canGenerate = selectedPaths.size > 0 && !isRunning && !isStarting;
 
   const handleGenerate = async () => {
     if (!selectedConnectionId || selectedPaths.size === 0) return;
 
-    setIsGenerating(true);
+    setIsStarting(true);
     setResult(null);
+    setLiveSteps([]);
+    setSelectedRunId(null);
+    selectedRunIdRef.current = null;
 
     try {
-      const response = await post<GenerateResponse>('/api/ontology/generate-from-connection', {
+      const response = await post<{ run_id: string; status: string }>('/api/ontology/generate-from-connection', {
         connection_id: selectedConnectionId,
         selected_paths: Array.from(selectedPaths),
         guidelines,
@@ -160,26 +279,72 @@ export default function OntologyGeneratorView() {
       });
 
       if (response.error) {
-        toast({ title: 'Generation failed', description: response.error, variant: 'destructive' });
+        toast({ title: 'Failed to start generation', description: response.error, variant: 'destructive' });
         return;
       }
 
-      setResult(response.data ?? null);
-
-      if (response.data?.success) {
-        toast({
-          title: 'Ontology generated',
-          description: `${response.data.classes.length} classes, ${response.data.properties.length} properties in ${response.data.iterations} iteration(s).`,
-        });
-      } else if (response.data?.error) {
-        toast({ title: 'Generation incomplete', description: response.data.error, variant: 'destructive' });
+      if (response.data?.run_id) {
+        setActiveRunId(response.data.run_id);
+        setProgressMessage('Starting...');
+        toast({ title: 'Generation started', description: 'The LLM agent is working in the background.' });
       }
     } catch (err) {
       toast({ title: 'Error', description: String(err), variant: 'destructive' });
     } finally {
-      setIsGenerating(false);
+      setIsStarting(false);
     }
   };
+
+  // -- Cancel --
+
+  const handleCancel = async () => {
+    if (!activeRunId) return;
+    try {
+      await apiDelete(`/api/ontology/runs/${activeRunId}`);
+      stopPolling();
+      setActiveRunId(null);
+      setProgressMessage(null);
+      fetchRuns();
+    } catch (err) {
+      toast({ title: 'Cancel failed', description: String(err), variant: 'destructive' });
+    }
+  };
+
+  // -- Load past run result --
+
+  const loadRunResult = async (runId: string) => {
+    try {
+      const resp = await apiGet<RunDetail>(`/api/ontology/runs/${runId}`);
+      if (resp.data?.result) {
+        setResult(resp.data.result);
+        setSelectedRunId(runId);
+        selectedRunIdRef.current = runId;
+        setLiveSteps(resp.data.steps || []);
+      } else {
+        toast({ title: 'No result', description: 'This run has no result data.', variant: 'destructive' });
+      }
+    } catch (err) {
+      toast({ title: 'Error', description: String(err), variant: 'destructive' });
+    }
+  };
+
+  const deleteRun = async (runId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await apiDelete(`/api/ontology/runs/${runId}`);
+      if (selectedRunId === runId) {
+        setResult(null);
+        setSelectedRunId(null);
+        selectedRunIdRef.current = null;
+        setLiveSteps([]);
+      }
+      fetchRuns();
+    } catch (err) {
+      toast({ title: 'Delete failed', description: String(err), variant: 'destructive' });
+    }
+  };
+
+  // -- Turtle helpers --
 
   const copyTurtle = () => {
     if (result?.owl_content) {
@@ -199,6 +364,8 @@ export default function OntologyGeneratorView() {
       URL.revokeObjectURL(url);
     }
   };
+
+  // -- Save to collection --
 
   const handleSaveToCollection = async () => {
     if (!result?.owl_content || !collectionName.trim()) return;
@@ -229,21 +396,38 @@ export default function OntologyGeneratorView() {
         setIsSaveDialogOpen(false);
         setCollectionName('');
         setCollectionDescription('');
-        // Refresh any open Concepts/Graph views so the new collection
-        // appears without requiring a manual reload.
         bumpKnowledgeGraphRefresh('ontology-save');
       } else {
-        toast({
-          title: 'Save failed',
-          description: response.data?.error || 'Unknown error',
-          variant: 'destructive',
-        });
+        toast({ title: 'Save failed', description: response.data?.error || 'Unknown error', variant: 'destructive' });
       }
     } catch (err) {
       toast({ title: 'Error', description: String(err), variant: 'destructive' });
     } finally {
       setIsSaving(false);
     }
+  };
+
+  // -- Render helpers --
+
+  const formatTime = (iso?: string) => {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const StatusIcon = ({ status }: { status: string }) => {
+    const cfg = STATUS_CONFIG[status] || STATUS_CONFIG.pending;
+    const Icon = cfg.icon;
+    const colorMap: Record<string, string> = {
+      pending: 'text-muted-foreground',
+      running: 'text-primary',
+      completed: 'text-green-600',
+      failed: 'text-destructive',
+      cancelled: 'text-muted-foreground',
+    };
+    return (
+      <Icon className={`h-4 w-4 shrink-0 ${colorMap[status] || 'text-muted-foreground'} ${status === 'running' ? 'animate-spin' : ''}`} />
+    );
   };
 
   return (
@@ -256,42 +440,32 @@ export default function OntologyGeneratorView() {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[300px_1fr]">
-        {/* Left panel: connection + options */}
+        {/* Left panel */}
         <div className="space-y-4">
           {/* Connection selector */}
           <Card>
             <CardHeader className="pb-3">
               <CardTitle className="text-sm font-medium">Connection</CardTitle>
-              <CardDescription className="text-xs">
-                Select a data platform connection
-              </CardDescription>
+              <CardDescription className="text-xs">Select a data platform connection</CardDescription>
             </CardHeader>
             <CardContent>
               {isLoadingConnections ? (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Loading...
+                  <Loader2 className="h-4 w-4 animate-spin" /> Loading...
                 </div>
               ) : connections.length === 0 ? (
                 <p className="text-sm text-muted-foreground">
                   No connections configured. Add one in Settings &gt; Connectors.
                 </p>
               ) : (
-                <Select
-                  value={selectedConnectionId || ''}
-                  onValueChange={handleConnectionChange}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Choose connection..." />
-                  </SelectTrigger>
+                <Select value={selectedConnectionId || ''} onValueChange={handleConnectionChange}>
+                  <SelectTrigger><SelectValue placeholder="Choose connection..." /></SelectTrigger>
                   <SelectContent>
                     {connections.map((c) => (
                       <SelectItem key={c.id} value={c.id}>
                         <div className="flex items-center gap-2">
                           <span>{c.name}</span>
-                          <Badge variant="outline" className="text-[10px] px-1 py-0">
-                            {c.connector_type}
-                          </Badge>
+                          <Badge variant="outline" className="text-[10px] px-1 py-0">{c.connector_type}</Badge>
                         </div>
                       </SelectItem>
                     ))}
@@ -305,30 +479,16 @@ export default function OntologyGeneratorView() {
           <Card>
             <CardHeader className="pb-3">
               <CardTitle className="text-sm font-medium">Generation Options</CardTitle>
-              <CardDescription className="text-xs">
-                Customize the ontology generation
-              </CardDescription>
+              <CardDescription className="text-xs">Customize the ontology generation</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               <div>
                 <Label htmlFor="guidelines" className="text-xs">Guidelines</Label>
-                <Textarea
-                  id="guidelines"
-                  placeholder="E.g., Create a domain ontology for e-commerce data..."
-                  value={guidelines}
-                  onChange={(e) => setGuidelines(e.target.value)}
-                  rows={3}
-                  className="mt-1 text-sm"
-                />
+                <Textarea id="guidelines" placeholder="E.g., Create a domain ontology for e-commerce data..." value={guidelines} onChange={(e) => setGuidelines(e.target.value)} rows={3} className="mt-1 text-sm" />
               </div>
               <div>
                 <Label htmlFor="baseUri" className="text-xs">Base URI</Label>
-                <Input
-                  id="baseUri"
-                  value={baseUri}
-                  onChange={(e) => setBaseUri(e.target.value)}
-                  className="mt-1 font-mono text-xs"
-                />
+                <Input id="baseUri" value={baseUri} onChange={(e) => setBaseUri(e.target.value)} className="mt-1 font-mono text-xs" />
               </div>
               <Separator />
               <div className="space-y-2">
@@ -348,59 +508,164 @@ export default function OntologyGeneratorView() {
             </CardContent>
           </Card>
 
-          {/* Generate button */}
-          <Button onClick={handleGenerate} disabled={!canGenerate} className="w-full">
-            {isGenerating ? (
-              <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Generating...</>
+          {/* Generate / Cancel buttons */}
+          <div className="space-y-2">
+            {isRunning ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground px-1">
+                  <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                  <span className="truncate">{progressMessage || 'Working...'}</span>
+                </div>
+                <Button variant="destructive" onClick={handleCancel} className="w-full">
+                  <XCircle className="h-4 w-4 mr-2" /> Cancel Generation
+                </Button>
+              </div>
             ) : (
-              <><Wand2 className="h-4 w-4 mr-2" /> Generate Ontology ({selectedPaths.size} selected)</>
+              <Button onClick={handleGenerate} disabled={!canGenerate} className="w-full">
+                {isStarting ? (
+                  <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Starting...</>
+                ) : (
+                  <><Wand2 className="h-4 w-4 mr-2" /> Generate Ontology ({selectedPaths.size} selected)</>
+                )}
+              </Button>
             )}
-          </Button>
+          </div>
+
+          {/* Recent Runs */}
+          <Card>
+            <CardHeader
+              className="py-3 cursor-pointer select-none hover:bg-muted/50 transition-colors rounded-t-lg"
+              onClick={() => setShowRecentRuns(!showRecentRuns)}
+            >
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <History className="h-4 w-4" /> Recent Runs
+                  {runs.length > 0 && <Badge variant="secondary" className="text-xs">{runs.length}</Badge>}
+                </CardTitle>
+                <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${showRecentRuns ? 'rotate-180' : ''}`} />
+              </div>
+            </CardHeader>
+            {showRecentRuns && (
+              <CardContent className="pt-0 pb-3">
+                <ScrollArea className="max-h-[300px]">
+                  {runs.length === 0 ? (
+                    <p className="text-xs text-muted-foreground text-center py-4">No runs yet</p>
+                  ) : (
+                    <div className="space-y-0.5">
+                      {runs.map((run) => (
+                        <HoverCard key={run.run_id} openDelay={300} closeDelay={100}>
+                          <HoverCardTrigger asChild>
+                            <div
+                              className={`flex items-center gap-2 px-2 py-1.5 rounded-md text-xs cursor-pointer hover:bg-muted transition-colors ${selectedRunId === run.run_id ? 'bg-muted ring-1 ring-primary/20' : ''}`}
+                              onClick={() => {
+                                if (run.status === 'completed') loadRunResult(run.run_id);
+                              }}
+                            >
+                              <StatusIcon status={run.status} />
+                              <span className="flex-1 truncate font-medium">
+                                {run.params.connection_name || 'Direct'}
+                              </span>
+                              <span className="text-muted-foreground shrink-0">{formatTime(run.created_at)}</span>
+                              {run.status !== 'running' && run.status !== 'pending' && (
+                                <button
+                                  className="p-0.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors shrink-0"
+                                  onClick={(e) => deleteRun(run.run_id, e)}
+                                  title="Delete run"
+                                >
+                                  <Trash2 className="h-3 w-3" />
+                                </button>
+                              )}
+                            </div>
+                          </HoverCardTrigger>
+                          <HoverCardContent side="right" align="start" className="w-72 text-xs">
+                            <div className="space-y-2">
+                              <div className="flex items-center justify-between">
+                                <span className="font-semibold">{run.params.connection_name || 'Direct generation'}</span>
+                                <Badge variant={STATUS_CONFIG[run.status]?.variant || 'outline'} className="text-[10px]">
+                                  {STATUS_CONFIG[run.status]?.label || run.status}
+                                </Badge>
+                              </div>
+                              <Separator />
+                              <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-muted-foreground">
+                                <span>Paths</span><span className="font-mono">{run.params.path_count}</span>
+                                <span>Steps</span><span className="font-mono">{run.step_count}</span>
+                                <span>Started</span><span>{run.created_at ? new Date(run.created_at).toLocaleString([], { dateStyle: 'short', timeStyle: 'medium' }) : '—'}</span>
+                                {run.completed_at && (<><span>Finished</span><span>{new Date(run.completed_at).toLocaleString([], { dateStyle: 'short', timeStyle: 'medium' })}</span></>)}
+                              </div>
+                              {run.params.guidelines && (
+                                <>
+                                  <Separator />
+                                  <div>
+                                    <span className="text-muted-foreground">Guidelines:</span>
+                                    <p className="mt-0.5 line-clamp-2">{run.params.guidelines}</p>
+                                  </div>
+                                </>
+                              )}
+                              {run.error && (
+                                <>
+                                  <Separator />
+                                  <p className="text-destructive line-clamp-2">{run.error}</p>
+                                </>
+                              )}
+                            </div>
+                          </HoverCardContent>
+                        </HoverCard>
+                      ))}
+                    </div>
+                  )}
+                </ScrollArea>
+              </CardContent>
+            )}
+          </Card>
         </div>
 
-        {/* Right panel: tree + results */}
+        {/* Right panel */}
         <div className="space-y-4">
-          {/* Tree browser */}
+          {/* Schema tree browser */}
           <Card>
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle className="text-sm font-medium">
-                    {selectedConnection
-                      ? `${selectedConnection.name} — Resources`
-                      : 'Resources'}
+                    {selectedConnection ? `${selectedConnection.name} — Resources` : 'Resources'}
                   </CardTitle>
-                  <CardDescription className="text-xs">
-                    Select the catalogs, schemas, or tables to generate an ontology from
-                  </CardDescription>
+                  <CardDescription className="text-xs">Select the catalogs, schemas, or tables to generate an ontology from</CardDescription>
                 </div>
-                {selectedPaths.size > 0 && (
-                  <Badge variant="secondary">{selectedPaths.size} selected</Badge>
-                )}
+                {selectedPaths.size > 0 && <Badge variant="secondary">{selectedPaths.size} selected</Badge>}
               </div>
             </CardHeader>
             <CardContent>
-              <SchemaBrowser
-                connectionId={selectedConnectionId}
-                selectedPaths={selectedPaths}
-                onSelectionChange={setSelectedPaths}
-              />
+              <SchemaBrowser connectionId={selectedConnectionId} selectedPaths={selectedPaths} onSelectionChange={setSelectedPaths} />
             </CardContent>
           </Card>
 
-          {/* Results */}
-          {isGenerating && (
+          {/* Live progress while running */}
+          {isRunning && liveSteps.length > 0 && (
             <Card>
-              <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-                <Loader2 className="h-10 w-10 mb-3 animate-spin text-primary" />
-                <p className="text-lg font-medium">Generating ontology...</p>
-                <p className="text-sm text-muted-foreground mt-1">
-                  The LLM agent is fetching schemas and building the ontology.
-                </p>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Agent Progress
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ScrollArea className="h-[200px]">
+                  <div className="space-y-1">
+                    {liveSteps.map((step, i) => (
+                      <div key={i} className="flex items-center gap-2 text-xs py-1">
+                        <Badge variant={step.step_type === 'tool_call' ? 'default' : step.step_type === 'tool_result' ? 'secondary' : 'outline'} className="text-[10px] shrink-0">
+                          {step.step_type}
+                        </Badge>
+                        {step.tool_name && <span className="font-mono text-muted-foreground">{step.tool_name}</span>}
+                        <span className="truncate text-muted-foreground">{step.content.slice(0, 80)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
               </CardContent>
             </Card>
           )}
 
+          {/* Results tabs */}
           {result && (
             <Tabs defaultValue="classes">
               <TabsList className="w-full">
@@ -434,26 +699,16 @@ export default function OntologyGeneratorView() {
                               <TableCell>
                                 <div className="flex flex-wrap gap-1">
                                   {cls.dataProperties.map((dp) => (
-                                    <Badge key={dp.name} variant="secondary" className="text-xs font-mono">
-                                      {dp.name}
-                                    </Badge>
+                                    <Badge key={dp.name} variant="secondary" className="text-xs font-mono">{dp.name}</Badge>
                                   ))}
-                                  {cls.dataProperties.length === 0 && (
-                                    <span className="text-muted-foreground text-xs">none</span>
-                                  )}
+                                  {cls.dataProperties.length === 0 && <span className="text-muted-foreground text-xs">none</span>}
                                 </div>
                               </TableCell>
-                              <TableCell className="text-sm text-muted-foreground max-w-[200px] truncate">
-                                {cls.comment || '—'}
-                              </TableCell>
+                              <TableCell className="text-sm text-muted-foreground max-w-[200px] truncate">{cls.comment || '—'}</TableCell>
                             </TableRow>
                           ))}
                           {result.classes.length === 0 && (
-                            <TableRow>
-                              <TableCell colSpan={4} className="text-center text-muted-foreground">
-                                No classes generated
-                              </TableCell>
-                            </TableRow>
+                            <TableRow><TableCell colSpan={4} className="text-center text-muted-foreground">No classes generated</TableCell></TableRow>
                           )}
                         </TableBody>
                       </Table>
@@ -480,10 +735,7 @@ export default function OntologyGeneratorView() {
                             <TableRow key={prop.uri}>
                               <TableCell className="font-mono font-medium">{prop.name}</TableCell>
                               <TableCell>
-                                <Badge
-                                  variant={prop.type === 'ObjectProperty' ? 'default' : 'secondary'}
-                                  className="text-xs"
-                                >
+                                <Badge variant={prop.type === 'ObjectProperty' ? 'default' : 'secondary'} className="text-xs">
                                   {prop.type === 'ObjectProperty' ? 'Object' : 'Data'}
                                 </Badge>
                               </TableCell>
@@ -492,11 +744,7 @@ export default function OntologyGeneratorView() {
                             </TableRow>
                           ))}
                           {result.properties.length === 0 && (
-                            <TableRow>
-                              <TableCell colSpan={4} className="text-center text-muted-foreground">
-                                No properties generated
-                              </TableCell>
-                            </TableRow>
+                            <TableRow><TableCell colSpan={4} className="text-center text-muted-foreground">No properties generated</TableCell></TableRow>
                           )}
                         </TableBody>
                       </Table>
@@ -511,23 +759,15 @@ export default function OntologyGeneratorView() {
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-sm">Generated Turtle</CardTitle>
                       <div className="flex gap-2">
-                        <Button variant="outline" size="sm" onClick={copyTurtle}>
-                          <Copy className="h-3.5 w-3.5 mr-1" /> Copy
-                        </Button>
-                        <Button variant="outline" size="sm" onClick={downloadTurtle}>
-                          <Download className="h-3.5 w-3.5 mr-1" /> Download
-                        </Button>
-                        <Button size="sm" onClick={() => setIsSaveDialogOpen(true)}>
-                          <Save className="h-3.5 w-3.5 mr-1" /> Save to Collection
-                        </Button>
+                        <Button variant="outline" size="sm" onClick={copyTurtle}><Copy className="h-3.5 w-3.5 mr-1" /> Copy</Button>
+                        <Button variant="outline" size="sm" onClick={downloadTurtle}><Download className="h-3.5 w-3.5 mr-1" /> Download</Button>
+                        <Button size="sm" onClick={() => setIsSaveDialogOpen(true)}><Save className="h-3.5 w-3.5 mr-1" /> Save to Collection</Button>
                       </div>
                     </div>
                   </CardHeader>
                   <CardContent>
                     <ScrollArea className="h-[400px]">
-                      <pre className="text-xs font-mono whitespace-pre-wrap bg-muted p-4 rounded-md">
-                        {result.owl_content || '(empty)'}
-                      </pre>
+                      <pre className="text-xs font-mono whitespace-pre-wrap bg-muted p-4 rounded-md">{result.owl_content || '(empty)'}</pre>
                     </ScrollArea>
                   </CardContent>
                 </Card>
@@ -538,9 +778,7 @@ export default function OntologyGeneratorView() {
                   <CardHeader className="pb-2">
                     <CardTitle className="text-sm">Agent Execution Log</CardTitle>
                     <CardDescription>
-                      {result.iterations} iteration(s) ·{' '}
-                      {result.usage.prompt_tokens ?? 0} prompt tokens ·{' '}
-                      {result.usage.completion_tokens ?? 0} completion tokens
+                      {result.iterations} iteration(s) · {result.usage?.prompt_tokens ?? 0} prompt tokens · {result.usage?.completion_tokens ?? 0} completion tokens
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
@@ -549,38 +787,15 @@ export default function OntologyGeneratorView() {
                         {result.steps.map((step, i) => (
                           <div key={i} className="border rounded-md p-3">
                             <div className="flex items-center gap-2 mb-1">
-                              <Badge
-                                variant={
-                                  step.step_type === 'tool_call'
-                                    ? 'default'
-                                    : step.step_type === 'tool_result'
-                                      ? 'secondary'
-                                      : 'outline'
-                                }
-                                className="text-xs"
-                              >
-                                {step.step_type}
-                              </Badge>
-                              {step.tool_name && (
-                                <span className="text-xs font-mono text-muted-foreground">
-                                  {step.tool_name}
-                                </span>
-                              )}
-                              {step.duration_ms > 0 && (
-                                <span className="text-xs text-muted-foreground ml-auto">
-                                  {step.duration_ms}ms
-                                </span>
-                              )}
+                              <Badge variant={step.step_type === 'tool_call' ? 'default' : step.step_type === 'tool_result' ? 'secondary' : 'outline'} className="text-xs">{step.step_type}</Badge>
+                              {step.tool_name && <span className="text-xs font-mono text-muted-foreground">{step.tool_name}</span>}
+                              {step.duration_ms > 0 && <span className="text-xs text-muted-foreground ml-auto">{step.duration_ms}ms</span>}
                             </div>
-                            <pre className="text-xs font-mono whitespace-pre-wrap text-muted-foreground mt-1 max-h-32 overflow-auto">
-                              {step.content}
-                            </pre>
+                            <pre className="text-xs font-mono whitespace-pre-wrap text-muted-foreground mt-1 max-h-32 overflow-auto">{step.content}</pre>
                           </div>
                         ))}
                         {result.steps.length === 0 && (
-                          <p className="text-center text-muted-foreground text-sm">
-                            No agent steps recorded
-                          </p>
+                          <p className="text-center text-muted-foreground text-sm">No agent steps recorded</p>
                         )}
                       </div>
                     </ScrollArea>
@@ -605,31 +820,16 @@ export default function OntologyGeneratorView() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Save to Concept Collection</DialogTitle>
-            <DialogDescription>
-              Create a new ontology collection and import the generated triples into the knowledge graph.
-            </DialogDescription>
+            <DialogDescription>Create a new ontology collection and import the generated triples into the knowledge graph.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div>
               <Label htmlFor="collName">Collection Name</Label>
-              <Input
-                id="collName"
-                placeholder="e.g., Customer Domain Ontology"
-                value={collectionName}
-                onChange={(e) => setCollectionName(e.target.value)}
-                className="mt-1"
-              />
+              <Input id="collName" placeholder="e.g., Customer Domain Ontology" value={collectionName} onChange={(e) => setCollectionName(e.target.value)} className="mt-1" />
             </div>
             <div>
               <Label htmlFor="collDesc">Description (optional)</Label>
-              <Textarea
-                id="collDesc"
-                placeholder="Describe the purpose of this ontology collection..."
-                value={collectionDescription}
-                onChange={(e) => setCollectionDescription(e.target.value)}
-                rows={3}
-                className="mt-1"
-              />
+              <Textarea id="collDesc" placeholder="Describe the purpose of this ontology collection..." value={collectionDescription} onChange={(e) => setCollectionDescription(e.target.value)} rows={3} className="mt-1" />
             </div>
             {result && (
               <p className="text-xs text-muted-foreground">
@@ -638,15 +838,9 @@ export default function OntologyGeneratorView() {
             )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsSaveDialogOpen(false)} disabled={isSaving}>
-              Cancel
-            </Button>
+            <Button variant="outline" onClick={() => setIsSaveDialogOpen(false)} disabled={isSaving}>Cancel</Button>
             <Button onClick={handleSaveToCollection} disabled={isSaving || !collectionName.trim()}>
-              {isSaving ? (
-                <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Saving...</>
-              ) : (
-                <><Save className="h-4 w-4 mr-2" /> Save</>
-              )}
+              {isSaving ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Saving...</> : <><Save className="h-4 w-4 mr-2" /> Save</>}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary

Closes #338

- Replace synchronous ontology generation with background-threaded execution that returns HTTP 202 immediately
- Persist generation runs to a dedicated `ontology_generation_runs` DB table (survives server restarts)
- Add concurrent-run cap (3 per user) with graceful cancellation between LLM iterations
- User-scoped run visibility with admin override
- Frontend: async polling with live progress, Recent Runs panel with hover cards, delete/cancel, save from any completed run
- Fix `urn:ontology:` missing from `target_contexts` in `_compute_all_concepts`

## Test plan

- [ ] Start an ontology generation run — verify 202 response and polling works
- [ ] Cancel a running generation — verify graceful stop
- [ ] Reload page during a run — verify it resumes polling from the DB record
- [ ] Click a completed past run — verify result loads without being overwritten by an active run
- [ ] Delete a past run from the Recent Runs panel
- [ ] Verify concurrent-run cap (start 4 runs, 4th should be rejected with 429)
- [ ] Verify admin can see all users' runs
- [ ] Save to Collection from a past completed run