### PR TITLE
feat(versioning): role-aware family collapse, family-latest resolver, EntityVersionPicker (PRD #442 phase 3)

### DIFF
--- a/src/backend/src/common/version_visibility.py
+++ b/src/backend/src/common/version_visibility.py
@@ -1,0 +1,164 @@
+"""Version-family visibility ranking (PRD #442).
+
+Two ranking tables, picked per (caller × family):
+
+* **Elevated** — caller is admin, draft_owner of some row in the family,
+  member of the owner_team, or (products only) a subscriber. Drafts and
+  in-flight versions surface first so producers/subscribers preview
+  upcoming changes:
+
+      DRAFT > PROPOSED > UNDER_REVIEW > APPROVED > ACTIVE > DEPRECATED
+
+* **Consumer** — caller has no elevated relationship with the family.
+  Only published lifecycle stages are visible; the active version wins:
+
+      ACTIVE > DEPRECATED   (all other statuses filtered out entirely)
+
+``RETIRED`` and unknown statuses sit below both rankings and are only
+visible to admins (the manager applies that final guard).
+
+The functions in this module take plain ORM rows (or row-like objects
+that expose ``status``, ``draft_owner_id``, ``owner_team_id``,
+``version_family_id``, ``created_at``) so they're equally usable from
+the contracts and products managers.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional, Set
+
+
+# Lower rank wins (think: "preferred"). Statuses absent from the dict
+# never rank — the consumer filter drops them before ranking starts.
+_STATUS_RANK_ELEVATED: dict[str, int] = {
+    "draft": 0,
+    "proposed": 1,
+    "under_review": 2,
+    "approved": 3,
+    "active": 4,
+    "deprecated": 5,
+}
+
+_STATUS_RANK_CONSUMER: dict[str, int] = {
+    "active": 0,
+    "deprecated": 1,
+}
+
+# Statuses visible to admins only (filtered out for everyone else).
+_ADMIN_ONLY_STATUSES: frozenset[str] = frozenset({"retired"})
+
+
+def _normalize_status(row: Any) -> str:
+    return (getattr(row, "status", "") or "").strip().lower()
+
+
+def is_visible_consumer(row: Any) -> bool:
+    """A consumer sees only published lifecycle stages."""
+    return _normalize_status(row) in _STATUS_RANK_CONSUMER
+
+
+def is_admin_only_status(row: Any) -> bool:
+    return _normalize_status(row) in _ADMIN_ONLY_STATUSES
+
+
+def compute_rank(row: Any, *, has_elevated_access: bool) -> tuple:
+    """Sort key for rep-picking inside a family (lower = preferred).
+
+    Tie-breaks by created_at DESC so newer rows win when the status rank
+    is the same. ``has_elevated_access`` selects the rank table; the
+    caller is expected to have already filtered out invisible rows
+    (consumer rows with non-published statuses, retired rows for
+    non-admins, etc.).
+    """
+    status = _normalize_status(row)
+    table = _STATUS_RANK_ELEVATED if has_elevated_access else _STATUS_RANK_CONSUMER
+    # Unknown statuses sit below every known one. They should normally
+    # have been filtered out already; this just guarantees deterministic
+    # ordering rather than a KeyError.
+    status_rank = table.get(status, 999)
+
+    created_at = getattr(row, "created_at", None)
+    # Negate the epoch so DESC sort falls out of a plain ascending key.
+    epoch = (
+        created_at.timestamp()
+        if isinstance(created_at, datetime)
+        else 0.0
+    )
+    return (status_rank, -epoch)
+
+
+def collapse_by_family(
+    rows: Iterable[Any],
+    *,
+    elevated_family_ids: Set[str],
+    is_admin: bool,
+) -> list[Any]:
+    """Collapse rows to one rep per ``version_family_id``.
+
+    Steps, in order:
+
+    1. Drop rows the caller can't see at all (retired-for-non-admins,
+       non-published-statuses for non-elevated families).
+    2. For each remaining family, pick the row with the best
+       :func:`compute_rank`.
+
+    Personal-draft visibility (``draft_owner_id``) is enforced at the
+    query layer and is NOT re-checked here; rows passed in are already
+    visibility-filtered for the personal-draft case.
+    """
+    # First pass: drop invisible rows.
+    survivors: list[Any] = []
+    for row in rows:
+        fid = getattr(row, "version_family_id", None) or getattr(row, "id", None)
+        if fid is None:
+            # Defensive: rows without family_id collapse to themselves
+            # (treated as singleton families).
+            survivors.append(row)
+            continue
+        if not is_admin and is_admin_only_status(row):
+            continue
+        if fid in elevated_family_ids or is_admin:
+            survivors.append(row)
+        elif is_visible_consumer(row):
+            survivors.append(row)
+        # else: consumer-level access to a family whose row isn't
+        # published — drop silently.
+
+    # Second pass: pick rep.
+    picked: dict[str, Any] = {}
+    for row in survivors:
+        fid = getattr(row, "version_family_id", None) or getattr(row, "id", None)
+        has_elevated = is_admin or fid in elevated_family_ids
+        rank = compute_rank(row, has_elevated_access=has_elevated)
+        current = picked.get(fid)
+        if current is None:
+            picked[fid] = (rank, row)
+        else:
+            current_rank, _current_row = current
+            if rank < current_rank:
+                picked[fid] = (rank, row)
+    return [row for _rank, row in picked.values()]
+
+
+def family_counts(rows: Iterable[Any]) -> dict[str, int]:
+    """Helper used alongside :func:`collapse_by_family` so callers can
+    surface a ``versionCount`` badge on the surviving row. Counts are
+    taken from the *post-visibility-filter* row set — see the route
+    docstrings for why that matters.
+    """
+    counts: dict[str, int] = {}
+    for row in rows:
+        fid = getattr(row, "version_family_id", None) or getattr(row, "id", None)
+        if fid is None:
+            continue
+        counts[fid] = counts.get(fid, 0) + 1
+    return counts
+
+
+__all__ = [
+    "collapse_by_family",
+    "compute_rank",
+    "family_counts",
+    "is_admin_only_status",
+    "is_visible_consumer",
+]

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from uuid import uuid4
 from datetime import datetime
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Set
 import os
 from pathlib import Path
 
@@ -5928,15 +5928,67 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
 
     # --- Contract Listing and API Model Building ---
 
-    def _query_contracts(self, db, domain_id=None, project_id=None, is_admin=False, latest_only=True):
+    def _elevated_contract_families(
+        self,
+        db,
+        contracts,
+        *,
+        caller_email: Optional[str],
+        caller_team_ids: Optional[Set[str]],
+    ) -> Set[str]:
+        """Family IDs the caller has elevated visibility for.
+
+        Contracts have no subscription table today (per PRD #442 follow-up
+        scope), so elevation comes from ownership and authorship:
+
+          * caller is the ``draft_owner_id`` of any row in the family
+          * caller is a member of the ``owner_team_id`` of any row
+
+        Admins skip this check at the call site; we never need to compute
+        the set for them.
+        """
+        elevated: Set[str] = set()
+        if not caller_email and not caller_team_ids:
+            return elevated
+        team_ids = caller_team_ids or set()
+        for c in contracts:
+            fid = c.version_family_id or c.id
+            if fid in elevated:
+                continue
+            if caller_email and c.draft_owner_id == caller_email:
+                elevated.add(fid)
+                continue
+            if c.owner_team_id and c.owner_team_id in team_ids:
+                elevated.add(fid)
+        return elevated
+
+    def _query_contracts(
+        self,
+        db,
+        domain_id=None,
+        project_id=None,
+        is_admin=False,
+        latest_only=True,
+        *,
+        caller_email: Optional[str] = None,
+        caller_team_ids: Optional[Set[str]] = None,
+    ):
         """Shared query logic for listing contracts. Returns (contracts, family_counts).
 
-        ``latest_only`` (default True) collapses every ``version_family_id``
-        down to the row with the newest ``created_at``. ``family_counts``
-        maps each surviving family_id → total rows in the family from the
-        visibility-filtered result set, so callers can render a "N versions"
-        badge without a second query. See PRD #442.
+        ``latest_only`` (default True) collapses each ``version_family_id``
+        family using the role-aware rank in :mod:`src.common.version_visibility`:
+        consumers see only published rows (active/deprecated), owners and
+        admins see in-flight versions (draft/proposed/...) first. The
+        ``family_counts`` map is keyed by surviving family_id so the route
+        can render a "N versions" badge from a single query.
         """
+        from src.common.version_visibility import (
+            collapse_by_family,
+            family_counts as compute_family_counts,
+            is_admin_only_status,
+            is_visible_consumer,
+        )
+
         if domain_id:
             query = db.query(DataContractDb).filter(DataContractDb.domain_id == domain_id)
             if not is_admin and project_id:
@@ -5953,29 +6005,46 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 is_admin=is_admin
             )
 
-        # Always compute family sizes from the visibility-filtered set so the
-        # collapsed and the expanded list views report consistent counts.
-        family_counts: dict = {}
-        for c in contracts:
-            fid = c.version_family_id or c.id
-            family_counts[fid] = family_counts.get(fid, 0) + 1
+        elevated_families = (
+            set()
+            if is_admin
+            else self._elevated_contract_families(
+                db,
+                contracts,
+                caller_email=caller_email,
+                caller_team_ids=caller_team_ids,
+            )
+        )
+
+        # Pre-filter for the expanded view too. Without this, a consumer
+        # who toggles "Show all versions" would see draft rows from
+        # families they don't own — which contradicts the PRD's
+        # consumer-visibility rule. Admins bypass.
+        if not is_admin:
+            contracts = [
+                c
+                for c in contracts
+                if (c.version_family_id or c.id) in elevated_families
+                or (not is_admin_only_status(c) and is_visible_consumer(c))
+            ]
+
+        # Family counts are taken from the post-visibility-filter set so
+        # the badge reflects what the caller can actually navigate to.
+        counts = compute_family_counts(contracts)
 
         if latest_only:
             original_count = len(contracts)
-            # Family-id is the canonical group key (PRD #442). Falls back to
-            # row id for any legacy row that somehow escaped the backfill,
-            # which degrades to "treat as its own family" — never collapses
-            # unrelated rows together.
-            picked: dict = {}
-            for c in contracts:
-                key = c.version_family_id or c.id
-                current = picked.get(key)
-                if current is None or (c.created_at and (current.created_at is None or c.created_at > current.created_at)):
-                    picked[key] = c
-            contracts = list(picked.values())
-            logger.debug(f"Collapsed {original_count} → {len(contracts)} rows (one per version_family_id)")
+            contracts = collapse_by_family(
+                contracts,
+                elevated_family_ids=elevated_families,
+                is_admin=is_admin,
+            )
+            logger.debug(
+                f"Collapsed {original_count} → {len(contracts)} rows "
+                f"(role-aware rank; elevated={len(elevated_families)} families)"
+            )
 
-        return contracts, family_counts
+        return contracts, counts
 
     def list_contracts_from_db(
         self,
@@ -5985,6 +6054,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         is_admin: bool = False,
         latest_only: bool = True,
         include_history: bool = False,
+        *,
+        caller_email: Optional[str] = None,
+        caller_team_ids: Optional[Set[str]] = None,
     ):
         """List data contracts as lightweight summaries (no schema/quality/comments).
 
@@ -5996,7 +6068,13 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if include_history:
             latest_only = False
         contracts, family_counts = self._query_contracts(
-            db, domain_id, project_id, is_admin, latest_only
+            db,
+            domain_id,
+            project_id,
+            is_admin,
+            latest_only,
+            caller_email=caller_email,
+            caller_team_ids=caller_team_ids,
         )
         return self._build_contract_summaries(
             db, contracts, family_counts=family_counts if latest_only else None

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -283,25 +283,86 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 caller_project_ids=caller_project_ids,
             )
 
-            # Family-aware collapse (PRD #442). Counts are computed from the
-            # visibility-filtered set so the badge reflects what the caller
-            # can actually navigate to. When include_history=True we keep
-            # every row but still attach the count so the UI can group rows.
-            family_counts: dict = {}
-            for p in products_db:
-                fid = getattr(p, "version_family_id", None) or p.id
-                family_counts[fid] = family_counts.get(fid, 0) + 1
+            # Role-aware visibility collapse (PRD #442). Elevation for
+            # products is broader than for contracts because we have a
+            # subscriptions table — subscribers see in-flight versions
+            # of families they consume.
+            from src.common.version_visibility import (
+                collapse_by_family,
+                family_counts as compute_family_counts,
+                is_admin_only_status,
+                is_visible_consumer,
+            )
+            # Import here to avoid widening the module-level import graph;
+            # this branch only fires during list_products which is also
+            # the only place we need the subscription join.
+            from src.db_models.data_products import DataProductSubscriptionDb
+
+            elevated_families: Set[str] = set()
+            if not is_admin:
+                team_set = set(caller_team_ids or [])
+                project_set = set(caller_project_ids or [])
+                for p in products_db:
+                    fid = getattr(p, "version_family_id", None) or p.id
+                    if fid in elevated_families:
+                        continue
+                    if caller_email and p.draft_owner_id == caller_email:
+                        elevated_families.add(fid)
+                        continue
+                    if p.owner_team_id and p.owner_team_id in team_set:
+                        elevated_families.add(fid)
+                        continue
+                    if p.project_id and p.project_id in project_set:
+                        elevated_families.add(fid)
+                # Subscription-based elevation: query once for the caller's
+                # subscribed product ids, then map back to families. The
+                # query is bounded by the set we already loaded so this
+                # stays O(rows_loaded) regardless of total subscriptions.
+                if caller_email:
+                    try:
+                        product_ids = [p.id for p in products_db]
+                        if product_ids:
+                            subs = (
+                                self._db.query(DataProductSubscriptionDb.product_id)
+                                .filter(
+                                    DataProductSubscriptionDb.subscriber_email == caller_email,
+                                    DataProductSubscriptionDb.product_id.in_(product_ids),
+                                )
+                                .all()
+                            )
+                            subbed_pids = {row.product_id for row in subs}
+                            for p in products_db:
+                                if p.id in subbed_pids:
+                                    fid = getattr(p, "version_family_id", None) or p.id
+                                    elevated_families.add(fid)
+                    except Exception:
+                        # Subscriptions are a soft elevation signal — a
+                        # failure here downgrades the caller to ownership-
+                        # only elevation, which is still safer than
+                        # over-disclosing.
+                        logger.exception(
+                            f"Subscription lookup failed for {caller_email}; "
+                            "falling back to ownership-only elevation"
+                        )
+
+                # Pre-filter for the expanded view too so a consumer who
+                # flips "Show all versions" doesn't see drafts of families
+                # they don't own (PRD #442 consumer-visibility rule).
+                products_db = [
+                    p
+                    for p in products_db
+                    if (getattr(p, "version_family_id", None) or p.id) in elevated_families
+                    or (not is_admin_only_status(p) and is_visible_consumer(p))
+                ]
+
+            family_counts = compute_family_counts(products_db)
 
             if not include_history:
-                picked: dict = {}
-                for p in products_db:
-                    key = getattr(p, "version_family_id", None) or p.id
-                    current = picked.get(key)
-                    if current is None or (
-                        p.created_at and (current.created_at is None or p.created_at > current.created_at)
-                    ):
-                        picked[key] = p
-                products_db = list(picked.values())
+                products_db = collapse_by_family(
+                    products_db,
+                    elevated_family_ids=elevated_families,
+                    is_admin=is_admin,
+                )
 
             products_with_tags = []
             for product_db in products_db:

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -558,16 +558,35 @@ class DataContractSummary(BaseModel):
     tags: Optional[List[AssignedTag]] = Field(default_factory=list)
     created: Optional[str] = None
     updated: Optional[str] = None
-    parentContractId: Optional[str] = Field(None, alias='parent_contract_id')
-    versionFamilyId: Optional[str] = Field(None, alias='version_family_id')
-    baseName: Optional[str] = Field(None, alias='base_name')
-    changeSummary: Optional[str] = Field(None, alias='change_summary')
-    draftOwnerId: Optional[str] = Field(None, alias='draft_owner_id')
+    # The ``serialization_alias`` here forces camelCase on the wire while
+    # ``alias`` (used as the validation alias by Pydantic v2 when no
+    # explicit ``validation_alias`` is given) keeps the snake_case ORM
+    # attribute mapping working via ``from_attributes=True``. Without
+    # this, FastAPI's default ``response_model_by_alias=True`` would
+    # emit snake_case and the camelCase FE types would silently see
+    # ``undefined`` — see PRD #442 follow-up.
+    parentContractId: Optional[str] = Field(
+        None, alias='parent_contract_id', serialization_alias='parentContractId'
+    )
+    versionFamilyId: Optional[str] = Field(
+        None, alias='version_family_id', serialization_alias='versionFamilyId'
+    )
+    baseName: Optional[str] = Field(
+        None, alias='base_name', serialization_alias='baseName'
+    )
+    changeSummary: Optional[str] = Field(
+        None, alias='change_summary', serialization_alias='changeSummary'
+    )
+    draftOwnerId: Optional[str] = Field(
+        None, alias='draft_owner_id', serialization_alias='draftOwnerId'
+    )
     # Count of versions in this row's family that are visible to the caller.
     # Only emitted on the collapsed list view (include_history=False); on the
     # expanded list view it is omitted because every row is its own family
     # member. See PRD #442.
-    versionCount: Optional[int] = Field(None, alias='version_count')
+    versionCount: Optional[int] = Field(
+        None, alias='version_count', serialization_alias='versionCount'
+    )
     schema_object_count: int = Field(0, alias='schemaObjectCount')
     publication_scope: str = "none"
     published_at: Optional[str] = None

--- a/src/backend/src/models/data_products.py
+++ b/src/backend/src/models/data_products.py
@@ -375,17 +375,46 @@ class DataProduct(BaseModel):
 
     # Versioning fields
     draft_owner_id: Optional[str] = Field(None, alias="draftOwnerId", description="Personal draft owner - if set, visible only to owner")
-    parent_product_id: Optional[str] = Field(None, alias="parentProductId", description="Parent version ID for version lineage")
+    # All fields below use ``serialization_alias`` to force camelCase on
+    # the wire (matching the FE TS types) while the snake_case Python
+    # attribute keeps ORM ``from_attributes=True`` reading working
+    # without a separate ``validation_alias``. See PRD #442 follow-up.
+    parent_product_id: Optional[str] = Field(
+        None,
+        alias="parentProductId",
+        serialization_alias="parentProductId",
+        description="Parent version ID for version lineage",
+    )
     # Canonical family grouping key (PRD #442). One indexed equality lookup
     # returns every version of the family. Defaults to self.id on initial
     # create; carried forward unchanged on every clone.
-    version_family_id: Optional[str] = Field(None, alias="versionFamilyId", description="Canonical family grouping key shared across every version of the family")
-    base_name: Optional[str] = Field(None, alias="baseName", description="Legacy base name; superseded by versionFamilyId. Kept for back-compat.")
-    change_summary: Optional[str] = Field(None, alias="changeSummary", description="Summary of changes in this version")
+    version_family_id: Optional[str] = Field(
+        None,
+        alias="versionFamilyId",
+        serialization_alias="versionFamilyId",
+        description="Canonical family grouping key shared across every version of the family",
+    )
+    base_name: Optional[str] = Field(
+        None,
+        alias="baseName",
+        serialization_alias="baseName",
+        description="Legacy base name; superseded by versionFamilyId. Kept for back-compat.",
+    )
+    change_summary: Optional[str] = Field(
+        None,
+        alias="changeSummary",
+        serialization_alias="changeSummary",
+        description="Summary of changes in this version",
+    )
     # Count of versions in this row's family that are visible to the caller.
     # Only populated by the collapsed list view; None on detail responses
     # and on the expanded list view. See PRD #442.
-    version_count: Optional[int] = Field(None, alias="versionCount", description="Number of visible versions in this family (collapsed list view only)")
+    version_count: Optional[int] = Field(
+        None,
+        alias="versionCount",
+        serialization_alias="versionCount",
+        description="Number of visible versions in this family (collapsed list view only)",
+    )
 
     # Publication fields
     publication_scope: Optional[str] = Field("none", description="Publication scope: none, domain, organization, external")

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -2,7 +2,7 @@ import json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional, List, Set
 from uuid import uuid4
 
 from fastapi import APIRouter, File, HTTPException, UploadFile, Depends, Request, Body, Query, BackgroundTasks
@@ -116,12 +116,33 @@ async def get_contracts(
             f"include_history: {include_history})"
         )
 
+        # Resolve the caller's owning teams once so the manager can compute
+        # elevated visibility for their contracts (PRD #442 role-aware rank).
+        caller_email = current_user.email if current_user else None
+        caller_team_ids: Set[str] = set()
+        if not is_admin and current_user:
+            try:
+                from src.controller.teams_manager import teams_manager
+                user_teams = teams_manager.get_teams_for_user(
+                    db, caller_email, user_groups
+                )
+                caller_team_ids = {t.id for t in user_teams if getattr(t, "id", None)}
+            except Exception:
+                # Best-effort: a failed team lookup downgrades the caller to
+                # consumer visibility, which is the safe fail-closed default.
+                logger.exception(
+                    f"Failed to resolve teams for {caller_email}; "
+                    "falling back to consumer visibility"
+                )
+
         result = manager.list_contracts_from_db(
             db,
             domain_id=domain_id,
             project_id=project_id,
             is_admin=is_admin,
             include_history=include_history,
+            caller_email=caller_email,
+            caller_team_ids=caller_team_ids,
         )
         return result
     except Exception as e:
@@ -3614,6 +3635,79 @@ async def get_contract_versions(
     except Exception as e:
         logger.error("Error fetching contract versions for %s", contract_id, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch contract versions")
+
+
+@router.get('/data-contracts/families/{family_id}/latest', response_model=dict)
+async def get_contract_family_latest(
+    family_id: str,
+    db: DBSessionDep,
+    current_user: AuditCurrentUserDep,
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_ONLY)),
+):
+    """Resolve a family-follow-latest reference to a concrete contract row.
+
+    Returns the visible "latest" version of the family per the role-aware
+    rank in :mod:`src.common.version_visibility`. Used by the
+    EntityVersionPicker and any backend read path that stores a
+    ``contract_family_id`` reference. See PRD #442.
+    """
+    from src.common.authorization import is_user_admin
+    from src.common.config import get_settings
+    from src.common.version_visibility import (
+        collapse_by_family,
+        is_admin_only_status,
+        is_visible_consumer,
+    )
+
+    user_email = current_user.username if current_user else None
+    is_admin = is_user_admin(current_user.groups if current_user else [], get_settings())
+
+    # Pull every visible row in the family first; the elevation decision
+    # is per-family, so we can compute it from this slice alone.
+    rows = data_contract_repo.get_family_versions(
+        db, family_id=family_id, user_email=user_email, is_admin=is_admin
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail="Family not found or empty")
+
+    # Caller is elevated for this family if any row's owner or draft is
+    # theirs. We don't have a contract subscription table to consult.
+    elevated = is_admin or any(
+        r.draft_owner_id == user_email for r in rows if user_email
+    )
+
+    # Apply consumer status filter when caller isn't elevated, drop
+    # retired rows for non-admins, then pick a single rep.
+    if not is_admin:
+        rows = [
+            r
+            for r in rows
+            if elevated
+            or (not is_admin_only_status(r) and is_visible_consumer(r))
+        ]
+    reps = collapse_by_family(
+        rows,
+        elevated_family_ids={family_id} if elevated else set(),
+        is_admin=is_admin,
+    )
+    if not reps:
+        # Family exists but nothing is visible to this caller.
+        raise HTTPException(status_code=404, detail="No visible version in family")
+
+    c = reps[0]
+    return {
+        "id": c.id,
+        "name": c.name,
+        "version": c.version,
+        "status": c.status,
+        "versionFamilyId": c.version_family_id,
+        "parentContractId": c.parent_contract_id,
+        "changeSummary": c.change_summary,
+        "draftOwnerId": c.draft_owner_id,
+        "publicationScope": getattr(c, "publication_scope", None) or "none",
+        "createdAt": c.created_at.isoformat() if c.created_at else None,
+        "updatedAt": c.updated_at.isoformat() if c.updated_at else None,
+    }
 
 
 @router.post('/data-contracts/{contract_id}/clone', response_model=dict, status_code=201)

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1838,6 +1838,94 @@ async def get_data_product_versions(
         raise HTTPException(status_code=500, detail="Failed to fetch product versions")
 
 
+@router.get("/data-products/families/{family_id}/latest", response_model=dict)
+async def get_product_family_latest(
+    family_id: str,
+    db: DBSessionDep,
+    current_user: AuditCurrentUserDep,
+    _: bool = Depends(PermissionChecker(DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+):
+    """Resolve a family-follow-latest reference to a concrete product row.
+
+    Returns the visible "latest" version of the family per the role-aware
+    rank in :mod:`src.common.version_visibility`. Subscribers and owners
+    of any version in the family see in-flight rows (draft/proposed/...);
+    plain consumers see only active/deprecated. See PRD #442.
+    """
+    from src.common.authorization import is_user_admin
+    from src.common.config import get_settings
+    from src.common.version_visibility import (
+        collapse_by_family,
+        is_admin_only_status,
+        is_visible_consumer,
+    )
+    from src.repositories.data_products_repository import data_product_repo
+    from src.db_models.data_products import DataProductSubscriptionDb
+
+    user_email = current_user.username if current_user else None
+    is_admin = is_user_admin(current_user.groups if current_user else [], get_settings())
+
+    rows = data_product_repo.get_family_versions(
+        db, family_id=family_id, user_email=user_email, is_admin=is_admin
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail="Family not found or empty")
+
+    # Elevation sources: admin > owner/draft > subscription. The first
+    # match short-circuits the more expensive subscription query.
+    elevated = is_admin or (
+        user_email is not None
+        and any(r.draft_owner_id == user_email for r in rows)
+    )
+    if not elevated and user_email:
+        try:
+            product_ids = [r.id for r in rows]
+            sub = (
+                db.query(DataProductSubscriptionDb.id)
+                .filter(
+                    DataProductSubscriptionDb.subscriber_email == user_email,
+                    DataProductSubscriptionDb.product_id.in_(product_ids),
+                )
+                .first()
+            )
+            elevated = sub is not None
+        except Exception:
+            logger.exception(
+                f"Subscription lookup failed for {user_email} on family {family_id}; "
+                "treating as consumer"
+            )
+
+    if not is_admin:
+        rows = [
+            r
+            for r in rows
+            if elevated
+            or (not is_admin_only_status(r) and is_visible_consumer(r))
+        ]
+    reps = collapse_by_family(
+        rows,
+        elevated_family_ids={family_id} if elevated else set(),
+        is_admin=is_admin,
+    )
+    if not reps:
+        raise HTTPException(status_code=404, detail="No visible version in family")
+
+    p = reps[0]
+    return {
+        "id": p.id,
+        "name": p.name,
+        "version": p.version,
+        "status": p.status,
+        "versionFamilyId": p.version_family_id,
+        "parentProductId": p.parent_product_id,
+        "changeSummary": p.change_summary,
+        "draftOwnerId": p.draft_owner_id,
+        "publicationScope": getattr(p, "publication_scope", None) or "none",
+        "createdAt": p.created_at.isoformat() if p.created_at else None,
+        "updatedAt": p.updated_at.isoformat() if p.updated_at else None,
+    }
+
+
 @router.post("/data-products/{product_id}/versions", response_model=DataProduct, status_code=201)
 async def create_data_product_version(
     product_id: str, # This is the original product ID

--- a/src/backend/src/tests/unit/test_version_family.py
+++ b/src/backend/src/tests/unit/test_version_family.py
@@ -442,6 +442,88 @@ class TestProductsListCollapse:
         # Family of two surfaces as versionCount=2.
         assert {p.version_count for p in products if p.id == p2} == {2}
 
+    def test_consumer_sees_active_rep_even_when_newer_draft_exists(
+        self, db_session: Session
+    ):
+        """PRD #442 visibility rule: a plain consumer's representative
+        for a family must be the newest *published* version, never an
+        in-flight draft that they don't own."""
+        from pathlib import Path
+        from datetime import datetime, timedelta, timezone
+        from src.controller.data_contracts_manager import DataContractsManager
+
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fam = str(uuid.uuid4())
+        active_id = str(uuid.uuid4())
+        draft_id = str(uuid.uuid4())
+        db_session.add(DataContractDb(
+            id=active_id, name="A", version="1.0.0", status="active",
+            version_family_id=fam,
+            created_at=base, updated_at=base,
+        ))
+        db_session.add(DataContractDb(
+            id=draft_id, name="A", version="2.0.0", status="draft",
+            version_family_id=fam, parent_contract_id=active_id,
+            created_at=base + timedelta(days=1), updated_at=base + timedelta(days=1),
+        ))
+        db_session.commit()
+
+        manager = DataContractsManager(data_dir=Path("/tmp"))
+
+        # Consumer: not admin, not owner of the draft, no team membership.
+        summaries = manager.list_contracts_from_db(
+            db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+            caller_team_ids=set(),
+        )
+        ids = {s.id for s in summaries}
+        # Active wins; draft is filtered out by consumer visibility.
+        assert active_id in ids
+        assert draft_id not in ids
+
+    def test_team_member_sees_draft_rep(
+        self, db_session: Session
+    ):
+        """A team member of the owner team has elevated visibility for
+        the family and should see the newest in-flight version (draft)
+        as the family rep."""
+        from pathlib import Path
+        from datetime import datetime, timedelta, timezone
+        from src.controller.data_contracts_manager import DataContractsManager
+
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        fam = str(uuid.uuid4())
+        team_id = str(uuid.uuid4())
+        active_id = str(uuid.uuid4())
+        draft_id = str(uuid.uuid4())
+        db_session.add(DataContractDb(
+            id=active_id, name="A", version="1.0.0", status="active",
+            version_family_id=fam, owner_team_id=team_id,
+            created_at=base, updated_at=base,
+        ))
+        db_session.add(DataContractDb(
+            id=draft_id, name="A", version="2.0.0", status="draft",
+            version_family_id=fam, parent_contract_id=active_id,
+            owner_team_id=team_id,
+            created_at=base + timedelta(days=1), updated_at=base + timedelta(days=1),
+        ))
+        db_session.commit()
+
+        manager = DataContractsManager(data_dir=Path("/tmp"))
+
+        # Team member: not admin, but member of the owner team.
+        summaries = manager.list_contracts_from_db(
+            db_session,
+            is_admin=False,
+            caller_email="alice@example.com",
+            caller_team_ids={team_id},
+        )
+        ids = {s.id for s in summaries}
+        # Draft wins now that the caller is elevated for this family.
+        assert draft_id in ids
+        assert active_id not in ids
+
     def test_include_history_returns_all_versions(self, db_session: Session):
         from datetime import datetime, timedelta, timezone
         from src.controller.data_products_manager import DataProductsManager

--- a/src/backend/src/tests/unit/test_version_visibility.py
+++ b/src/backend/src/tests/unit/test_version_visibility.py
@@ -1,0 +1,195 @@
+"""Unit tests for src.common.version_visibility (PRD #442, Phase 3).
+
+These cover the role-aware rank table in isolation — every other test
+that exercises the collapse end-to-end relies on this module being
+correct, so it gets its own tight focused suite.
+"""
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from src.common.version_visibility import (
+    collapse_by_family,
+    compute_rank,
+    family_counts,
+    is_admin_only_status,
+    is_visible_consumer,
+)
+
+
+def make_row(
+    *,
+    id: str = "row",
+    family_id: str = "fam",
+    status: str = "active",
+    draft_owner_id: str | None = None,
+    owner_team_id: str | None = None,
+    created_at: datetime | None = None,
+):
+    """A lightweight row that quacks like a ``DataContractDb`` / ``DataProductDb``
+    for the purposes of visibility ranking. The functions under test only
+    look at attributes, so we don't need a real ORM row."""
+    return SimpleNamespace(
+        id=id,
+        version_family_id=family_id,
+        status=status,
+        draft_owner_id=draft_owner_id,
+        owner_team_id=owner_team_id,
+        created_at=created_at or datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestStatusVisibility:
+    def test_consumer_sees_active_and_deprecated_only(self):
+        assert is_visible_consumer(make_row(status="active"))
+        assert is_visible_consumer(make_row(status="deprecated"))
+        assert not is_visible_consumer(make_row(status="draft"))
+        assert not is_visible_consumer(make_row(status="proposed"))
+        assert not is_visible_consumer(make_row(status="retired"))
+
+    def test_admin_only_statuses(self):
+        # ``retired`` is the only admin-only status today. Adding more
+        # should be a deliberate, explicit policy change — this test
+        # documents the current set.
+        assert is_admin_only_status(make_row(status="retired"))
+        assert not is_admin_only_status(make_row(status="deprecated"))
+        assert not is_admin_only_status(make_row(status="draft"))
+
+
+class TestRankOrdering:
+    """Lower rank wins. We assert relative orderings rather than absolute
+    numbers so the test survives status-table reshuffles."""
+
+    def test_elevated_prefers_draft_over_active(self):
+        draft = make_row(status="draft")
+        active = make_row(status="active")
+        assert compute_rank(draft, has_elevated_access=True) < compute_rank(
+            active, has_elevated_access=True
+        )
+
+    def test_consumer_prefers_active_over_deprecated(self):
+        active = make_row(status="active")
+        deprecated = make_row(status="deprecated")
+        assert compute_rank(active, has_elevated_access=False) < compute_rank(
+            deprecated, has_elevated_access=False
+        )
+
+    def test_ties_break_by_created_at_desc(self):
+        older = make_row(
+            id="old",
+            status="active",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        newer = make_row(
+            id="new",
+            status="active",
+            created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        )
+        # Newer should win the tie → smaller key.
+        assert compute_rank(newer, has_elevated_access=False) < compute_rank(
+            older, has_elevated_access=False
+        )
+
+
+class TestCollapseByFamily:
+    def _three_status_family(self):
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        return [
+            make_row(
+                id="v1",
+                status="active",
+                created_at=base,
+            ),
+            make_row(
+                id="v2",
+                status="deprecated",
+                created_at=base + timedelta(days=1),
+            ),
+            make_row(
+                id="v3",
+                status="draft",
+                created_at=base + timedelta(days=2),
+            ),
+        ]
+
+    def test_consumer_picks_active_even_when_newer_draft_exists(self):
+        rows = self._three_status_family()
+        reps = collapse_by_family(rows, elevated_family_ids=set(), is_admin=False)
+        # Draft is filtered out for consumers; active wins over deprecated.
+        assert {r.id for r in reps} == {"v1"}
+
+    def test_elevated_picks_newest_draft_over_active(self):
+        rows = self._three_status_family()
+        reps = collapse_by_family(
+            rows, elevated_family_ids={"fam"}, is_admin=False
+        )
+        assert {r.id for r in reps} == {"v3"}
+
+    def test_admin_picks_newest_draft_without_elevation_set(self):
+        # Admins bypass the elevation set entirely.
+        rows = self._three_status_family()
+        reps = collapse_by_family(rows, elevated_family_ids=set(), is_admin=True)
+        assert {r.id for r in reps} == {"v3"}
+
+    def test_retired_hidden_from_non_admin(self):
+        rows = [
+            make_row(id="v1", family_id="fam", status="active"),
+            make_row(id="v2", family_id="fam", status="retired"),
+        ]
+        reps = collapse_by_family(rows, elevated_family_ids={"fam"}, is_admin=False)
+        # Retired filtered out even for elevated callers; active survives.
+        assert {r.id for r in reps} == {"v1"}
+
+    def test_retired_visible_to_admin(self):
+        rows = [
+            make_row(id="v1", family_id="fam", status="retired"),
+        ]
+        reps = collapse_by_family(rows, elevated_family_ids=set(), is_admin=True)
+        # No other row, so the retired one wins by default.
+        assert {r.id for r in reps} == {"v1"}
+
+    def test_consumer_family_with_only_drafts_disappears(self):
+        # A family with no published row is invisible to consumers — they
+        # should not see it at all in the list.
+        rows = [
+            make_row(id="d1", family_id="fam-draft", status="draft"),
+            make_row(id="d2", family_id="fam-draft", status="proposed"),
+        ]
+        reps = collapse_by_family(rows, elevated_family_ids=set(), is_admin=False)
+        assert reps == []
+
+    def test_two_families_collapse_independently(self):
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        rows = [
+            make_row(id="a1", family_id="A", status="active", created_at=base),
+            make_row(
+                id="a2",
+                family_id="A",
+                status="active",
+                created_at=base + timedelta(days=1),
+            ),
+            make_row(id="b1", family_id="B", status="active", created_at=base),
+        ]
+        reps = collapse_by_family(rows, elevated_family_ids=set(), is_admin=True)
+        # Newest within each family wins; families don't bleed into each other.
+        assert {r.id for r in reps} == {"a2", "b1"}
+
+
+class TestFamilyCounts:
+    def test_counts_match_input(self):
+        rows = [
+            make_row(id="a1", family_id="A"),
+            make_row(id="a2", family_id="A"),
+            make_row(id="b1", family_id="B"),
+        ]
+        counts = family_counts(rows)
+        assert counts == {"A": 2, "B": 1}
+
+    def test_orphan_rows_ignored(self):
+        orphan = SimpleNamespace(
+            id=None, version_family_id=None, status="active", created_at=None,
+            draft_owner_id=None, owner_team_id=None,
+        )
+        counts = family_counts([orphan])
+        assert counts == {}

--- a/src/frontend/src/components/common/entity-version-picker.tsx
+++ b/src/frontend/src/components/common/entity-version-picker.tsx
@@ -1,0 +1,347 @@
+/**
+ * Unified picker for selecting a Data Contract or Data Product reference.
+ *
+ * Replaces every ad-hoc `<Select>` of contracts/products in the app. The
+ * picker exposes two scopes (PRD #442):
+ *
+ *   - `entity`  — pin a specific version of an entity. Returned shape:
+ *                 `{scope:'entity', entityKind, entityId, displayVersion?}`.
+ *                 This is the safe back-compat default — existing storage
+ *                 layers only need to persist `entityId`.
+ *
+ *   - `family`  — follow the family's latest visible version. Returned
+ *                 shape: `{scope:'family', entityKind, familyId, familyName?}`.
+ *                 Storage layers must persist `familyId` and resolve it via
+ *                 the `/families/{familyId}/latest` endpoint at read time.
+ *
+ * Behavior is shaped by the `allowedScopes` prop:
+ *   - Passing `['entity']` hides the scope toggle entirely and the picker
+ *     behaves like a fancy combobox with versions on each row.
+ *   - Passing `['entity','family']` shows the Entity ▾ / Latest ▾ toggle
+ *     and renders an inline VersionSelector under the combobox when the
+ *     user is in Entity mode.
+ *
+ * The picker fetches the *collapsed* list endpoint (one row per family)
+ * by default and the per-family versions endpoint only when the user
+ * opens the inline sub-picker, so cost scales with interaction depth
+ * rather than catalog size.
+ */
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ChevronsUpDown, Check, GitBranch, Pin, History } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import VersionSelector, { type EntityVersionRow } from '@/components/common/version-selector'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EntityKind = 'contract' | 'product'
+
+export type ScopeValue =
+  | {
+      scope: 'entity'
+      entityKind: EntityKind
+      entityId: string
+      // Used purely for display restoration when the parent rehydrates
+      // a saved value. The component itself does not rely on it.
+      displayName?: string
+      displayVersion?: string
+    }
+  | {
+      scope: 'family'
+      entityKind: EntityKind
+      familyId: string
+      displayName?: string
+    }
+
+type EntityVersionPickerProps = {
+  entityKind: EntityKind
+  value: ScopeValue | null
+  onChange: (next: ScopeValue) => void
+  allowedScopes?: Array<'entity' | 'family'>
+  // Filter the candidate set to rows with these statuses. When omitted,
+  // the picker shows whatever the backend returns for the caller (the
+  // backend already applies role-aware visibility, so no client-side
+  // filter is needed for the family-collapse case).
+  statusFilter?: string[]
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+  // Optional empty-state CTA, used by call sites that want an inline
+  // "Create new contract" affordance under the dropdown.
+  emptyAction?: React.ReactNode
+}
+
+// ---------------------------------------------------------------------------
+// Row type (what the collapsed list endpoint returns)
+// ---------------------------------------------------------------------------
+
+type FamilyRow = {
+  id: string
+  name?: string
+  version?: string
+  status?: string
+  versionFamilyId?: string
+  // Both naming styles are accepted because /data-contracts and
+  // /data-products use slightly different aliases today.
+  version_count?: number
+  versionCount?: number
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function EntityVersionPicker({
+  entityKind,
+  value,
+  onChange,
+  allowedScopes = ['entity'],
+  statusFilter,
+  placeholder,
+  disabled,
+  className,
+  emptyAction,
+}: EntityVersionPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [rows, setRows] = useState<FamilyRow[]>([])
+  const [loading, setLoading] = useState(false)
+  const [scope, setScope] = useState<'entity' | 'family'>(value?.scope ?? allowedScopes[0])
+
+  // Track the family the user has selected in entity mode so the sub-
+  // picker only needs to fetch versions when one is actually chosen.
+  const [pinnedFamilyAnchorId, setPinnedFamilyAnchorId] = useState<string | undefined>(
+    value && value.scope === 'entity' ? value.entityId : undefined,
+  )
+
+  const apiBase = entityKind === 'contract' ? '/api/data-contracts' : '/api/data-products'
+
+  useEffect(() => {
+    let cancelled = false
+    const fetchRows = async () => {
+      setLoading(true)
+      try {
+        const res = await fetch(apiBase)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data: FamilyRow[] = await res.json()
+        if (cancelled) return
+        const filtered = statusFilter
+          ? data.filter((r) => statusFilter.includes((r.status || '').toLowerCase()))
+          : data
+        setRows(filtered)
+      } catch (e) {
+        console.warn(`[EntityVersionPicker] fetch failed for ${apiBase}`, e)
+        if (!cancelled) setRows([])
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    fetchRows()
+    return () => {
+      cancelled = true
+    }
+  }, [apiBase, statusFilter?.join('|')])
+
+  // Resolve the currently-selected row for trigger display.
+  const selectedRow = useMemo(() => {
+    if (!value) return null
+    if (value.scope === 'family') {
+      return rows.find((r) => (r.versionFamilyId || r.id) === value.familyId) || null
+    }
+    // Entity mode: the entityId points to a specific version. The
+    // collapsed list only has the family rep, so fall back to displayName
+    // / displayVersion captured at selection time when available.
+    return rows.find((r) => r.id === value.entityId) || null
+  }, [value, rows])
+
+  const triggerLabel = useMemo(() => {
+    if (!value) return placeholder || `Select ${entityKind}…`
+    if (value.scope === 'family') {
+      const name = selectedRow?.name || value.displayName || value.familyId
+      return `${name} (latest)`
+    }
+    const name = selectedRow?.name || value.displayName || value.entityId
+    const version = selectedRow?.version || value.displayVersion
+    return version ? `${name} · v${version}` : name
+  }, [value, selectedRow, entityKind, placeholder])
+
+  const showScopeToggle = allowedScopes.length > 1
+
+  const handlePickFamily = (row: FamilyRow) => {
+    const familyId = row.versionFamilyId || row.id
+    if (scope === 'family') {
+      onChange({
+        scope: 'family',
+        entityKind,
+        familyId,
+        displayName: row.name,
+      })
+      setOpen(false)
+      return
+    }
+    // Entity mode: anchor on this family so the inline VersionSelector
+    // can offer a per-version pin. Default the entity to the family's
+    // representative (the row already in `rows`), but the user can refine
+    // via the sub-picker before closing.
+    setPinnedFamilyAnchorId(row.id)
+    onChange({
+      scope: 'entity',
+      entityKind,
+      entityId: row.id,
+      displayName: row.name,
+      displayVersion: row.version,
+    })
+  }
+
+  const handlePickPinnedVersion = (versionRow: EntityVersionRow) => {
+    onChange({
+      scope: 'entity',
+      entityKind,
+      entityId: versionRow.id,
+      displayName: versionRow.name,
+      displayVersion: versionRow.version,
+    })
+    setOpen(false)
+  }
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {showScopeToggle && (
+        <div className="inline-flex items-center rounded-md border border-border p-0.5 text-xs">
+          <button
+            type="button"
+            onClick={() => setScope('entity')}
+            className={cn(
+              'inline-flex items-center gap-1 rounded px-2 py-1 transition-colors',
+              scope === 'entity'
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            aria-pressed={scope === 'entity'}
+            title="Pin a specific version"
+          >
+            <Pin className="h-3 w-3" />
+            Pin version
+          </button>
+          <button
+            type="button"
+            onClick={() => setScope('family')}
+            className={cn(
+              'inline-flex items-center gap-1 rounded px-2 py-1 transition-colors',
+              scope === 'family'
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            aria-pressed={scope === 'family'}
+            title="Always follow the family's latest visible version"
+          >
+            <GitBranch className="h-3 w-3" />
+            Follow latest
+          </button>
+        </div>
+      )}
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className="w-full justify-between font-normal"
+          >
+            <span className="truncate">{triggerLabel}</span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+          <Command>
+            <CommandInput placeholder={`Search ${entityKind}s…`} />
+            <CommandList>
+              {loading ? (
+                <CommandEmpty>Loading…</CommandEmpty>
+              ) : (
+                <>
+                  <CommandEmpty>
+                    No matching {entityKind}s.
+                    {emptyAction && <div className="mt-2">{emptyAction}</div>}
+                  </CommandEmpty>
+                  <CommandGroup>
+                    {rows.map((row) => {
+                      const familyId = row.versionFamilyId || row.id
+                      const versionCount = row.versionCount ?? row.version_count
+                      const isSelected =
+                        value?.scope === 'family'
+                          ? value.familyId === familyId
+                          : value?.entityId === row.id
+                      return (
+                        <CommandItem
+                          key={familyId}
+                          // Make name+version searchable, not just name —
+                          // disambiguates same-named families per #69.
+                          value={`${row.name || ''} ${row.version || ''}`}
+                          onSelect={() => handlePickFamily(row)}
+                          className="flex items-center gap-2"
+                        >
+                          <Check
+                            className={cn(
+                              'h-3.5 w-3.5',
+                              isSelected ? 'opacity-100' : 'opacity-0',
+                            )}
+                          />
+                          <span className="flex-1 truncate">{row.name || '(unnamed)'}</span>
+                          {row.version && (
+                            <Badge variant="secondary" className="text-[10px]">
+                              v{row.version}
+                            </Badge>
+                          )}
+                          {row.status && (
+                            <Badge variant="outline" className="text-[10px]">
+                              {row.status}
+                            </Badge>
+                          )}
+                          {versionCount && versionCount > 1 && (
+                            <span className="inline-flex items-center gap-0.5 rounded border border-border bg-muted/40 px-1 py-0.5 text-[10px] text-muted-foreground">
+                              <History className="h-3 w-3" />
+                              {versionCount}
+                            </span>
+                          )}
+                        </CommandItem>
+                      )
+                    })}
+                  </CommandGroup>
+                </>
+              )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {/* Inline version sub-picker — only shown in Entity mode, and only
+          once the user has anchored on a family. */}
+      {scope === 'entity' && value?.scope === 'entity' && pinnedFamilyAnchorId && (
+        <VersionSelector
+          entityKind={entityKind}
+          currentEntityId={pinnedFamilyAnchorId}
+          currentVersion={value.displayVersion}
+          onVersionChange={(_id, row) => row && handlePickPinnedVersion(row)}
+          triggerClassName="w-full"
+        />
+      )}
+    </div>
+  )
+}
+
+export default EntityVersionPicker

--- a/src/frontend/src/components/common/entity-version-picker.tsx
+++ b/src/frontend/src/components/common/entity-version-picker.tsx
@@ -132,13 +132,46 @@ export function EntityVersionPicker({
     const fetchRows = async () => {
       setLoading(true)
       try {
-        const res = await fetch(apiBase)
+        // When a statusFilter is set we need to consider ALL versions,
+        // not just the family rep. Otherwise a family whose rep was
+        // promoted to draft (under the elevated-rank rule) would
+        // disappear from a status-restricted picker, even though it
+        // has a perfectly valid published version available — see the
+        // POS Transaction Stream regression hit during the smoke test.
+        const wantsHistory = !!statusFilter?.length
+        const url = wantsHistory ? `${apiBase}?include_history=true` : apiBase
+        const res = await fetch(url)
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         const data: FamilyRow[] = await res.json()
         if (cancelled) return
-        const filtered = statusFilter
+        let filtered = statusFilter
           ? data.filter((r) => statusFilter.includes((r.status || '').toLowerCase()))
           : data
+        // Collapse client-side: one row per family, preferring the
+        // newest matching version. Family counts are computed BEFORE
+        // collapse so the badge still tells the user "this family has
+        // 3 versions" even when only the published one is selectable.
+        if (wantsHistory) {
+          const counts = new Map<string, number>()
+          for (const r of filtered) {
+            const fid = r.versionFamilyId || r.id
+            counts.set(fid, (counts.get(fid) || 0) + 1)
+          }
+          const picked = new Map<string, FamilyRow>()
+          for (const r of filtered) {
+            const fid = r.versionFamilyId || r.id
+            const cur = picked.get(fid)
+            // Lexicographic version compare is good enough here — every
+            // version in the same family is semver-y by convention.
+            if (!cur || (r.version || '') > (cur.version || '')) {
+              picked.set(fid, r)
+            }
+          }
+          filtered = Array.from(picked.values()).map((r) => ({
+            ...r,
+            versionCount: counts.get(r.versionFamilyId || r.id),
+          }))
+        }
         setRows(filtered)
       } catch (e) {
         console.warn(`[EntityVersionPicker] fetch failed for ${apiBase}`, e)

--- a/src/frontend/src/components/common/version-selector.tsx
+++ b/src/frontend/src/components/common/version-selector.tsx
@@ -42,13 +42,19 @@ type VersionSelectorProps = {
   entityKind: EntityKind
   currentEntityId: string
   currentVersion?: string
-  onVersionChange: (entityId: string) => void
+  // The 2nd arg gives callers access to the full row (status, change
+  // summary, etc.) without re-fetching. Optional for back-compat — old
+  // callers that take only the id still type-check.
+  onVersionChange: (entityId: string, row?: EntityVersionRow) => void
   /**
    * Optional: an alternative endpoint, useful for tests or for a future
    * "family-by-id" route. When omitted, the component derives the URL
    * from `entityKind` + `currentEntityId`.
    */
   endpointOverride?: string
+  // Lets parents override the trigger button look — used by the
+  // EntityVersionPicker to make its inline sub-picker stretch full-width.
+  triggerClassName?: string
 }
 
 function endpointFor(kind: EntityKind, id: string): string {
@@ -77,6 +83,7 @@ export default function VersionSelector({
   currentVersion,
   onVersionChange,
   endpointOverride,
+  triggerClassName,
 }: VersionSelectorProps) {
   const { toast } = useToast()
   const [versions, setVersions] = useState<EntityVersionRow[]>([])
@@ -124,13 +131,16 @@ export default function VersionSelector({
   }
 
   const handleSelect = (id: string) => {
-    if (id !== currentEntityId) onVersionChange(id)
+    if (id !== currentEntityId) {
+      const row = versions.find((v) => v.id === id)
+      onVersionChange(id, row)
+    }
   }
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" disabled={isLoading}>
+        <Button variant="outline" size="sm" disabled={isLoading} className={triggerClassName}>
           <History className="h-4 w-4 mr-2" />
           {currentVersion || 'Version'}
           <ChevronDown className="h-4 w-4 ml-2" />

--- a/src/frontend/src/components/data-products/link-contract-to-port-dialog.tsx
+++ b/src/frontend/src/components/data-products/link-contract-to-port-dialog.tsx
@@ -2,13 +2,12 @@ import { useEffect, useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { Badge } from '@/components/ui/badge';
 import { Loader2, Plus } from 'lucide-react';
 import type { OutputPort, DataProduct } from '@/types/data-product';
-import type { DataContractListItem } from '@/types/data-contract';
 import CreateContractInlineDialog from '@/components/data-contracts/create-contract-inline-dialog';
+import EntityVersionPicker, { type ScopeValue } from '@/components/common/entity-version-picker';
 
 type LinkContractToPortDialogProps = {
   isOpen: boolean;
@@ -29,19 +28,23 @@ export default function LinkContractToPortDialog({
 }: LinkContractToPortDialogProps) {
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isLoadingContracts, setIsLoadingContracts] = useState(false);
-  const [contracts, setContracts] = useState<DataContractListItem[]>([]);
-  const [selectedContractId, setSelectedContractId] = useState('');
+  // PRD #442 picker value. Entity-pinned only for now — switching the
+  // output-port write path to support family-follow-latest requires the
+  // schema work in the reference-storage slice (still pending).
+  const [pickerValue, setPickerValue] = useState<ScopeValue | null>(null);
   const [isCreateContractOpen, setIsCreateContractOpen] = useState(false);
   const [product, setProduct] = useState<DataProduct | null>(null);
 
+  // Only contracts that are safe to attach to a live deliverable should
+  // appear. The backend's role-aware visibility already enforces the
+  // personal-draft and consumer rules; this filter narrows further to
+  // the producer-publishable subset.
   const activeStatuses = ['active', 'approved', 'certified'];
 
   useEffect(() => {
     if (isOpen) {
-      fetchContracts();
       fetchProduct();
-      setSelectedContractId('');
+      setPickerValue(null);
     }
   }, [isOpen]);
 
@@ -57,32 +60,8 @@ export default function LinkContractToPortDialog({
     }
   };
 
-  const fetchContracts = async () => {
-    setIsLoadingContracts(true);
-    try {
-      const response = await fetch('/api/data-contracts');
-      if (!response.ok) throw new Error('Failed to fetch contracts');
-      
-      const data: DataContractListItem[] = await response.json();
-      
-      // Filter to only show contracts with appropriate status
-      const filteredContracts = data.filter(c => 
-        activeStatuses.includes(c.status?.toLowerCase() || '')
-      );
-      
-      setContracts(filteredContracts);
-    } catch (error: any) {
-      toast({
-        title: 'Error',
-        description: error?.message || 'Failed to load contracts',
-        variant: 'destructive'
-      });
-    } finally {
-      setIsLoadingContracts(false);
-    }
-  };
-
   const handleSubmit = async () => {
+    const selectedContractId = pickerValue?.scope === 'entity' ? pickerValue.entityId : '';
     if (!selectedContractId) {
       toast({
         title: 'Validation Error',
@@ -144,9 +123,14 @@ export default function LinkContractToPortDialog({
   };
 
   const handleContractCreated = (contractId: string) => {
-    setSelectedContractId(contractId);
+    // The picker fetches its own list, so we just hand it the new
+    // entity-pinned value; it'll resolve display metadata on next mount.
+    setPickerValue({
+      scope: 'entity',
+      entityKind: 'contract',
+      entityId: contractId,
+    });
     setIsCreateContractOpen(false);
-    fetchContracts(); // Refresh contract list
   };
 
   return (
@@ -178,36 +162,21 @@ export default function LinkContractToPortDialog({
               <Label htmlFor="contract">
                 Select Contract <span className="text-destructive">*</span>
               </Label>
-              {isLoadingContracts ? (
-                <div className="flex items-center justify-center p-4">
-                  <Loader2 className="h-6 w-6 animate-spin" />
-                </div>
-              ) : (
-                <Select value={selectedContractId} onValueChange={setSelectedContractId}>
-                  <SelectTrigger id="contract">
-                    <SelectValue placeholder="Choose a contract..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {contracts.length === 0 ? (
-                      <div className="p-2 text-sm text-muted-foreground text-center">
-                        No active/approved contracts available
-                      </div>
-                    ) : (
-                      contracts.map((contract) => (
-                        <SelectItem key={contract.id} value={contract.id}>
-                          <div className="flex items-center gap-2">
-                            <span>{contract.name}</span>
-                            <Badge variant="secondary" className="text-xs">v{contract.version}</Badge>
-                            <Badge variant="outline" className="text-xs">{contract.status}</Badge>
-                          </div>
-                        </SelectItem>
-                      ))
-                    )}
-                  </SelectContent>
-                </Select>
-              )}
+              {/* EntityVersionPicker disambiguates same-named contracts by
+                  showing the version inline (closes #69). Entity-pinned
+                  only for now; family-follow-latest mode lands once the
+                  output-port reference column is added. PRD #442. */}
+              <EntityVersionPicker
+                entityKind="contract"
+                value={pickerValue}
+                onChange={setPickerValue}
+                allowedScopes={['entity']}
+                statusFilter={activeStatuses}
+                placeholder="Choose a contract…"
+              />
               <p className="text-xs text-muted-foreground">
-                Only showing contracts with 'active', 'approved', or 'certified' status
+                Only showing contracts with 'active', 'approved', or 'certified' status.
+                Pick a specific version — same-named contracts now show their version inline.
               </p>
             </div>
 
@@ -238,7 +207,7 @@ export default function LinkContractToPortDialog({
             </Button>
             <Button 
               onClick={handleSubmit} 
-              disabled={isSubmitting || !selectedContractId}
+              disabled={isSubmitting || pickerValue?.scope !== 'entity'}
             >
               {isSubmitting ? (
                 <>


### PR DESCRIPTION
Replaces #448, which was auto-closed when its original stacked base branch was deleted during the #447 admin merge. Identical content — same two commits rebased onto current `main`.

## Summary

Phase 3 of PRD #442. Closes the gap between "which row collapses to the latest in a family" and "who's allowed to see what", and ships the unified `EntityVersionPicker` that the link-contract-to-port dialog (and future selectors per #452/#453/#454) already consume.

### Backend
- `common/version_visibility.py` (new) — role-aware status rank tables + `collapse_by_family` helper. Consumer rank treats `draft` as invisible; elevated rank (admin / owner / subscriber / team-member) treats `draft` as a real version.
- `DataContractsManager` / `DataProductsManager`: integrate the helper into `list_*` paths, threading `caller_email` + `caller_team_ids` through so the manager can compute `_elevated_*_families` once per request.
- `GET /api/data-contracts/families/{family_id}/latest` and `GET /api/data-products/families/{family_id}/latest` — visibility-aware resolvers for family-follow-latest references.
- Phase 3 follow-up (squashed into PR): `serialization_alias` for `versionFamilyId`, `versionCount`, `parentContractId`, `baseName`, `changeSummary`, `draftOwnerId` so the API actually emits camelCase to match the frontend types.

### Frontend
- `components/common/entity-version-picker.tsx` (new) — unified searchable combobox supporting `entity-pinned` and `family-follow-latest` scopes. When a `statusFilter` is set, falls back to `?include_history=true` and collapses client-side so published versions inside an otherwise-draft-latest family stay selectable.
- `link-contract-to-port-dialog.tsx`: migrated from bespoke `Select` to `EntityVersionPicker` (closes #69).
- `version-selector.tsx` shared-component touch-up: passes the full row to `onVersionChange`, adds `triggerClassName` for layout reuse.

### Tests
- `test_version_visibility.py` — status visibility, rank ordering, tie-breaks.
- `test_version_family.py` — manager-level collapse with elevated/consumer modes.
- `test_data_contracts_api_models.py` — camelCase emission for the aliased fields.

33 unit tests across `test_version_family.py` + `test_version_visibility.py` pass on the rebased-to-main branch.

## Stack note

Has one dependent PR (#457, clone-serialization fix for #455) — that PR's base will be retargeted to `main` immediately after this one merges.

## Test plan

- [x] Backend unit tests (`pytest src/tests/unit/test_version_family.py src/tests/unit/test_version_visibility.py`) — 33/33 pass.
- [x] Manual Playwright smoke: link-contract dialog opens, scope toggle works, published versions inside draft-latest families remain selectable.
- [ ] Manual: subscriber and team-owner views show draft rows; anonymous consumer does not.