### PR TITLE
fix(demo-data): complete schemas, add Column assets, dedupe, and add DQ checks

### DIFF
--- a/src/backend/src/data/demo_data_auto.sql
+++ b/src/backend/src/data/demo_data_auto.sql
@@ -165,7 +165,69 @@ INSERT INTO data_contract_schema_properties (id, object_id, name, logical_type, 
 ('00600012-0004-4000-8000-000000000018', '00500008-0004-4000-8000-000000000008', 'vin', 'string', true, false, false, false, -1, -1, true, 'Vehicle Identification Number'),
 ('00600013-0004-4000-8000-000000000019', '00500008-0004-4000-8000-000000000008', 'failure_code', 'string', true, false, false, false, -1, -1, true, 'Standardized failure mode code'),
 ('00600014-0004-4000-8000-000000000020', '00500008-0004-4000-8000-000000000008', 'mileage_km', 'integer', true, false, false, false, -1, -1, false, 'Vehicle odometer at time of claim'),
-('00600015-0004-4000-8000-000000000021', '00500008-0004-4000-8000-000000000008', 'claim_cost_usd', 'decimal', true, false, false, false, -1, -1, true, 'Total claim cost (parts + labor)')
+('00600015-0004-4000-8000-000000000021', '00500008-0004-4000-8000-000000000008', 'claim_cost_usd', 'decimal', true, false, false, false, -1, -1, true, 'Total claim cost (parts + labor)'),
+
+-- diagnostic_codes table (00500002 — Vehicle Telematics)
+('00600016-0004-4000-8000-000000000022', '00500002-0004-4000-8000-000000000002', 'event_id', 'string', true, true, true, false, 1, -1, true, 'Unique DTC event identifier'),
+('00600017-0004-4000-8000-000000000023', '00500002-0004-4000-8000-000000000002', 'vin', 'string', true, false, false, false, -1, -1, true, 'Vehicle Identification Number'),
+('00600018-0004-4000-8000-000000000024', '00500002-0004-4000-8000-000000000002', 'dtc_code', 'string', true, false, false, false, -1, -1, true, 'SAE J2012 diagnostic trouble code (e.g. P0420)'),
+('00600019-0004-4000-8000-000000000025', '00500002-0004-4000-8000-000000000002', 'severity', 'string', true, false, false, false, -1, -1, true, 'pending | confirmed | permanent'),
+('0060001a-0004-4000-8000-000000000026', '00500002-0004-4000-8000-000000000002', 'first_seen_ts', 'timestamp', true, false, false, true, -1, 1, false, 'First occurrence timestamp (UTC)'),
+('0060001b-0004-4000-8000-000000000027', '00500002-0004-4000-8000-000000000002', 'mileage_km', 'integer', true, false, false, false, -1, -1, false, 'Odometer at first occurrence'),
+
+-- driving_events table (00500003)
+('0060001c-0004-4000-8000-000000000028', '00500003-0004-4000-8000-000000000003', 'event_id', 'string', true, true, true, false, 1, -1, true, 'Unique driving event identifier'),
+('0060001d-0004-4000-8000-000000000029', '00500003-0004-4000-8000-000000000003', 'vin', 'string', true, false, false, false, -1, -1, true, 'Vehicle Identification Number'),
+('0060001e-0004-4000-8000-000000000030', '00500003-0004-4000-8000-000000000003', 'event_type', 'string', true, false, false, false, -1, -1, false, 'hard_brake | rapid_accel | hard_corner'),
+('0060001f-0004-4000-8000-000000000031', '00500003-0004-4000-8000-000000000003', 'event_ts', 'timestamp', true, false, false, true, -1, 1, false, 'Event timestamp (UTC)'),
+('00600020-0004-4000-8000-000000000032', '00500003-0004-4000-8000-000000000003', 'lat', 'decimal', true, false, false, false, -1, -1, false, 'Latitude (WGS84)'),
+('00600021-0004-4000-8000-000000000033', '00500003-0004-4000-8000-000000000003', 'lon', 'decimal', true, false, false, false, -1, -1, false, 'Longitude (WGS84)'),
+('00600022-0004-4000-8000-000000000034', '00500003-0004-4000-8000-000000000003', 'speed_kph', 'decimal', true, false, false, false, -1, -1, false, 'Vehicle speed at event time'),
+
+-- annotations table (00500005 — ADAS Sensor Data)
+('00600023-0004-4000-8000-000000000035', '00500005-0004-4000-8000-000000000005', 'annotation_id', 'string', true, true, true, false, 1, -1, true, 'Unique annotation identifier'),
+('00600024-0004-4000-8000-000000000036', '00500005-0004-4000-8000-000000000005', 'recording_id', 'string', true, false, false, false, -1, -1, true, 'FK to sensor_recordings.recording_id'),
+('00600025-0004-4000-8000-000000000037', '00500005-0004-4000-8000-000000000005', 'frame_index', 'integer', true, false, false, false, -1, -1, false, 'Frame index within the recording'),
+('00600026-0004-4000-8000-000000000038', '00500005-0004-4000-8000-000000000005', 'object_class', 'string', true, false, false, false, -1, -1, false, 'vehicle | pedestrian | cyclist | traffic_sign | lane_marking'),
+('00600027-0004-4000-8000-000000000039', '00500005-0004-4000-8000-000000000005', 'bbox_3d', 'string', false, false, false, false, -1, -1, false, '3D bounding box (JSON encoded)'),
+('00600028-0004-4000-8000-000000000040', '00500005-0004-4000-8000-000000000005', 'labeller_id', 'string', true, false, false, false, -1, -1, false, 'Labeller / annotation tool identifier'),
+
+-- incoming_inspections table (00500007 — Supplier Quality)
+('00600029-0004-4000-8000-000000000041', '00500007-0004-4000-8000-000000000007', 'inspection_id', 'string', true, true, true, false, 1, -1, true, 'Unique inspection record identifier'),
+('0060002a-0004-4000-8000-000000000042', '00500007-0004-4000-8000-000000000007', 'supplier_code', 'string', true, false, false, false, -1, -1, true, 'DUNS or internal supplier code'),
+('0060002b-0004-4000-8000-000000000043', '00500007-0004-4000-8000-000000000007', 'part_number', 'string', true, false, false, false, -1, -1, true, 'OEM part number'),
+('0060002c-0004-4000-8000-000000000044', '00500007-0004-4000-8000-000000000007', 'lot_size', 'integer', true, false, false, false, -1, -1, false, 'Lot size received'),
+('0060002d-0004-4000-8000-000000000045', '00500007-0004-4000-8000-000000000007', 'defects_found', 'integer', true, false, false, false, -1, -1, true, 'Number of defective units'),
+('0060002e-0004-4000-8000-000000000046', '00500007-0004-4000-8000-000000000007', 'inspection_date', 'date', true, false, false, true, -1, 1, false, 'Inspection date (partition key)'),
+
+-- recall_campaigns table (00500009 — Warranty Claims)
+('0060002f-0004-4000-8000-000000000047', '00500009-0004-4000-8000-000000000009', 'campaign_id', 'string', true, true, true, false, 1, -1, true, 'Unique recall campaign identifier'),
+('00600030-0004-4000-8000-000000000048', '00500009-0004-4000-8000-000000000009', 'campaign_type', 'string', true, false, false, false, -1, -1, true, 'safety | non_safety | service_action'),
+('00600031-0004-4000-8000-000000000049', '00500009-0004-4000-8000-000000000009', 'announced_date', 'date', true, false, false, false, -1, -1, false, 'Public announcement date'),
+('00600032-0004-4000-8000-000000000050', '00500009-0004-4000-8000-000000000009', 'affected_vins', 'integer', true, false, false, false, -1, -1, true, 'Estimated affected VIN count'),
+('00600033-0004-4000-8000-000000000051', '00500009-0004-4000-8000-000000000009', 'nhtsa_id', 'string', false, false, false, false, -1, -1, false, 'NHTSA recall reference (if applicable)')
+
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 4d. DATA CONTRACT QUALITY CHECKS (Auto-specific)
+-- ============================================================================
+
+INSERT INTO data_contract_quality_checks (id, object_id, property_id, level, name, description, dimension, business_impact, severity, type, rule, must_be, must_not_be, must_be_gt, must_be_ge, must_be_lt, must_be_le, must_be_between_min, must_be_between_max, query, engine, implementation, schedule, scheduler) VALUES
+-- Vehicle signals
+('03000001-0004-4000-8000-000000000001', '00500001-0004-4000-8000-000000000001', '00600001-0004-4000-8000-000000000001', 'property', 'vin_format',           'VIN must be 17 alphanumeric characters (excluding I/O/Q)',  'conformity',   'regulatory',  'error',   'library', 'regex',      '^[A-HJ-NPR-Z0-9]{17}$', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',  'airflow'),
+('03000002-0004-4000-8000-000000000002', '00500001-0004-4000-8000-000000000001', NULL,                                  'object',   'freshness_1h',         'CAN signals stream must have data within last hour',         'timeliness',   'operational', 'error',   'sql',     NULL,         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'SELECT MAX(timestamp_utc) > NOW() - INTERVAL ''1 hour'' FROM telematics.can_bus_signals', 'spark', NULL, '*/10 * * * *', 'airflow'),
+-- Diagnostic codes
+('03000003-0004-4000-8000-000000000003', '00500002-0004-4000-8000-000000000002', '00600019-0004-4000-8000-000000000025', 'property', 'severity_values',      'severity must be one of pending/confirmed/permanent',         'conformity',   'operational', 'error',   'library', 'enumValues', 'pending,confirmed,permanent', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',  'airflow'),
+-- PPAP
+('03000004-0004-4000-8000-000000000004', '00500006-0004-4000-8000-000000000006', '0060000f-0004-4000-8000-000000000015', 'property', 'ppap_level_range',     'PPAP level must be in range [1,5] per AIAG',                  'accuracy',     'regulatory',  'error',   'library', 'rangeCheck', NULL, NULL, NULL, NULL, NULL, NULL, '1', '5', NULL, NULL, NULL, '@daily',  'airflow'),
+('03000005-0004-4000-8000-000000000005', '00500006-0004-4000-8000-000000000006', '00600010-0004-4000-8000-000000000016', 'property', 'disposition_values',   'disposition must be one of approved/interim_approved/rejected','conformity',  'regulatory',  'error',   'library', 'enumValues', 'approved,interim_approved,rejected', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',  'airflow'),
+-- Warranty claims
+('03000006-0004-4000-8000-000000000006', '00500008-0004-4000-8000-000000000008', '00600011-0004-4000-8000-000000000017', 'property', 'claim_id_unique',      'claim_id must be unique',                                     'uniqueness',   'operational', 'error',   'library', 'unique',     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',  'airflow'),
+('03000007-0004-4000-8000-000000000007', '00500008-0004-4000-8000-000000000008', '00600015-0004-4000-8000-000000000021', 'property', 'claim_cost_non_neg',   'claim_cost_usd must be >= 0',                                  'accuracy',     'operational', 'error',   'library', 'rangeCheck', NULL, NULL, NULL, '0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',   'airflow'),
+-- Recalls
+('03000008-0004-4000-8000-000000000008', '00500009-0004-4000-8000-000000000009', '00600030-0004-4000-8000-000000000048', 'property', 'campaign_type_values', 'campaign_type must be safety/non_safety/service_action',      'conformity',   'regulatory',  'error',   'library', 'enumValues', 'safety,non_safety,service_action', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',  'airflow')
 
 ON CONFLICT (id) DO NOTHING;
 
@@ -529,7 +591,53 @@ INSERT INTO assets (id, name, description, asset_type_id, platform, location, do
  '00000004-0004-4000-8000-000000000004',
  '{"catalog": "lakehouse", "schema": "auto_supply", "table_name": "tier_n_inventory", "row_count": 280000, "format": "delta"}',
  '[]',
- 'active', 'system@demo', NOW(), NOW())
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- ── Column assets for the Auto Tables / Streams above ──
+-- 0f300103 lakehouse.auto.telemetry.can_signals
+('0f520103-0004-4000-8000-000000000003', 'vin',           'Vehicle Identification Number',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.vin',           '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["telematics", "pii"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520104-0004-4000-8000-000000000004', 'trip_id',       'Unique trip session identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.trip_id',       '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}',  '["telematics", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520105-0004-4000-8000-000000000005', 'signal_name',   'CAN signal name per DBC definition',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.signal_name',   '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520106-0004-4000-8000-000000000006', 'signal_value',  'Decoded physical signal value',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.signal_value',  '00000002-0004-4000-8000-000000000002', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520107-0004-4000-8000-000000000007', 'timestamp_utc', 'Signal timestamp (UTC, millisecond precision)',   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.timestamp_utc', '00000002-0004-4000-8000-000000000002', '{"data_type": "TIMESTAMP",     "nullable": false, "partition_key": true}',   '["telematics", "partition"]','active', 'system@demo', NOW(), NOW()),
+('0f520108-0004-4000-8000-000000000008', 'ecu_id',        'Source ECU identifier',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.ecu_id',        '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300104 kafka.fleet.events.diagnostic_trouble_codes (Stream)
+('0f520111-0004-4000-8000-000000000011', 'event_id',      'Unique DTC event identifier',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.event_id',  '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false, "is_primary_key": true}', '["telematics", "key"]',      'active', 'system@demo', NOW(), NOW()),
+('0f520112-0004-4000-8000-000000000012', 'vin',           'Vehicle Identification Number',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.vin',       '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false}',                          '["telematics", "pii"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520113-0004-4000-8000-000000000013', 'dtc_code',      'SAE J2012 diagnostic trouble code',               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.dtc_code',  '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520114-0004-4000-8000-000000000014', 'severity',      'pending | confirmed | permanent',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.severity',  '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520115-0004-4000-8000-000000000015', 'first_seen_ts', 'First occurrence timestamp (UTC)',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.first_seen_ts','00000002-0004-4000-8000-000000000002','{"data_type": "TIMESTAMP","nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300108 lakehouse.auto.supply.tier_n_inventory
+('0f520121-0004-4000-8000-000000000021', 'part_number',     'OEM part number (PK)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.part_number',     '00000004-0004-4000-8000-000000000004', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}',     '["supply-chain", "key"]',  'active', 'system@demo', NOW(), NOW()),
+('0f520122-0004-4000-8000-000000000022', 'supplier_code',   'Supplier code (PK with part_number)',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.supplier_code',   '00000004-0004-4000-8000-000000000004', '{"data_type": "STRING",  "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520123-0004-4000-8000-000000000023', 'tier',            'Supplier tier (1=direct, 2/3=upstream)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.tier',            '00000004-0004-4000-8000-000000000004', '{"data_type": "INT",     "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520124-0004-4000-8000-000000000024', 'on_hand_qty',     'Current on-hand quantity',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.on_hand_qty',     '00000004-0004-4000-8000-000000000004', '{"data_type": "INT",     "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520125-0004-4000-8000-000000000025', 'last_shipment_ts','Last shipment timestamp (UTC)',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.last_shipment_ts','00000004-0004-4000-8000-000000000004', '{"data_type": "TIMESTAMP","nullable": true }',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15b. hasColumn RELATIONSHIPS (Auto)
+-- ============================================================================
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, properties, created_by, created_at) VALUES
+('0f620103-0004-4000-8000-000000000003', 'Table',  '0f300103-0004-4000-8000-000000000003', 'Column', '0f520103-0004-4000-8000-000000000003', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620104-0004-4000-8000-000000000004', 'Table',  '0f300103-0004-4000-8000-000000000003', 'Column', '0f520104-0004-4000-8000-000000000004', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620105-0004-4000-8000-000000000005', 'Table',  '0f300103-0004-4000-8000-000000000003', 'Column', '0f520105-0004-4000-8000-000000000005', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620106-0004-4000-8000-000000000006', 'Table',  '0f300103-0004-4000-8000-000000000003', 'Column', '0f520106-0004-4000-8000-000000000006', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620107-0004-4000-8000-000000000007', 'Table',  '0f300103-0004-4000-8000-000000000003', 'Column', '0f520107-0004-4000-8000-000000000007', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620108-0004-4000-8000-000000000008', 'Table',  '0f300103-0004-4000-8000-000000000003', 'Column', '0f520108-0004-4000-8000-000000000008', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620111-0004-4000-8000-000000000011', 'Stream', '0f300104-0004-4000-8000-000000000004', 'Column', '0f520111-0004-4000-8000-000000000011', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620112-0004-4000-8000-000000000012', 'Stream', '0f300104-0004-4000-8000-000000000004', 'Column', '0f520112-0004-4000-8000-000000000012', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620113-0004-4000-8000-000000000013', 'Stream', '0f300104-0004-4000-8000-000000000004', 'Column', '0f520113-0004-4000-8000-000000000013', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620114-0004-4000-8000-000000000014', 'Stream', '0f300104-0004-4000-8000-000000000004', 'Column', '0f520114-0004-4000-8000-000000000014', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620115-0004-4000-8000-000000000015', 'Stream', '0f300104-0004-4000-8000-000000000004', 'Column', '0f520115-0004-4000-8000-000000000015', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620121-0004-4000-8000-000000000021', 'Table',  '0f300108-0004-4000-8000-000000000008', 'Column', '0f520121-0004-4000-8000-000000000021', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620122-0004-4000-8000-000000000022', 'Table',  '0f300108-0004-4000-8000-000000000008', 'Column', '0f520122-0004-4000-8000-000000000022', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620123-0004-4000-8000-000000000023', 'Table',  '0f300108-0004-4000-8000-000000000008', 'Column', '0f520123-0004-4000-8000-000000000023', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620124-0004-4000-8000-000000000024', 'Table',  '0f300108-0004-4000-8000-000000000008', 'Column', '0f520124-0004-4000-8000-000000000024', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620125-0004-4000-8000-000000000025', 'Table',  '0f300108-0004-4000-8000-000000000008', 'Column', '0f520125-0004-4000-8000-000000000025', 'hasColumn', NULL, 'system@demo', NOW())
 ON CONFLICT (id) DO NOTHING;
 
 

--- a/src/backend/src/data/demo_data_fsi.sql
+++ b/src/backend/src/data/demo_data_fsi.sql
@@ -156,7 +156,79 @@ INSERT INTO data_contract_schema_properties (id, object_id, name, logical_type, 
 ('0060000c-0002-4000-8000-000000000012', '00500006-0002-4000-8000-000000000006', 'risk_rating', 'string', true, false, false, false, -1, -1, true, 'low, medium, high, prohibited'),
 ('0060000d-0002-4000-8000-000000000013', '00500006-0002-4000-8000-000000000006', 'pep_status', 'boolean', true, false, false, false, -1, -1, true, 'Politically Exposed Person flag'),
 ('0060000e-0002-4000-8000-000000000014', '00500006-0002-4000-8000-000000000006', 'last_review_date', 'date', true, false, false, false, -1, -1, false, 'Date of most recent KYC review'),
-('0060000f-0002-4000-8000-000000000015', '00500006-0002-4000-8000-000000000006', 'beneficial_owners', 'string', false, false, false, false, -1, -1, true, 'JSON array of beneficial owners (>25% threshold)')
+('0060000f-0002-4000-8000-000000000015', '00500006-0002-4000-8000-000000000006', 'beneficial_owners', 'string', false, false, false, false, -1, -1, true, 'JSON array of beneficial owners (>25% threshold)'),
+
+-- positions table (00500002 — Trading & Market Data)
+('00600010-0002-4000-8000-000000000016', '00500002-0002-4000-8000-000000000002', 'position_id', 'string', true, true, true, false, 1, -1, true, 'Unique end-of-day position identifier'),
+('00600011-0002-4000-8000-000000000017', '00500002-0002-4000-8000-000000000002', 'desk', 'string', true, false, false, false, -1, -1, true, 'Trading desk that owns the position'),
+('00600012-0002-4000-8000-000000000018', '00500002-0002-4000-8000-000000000002', 'instrument_id', 'string', true, false, false, false, -1, -1, true, 'ISIN or internal security identifier'),
+('00600013-0002-4000-8000-000000000019', '00500002-0002-4000-8000-000000000002', 'net_quantity', 'decimal', true, false, false, false, -1, -1, true, 'Net long/short quantity (signed)'),
+('00600014-0002-4000-8000-000000000020', '00500002-0002-4000-8000-000000000002', 'mark_to_market_usd', 'decimal', true, false, false, false, -1, -1, true, 'Current MTM in USD'),
+('00600015-0002-4000-8000-000000000021', '00500002-0002-4000-8000-000000000002', 'snapshot_date', 'date', true, false, false, true, -1, 1, true, 'EOD snapshot date (partition key)'),
+
+-- market_data table (00500003)
+('00600016-0002-4000-8000-000000000022', '00500003-0002-4000-8000-000000000003', 'instrument_id', 'string', true, false, true, false, 1, -1, true, 'Composite PK with tick_ts'),
+('00600017-0002-4000-8000-000000000023', '00500003-0002-4000-8000-000000000003', 'tick_ts', 'timestamp', true, false, true, true, 2, 1, true, 'Tick timestamp (nanosecond precision, partition)'),
+('00600018-0002-4000-8000-000000000024', '00500003-0002-4000-8000-000000000003', 'bid', 'decimal', true, false, false, false, -1, -1, false, 'Best bid'),
+('00600019-0002-4000-8000-000000000025', '00500003-0002-4000-8000-000000000003', 'ask', 'decimal', true, false, false, false, -1, -1, false, 'Best ask'),
+('0060001a-0002-4000-8000-000000000026', '00500003-0002-4000-8000-000000000003', 'last_price', 'decimal', false, false, false, false, -1, -1, false, 'Last traded price'),
+('0060001b-0002-4000-8000-000000000027', '00500003-0002-4000-8000-000000000003', 'volume', 'integer', false, false, false, false, -1, -1, false, 'Volume on the tick'),
+
+-- stress_scenarios table (00500005 — Risk Exposure)
+('0060001c-0002-4000-8000-000000000028', '00500005-0002-4000-8000-000000000005', 'scenario_id', 'string', true, false, true, false, 1, -1, true, 'Stress scenario identifier (composite PK)'),
+('0060001d-0002-4000-8000-000000000029', '00500005-0002-4000-8000-000000000005', 'desk', 'string', true, false, true, false, 2, -1, true, 'Desk identifier (composite PK)'),
+('0060001e-0002-4000-8000-000000000030', '00500005-0002-4000-8000-000000000005', 'pnl_impact_usd', 'decimal', true, false, false, false, -1, -1, true, 'Modeled P&L impact in USD'),
+('0060001f-0002-4000-8000-000000000031', '00500005-0002-4000-8000-000000000005', 'severity', 'string', true, false, false, false, -1, -1, false, 'mild | severe | extreme'),
+('00600020-0002-4000-8000-000000000032', '00500005-0002-4000-8000-000000000005', 'reporting_date', 'date', true, false, false, true, -1, 1, false, 'Reporting date (partition key)'),
+
+-- aml_alerts table (00500007 — KYC/AML)
+('00600021-0002-4000-8000-000000000033', '00500007-0002-4000-8000-000000000007', 'alert_id', 'string', true, true, true, false, 1, -1, true, 'Unique AML alert identifier'),
+('00600022-0002-4000-8000-000000000034', '00500007-0002-4000-8000-000000000007', 'customer_id', 'string', true, false, false, false, -1, -1, true, 'FK to customer_kyc.customer_id'),
+('00600023-0002-4000-8000-000000000035', '00500007-0002-4000-8000-000000000007', 'scenario_code', 'string', true, false, false, false, -1, -1, true, 'AML rule / ML scenario that fired'),
+('00600024-0002-4000-8000-000000000036', '00500007-0002-4000-8000-000000000007', 'severity', 'string', true, false, false, false, -1, -1, true, 'low | medium | high | critical'),
+('00600025-0002-4000-8000-000000000037', '00500007-0002-4000-8000-000000000007', 'alert_ts', 'timestamp', true, false, false, true, -1, 1, true, 'Alert generation timestamp (UTC)'),
+('00600026-0002-4000-8000-000000000038', '00500007-0002-4000-8000-000000000007', 'analyst_disposition', 'string', false, false, false, false, -1, -1, false, 'pending | escalated | suppressed | sar_filed'),
+
+-- accounts table (00500008 — Account & Transaction Contract)
+('00600027-0002-4000-8000-000000000039', '00500008-0002-4000-8000-000000000008', 'account_id', 'string', true, true, true, false, 1, -1, true, 'Internal account identifier'),
+('00600028-0002-4000-8000-000000000040', '00500008-0002-4000-8000-000000000008', 'customer_id', 'string', true, false, false, false, -1, -1, true, 'FK to customer_kyc.customer_id'),
+('00600029-0002-4000-8000-000000000041', '00500008-0002-4000-8000-000000000008', 'product_type', 'string', true, false, false, false, -1, -1, false, 'checking | savings | credit_card | mortgage | brokerage'),
+('0060002a-0002-4000-8000-000000000042', '00500008-0002-4000-8000-000000000008', 'currency', 'string', true, false, false, false, -1, -1, true, 'ISO-4217 base currency'),
+('0060002b-0002-4000-8000-000000000043', '00500008-0002-4000-8000-000000000008', 'opened_date', 'date', true, false, false, false, -1, -1, false, 'Account opening date'),
+('0060002c-0002-4000-8000-000000000044', '00500008-0002-4000-8000-000000000008', 'status', 'string', true, false, false, false, -1, -1, false, 'active | dormant | closed | frozen'),
+
+-- transactions table (00500009)
+('0060002d-0002-4000-8000-000000000045', '00500009-0002-4000-8000-000000000009', 'transaction_id', 'string', true, true, true, false, 1, -1, true, 'Unique transaction identifier'),
+('0060002e-0002-4000-8000-000000000046', '00500009-0002-4000-8000-000000000009', 'account_id', 'string', true, false, false, false, -1, -1, true, 'FK to accounts.account_id'),
+('0060002f-0002-4000-8000-000000000047', '00500009-0002-4000-8000-000000000009', 'amount', 'decimal', true, false, false, false, -1, -1, true, 'Signed transaction amount'),
+('00600030-0002-4000-8000-000000000048', '00500009-0002-4000-8000-000000000009', 'currency', 'string', true, false, false, false, -1, -1, true, 'ISO-4217 currency code'),
+('00600031-0002-4000-8000-000000000049', '00500009-0002-4000-8000-000000000009', 'transaction_ts', 'timestamp', true, false, false, true, -1, 1, true, 'Transaction timestamp (UTC)'),
+('00600032-0002-4000-8000-000000000050', '00500009-0002-4000-8000-000000000009', 'channel', 'string', true, false, false, false, -1, -1, false, 'atm | branch | mobile | online | wire')
+
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 4d. DATA CONTRACT QUALITY CHECKS (FSI-specific)
+-- ============================================================================
+
+INSERT INTO data_contract_quality_checks (id, object_id, property_id, level, name, description, dimension, business_impact, severity, type, rule, must_be, must_not_be, must_be_gt, must_be_ge, must_be_lt, must_be_le, must_be_between_min, must_be_between_max, query, engine, implementation, schedule, scheduler) VALUES
+-- Trades — 00500001
+('03000001-0002-4000-8000-000000000001', '00500001-0002-4000-8000-000000000001', '00600001-0002-4000-8000-000000000001', 'property', 'trade_id_unique',     'trade_id must be globally unique',                                'uniqueness',   'regulatory', 'error',   'library', 'unique',     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly', 'airflow'),
+('03000002-0002-4000-8000-000000000002', '00500001-0002-4000-8000-000000000001', '00600004-0002-4000-8000-000000000004', 'property', 'quantity_positive',   'quantity must be > 0',                                            'accuracy',     'regulatory', 'error',   'library', 'rangeCheck', NULL, NULL, '0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly', 'airflow'),
+('03000003-0002-4000-8000-000000000003', '00500001-0002-4000-8000-000000000001', '00600003-0002-4000-8000-000000000003', 'property', 'side_values',         'side must be BUY or SELL',                                        'conformity',   'regulatory', 'error',   'library', 'enumValues', 'BUY,SELL', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly', 'airflow'),
+-- Risk exposures — 00500004
+('03000004-0002-4000-8000-000000000004', '00500004-0002-4000-8000-000000000004', '00600009-0002-4000-8000-000000000009', 'property', 'var99_non_negative',  'var_99 must be >= 0 (loss measure)',                              'accuracy',     'regulatory', 'error',   'library', 'rangeCheck', NULL, NULL, NULL, '0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',   'airflow'),
+('03000005-0002-4000-8000-000000000005', '00500004-0002-4000-8000-000000000004', NULL,                                  'object',   'freshness_24h',       'Risk exposures must have at least one row in the last 24 hours',  'timeliness',   'regulatory', 'error',   'sql',     NULL,         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'SELECT MAX(reporting_date) >= CURRENT_DATE - 1 FROM risk.aggregated_exposures', 'spark', NULL, '0 7 * * *', 'airflow'),
+-- KYC — 00500006
+('03000006-0002-4000-8000-000000000006', '00500006-0002-4000-8000-000000000006', '0060000c-0002-4000-8000-000000000012', 'property', 'risk_rating_values',  'risk_rating must be one of the regulated values',                  'conformity',   'regulatory', 'error',   'library', 'enumValues', 'low,medium,high,prohibited', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',   'airflow'),
+('03000007-0002-4000-8000-000000000007', '00500006-0002-4000-8000-000000000006', '0060000e-0002-4000-8000-000000000014', 'property', 'kyc_review_freshness','KYC last_review_date must be within the last 365 days',           'timeliness',   'regulatory', 'warning', 'sql',     NULL,         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'SELECT MIN(last_review_date) >= CURRENT_DATE - INTERVAL ''365 days'' FROM compliance.customer_kyc_profiles', 'spark', NULL, '0 8 * * 1', 'airflow'),
+-- AML alerts — 00500007
+('03000008-0002-4000-8000-000000000008', '00500007-0002-4000-8000-000000000007', '00600024-0002-4000-8000-000000000036', 'property', 'severity_values',     'severity must be one of low/medium/high/critical',                'conformity',   'regulatory', 'error',   'library', 'enumValues', 'low,medium,high,critical', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',  'airflow'),
+-- Accounts — 00500008
+('03000009-0002-4000-8000-000000000009', '00500008-0002-4000-8000-000000000008', '0060002a-0002-4000-8000-000000000042', 'property', 'currency_iso4217',    'currency must be ISO-4217 (length=3 uppercase)',                  'conformity',   'regulatory', 'error',   'library', 'regex',      '^[A-Z]{3}$', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',   'airflow'),
+-- Transactions — 00500009
+('0300000a-0002-4000-8000-000000000010', '00500009-0002-4000-8000-000000000009', '0060002d-0002-4000-8000-000000000045', 'property', 'tx_id_unique',        'transaction_id must be globally unique',                          'uniqueness',   'regulatory', 'error',   'library', 'unique',     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',    'airflow')
 
 ON CONFLICT (id) DO NOTHING;
 
@@ -519,7 +591,69 @@ INSERT INTO assets (id, name, description, asset_type_id, platform, location, do
  '00000003-0002-4000-8000-000000000003',
  '{"refresh_schedule": "hourly", "audience": "cro-team"}',
  '["bcbs-239", "risk-tier-1"]',
- 'active', 'system@demo', NOW(), NOW())
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- ── Column assets for the FSI Tables / Streams above ──
+-- 0f300101 lakehouse.fsi.trading.executions
+('0f520101-0002-4000-8000-000000000001', 'trade_id',     'Unique trade execution identifier',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.trade_id',     '00000002-0002-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}',  '["mifid-ii", "key"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520102-0002-4000-8000-000000000002', 'instrument_id','ISIN or internal security identifier',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.instrument_id','00000002-0002-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520103-0002-4000-8000-000000000003', 'side',         'BUY or SELL',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.side',         '00000002-0002-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520104-0002-4000-8000-000000000004', 'quantity',     'Executed quantity',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.quantity',     '00000002-0002-4000-8000-000000000002', '{"data_type": "DECIMAL(18,4)", "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520105-0002-4000-8000-000000000005', 'price',        'Execution price (instrument currency)',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.price',        '00000002-0002-4000-8000-000000000002', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520106-0002-4000-8000-000000000006', 'execution_ts', 'Execution timestamp (nanosecond precision)', (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.execution_ts', '00000002-0002-4000-8000-000000000002', '{"data_type": "TIMESTAMP_NS",  "nullable": false, "partition_key": true}',   '["mifid-ii", "partition"]',          'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300104 lakehouse.fsi.risk.aggregated_var
+('0f520111-0002-4000-8000-000000000011', 'exposure_id',    'Unique exposure record identifier',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.exposure_id',   '00000003-0002-4000-8000-000000000003', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}', '["bcbs-239", "key"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520112-0002-4000-8000-000000000012', 'risk_type',      'credit | market | counterparty | operational',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.risk_type',     '00000003-0002-4000-8000-000000000003', '{"data_type": "STRING",        "nullable": false}',                         '["bcbs-239"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520113-0002-4000-8000-000000000013', 'desk',           'Trading desk identifier',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.desk',          '00000003-0002-4000-8000-000000000003', '{"data_type": "STRING",        "nullable": false}',                         '["bcbs-239"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520114-0002-4000-8000-000000000014', 'var_99',         'Value-at-Risk at 99% confidence',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.var_99',        '00000003-0002-4000-8000-000000000003', '{"data_type": "DECIMAL(18,2)", "nullable": false}',                         '["bcbs-239", "kpi"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520115-0002-4000-8000-000000000015', 'reporting_date', 'Risk reporting date (partition key)',       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.reporting_date','00000003-0002-4000-8000-000000000003', '{"data_type": "DATE",          "nullable": false, "partition_key": true}',  '["bcbs-239", "partition"]',          'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300105 kafka.fsi.aml.transaction_alerts (Stream — schema as advertised on the topic)
+('0f520121-0002-4000-8000-000000000021', 'alert_id',       'Unique AML alert identifier',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.alert_id',     '00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false, "is_primary_key": true}', '["aml", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520122-0002-4000-8000-000000000022', 'customer_id',    'FK to customer_kyc.customer_id',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.customer_id',  '00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false}',                          '["aml", "fk"]',      'active', 'system@demo', NOW(), NOW()),
+('0f520123-0002-4000-8000-000000000023', 'scenario_code',  'Scenario / model that fired',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.scenario_code','00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false}',                          '["aml"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520124-0002-4000-8000-000000000024', 'severity',       'low | medium | high | critical',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.severity',     '00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false}',                          '["aml"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520125-0002-4000-8000-000000000025', 'alert_ts',       'Alert generation timestamp (UTC)',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.alert_ts',     '00000004-0002-4000-8000-000000000004', '{"data_type": "TIMESTAMP", "nullable": false}',                       '["aml"]',            'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300107 lakehouse.fsi.banking.customer_master
+('0f520131-0002-4000-8000-000000000031', 'customer_id',  'Unique customer identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.customer_id', '00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["pii", "key"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520132-0002-4000-8000-000000000032', 'kyc_tier',     'Tier of customer due diligence applied',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.kyc_tier',    '00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false}',                          '["aml-monitored"]',       'active', 'system@demo', NOW(), NOW()),
+('0f520133-0002-4000-8000-000000000033', 'segment',      'Retail | Mass-Affluent | Private | SMB | Corp',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.segment',     '00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false}',                          '["banking"]',             'active', 'system@demo', NOW(), NOW()),
+('0f520134-0002-4000-8000-000000000034', 'opened_date',  'Earliest account opening date for customer',   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.opened_date', '00000001-0002-4000-8000-000000000001', '{"data_type": "DATE",    "nullable": false}',                          '["banking"]',             'active', 'system@demo', NOW(), NOW()),
+('0f520135-0002-4000-8000-000000000035', 'country_code', 'ISO 3166-1 alpha-2 of customer residence',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.country_code','00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false}',                          '["banking", "pii"]',      'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15b. hasColumn RELATIONSHIPS (FSI)
+-- ============================================================================
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, properties, created_by, created_at) VALUES
+-- 0f300101 → 6 columns
+('0f620101-0002-4000-8000-000000000001', 'Table',  '0f300101-0002-4000-8000-000000000001', 'Column', '0f520101-0002-4000-8000-000000000001', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620102-0002-4000-8000-000000000002', 'Table',  '0f300101-0002-4000-8000-000000000001', 'Column', '0f520102-0002-4000-8000-000000000002', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620103-0002-4000-8000-000000000003', 'Table',  '0f300101-0002-4000-8000-000000000001', 'Column', '0f520103-0002-4000-8000-000000000003', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620104-0002-4000-8000-000000000004', 'Table',  '0f300101-0002-4000-8000-000000000001', 'Column', '0f520104-0002-4000-8000-000000000004', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620105-0002-4000-8000-000000000005', 'Table',  '0f300101-0002-4000-8000-000000000001', 'Column', '0f520105-0002-4000-8000-000000000005', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620106-0002-4000-8000-000000000006', 'Table',  '0f300101-0002-4000-8000-000000000001', 'Column', '0f520106-0002-4000-8000-000000000006', 'hasColumn', NULL, 'system@demo', NOW()),
+-- 0f300104 → 5 columns
+('0f620111-0002-4000-8000-000000000011', 'Table',  '0f300104-0002-4000-8000-000000000004', 'Column', '0f520111-0002-4000-8000-000000000011', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620112-0002-4000-8000-000000000012', 'Table',  '0f300104-0002-4000-8000-000000000004', 'Column', '0f520112-0002-4000-8000-000000000012', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620113-0002-4000-8000-000000000013', 'Table',  '0f300104-0002-4000-8000-000000000004', 'Column', '0f520113-0002-4000-8000-000000000013', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620114-0002-4000-8000-000000000014', 'Table',  '0f300104-0002-4000-8000-000000000004', 'Column', '0f520114-0002-4000-8000-000000000014', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620115-0002-4000-8000-000000000015', 'Table',  '0f300104-0002-4000-8000-000000000004', 'Column', '0f520115-0002-4000-8000-000000000015', 'hasColumn', NULL, 'system@demo', NOW()),
+-- 0f300105 (Stream) → 5 columns (advertised topic schema)
+('0f620121-0002-4000-8000-000000000021', 'Stream', '0f300105-0002-4000-8000-000000000005', 'Column', '0f520121-0002-4000-8000-000000000021', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620122-0002-4000-8000-000000000022', 'Stream', '0f300105-0002-4000-8000-000000000005', 'Column', '0f520122-0002-4000-8000-000000000022', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620123-0002-4000-8000-000000000023', 'Stream', '0f300105-0002-4000-8000-000000000005', 'Column', '0f520123-0002-4000-8000-000000000023', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620124-0002-4000-8000-000000000024', 'Stream', '0f300105-0002-4000-8000-000000000005', 'Column', '0f520124-0002-4000-8000-000000000024', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620125-0002-4000-8000-000000000025', 'Stream', '0f300105-0002-4000-8000-000000000005', 'Column', '0f520125-0002-4000-8000-000000000025', 'hasColumn', NULL, 'system@demo', NOW()),
+-- 0f300107 → 5 columns
+('0f620131-0002-4000-8000-000000000031', 'Table',  '0f300107-0002-4000-8000-000000000007', 'Column', '0f520131-0002-4000-8000-000000000031', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620132-0002-4000-8000-000000000032', 'Table',  '0f300107-0002-4000-8000-000000000007', 'Column', '0f520132-0002-4000-8000-000000000032', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620133-0002-4000-8000-000000000033', 'Table',  '0f300107-0002-4000-8000-000000000007', 'Column', '0f520133-0002-4000-8000-000000000033', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620134-0002-4000-8000-000000000034', 'Table',  '0f300107-0002-4000-8000-000000000007', 'Column', '0f520134-0002-4000-8000-000000000034', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620135-0002-4000-8000-000000000035', 'Table',  '0f300107-0002-4000-8000-000000000007', 'Column', '0f520135-0002-4000-8000-000000000035', 'hasColumn', NULL, 'system@demo', NOW())
 ON CONFLICT (id) DO NOTHING;
 
 

--- a/src/backend/src/data/demo_data_hls.sql
+++ b/src/backend/src/data/demo_data_hls.sql
@@ -166,7 +166,73 @@ INSERT INTO data_contract_schema_properties (id, object_id, name, logical_type, 
 ('00600011-0001-4000-8000-000000000017', '00500007-0001-4000-8000-000000000007', 'meddra_pt', 'string', true, false, false, false, -1, -1, true, 'MedDRA Preferred Term'),
 ('00600012-0001-4000-8000-000000000018', '00500007-0001-4000-8000-000000000007', 'seriousness', 'string', true, false, false, false, -1, -1, true, 'serious, non_serious'),
 ('00600013-0001-4000-8000-000000000019', '00500007-0001-4000-8000-000000000007', 'onset_date', 'date', true, false, false, false, -1, -1, false, 'Date of AE onset'),
-('00600014-0001-4000-8000-000000000020', '00500007-0001-4000-8000-000000000007', 'outcome', 'string', true, false, false, false, -1, -1, false, 'recovered, recovering, not_recovered, fatal, unknown')
+('00600014-0001-4000-8000-000000000020', '00500007-0001-4000-8000-000000000007', 'outcome', 'string', true, false, false, false, -1, -1, false, 'recovered, recovering, not_recovered, fatal, unknown'),
+
+-- diagnoses table (00500003 — Patient EHR)
+('00600015-0001-4000-8000-000000000021', '00500003-0001-4000-8000-000000000003', 'diagnosis_id', 'string', true, true, true, false, 1, -1, true, 'Unique diagnosis row identifier'),
+('00600016-0001-4000-8000-000000000022', '00500003-0001-4000-8000-000000000003', 'encounter_id', 'string', true, false, false, false, -1, -1, true, 'FK to encounters.encounter_id'),
+('00600017-0001-4000-8000-000000000023', '00500003-0001-4000-8000-000000000003', 'icd10_code', 'string', true, false, false, false, -1, -1, true, 'ICD-10-CM diagnosis code'),
+('00600018-0001-4000-8000-000000000024', '00500003-0001-4000-8000-000000000003', 'is_primary', 'boolean', true, false, false, false, -1, -1, false, 'Primary diagnosis flag'),
+('00600019-0001-4000-8000-000000000025', '00500003-0001-4000-8000-000000000003', 'diagnosed_at', 'timestamp', true, false, false, false, -1, -1, false, 'Diagnosis timestamp (UTC)'),
+
+-- visits table (00500005 — Clinical Trials)
+('0060001a-0001-4000-8000-000000000026', '00500005-0001-4000-8000-000000000005', 'visit_id', 'string', true, true, true, false, 1, -1, true, 'Unique visit identifier'),
+('0060001b-0001-4000-8000-000000000027', '00500005-0001-4000-8000-000000000005', 'subject_id', 'string', true, false, false, false, -1, -1, true, 'FK to subjects.subject_id'),
+('0060001c-0001-4000-8000-000000000028', '00500005-0001-4000-8000-000000000005', 'visit_name', 'string', true, false, false, false, -1, -1, false, 'Protocol-defined visit label (e.g. V1, V2)'),
+('0060001d-0001-4000-8000-000000000029', '00500005-0001-4000-8000-000000000005', 'scheduled_date', 'date', true, false, false, false, -1, -1, false, 'Scheduled visit date'),
+('0060001e-0001-4000-8000-000000000030', '00500005-0001-4000-8000-000000000005', 'completed_date', 'date', false, false, false, false, -1, -1, false, 'Actual completion date (NULL if missed)'),
+
+-- endpoints table (00500006)
+('0060001f-0001-4000-8000-000000000031', '00500006-0001-4000-8000-000000000006', 'endpoint_id', 'string', true, true, true, false, 1, -1, true, 'Unique endpoint measurement identifier'),
+('00600020-0001-4000-8000-000000000032', '00500006-0001-4000-8000-000000000006', 'subject_id', 'string', true, false, false, false, -1, -1, true, 'FK to subjects.subject_id'),
+('00600021-0001-4000-8000-000000000033', '00500006-0001-4000-8000-000000000006', 'endpoint_name', 'string', true, false, false, false, -1, -1, true, 'Endpoint measure name (e.g. ORR, OS, PFS)'),
+('00600022-0001-4000-8000-000000000034', '00500006-0001-4000-8000-000000000006', 'value_numeric', 'decimal', false, false, false, false, -1, -1, true, 'Numeric value (NULL for categorical)'),
+('00600023-0001-4000-8000-000000000035', '00500006-0001-4000-8000-000000000006', 'value_text', 'string', false, false, false, false, -1, -1, false, 'Categorical value (NULL for numeric)'),
+('00600024-0001-4000-8000-000000000036', '00500006-0001-4000-8000-000000000006', 'measured_date', 'date', true, false, false, false, -1, -1, false, 'Measurement date'),
+
+-- signal_assessments table (00500008)
+('00600025-0001-4000-8000-000000000037', '00500008-0001-4000-8000-000000000008', 'assessment_id', 'string', true, true, true, false, 1, -1, true, 'Unique signal assessment identifier'),
+('00600026-0001-4000-8000-000000000038', '00500008-0001-4000-8000-000000000008', 'product_id', 'string', true, false, false, false, -1, -1, true, 'Product identifier (substance code)'),
+('00600027-0001-4000-8000-000000000039', '00500008-0001-4000-8000-000000000008', 'meddra_pt', 'string', true, false, false, false, -1, -1, true, 'Adverse event PT under assessment'),
+('00600028-0001-4000-8000-000000000040', '00500008-0001-4000-8000-000000000008', 'signal_score', 'decimal', true, false, false, false, -1, -1, true, 'Disproportionality / ML signal score'),
+('00600029-0001-4000-8000-000000000041', '00500008-0001-4000-8000-000000000008', 'assessment_date', 'date', true, false, false, true, -1, 1, false, 'Assessment cycle date (partition key)'),
+
+-- claims table (00500009)
+('0060002a-0001-4000-8000-000000000042', '00500009-0001-4000-8000-000000000009', 'claim_id', 'string', true, true, true, false, 1, -1, true, 'Unique medical claim identifier'),
+('0060002b-0001-4000-8000-000000000043', '00500009-0001-4000-8000-000000000009', 'member_id', 'string', true, false, false, false, -1, -1, true, 'FK to members (insurance plan member)'),
+('0060002c-0001-4000-8000-000000000044', '00500009-0001-4000-8000-000000000009', 'service_date', 'date', true, false, false, true, -1, 1, true, 'Date of service (partition key)'),
+('0060002d-0001-4000-8000-000000000045', '00500009-0001-4000-8000-000000000009', 'cpt_code', 'string', true, false, false, false, -1, -1, true, 'CMS HCPCS / CPT procedure code'),
+('0060002e-0001-4000-8000-000000000046', '00500009-0001-4000-8000-000000000009', 'billed_amount', 'decimal', true, false, false, false, -1, -1, true, 'Amount billed (>= 0)'),
+('0060002f-0001-4000-8000-000000000047', '00500009-0001-4000-8000-000000000009', 'allowed_amount', 'decimal', true, false, false, false, -1, -1, true, 'Amount allowed by payer'),
+
+-- remittances table (0050000a)
+('00600030-0001-4000-8000-000000000048', '0050000a-0001-4000-8000-000000000010', 'remittance_id', 'string', true, true, true, false, 1, -1, true, 'Unique remittance advice identifier'),
+('00600031-0001-4000-8000-000000000049', '0050000a-0001-4000-8000-000000000010', 'claim_id', 'string', true, false, false, false, -1, -1, true, 'FK to claims.claim_id'),
+('00600032-0001-4000-8000-000000000050', '0050000a-0001-4000-8000-000000000010', 'paid_amount', 'decimal', true, false, false, false, -1, -1, true, 'Amount paid by payer'),
+('00600033-0001-4000-8000-000000000051', '0050000a-0001-4000-8000-000000000010', 'denial_code', 'string', false, false, false, false, -1, -1, false, 'CARC reason code (NULL if paid)'),
+('00600034-0001-4000-8000-000000000052', '0050000a-0001-4000-8000-000000000010', 'paid_date', 'date', true, false, false, false, -1, -1, false, 'Payment processed date')
+
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 4d. DATA CONTRACT QUALITY CHECKS (HLS-specific)
+-- ============================================================================
+
+INSERT INTO data_contract_quality_checks (id, object_id, property_id, level, name, description, dimension, business_impact, severity, type, rule, must_be, must_not_be, must_be_gt, must_be_ge, must_be_lt, must_be_le, must_be_between_min, must_be_between_max, query, engine, implementation, schedule, scheduler) VALUES
+-- Patients
+('03000001-0001-4000-8000-000000000001', '00500001-0001-4000-8000-000000000001', '00600001-0001-4000-8000-000000000001', 'property', 'patient_id_unique', 'patient_id (de-identified) must be unique',          'uniqueness',   'regulatory', 'error',   'library', 'unique',     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',   'airflow'),
+('03000002-0001-4000-8000-000000000002', '00500001-0001-4000-8000-000000000001', '00600003-0001-4000-8000-000000000003', 'property', 'gender_values',     'gender must be one of M/F/O/U',                       'conformity',   'regulatory', 'warning', 'library', 'enumValues', 'M,F,O,U', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily', 'airflow'),
+-- Diagnoses
+('03000003-0001-4000-8000-000000000003', '00500003-0001-4000-8000-000000000003', '00600017-0001-4000-8000-000000000023', 'property', 'icd10_format',      'icd10_code should match ICD-10-CM regex',             'conformity',   'regulatory', 'warning', 'library', 'regex',      '^[A-Z][0-9]{2}(\\.[0-9A-Z]{1,4})?$', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',   'airflow'),
+-- Adverse events
+('03000004-0001-4000-8000-000000000004', '00500007-0001-4000-8000-000000000007', '00600012-0001-4000-8000-000000000018', 'property', 'seriousness_values','seriousness must be serious or non_serious',          'conformity',   'regulatory', 'error',   'library', 'enumValues', 'serious,non_serious', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly', 'airflow'),
+('03000005-0001-4000-8000-000000000005', '00500007-0001-4000-8000-000000000007', NULL,                                  'object',   'expedited_15d',     'Expedited reporting freshness — serious AEs reported within 15 calendar days', 'timeliness', 'regulatory', 'error', 'sql', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'SELECT MAX(EXTRACT(epoch FROM (NOW() - onset_date))/86400) FROM safety.adverse_events WHERE seriousness = ''serious''', 'spark', NULL, '0 4 * * *', 'airflow'),
+-- Endpoints
+('03000006-0001-4000-8000-000000000006', '00500006-0001-4000-8000-000000000006', '0060001f-0001-4000-8000-000000000031', 'property', 'endpoint_id_unique','endpoint_id must be unique',                          'uniqueness',   'regulatory', 'error',   'library', 'unique',     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',   'airflow'),
+-- Claims
+('03000007-0001-4000-8000-000000000007', '00500009-0001-4000-8000-000000000009', '0060002e-0001-4000-8000-000000000046', 'property', 'billed_non_neg',    'billed_amount must be >= 0',                          'accuracy',     'operational','error',   'library', 'rangeCheck', NULL, NULL, NULL, '0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',  'airflow'),
+('03000008-0001-4000-8000-000000000008', '00500009-0001-4000-8000-000000000009', '0060002d-0001-4000-8000-000000000045', 'property', 'cpt_format',        'CPT code is 5 alphanumeric characters',               'conformity',   'regulatory', 'warning', 'library', 'regex',      '^[A-Z0-9]{5}$', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily', 'airflow')
 
 ON CONFLICT (id) DO NOTHING;
 
@@ -543,7 +609,63 @@ INSERT INTO assets (id, name, description, asset_type_id, platform, location, do
  '00000006-0001-4000-8000-000000000006',
  '{"catalog": "lakehouse", "schema": "hls_claims", "table_name": "adjudicated", "row_count": 45000000, "format": "delta"}',
  '["curated"]',
- 'active', 'system@demo', NOW(), NOW())
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- ── Column assets for the HLS Tables / Streams above ──
+-- 0f300101 lakehouse.hls.curated.patients
+('0f520101-0001-4000-8000-000000000001', 'patient_id',     'De-identified patient identifier (hash of MRN)',  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.patient_id',     '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["phi", "key", "deidentified"]', 'active', 'system@demo', NOW(), NOW()),
+('0f520102-0001-4000-8000-000000000002', 'date_of_birth',  'Patient date of birth (Safe Harbor shifted)',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.date_of_birth',  '00000001-0001-4000-8000-000000000001', '{"data_type": "DATE",     "nullable": false}',                          '["phi", "deidentified"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520103-0001-4000-8000-000000000003', 'gender',         'Administrative gender (M/F/O/U)',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.gender',         '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+('0f520104-0001-4000-8000-000000000004', 'race_ethnicity', 'OMB race/ethnicity category',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.race_ethnicity', '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": true }',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+('0f520105-0001-4000-8000-000000000005', 'zip_3',          'First 3 digits of ZIP (Safe Harbor)',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.zip_3',          '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": true }',                          '["phi", "deidentified"]',         'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300102 lakehouse.hls.curated.encounters
+('0f520111-0001-4000-8000-000000000011', 'encounter_id',   'Unique encounter identifier',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.encounter_id',  '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["phi", "key"]',                  'active', 'system@demo', NOW(), NOW()),
+('0f520112-0001-4000-8000-000000000012', 'patient_id',     'FK to patients.patient_id',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.patient_id',    '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["phi", "fk"]',                   'active', 'system@demo', NOW(), NOW()),
+('0f520113-0001-4000-8000-000000000013', 'encounter_type', 'inpatient | outpatient | emergency | observation',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.encounter_type','00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+('0f520114-0001-4000-8000-000000000014', 'admit_date',     'Admit/visit date (UTC)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.admit_date',    '00000001-0001-4000-8000-000000000001', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["phi", "partition"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520115-0001-4000-8000-000000000015', 'discharge_date', 'Discharge date (NULL if still admitted)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.discharge_date','00000001-0001-4000-8000-000000000001', '{"data_type": "TIMESTAMP","nullable": true }',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300106 kafka.pharma.faers.case_events (Stream)
+('0f520121-0001-4000-8000-000000000021', 'case_id',        'ICSR case number',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.case_id',         '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["pharmacovigilance", "key"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520122-0001-4000-8000-000000000022', 'product_id',     'Product (substance) identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.product_id',      '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520123-0001-4000-8000-000000000023', 'meddra_pt',      'MedDRA preferred term',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.meddra_pt',       '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520124-0001-4000-8000-000000000024', 'seriousness',    'serious | non_serious',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.seriousness',     '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520125-0001-4000-8000-000000000025', 'received_ts',    'Submission receive timestamp (UTC)',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.received_ts',     '00000003-0001-4000-8000-000000000003', '{"data_type": "TIMESTAMP","nullable": false}',                         '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300108 lakehouse.hls.claims.adjudicated
+('0f520131-0001-4000-8000-000000000031', 'claim_id',       'Unique medical claim identifier',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.claim_id',      '00000006-0001-4000-8000-000000000006', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["claims", "key"]',               'active', 'system@demo', NOW(), NOW()),
+('0f520132-0001-4000-8000-000000000032', 'member_id',      'Insurance plan member identifier',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.member_id',     '00000006-0001-4000-8000-000000000006', '{"data_type": "STRING",  "nullable": false}',                          '["claims", "phi"]',               'active', 'system@demo', NOW(), NOW()),
+('0f520133-0001-4000-8000-000000000033', 'service_date',   'Date of service (partition)',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.service_date',  '00000006-0001-4000-8000-000000000006', '{"data_type": "DATE",    "nullable": false, "partition_key": true}',  '["claims", "partition"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520134-0001-4000-8000-000000000034', 'cpt_code',       'CMS HCPCS / CPT procedure code',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.cpt_code',      '00000006-0001-4000-8000-000000000006', '{"data_type": "STRING",  "nullable": false}',                          '["claims"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520135-0001-4000-8000-000000000035', 'allowed_amount', 'Amount allowed by payer (USD)',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.allowed_amount','00000006-0001-4000-8000-000000000006', '{"data_type": "DECIMAL(18,2)","nullable": false}',                     '["claims", "kpi"]',               'active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15b. hasColumn RELATIONSHIPS (HLS)
+-- ============================================================================
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, properties, created_by, created_at) VALUES
+('0f620101-0001-4000-8000-000000000001', 'Table',  '0f300101-0001-4000-8000-000000000001', 'Column', '0f520101-0001-4000-8000-000000000001', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620102-0001-4000-8000-000000000002', 'Table',  '0f300101-0001-4000-8000-000000000001', 'Column', '0f520102-0001-4000-8000-000000000002', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620103-0001-4000-8000-000000000003', 'Table',  '0f300101-0001-4000-8000-000000000001', 'Column', '0f520103-0001-4000-8000-000000000003', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620104-0001-4000-8000-000000000004', 'Table',  '0f300101-0001-4000-8000-000000000001', 'Column', '0f520104-0001-4000-8000-000000000004', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620105-0001-4000-8000-000000000005', 'Table',  '0f300101-0001-4000-8000-000000000001', 'Column', '0f520105-0001-4000-8000-000000000005', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620111-0001-4000-8000-000000000011', 'Table',  '0f300102-0001-4000-8000-000000000002', 'Column', '0f520111-0001-4000-8000-000000000011', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620112-0001-4000-8000-000000000012', 'Table',  '0f300102-0001-4000-8000-000000000002', 'Column', '0f520112-0001-4000-8000-000000000012', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620113-0001-4000-8000-000000000013', 'Table',  '0f300102-0001-4000-8000-000000000002', 'Column', '0f520113-0001-4000-8000-000000000013', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620114-0001-4000-8000-000000000014', 'Table',  '0f300102-0001-4000-8000-000000000002', 'Column', '0f520114-0001-4000-8000-000000000014', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620115-0001-4000-8000-000000000015', 'Table',  '0f300102-0001-4000-8000-000000000002', 'Column', '0f520115-0001-4000-8000-000000000015', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620121-0001-4000-8000-000000000021', 'Stream', '0f300106-0001-4000-8000-000000000006', 'Column', '0f520121-0001-4000-8000-000000000021', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620122-0001-4000-8000-000000000022', 'Stream', '0f300106-0001-4000-8000-000000000006', 'Column', '0f520122-0001-4000-8000-000000000022', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620123-0001-4000-8000-000000000023', 'Stream', '0f300106-0001-4000-8000-000000000006', 'Column', '0f520123-0001-4000-8000-000000000023', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620124-0001-4000-8000-000000000024', 'Stream', '0f300106-0001-4000-8000-000000000006', 'Column', '0f520124-0001-4000-8000-000000000024', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620125-0001-4000-8000-000000000025', 'Stream', '0f300106-0001-4000-8000-000000000006', 'Column', '0f520125-0001-4000-8000-000000000025', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620131-0001-4000-8000-000000000031', 'Table',  '0f300108-0001-4000-8000-000000000008', 'Column', '0f520131-0001-4000-8000-000000000031', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620132-0001-4000-8000-000000000032', 'Table',  '0f300108-0001-4000-8000-000000000008', 'Column', '0f520132-0001-4000-8000-000000000032', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620133-0001-4000-8000-000000000033', 'Table',  '0f300108-0001-4000-8000-000000000008', 'Column', '0f520133-0001-4000-8000-000000000033', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620134-0001-4000-8000-000000000034', 'Table',  '0f300108-0001-4000-8000-000000000008', 'Column', '0f520134-0001-4000-8000-000000000034', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620135-0001-4000-8000-000000000035', 'Table',  '0f300108-0001-4000-8000-000000000008', 'Column', '0f520135-0001-4000-8000-000000000035', 'hasColumn', NULL, 'system@demo', NOW())
 ON CONFLICT (id) DO NOTHING;
 
 

--- a/src/backend/src/data/demo_data_mfg.sql
+++ b/src/backend/src/data/demo_data_mfg.sql
@@ -162,7 +162,77 @@ INSERT INTO data_contract_schema_properties (id, object_id, name, logical_type, 
 ('0060000f-0003-4000-8000-000000000015', '00500007-0003-4000-8000-000000000007', 'sensor_type', 'string', true, false, false, false, -1, -1, false, 'vibration, temperature, pressure, current'),
 ('00600010-0003-4000-8000-000000000016', '00500007-0003-4000-8000-000000000007', 'reading_value', 'decimal', true, false, false, false, -1, -1, true, 'Sensor reading value in SI units'),
 ('00600011-0003-4000-8000-000000000017', '00500007-0003-4000-8000-000000000007', 'reading_ts', 'timestamp', true, false, false, true, -1, 1, false, 'Reading timestamp (UTC)'),
-('00600012-0003-4000-8000-000000000018', '00500007-0003-4000-8000-000000000007', 'health_score', 'decimal', false, false, false, false, -1, -1, true, 'ML-derived equipment health score (0-100)')
+('00600012-0003-4000-8000-000000000018', '00500007-0003-4000-8000-000000000007', 'health_score', 'decimal', false, false, false, false, -1, -1, true, 'ML-derived equipment health score (0-100)'),
+
+-- machine_states table (00500002 — Production Line)
+('00600013-0003-4000-8000-000000000019', '00500002-0003-4000-8000-000000000002', 'asset_id', 'string', true, false, true, false, 1, -1, true, 'Machine asset tag (composite PK with state_ts)'),
+('00600014-0003-4000-8000-000000000020', '00500002-0003-4000-8000-000000000002', 'state_ts', 'timestamp', true, false, true, true, 2, 1, true, 'State change timestamp (UTC, partition)'),
+('00600015-0003-4000-8000-000000000021', '00500002-0003-4000-8000-000000000002', 'state', 'string', true, false, false, false, -1, -1, true, 'running | idle | down | changeover'),
+('00600016-0003-4000-8000-000000000022', '00500002-0003-4000-8000-000000000002', 'reason_code', 'string', false, false, false, false, -1, -1, false, 'Operator-confirmed downtime reason code'),
+
+-- cycle_times table (00500003)
+('00600017-0003-4000-8000-000000000023', '00500003-0003-4000-8000-000000000003', 'cycle_id', 'string', true, true, true, false, 1, -1, true, 'Unique cycle identifier'),
+('00600018-0003-4000-8000-000000000024', '00500003-0003-4000-8000-000000000003', 'work_order_id', 'string', true, false, false, false, -1, -1, true, 'FK to work_orders.work_order_id'),
+('00600019-0003-4000-8000-000000000025', '00500003-0003-4000-8000-000000000003', 'standard_seconds', 'decimal', true, false, false, false, -1, -1, false, 'Standard cycle time (seconds)'),
+('0060001a-0003-4000-8000-000000000026', '00500003-0003-4000-8000-000000000003', 'actual_seconds', 'decimal', true, false, false, false, -1, -1, true, 'Actual cycle time (seconds)'),
+('0060001b-0003-4000-8000-000000000027', '00500003-0003-4000-8000-000000000003', 'measured_at', 'timestamp', true, false, false, true, -1, 1, false, 'Cycle measurement time'),
+
+-- defects table (00500005 — Quality Inspection)
+('0060001c-0003-4000-8000-000000000028', '00500005-0003-4000-8000-000000000005', 'defect_id', 'string', true, true, true, false, 1, -1, true, 'Unique defect identifier'),
+('0060001d-0003-4000-8000-000000000029', '00500005-0003-4000-8000-000000000005', 'inspection_id', 'string', true, false, false, false, -1, -1, true, 'FK to inspections.inspection_id'),
+('0060001e-0003-4000-8000-000000000030', '00500005-0003-4000-8000-000000000005', 'defect_code', 'string', true, false, false, false, -1, -1, true, 'Standardized defect classification code'),
+('0060001f-0003-4000-8000-000000000031', '00500005-0003-4000-8000-000000000005', 'severity', 'string', true, false, false, false, -1, -1, false, 'minor | major | critical'),
+('00600020-0003-4000-8000-000000000032', '00500005-0003-4000-8000-000000000005', 'disposition', 'string', true, false, false, false, -1, -1, true, 'rework | scrap | use_as_is | return_to_supplier'),
+
+-- spc_data table (00500006)
+('00600021-0003-4000-8000-000000000033', '00500006-0003-4000-8000-000000000006', 'spc_id', 'string', true, true, true, false, 1, -1, true, 'Unique SPC point identifier'),
+('00600022-0003-4000-8000-000000000034', '00500006-0003-4000-8000-000000000006', 'characteristic', 'string', true, false, false, false, -1, -1, true, 'Characteristic under control'),
+('00600023-0003-4000-8000-000000000035', '00500006-0003-4000-8000-000000000006', 'measurement', 'decimal', true, false, false, false, -1, -1, true, 'Measured value'),
+('00600024-0003-4000-8000-000000000036', '00500006-0003-4000-8000-000000000006', 'subgroup_id', 'string', false, false, false, false, -1, -1, false, 'Subgroup grouping for X-bar charts'),
+('00600025-0003-4000-8000-000000000037', '00500006-0003-4000-8000-000000000006', 'measured_ts', 'timestamp', true, false, false, true, -1, 1, false, 'Measurement timestamp'),
+
+-- maintenance_records table (00500008 — Equipment Health)
+('00600026-0003-4000-8000-000000000038', '00500008-0003-4000-8000-000000000008', 'wo_id', 'string', true, true, true, false, 1, -1, true, 'Maintenance work order identifier'),
+('00600027-0003-4000-8000-000000000039', '00500008-0003-4000-8000-000000000008', 'asset_id', 'string', true, false, false, false, -1, -1, true, 'FK to equipment asset'),
+('00600028-0003-4000-8000-000000000040', '00500008-0003-4000-8000-000000000008', 'maintenance_type', 'string', true, false, false, false, -1, -1, false, 'preventive | predictive | corrective'),
+('00600029-0003-4000-8000-000000000041', '00500008-0003-4000-8000-000000000008', 'completed_ts', 'timestamp', false, false, false, false, -1, -1, false, 'Completion timestamp (NULL until done)'),
+('0060002a-0003-4000-8000-000000000042', '00500008-0003-4000-8000-000000000008', 'labor_hours', 'decimal', true, false, false, false, -1, -1, false, 'Labor hours expended'),
+
+-- incidents table (00500009 — EHS)
+('0060002b-0003-4000-8000-000000000043', '00500009-0003-4000-8000-000000000009', 'incident_id', 'string', true, true, true, false, 1, -1, true, 'Unique incident identifier'),
+('0060002c-0003-4000-8000-000000000044', '00500009-0003-4000-8000-000000000009', 'incident_type', 'string', true, false, false, false, -1, -1, true, 'injury | near_miss | environmental | property_damage'),
+('0060002d-0003-4000-8000-000000000045', '00500009-0003-4000-8000-000000000009', 'severity', 'string', true, false, false, false, -1, -1, true, 'Severity per ANSI Z16.1'),
+('0060002e-0003-4000-8000-000000000046', '00500009-0003-4000-8000-000000000009', 'reported_at', 'timestamp', true, false, false, true, -1, 1, false, 'Incident reported timestamp'),
+('0060002f-0003-4000-8000-000000000047', '00500009-0003-4000-8000-000000000009', 'osha_recordable', 'boolean', true, false, false, false, -1, -1, true, 'Whether incident is OSHA-recordable'),
+
+-- environmental_readings table (0050000a)
+('00600030-0003-4000-8000-000000000048', '0050000a-0003-4000-8000-000000000010', 'reading_id', 'string', true, true, true, false, 1, -1, true, 'Unique environmental reading identifier'),
+('00600031-0003-4000-8000-000000000049', '0050000a-0003-4000-8000-000000000010', 'metric_type', 'string', true, false, false, false, -1, -1, true, 'emissions | noise | waste'),
+('00600032-0003-4000-8000-000000000050', '0050000a-0003-4000-8000-000000000010', 'metric_value', 'decimal', true, false, false, false, -1, -1, true, 'Measured value (units depend on metric_type)'),
+('00600033-0003-4000-8000-000000000051', '0050000a-0003-4000-8000-000000000010', 'unit', 'string', true, false, false, false, -1, -1, false, 'Unit of measurement (ppm, dB, kg, ...)'),
+('00600034-0003-4000-8000-000000000052', '0050000a-0003-4000-8000-000000000010', 'measured_at', 'timestamp', true, false, false, true, -1, 1, false, 'Measurement timestamp')
+
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 4d. DATA CONTRACT QUALITY CHECKS (Manufacturing-specific)
+-- ============================================================================
+
+INSERT INTO data_contract_quality_checks (id, object_id, property_id, level, name, description, dimension, business_impact, severity, type, rule, must_be, must_not_be, must_be_gt, must_be_ge, must_be_lt, must_be_le, must_be_between_min, must_be_between_max, query, engine, implementation, schedule, scheduler) VALUES
+-- Work orders
+('03000001-0003-4000-8000-000000000001', '00500001-0003-4000-8000-000000000001', '00600005-0003-4000-8000-000000000005', 'property', 'scrap_non_negative',  'scrap_count must be >= 0',                                       'accuracy',     'operational', 'error',   'library', 'rangeCheck', NULL, NULL, NULL, '0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',  'airflow'),
+('03000002-0003-4000-8000-000000000002', '00500001-0003-4000-8000-000000000001', '00600004-0003-4000-8000-000000000004', 'property', 'qty_non_negative',    'quantity_produced must be >= 0',                                 'accuracy',     'operational', 'error',   'library', 'rangeCheck', NULL, NULL, NULL, '0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',  'airflow'),
+-- Machine states
+('03000003-0003-4000-8000-000000000003', '00500002-0003-4000-8000-000000000002', '00600015-0003-4000-8000-000000000021', 'property', 'state_values',        'state must be one of running/idle/down/changeover',              'conformity',   'operational', 'error',   'library', 'enumValues', 'running,idle,down,changeover', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',  'airflow'),
+-- Inspections
+('03000004-0003-4000-8000-000000000004', '00500004-0003-4000-8000-000000000004', '0060000d-0003-4000-8000-000000000013', 'property', 'disposition_values',  'disposition must be one of accept/reject/rework/use_as_is',      'conformity',   'regulatory',  'error',   'library', 'enumValues', 'accept,reject,rework,use_as_is', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',  'airflow'),
+('03000005-0003-4000-8000-000000000005', '00500004-0003-4000-8000-000000000004', NULL,                                  'object',   'spec_consistency',    'upper_spec must be > lower_spec for all rows',                   'consistency',  'operational', 'warning', 'sql',     NULL,         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'SELECT MIN(upper_spec - lower_spec) > 0 FROM quality.inspection_results', 'spark', NULL, '@daily', 'airflow'),
+-- Sensor readings
+('03000006-0003-4000-8000-000000000006', '00500007-0003-4000-8000-000000000007', '00600012-0003-4000-8000-000000000018', 'property', 'health_score_range',  'health_score must be in [0, 100]',                               'accuracy',     'operational', 'warning', 'library', 'rangeCheck', NULL, NULL, NULL, NULL, NULL, NULL, '0', '100', NULL, NULL, NULL, '@hourly',  'airflow'),
+('03000007-0003-4000-8000-000000000007', '00500007-0003-4000-8000-000000000007', NULL,                                  'object',   'freshness_15min',     'sensor_readings must have rows within last 15 minutes',          'timeliness',   'operational', 'error',   'sql',     NULL,         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'SELECT MAX(reading_ts) > NOW() - INTERVAL ''15 minutes'' FROM maintenance.sensor_timeseries', 'spark', NULL, '*/5 * * * *', 'airflow'),
+-- EHS incidents
+('03000008-0003-4000-8000-000000000008', '00500009-0003-4000-8000-000000000009', '0060002c-0003-4000-8000-000000000044', 'property', 'incident_type_values', 'incident_type must be one of injury/near_miss/environmental/property_damage', 'conformity', 'regulatory', 'error', 'library', 'enumValues', 'injury,near_miss,environmental,property_damage', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly', 'airflow')
 
 ON CONFLICT (id) DO NOTHING;
 
@@ -523,7 +593,69 @@ INSERT INTO assets (id, name, description, asset_type_id, platform, location, do
  '00000004-0003-4000-8000-000000000004',
  '{"catalog": "lakehouse", "schema": "mfg_ehs", "table_name": "incidents", "row_count": 1280, "format": "delta"}',
  '["osha-recordable", "iso-14001"]',
- 'active', 'system@demo', NOW(), NOW())
+ 'active', 'system@demo', NOW(), NOW()),
+
+-- ── Column assets for the MFG Tables / Streams above ──
+-- 0f300104 kafka.factory.telemetry.equipment (Stream)
+('0f520104-0003-4000-8000-000000000004', 'asset_id',     'Equipment asset tag',                              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.asset_id',     '00000003-0003-4000-8000-000000000003', '{"data_type": "STRING",   "nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520105-0003-4000-8000-000000000005', 'sensor_type',  'vibration | temperature | pressure | current',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.sensor_type',  '00000003-0003-4000-8000-000000000003', '{"data_type": "STRING",   "nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520106-0003-4000-8000-000000000006', 'reading_value','Sensor value (SI units)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.reading_value','00000003-0003-4000-8000-000000000003', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                     '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520107-0003-4000-8000-000000000007', 'reading_ts',   'Reading timestamp (UTC)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.reading_ts',   '00000003-0003-4000-8000-000000000003', '{"data_type": "TIMESTAMP","nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520108-0003-4000-8000-000000000008', 'health_score', 'ML-derived equipment health score (0-100)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.health_score', '00000003-0003-4000-8000-000000000003', '{"data_type": "DECIMAL(6,2)","nullable": true }',                       '["telemetry", "ml"]',     'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300105 lakehouse.mfg.wip.work_orders
+('0f520111-0003-4000-8000-000000000011', 'work_order_id',     'MES work order number',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.work_order_id',     '00000001-0003-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["mes", "key"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520112-0003-4000-8000-000000000012', 'part_number',       'Manufactured part number',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.part_number',       '00000001-0003-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["mes"]',                 'active', 'system@demo', NOW(), NOW()),
+('0f520113-0003-4000-8000-000000000013', 'quantity_planned',  'Planned quantity',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.quantity_planned',  '00000001-0003-4000-8000-000000000001', '{"data_type": "INT",      "nullable": false}',                          '["mes"]',                 'active', 'system@demo', NOW(), NOW()),
+('0f520114-0003-4000-8000-000000000014', 'quantity_produced', 'Good quantity produced',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.quantity_produced', '00000001-0003-4000-8000-000000000001', '{"data_type": "INT",      "nullable": false}',                          '["mes", "kpi"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520115-0003-4000-8000-000000000015', 'scrap_count',       'Scrap count',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.scrap_count',       '00000001-0003-4000-8000-000000000001', '{"data_type": "INT",      "nullable": false}',                          '["mes", "kpi"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520116-0003-4000-8000-000000000016', 'start_time',        'Work order start timestamp (partition)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.start_time',        '00000001-0003-4000-8000-000000000001', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["mes", "partition"]',    'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300106 lakehouse.mfg.quality.defect_log
+('0f520121-0003-4000-8000-000000000021', 'defect_id',     'Unique defect identifier',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.defect_id',     '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["quality", "key"]',       'active', 'system@demo', NOW(), NOW()),
+('0f520122-0003-4000-8000-000000000022', 'inspection_id', 'FK to inspections.inspection_id',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.inspection_id', '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false}',                          '["quality", "fk"]',        'active', 'system@demo', NOW(), NOW()),
+('0f520123-0003-4000-8000-000000000023', 'defect_code',   'Standardized defect classification',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.defect_code',   '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false}',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
+('0f520124-0003-4000-8000-000000000024', 'severity',      'minor | major | critical',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.severity',      '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false}',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
+('0f520125-0003-4000-8000-000000000025', 'capa_ref',      'CAPA reference number (NULL if none)',            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.capa_ref',      '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": true }',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300108 lakehouse.mfg.ehs.incidents
+('0f520131-0003-4000-8000-000000000031', 'incident_id',     'Unique incident identifier',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.incident_id',     '00000004-0003-4000-8000-000000000004', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["ehs", "key"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520132-0003-4000-8000-000000000032', 'incident_type',   'injury | near_miss | environmental | property_damage', (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.incident_type',   '00000004-0003-4000-8000-000000000004', '{"data_type": "STRING",   "nullable": false}',                          '["ehs", "osha-recordable"]','active', 'system@demo', NOW(), NOW()),
+('0f520133-0003-4000-8000-000000000033', 'severity',        'Severity per ANSI Z16.1',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.severity',        '00000004-0003-4000-8000-000000000004', '{"data_type": "STRING",   "nullable": false}',                          '["ehs"]',                  'active', 'system@demo', NOW(), NOW()),
+('0f520134-0003-4000-8000-000000000034', 'reported_at',     'Incident reported timestamp (partition)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.reported_at',     '00000004-0003-4000-8000-000000000004', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["ehs", "partition"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520135-0003-4000-8000-000000000035', 'osha_recordable', 'Whether incident is OSHA-recordable',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.osha_recordable', '00000004-0003-4000-8000-000000000004', '{"data_type": "BOOLEAN",  "nullable": false}',                          '["ehs", "osha-recordable"]','active', 'system@demo', NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 15b. hasColumn RELATIONSHIPS (MFG)
+-- ============================================================================
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, properties, created_by, created_at) VALUES
+-- 0f300104 stream → 5 columns
+('0f620104-0003-4000-8000-000000000004', 'Stream', '0f300104-0003-4000-8000-000000000004', 'Column', '0f520104-0003-4000-8000-000000000004', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620105-0003-4000-8000-000000000005', 'Stream', '0f300104-0003-4000-8000-000000000004', 'Column', '0f520105-0003-4000-8000-000000000005', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620106-0003-4000-8000-000000000006', 'Stream', '0f300104-0003-4000-8000-000000000004', 'Column', '0f520106-0003-4000-8000-000000000006', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620107-0003-4000-8000-000000000007', 'Stream', '0f300104-0003-4000-8000-000000000004', 'Column', '0f520107-0003-4000-8000-000000000007', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620108-0003-4000-8000-000000000008', 'Stream', '0f300104-0003-4000-8000-000000000004', 'Column', '0f520108-0003-4000-8000-000000000008', 'hasColumn', NULL, 'system@demo', NOW()),
+-- 0f300105 work_orders → 6 columns
+('0f620111-0003-4000-8000-000000000011', 'Table',  '0f300105-0003-4000-8000-000000000005', 'Column', '0f520111-0003-4000-8000-000000000011', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620112-0003-4000-8000-000000000012', 'Table',  '0f300105-0003-4000-8000-000000000005', 'Column', '0f520112-0003-4000-8000-000000000012', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620113-0003-4000-8000-000000000013', 'Table',  '0f300105-0003-4000-8000-000000000005', 'Column', '0f520113-0003-4000-8000-000000000013', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620114-0003-4000-8000-000000000014', 'Table',  '0f300105-0003-4000-8000-000000000005', 'Column', '0f520114-0003-4000-8000-000000000014', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620115-0003-4000-8000-000000000015', 'Table',  '0f300105-0003-4000-8000-000000000005', 'Column', '0f520115-0003-4000-8000-000000000015', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620116-0003-4000-8000-000000000016', 'Table',  '0f300105-0003-4000-8000-000000000005', 'Column', '0f520116-0003-4000-8000-000000000016', 'hasColumn', NULL, 'system@demo', NOW()),
+-- 0f300106 defect_log → 5 columns
+('0f620121-0003-4000-8000-000000000021', 'Table',  '0f300106-0003-4000-8000-000000000006', 'Column', '0f520121-0003-4000-8000-000000000021', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620122-0003-4000-8000-000000000022', 'Table',  '0f300106-0003-4000-8000-000000000006', 'Column', '0f520122-0003-4000-8000-000000000022', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620123-0003-4000-8000-000000000023', 'Table',  '0f300106-0003-4000-8000-000000000006', 'Column', '0f520123-0003-4000-8000-000000000023', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620124-0003-4000-8000-000000000024', 'Table',  '0f300106-0003-4000-8000-000000000006', 'Column', '0f520124-0003-4000-8000-000000000024', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620125-0003-4000-8000-000000000025', 'Table',  '0f300106-0003-4000-8000-000000000006', 'Column', '0f520125-0003-4000-8000-000000000025', 'hasColumn', NULL, 'system@demo', NOW()),
+-- 0f300108 ehs.incidents → 5 columns
+('0f620131-0003-4000-8000-000000000031', 'Table',  '0f300108-0003-4000-8000-000000000008', 'Column', '0f520131-0003-4000-8000-000000000031', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620132-0003-4000-8000-000000000032', 'Table',  '0f300108-0003-4000-8000-000000000008', 'Column', '0f520132-0003-4000-8000-000000000032', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620133-0003-4000-8000-000000000033', 'Table',  '0f300108-0003-4000-8000-000000000008', 'Column', '0f520133-0003-4000-8000-000000000033', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620134-0003-4000-8000-000000000034', 'Table',  '0f300108-0003-4000-8000-000000000008', 'Column', '0f520134-0003-4000-8000-000000000034', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620135-0003-4000-8000-000000000035', 'Table',  '0f300108-0003-4000-8000-000000000008', 'Column', '0f520135-0003-4000-8000-000000000035', 'hasColumn', NULL, 'system@demo', NOW())
 ON CONFLICT (id) DO NOTHING;
 
 

--- a/src/backend/src/data/demo_data_retail.sql
+++ b/src/backend/src/data/demo_data_retail.sql
@@ -234,15 +234,29 @@ ON CONFLICT (id) DO NOTHING;
 -- ============================================================================
 
 INSERT INTO data_contract_schema_objects (id, contract_id, name, logical_type, physical_name, description) VALUES
--- Customer Data Contract schemas
+-- Customer Data Contract schemas (00400001 — active)
 ('00500001-0000-4000-8000-000000000001', '00400001-0000-4000-8000-000000000001', 'customers', 'object', 'crm.customers_v2', 'Core customer master table'),
 ('00500002-0000-4000-8000-000000000002', '00400001-0000-4000-8000-000000000001', 'customer_preferences', 'object', 'crm.customer_preferences', 'Customer preference settings'),
 ('00500003-0000-4000-8000-000000000003', '00400001-0000-4000-8000-000000000001', 'customer_addresses', 'object', 'crm.customer_addresses', 'Customer address information'),
 
--- IoT Device Data Contract schemas
+-- IoT Device Data Contract schemas (00400004 — active)
 ('00500004-0000-4000-8000-000000000004', '00400004-0000-4000-8000-000000000004', 'devices', 'object', 'iot.devices_master', 'IoT device registry'),
 ('00500005-0000-4000-8000-000000000005', '00400004-0000-4000-8000-000000000004', 'device_telemetry', 'object', 'iot.device_telemetry_live', 'Device telemetry readings'),
-('00500006-0000-4000-8000-000000000006', '00400004-0000-4000-8000-000000000004', 'device_events', 'object', 'iot.device_events_log', 'Device events and alerts')
+('00500006-0000-4000-8000-000000000006', '00400004-0000-4000-8000-000000000004', 'device_events', 'object', 'iot.device_events_log', 'Device events and alerts'),
+
+-- Product Catalog Contract schemas (00400002 — deprecated)
+('00500007-0000-4000-8000-000000000007', '00400002-0000-4000-8000-000000000002', 'products', 'object', 'catalog.products', 'Product master table'),
+('00500008-0000-4000-8000-000000000008', '00400002-0000-4000-8000-000000000002', 'product_categories', 'object', 'catalog.product_categories', 'Product category hierarchy'),
+
+-- IoT Sensor Data Contract schemas (00400005 — retired)
+('00500009-0000-4000-8000-000000000009', '00400005-0000-4000-8000-000000000005', 'sensor_readings', 'object', 'manufacturing.sensor_readings', 'Real-time sensor readings (legacy schema)'),
+
+-- Financial Transactions Contract schemas (00400006 — draft)
+('0050000a-0000-4000-8000-000000000010', '00400006-0000-4000-8000-000000000006', 'transactions', 'object', 'finance.daily_transactions', 'Daily financial transactions'),
+('0050000b-0000-4000-8000-000000000011', '00400006-0000-4000-8000-000000000006', 'currencies', 'object', 'finance.currency_rates', 'FX rates lookup table'),
+
+-- Inventory Management Contract schemas (00400007 — deprecated)
+('0050000c-0000-4000-8000-000000000012', '00400007-0000-4000-8000-000000000007', 'inventory_levels', 'object', 'supply_chain.inventory_current', 'Current stock levels per warehouse')
 
 ON CONFLICT (id) DO NOTHING;
 
@@ -269,7 +283,111 @@ INSERT INTO data_contract_schema_properties (id, object_id, name, logical_type, 
 ('0060000c-0000-4000-8000-000000000012', '00500004-0000-4000-8000-000000000004', 'device_serial', 'string', true, true, false, false, -1, -1, false, 'Manufacturer serial number'),
 ('0060000d-0000-4000-8000-000000000013', '00500004-0000-4000-8000-000000000004', 'device_type', 'string', true, false, false, false, -1, -1, false, 'Device type (sensor, actuator, gateway, controller)'),
 ('0060000e-0000-4000-8000-000000000014', '00500004-0000-4000-8000-000000000004', 'status', 'string', true, false, false, false, -1, -1, false, 'Device status (active, inactive, maintenance, faulty, decommissioned)'),
-('0060000f-0000-4000-8000-000000000015', '00500004-0000-4000-8000-000000000004', 'is_online', 'boolean', true, false, false, false, -1, -1, false, 'Current connectivity status')
+('0060000f-0000-4000-8000-000000000015', '00500004-0000-4000-8000-000000000004', 'is_online', 'boolean', true, false, false, false, -1, -1, false, 'Current connectivity status'),
+
+-- customer_preferences table properties (00500002)
+('00600010-0000-4000-8000-000000000016', '00500002-0000-4000-8000-000000000002', 'customer_id', 'string', true, false, true, false, 1, -1, true, 'FK to customers.customer_id'),
+('00600011-0000-4000-8000-000000000017', '00500002-0000-4000-8000-000000000002', 'preference_key', 'string', true, false, true, false, 2, -1, false, 'Preference name (channel, language, marketing_optin)'),
+('00600012-0000-4000-8000-000000000018', '00500002-0000-4000-8000-000000000002', 'preference_value', 'string', true, false, false, false, -1, -1, false, 'Preference value as string'),
+('00600013-0000-4000-8000-000000000019', '00500002-0000-4000-8000-000000000002', 'updated_at', 'timestamp', true, false, false, false, -1, -1, false, 'Last update timestamp (UTC)'),
+
+-- customer_addresses table properties (00500003)
+('00600014-0000-4000-8000-000000000020', '00500003-0000-4000-8000-000000000003', 'address_id', 'string', true, true, true, false, 1, -1, true, 'Unique address identifier (UUID)'),
+('00600015-0000-4000-8000-000000000021', '00500003-0000-4000-8000-000000000003', 'customer_id', 'string', true, false, false, false, -1, -1, true, 'FK to customers.customer_id'),
+('00600016-0000-4000-8000-000000000022', '00500003-0000-4000-8000-000000000003', 'address_type', 'string', true, false, false, false, -1, -1, false, 'billing | shipping | residential'),
+('00600017-0000-4000-8000-000000000023', '00500003-0000-4000-8000-000000000003', 'street', 'string', true, false, false, false, -1, -1, false, 'Street address line 1'),
+('00600018-0000-4000-8000-000000000024', '00500003-0000-4000-8000-000000000003', 'city', 'string', true, false, false, false, -1, -1, false, 'City'),
+('00600019-0000-4000-8000-000000000025', '00500003-0000-4000-8000-000000000003', 'postal_code', 'string', true, false, false, false, -1, -1, false, 'Postal/ZIP code'),
+('0060001a-0000-4000-8000-000000000026', '00500003-0000-4000-8000-000000000003', 'country_code', 'string', true, false, false, false, -1, -1, false, 'ISO 3166-1 alpha-2'),
+
+-- device_telemetry table properties (00500005)
+('0060001b-0000-4000-8000-000000000027', '00500005-0000-4000-8000-000000000005', 'reading_id', 'string', true, true, true, false, 1, -1, true, 'Unique reading identifier'),
+('0060001c-0000-4000-8000-000000000028', '00500005-0000-4000-8000-000000000005', 'device_id', 'string', true, false, false, false, -1, -1, true, 'FK to devices.device_id'),
+('0060001d-0000-4000-8000-000000000029', '00500005-0000-4000-8000-000000000005', 'metric_name', 'string', true, false, false, false, -1, -1, false, 'temperature | humidity | pressure | vibration'),
+('0060001e-0000-4000-8000-000000000030', '00500005-0000-4000-8000-000000000005', 'metric_value', 'decimal', true, false, false, false, -1, -1, true, 'Numeric measurement value'),
+('0060001f-0000-4000-8000-000000000031', '00500005-0000-4000-8000-000000000005', 'unit', 'string', true, false, false, false, -1, -1, false, 'Unit of measurement (C, %, kPa, mm/s)'),
+('00600020-0000-4000-8000-000000000032', '00500005-0000-4000-8000-000000000005', 'reading_timestamp', 'timestamp', true, false, false, true, -1, 1, true, 'Reading timestamp (UTC, partition key)'),
+
+-- device_events table properties (00500006)
+('00600021-0000-4000-8000-000000000033', '00500006-0000-4000-8000-000000000006', 'event_id', 'string', true, true, true, false, 1, -1, true, 'Unique event identifier'),
+('00600022-0000-4000-8000-000000000034', '00500006-0000-4000-8000-000000000006', 'device_id', 'string', true, false, false, false, -1, -1, true, 'FK to devices.device_id'),
+('00600023-0000-4000-8000-000000000035', '00500006-0000-4000-8000-000000000006', 'event_type', 'string', true, false, false, false, -1, -1, false, 'alert | error | info | maintenance'),
+('00600024-0000-4000-8000-000000000036', '00500006-0000-4000-8000-000000000006', 'severity', 'string', true, false, false, false, -1, -1, false, 'critical | high | medium | low'),
+('00600025-0000-4000-8000-000000000037', '00500006-0000-4000-8000-000000000006', 'message', 'string', false, false, false, false, -1, -1, false, 'Event payload message'),
+('00600026-0000-4000-8000-000000000038', '00500006-0000-4000-8000-000000000006', 'event_timestamp', 'timestamp', true, false, false, true, -1, 1, false, 'Event timestamp (UTC)'),
+
+-- products table properties (00500007 — Product Catalog Contract, deprecated)
+('00600027-0000-4000-8000-000000000039', '00500007-0000-4000-8000-000000000007', 'sku', 'string', true, true, true, false, 1, -1, true, 'Stock keeping unit (unique)'),
+('00600028-0000-4000-8000-000000000040', '00500007-0000-4000-8000-000000000007', 'product_name', 'string', true, false, false, false, -1, -1, false, 'Display name'),
+('00600029-0000-4000-8000-000000000041', '00500007-0000-4000-8000-000000000007', 'category_id', 'string', true, false, false, false, -1, -1, false, 'FK to product_categories'),
+('0060002a-0000-4000-8000-000000000042', '00500007-0000-4000-8000-000000000007', 'list_price', 'decimal', true, false, false, false, -1, -1, true, 'List price in store currency'),
+('0060002b-0000-4000-8000-000000000043', '00500007-0000-4000-8000-000000000007', 'is_active', 'boolean', true, false, false, false, -1, -1, false, 'Active in catalog'),
+
+-- product_categories table properties (00500008)
+('0060002c-0000-4000-8000-000000000044', '00500008-0000-4000-8000-000000000008', 'category_id', 'string', true, true, true, false, 1, -1, true, 'Unique category identifier'),
+('0060002d-0000-4000-8000-000000000045', '00500008-0000-4000-8000-000000000008', 'name', 'string', true, false, false, false, -1, -1, false, 'Category display name'),
+('0060002e-0000-4000-8000-000000000046', '00500008-0000-4000-8000-000000000008', 'parent_category_id', 'string', false, false, false, false, -1, -1, false, 'Parent (for hierarchy)'),
+
+-- sensor_readings table properties (00500009 — IoT Sensor Contract, retired)
+('0060002f-0000-4000-8000-000000000047', '00500009-0000-4000-8000-000000000009', 'sensor_id', 'string', true, false, true, false, 1, -1, true, 'Sensor identifier (composite PK with timestamp)'),
+('00600030-0000-4000-8000-000000000048', '00500009-0000-4000-8000-000000000009', 'reading_timestamp', 'timestamp', true, false, true, true, 2, 1, true, 'Reading time (composite PK, partition)'),
+('00600031-0000-4000-8000-000000000049', '00500009-0000-4000-8000-000000000009', 'value', 'decimal', true, false, false, false, -1, -1, false, 'Measured value'),
+('00600032-0000-4000-8000-000000000050', '00500009-0000-4000-8000-000000000009', 'unit', 'string', true, false, false, false, -1, -1, false, 'Unit of measurement'),
+
+-- transactions table properties (0050000a — Financial Transactions, draft)
+('00600033-0000-4000-8000-000000000051', '0050000a-0000-4000-8000-000000000010', 'transaction_id', 'string', true, true, true, false, 1, -1, true, 'Unique transaction identifier'),
+('00600034-0000-4000-8000-000000000052', '0050000a-0000-4000-8000-000000000010', 'account_id', 'string', true, false, false, false, -1, -1, true, 'Internal account identifier'),
+('00600035-0000-4000-8000-000000000053', '0050000a-0000-4000-8000-000000000010', 'amount', 'decimal', true, false, false, false, -1, -1, true, 'Transaction amount (>= 0)'),
+('00600036-0000-4000-8000-000000000054', '0050000a-0000-4000-8000-000000000010', 'currency', 'string', true, false, false, false, -1, -1, true, 'ISO-4217 currency code'),
+('00600037-0000-4000-8000-000000000055', '0050000a-0000-4000-8000-000000000010', 'transaction_date', 'date', true, false, false, true, -1, 1, false, 'Transaction date (partition key)'),
+('00600038-0000-4000-8000-000000000056', '0050000a-0000-4000-8000-000000000010', 'transaction_type', 'string', true, false, false, false, -1, -1, false, 'debit | credit | transfer'),
+
+-- currencies table properties (0050000b)
+('00600039-0000-4000-8000-000000000057', '0050000b-0000-4000-8000-000000000011', 'currency_code', 'string', true, false, true, false, 1, -1, true, 'ISO-4217 code (composite PK with date)'),
+('0060003a-0000-4000-8000-000000000058', '0050000b-0000-4000-8000-000000000011', 'rate_date', 'date', true, false, true, false, 2, -1, true, 'Rate effective date (composite PK)'),
+('0060003b-0000-4000-8000-000000000059', '0050000b-0000-4000-8000-000000000011', 'rate_to_usd', 'decimal', true, false, false, false, -1, -1, false, 'FX rate to USD on the given date'),
+
+-- inventory_levels table properties (0050000c — Inventory Management Contract, deprecated)
+('0060003c-0000-4000-8000-000000000060', '0050000c-0000-4000-8000-000000000012', 'product_id', 'string', true, false, true, false, 1, -1, true, 'FK to products.sku (composite PK with warehouse_id)'),
+('0060003d-0000-4000-8000-000000000061', '0050000c-0000-4000-8000-000000000012', 'warehouse_id', 'string', true, false, true, false, 2, -1, true, 'Warehouse identifier (composite PK)'),
+('0060003e-0000-4000-8000-000000000062', '0050000c-0000-4000-8000-000000000012', 'quantity_on_hand', 'integer', true, false, false, false, -1, -1, true, 'Current quantity on hand (>= 0)'),
+('0060003f-0000-4000-8000-000000000063', '0050000c-0000-4000-8000-000000000012', 'reorder_point', 'integer', false, false, false, false, -1, -1, false, 'Quantity at which reorder is triggered'),
+('00600040-0000-4000-8000-000000000064', '0050000c-0000-4000-8000-000000000012', 'last_updated', 'timestamp', true, false, false, false, -1, -1, false, 'Last stock update timestamp (UTC)')
+
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
+-- 4d. DATA CONTRACT QUALITY CHECKS (type=030)
+-- ============================================================================
+-- ODCS quality checks — object-level (table) and property-level (column).
+-- Demonstrates not-null, uniqueness, range, regex, and freshness rules.
+
+INSERT INTO data_contract_quality_checks (id, object_id, property_id, level, name, description, dimension, business_impact, severity, type, rule, must_be, must_not_be, must_be_gt, must_be_ge, must_be_lt, must_be_le, must_be_between_min, must_be_between_max, query, engine, implementation, schedule, scheduler) VALUES
+-- Customers table — 00500001
+('03000001-0000-4000-8000-000000000001', '00500001-0000-4000-8000-000000000001', NULL,                                       'object',   'row_count_min',         'Customers table should have at least 1,000 rows in production', 'completeness', 'operational', 'error',   'library', 'rowCountCheck',     NULL, NULL, NULL, '1000', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '0 6 * * *',    'airflow'),
+('03000002-0000-4000-8000-000000000002', '00500001-0000-4000-8000-000000000001', '00600001-0000-4000-8000-000000000001',     'property', 'customer_id_not_null',  'customer_id must never be NULL',                                'completeness', 'regulatory',  'error',   'library', 'notNull',           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',      'airflow'),
+('03000003-0000-4000-8000-000000000003', '00500001-0000-4000-8000-000000000001', '00600001-0000-4000-8000-000000000001',     'property', 'customer_id_unique',    'customer_id must be unique across the customers table',         'uniqueness',   'regulatory',  'error',   'library', 'unique',            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',       'airflow'),
+('03000004-0000-4000-8000-000000000004', '00500001-0000-4000-8000-000000000001', '00600002-0000-4000-8000-000000000002',     'property', 'email_format',          'email must match RFC-5322 simple regex',                        'conformity',   'operational', 'warning', 'library', 'regex',             '^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily', 'airflow'),
+('03000005-0000-4000-8000-000000000005', '00500001-0000-4000-8000-000000000001', '00600007-0000-4000-8000-000000000007',     'property', 'country_code_iso',      'country_code must be ISO 3166-1 alpha-2 (length=2 uppercase)',  'conformity',   'operational', 'warning', 'library', 'regex',             '^[A-Z]{2}$', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',       'airflow'),
+('03000006-0000-4000-8000-000000000006', '00500001-0000-4000-8000-000000000001', '00600009-0000-4000-8000-000000000009',     'property', 'account_status_values', 'account_status must be one of the allowed values',              'conformity',   'operational', 'error',   'library', 'enumValues',        'active,suspended,closed,pending_verification', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly', 'airflow'),
+
+-- Devices table — 00500004
+('03000007-0000-4000-8000-000000000007', '00500004-0000-4000-8000-000000000004', '0060000b-0000-4000-8000-000000000011',     'property', 'device_id_not_null',    'device_id must never be NULL',                                  'completeness', 'operational', 'error',   'library', 'notNull',           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',      'airflow'),
+('03000008-0000-4000-8000-000000000008', '00500004-0000-4000-8000-000000000004', '0060000b-0000-4000-8000-000000000011',     'property', 'device_id_unique',      'device_id must be globally unique',                             'uniqueness',   'operational', 'error',   'library', 'unique',            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',       'airflow'),
+('03000009-0000-4000-8000-000000000009', '00500004-0000-4000-8000-000000000004', '0060000e-0000-4000-8000-000000000014',     'property', 'status_values',         'status must be one of the allowed device states',               'conformity',   'operational', 'warning', 'library', 'enumValues',        'active,inactive,maintenance,faulty,decommissioned', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly', 'airflow'),
+
+-- Device telemetry table — 00500005
+('0300000a-0000-4000-8000-000000000010', '00500005-0000-4000-8000-000000000005', '0060001e-0000-4000-8000-000000000030',     'property', 'metric_value_range',    'metric_value must be in plausible sensor range [-100, 10000]',  'accuracy',     'operational', 'warning', 'library', 'rangeCheck',        NULL, NULL, NULL, NULL, NULL, NULL, '-100', '10000', NULL, NULL, NULL, '@hourly', 'airflow'),
+('0300000b-0000-4000-8000-000000000011', '00500005-0000-4000-8000-000000000005', NULL,                                       'object',   'freshness_30min',       'Telemetry table must have rows within last 30 minutes',         'timeliness',   'operational', 'error',   'sql',     NULL,                NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'SELECT MAX(reading_timestamp) > NOW() - INTERVAL ''30 minutes'' FROM iot.device_telemetry_live', 'spark', NULL, '*/15 * * * *', 'airflow'),
+
+-- Financial Transactions (draft contract — 0050000a)
+('0300000c-0000-4000-8000-000000000012', '0050000a-0000-4000-8000-000000000010', '00600035-0000-4000-8000-000000000053',     'property', 'amount_non_negative',   'amount must be >= 0',                                           'accuracy',     'regulatory',  'error',   'library', 'rangeCheck',        NULL, NULL, NULL, '0',  NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@hourly',      'airflow'),
+('0300000d-0000-4000-8000-000000000013', '0050000a-0000-4000-8000-000000000010', '00600036-0000-4000-8000-000000000054',     'property', 'currency_iso4217',      'currency must be ISO-4217 (length=3 uppercase)',                'conformity',   'regulatory',  'error',   'library', 'regex',             '^[A-Z]{3}$', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',       'airflow'),
+('0300000e-0000-4000-8000-000000000014', '0050000a-0000-4000-8000-000000000010', '00600033-0000-4000-8000-000000000051',     'property', 'transaction_id_unique', 'transaction_id must be unique',                                 'uniqueness',   'regulatory',  'error',   'library', 'unique',            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',       'airflow'),
+
+-- Inventory levels (deprecated contract — 0050000c)
+('0300000f-0000-4000-8000-000000000015', '0050000c-0000-4000-8000-000000000012', '0060003e-0000-4000-8000-000000000062',     'property', 'qty_non_negative',      'quantity_on_hand must be an integer >= 0',                      'accuracy',     'operational', 'error',   'library', 'rangeCheck',        NULL, NULL, NULL, '0',  NULL, NULL, NULL, NULL, NULL, NULL, NULL, '@daily',       'airflow')
 
 ON CONFLICT (id) DO NOTHING;
 
@@ -1417,6 +1535,234 @@ ON CONFLICT DO NOTHING;
 
 
 -- ============================================================================
+-- 15e. COLUMN ASSETS + hasColumn RELATIONSHIPS (Tables/Views in 15b)
+-- ============================================================================
+-- Every Table and View in section 15b gets a representative set of Column
+-- assets and hasColumn relationships so the asset detail UI can render its
+-- "columns" tree. Locations include the parent path + ".<column>" to satisfy
+-- the assets uq_asset_identity (name, asset_type_id, platform, location)
+-- unique constraint.
+
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
+-- 02500001 Customers Master Table — prod_catalog.crm.customers_master
+('0f520001-0000-4000-8000-000000000001', 'customer_id',       'Unique customer identifier (UUID)',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.customer_id',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["pii", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520002-0000-4000-8000-000000000002', 'email',             'Customer email address',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.email',             NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520003-0000-4000-8000-000000000003', 'first_name',        'Customer first name',                                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.first_name',        NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520004-0000-4000-8000-000000000004', 'last_name',         'Customer last name',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.last_name',         NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520005-0000-4000-8000-000000000005', 'registration_date', 'Account registration timestamp (UTC)',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.registration_date', NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+
+-- 02500002 Snowflake Customers Replica — ANALYTICS_DB.CRM.CUSTOMERS_MASTER
+('0f520011-0000-4000-8000-000000000011', 'CUSTOMER_ID',       'Unique customer identifier (UUID, Snowflake replica)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.CUSTOMER_ID',       NULL, '{"data_type": "VARCHAR",   "nullable": false, "is_primary_key": true}',  '["pii", "key", "snowflake"]', 'active', 'system@demo', NOW(), NOW()),
+('0f520012-0000-4000-8000-000000000012', 'EMAIL',             'Customer email (Snowflake replica)',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.EMAIL',             NULL, '{"data_type": "VARCHAR",   "nullable": false}',                          '["pii", "snowflake"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520013-0000-4000-8000-000000000013', 'FIRST_NAME',        'Customer first name (Snowflake replica)',                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.FIRST_NAME',        NULL, '{"data_type": "VARCHAR",   "nullable": false}',                          '["pii", "snowflake"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520014-0000-4000-8000-000000000014', 'REGISTRATION_DATE', 'Registration date (Snowflake replica)',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.REGISTRATION_DATE', NULL, '{"data_type": "TIMESTAMP_NTZ", "nullable": false}',                      '["snowflake"]',          'active', 'system@demo', NOW(), NOW()),
+
+-- 02500003 Dev Customers Table — dev_catalog.crm.customers_master
+('0f520021-0000-4000-8000-000000000021', 'customer_id',       'Unique customer identifier (dev)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.customer_id',        NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["dev", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520022-0000-4000-8000-000000000022', 'email',             'Customer email (dev)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.email',              NULL, '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520023-0000-4000-8000-000000000023', 'first_name',        'Customer first name (dev)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.first_name',         NULL, '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520024-0000-4000-8000-000000000024', 'last_name',         'Customer last name (dev)',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.last_name',          NULL, '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
+
+-- 02500004 Customer Preferences View — prod_catalog.crm.v_customer_preferences
+('0f520031-0000-4000-8000-000000000031', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.customer_id', NULL, '{"data_type": "STRING",    "nullable": false}',                          '["fk"]',                 'active', 'system@demo', NOW(), NOW()),
+('0f520032-0000-4000-8000-000000000032', 'preference_key',    'Preference name (channel, language, marketing_optin)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.preference_key',NULL,'{"data_type": "STRING",    "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+('0f520033-0000-4000-8000-000000000033', 'preference_value',  'Preference value (string)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.preference_value',NULL,'{"data_type": "STRING", "nullable": false}',                            '[]',                     'active', 'system@demo', NOW(), NOW()),
+('0f520034-0000-4000-8000-000000000034', 'updated_at',        'Last update timestamp (UTC)',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.updated_at',  NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+
+-- 02500005 Device Registry — iot_catalog.devices.device_registry
+('0f520041-0000-4000-8000-000000000041', 'device_id',         'Unique device identifier',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_id',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520042-0000-4000-8000-000000000042', 'device_serial',     'Manufacturer serial number',                                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_serial',   NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520043-0000-4000-8000-000000000043', 'device_type',       'sensor | actuator | gateway | controller',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_type',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520044-0000-4000-8000-000000000044', 'status',            'Operational state',                                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.status',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
+
+-- 02500006 Dev Device Registry — iot_dev.devices.device_registry
+('0f520051-0000-4000-8000-000000000051', 'device_id',         'Unique device identifier (dev)',                               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_id',           NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520052-0000-4000-8000-000000000052', 'device_serial',     'Manufacturer serial number (dev)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_serial',       NULL, '{"data_type": "STRING",    "nullable": true }',                          '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520053-0000-4000-8000-000000000053', 'device_type',       'Device type (dev)',                                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_type',         NULL, '{"data_type": "STRING",    "nullable": true }',                          '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
+
+-- 02500007 Device Readings — iot_catalog.telemetry.device_readings
+('0f520061-0000-4000-8000-000000000061', 'reading_id',        'Unique reading identifier',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.reading_id',    NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "telemetry", "key"]','active','system@demo', NOW(), NOW()),
+('0f520062-0000-4000-8000-000000000062', 'device_id',         'FK to devices.device_id',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.device_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "telemetry", "fk"]','active', 'system@demo', NOW(), NOW()),
+('0f520063-0000-4000-8000-000000000063', 'metric_value',      'Numeric measurement value',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.metric_value',  NULL, '{"data_type": "DECIMAL(10,4)", "nullable": false}',                      '["iot", "telemetry"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520064-0000-4000-8000-000000000064', 'reading_timestamp', 'Reading timestamp (UTC)',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.reading_timestamp', NULL, '{"data_type": "TIMESTAMP", "nullable": false, "partition_key": true}', '["iot", "telemetry", "partition"]', 'active', 'system@demo', NOW(), NOW()),
+
+-- 02500008 Daily Transactions — finance_dev.transactions.daily_transactions
+('0f520071-0000-4000-8000-000000000071', 'transaction_id',    'Unique transaction identifier',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.transaction_id', NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["finance", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520072-0000-4000-8000-000000000072', 'account_id',        'Internal account identifier',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.account_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance", "fk"]',      'active', 'system@demo', NOW(), NOW()),
+('0f520073-0000-4000-8000-000000000073', 'amount',            'Transaction amount (>= 0)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.amount',         NULL, '{"data_type": "DECIMAL(18,2)", "nullable": false}',                      '["finance", "amount"]',  'active', 'system@demo', NOW(), NOW()),
+('0f520074-0000-4000-8000-000000000074', 'currency',          'ISO-4217 currency code',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.currency',       NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520075-0000-4000-8000-000000000075', 'transaction_date',  'Transaction date (partition key)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.transaction_date',NULL,'{"data_type": "DATE",      "nullable": false, "partition_key": true}',   '["finance", "partition"]','active','system@demo', NOW(), NOW()),
+
+-- 02500009 Current Inventory (deprecated) — analytics_catalog.supply_chain.inventory_current
+('0f520081-0000-4000-8000-000000000081', 'product_id',        'FK to products.sku',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.product_id',   NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["supply-chain", "deprecated", "key"]', 'deprecated', 'system@demo', NOW(), NOW()),
+('0f520082-0000-4000-8000-000000000082', 'warehouse_id',      'Warehouse identifier',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.warehouse_id', NULL, '{"data_type": "STRING",    "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
+('0f520083-0000-4000-8000-000000000083', 'quantity_on_hand',  'Current quantity on hand (>= 0)',                              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.quantity_on_hand', NULL,'{"data_type": "INT",     "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
+('0f520084-0000-4000-8000-000000000084', 'last_updated',      'Last stock update timestamp (UTC)',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.last_updated', NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
+
+-- 0250000a Customer Addresses — prod_catalog.crm.customer_addresses
+('0f520091-0000-4000-8000-000000000091', 'address_id',        'Unique address identifier (UUID)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.address_id',      NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["pii", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520092-0000-4000-8000-000000000092', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.customer_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii", "fk"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520093-0000-4000-8000-000000000093', 'street',            'Street address line 1',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.street',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520094-0000-4000-8000-000000000094', 'city',              'City',                                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.city',            NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520095-0000-4000-8000-000000000095', 'country_code',      'ISO 3166-1 alpha-2',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.country_code',    NULL, '{"data_type": "STRING",    "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+
+-- 0250000b Countries Lookup — prod_catalog.reference.countries
+('0f5200a1-0000-4000-8000-0000000000a1', 'country_code',      'ISO 3166-1 alpha-2 (PK)',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.country_code',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["reference", "key"]',   'active', 'system@demo', NOW(), NOW()),
+('0f5200a2-0000-4000-8000-0000000000a2', 'country_name',      'Official country name',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.country_name',       NULL, '{"data_type": "STRING",    "nullable": false}',                          '["reference"]',          'active', 'system@demo', NOW(), NOW()),
+('0f5200a3-0000-4000-8000-0000000000a3', 'continent',         'Continent (Europe, Asia, ...)',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.continent',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["reference"]',          'active', 'system@demo', NOW(), NOW()),
+
+-- 0250000c Device Types — iot_catalog.devices.device_types
+('0f5200b1-0000-4000-8000-0000000000b1', 'type_id',           'Type identifier (PK)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.type_id',            NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "reference", "key"]','active','system@demo', NOW(), NOW()),
+('0f5200b2-0000-4000-8000-0000000000b2', 'type_name',         'Display name',                                                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.type_name',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
+('0f5200b3-0000-4000-8000-0000000000b3', 'manufacturer',      'Hardware manufacturer',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.manufacturer',       NULL, '{"data_type": "STRING",    "nullable": true }',                          '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
+('0f5200b4-0000-4000-8000-0000000000b4', 'capabilities',      'JSON-encoded device capabilities map',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.capabilities',       NULL, '{"data_type": "STRING",    "nullable": true,  "format": "json"}',        '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
+
+-- 0250000d Raw Device Data (staging) — iot_staging.devices.device_raw
+('0f5200c1-0000-4000-8000-0000000000c1', 'event_id',          'Raw event ID (UUID)',                                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.event_id',             NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "staging", "key"]','active', 'system@demo', NOW(), NOW()),
+('0f5200c2-0000-4000-8000-0000000000c2', 'device_id',         'Originating device',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.device_id',            NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "staging", "fk"]','active','system@demo', NOW(), NOW()),
+('0f5200c3-0000-4000-8000-0000000000c3', 'payload',           'Raw event payload (JSON)',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.payload',              NULL, '{"data_type": "STRING",    "nullable": false, "format": "json"}',        '["iot", "staging"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200c4-0000-4000-8000-0000000000c4', 'ingest_timestamp',  'Bronze ingest timestamp (UTC)',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.ingest_timestamp',     NULL, '{"data_type": "TIMESTAMP", "nullable": false, "partition_key": true}',   '["iot", "staging"]',     'active', 'system@demo', NOW(), NOW()),
+
+-- 02500010 Customer 360 Dashboard view — prod_catalog.crm.customer_360_dashboard
+('0f5200d1-0000-4000-8000-0000000000d1', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.customer_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["customer-360"]',       'active', 'system@demo', NOW(), NOW()),
+('0f5200d2-0000-4000-8000-0000000000d2', 'ltv',               'Lifetime value (USD)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.ltv',             NULL, '{"data_type": "DECIMAL(18,2)", "nullable": true }',                      '["customer-360", "kpi"]','active', 'system@demo', NOW(), NOW()),
+('0f5200d3-0000-4000-8000-0000000000d3', 'total_orders',      'Cumulative order count',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.total_orders',    NULL, '{"data_type": "INT",       "nullable": false}',                          '["customer-360", "kpi"]','active', 'system@demo', NOW(), NOW()),
+('0f5200d4-0000-4000-8000-0000000000d4', 'last_purchase_date','Most recent purchase date',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.last_purchase_date',NULL,'{"data_type": "DATE",     "nullable": true }',                          '["customer-360"]',       'active', 'system@demo', NOW(), NOW()),
+
+-- 02500011 PowerBI Customer Dataset — workspace://Workspaces/Analytics/Customer_Analysis
+('0f5200e1-0000-4000-8000-0000000000e1', 'CustomerKey',       'Surrogate key into the customer dimension',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.CustomerKey',  NULL, '{"data_type": "Int64",    "nullable": false, "is_primary_key": true}',   '["powerbi", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200e2-0000-4000-8000-0000000000e2', 'Email',             'Email (PowerBI semantic model)',                               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.Email',        NULL, '{"data_type": "Text",     "nullable": false}',                           '["powerbi", "pii"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200e3-0000-4000-8000-0000000000e3', 'Segment',           'Marketing segment label',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.Segment',      NULL, '{"data_type": "Text",     "nullable": false}',                           '["powerbi"]',            'active', 'system@demo', NOW(), NOW()),
+('0f5200e4-0000-4000-8000-0000000000e4', 'LifetimeValue',     'Computed CLV measure (USD)',                                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.LifetimeValue',NULL, '{"data_type": "Decimal",  "nullable": true,  "is_measure": true}',       '["powerbi", "kpi"]',     'active', 'system@demo', NOW(), NOW()),
+
+-- 0f300006 Invoices — lakehouse.finance.curated.invoices
+('0f5200f1-0000-4000-8000-0000000000f1', 'invoice_id',        'Unique invoice identifier',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.invoice_id',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["finance", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200f2-0000-4000-8000-0000000000f2', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.customer_id',      NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance", "fk"]',      'active', 'system@demo', NOW(), NOW()),
+('0f5200f3-0000-4000-8000-0000000000f3', 'total_amount',      'Invoice total in invoice currency (>= 0)',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.total_amount',     NULL, '{"data_type": "DECIMAL(18,2)", "nullable": false}',                      '["finance", "amount"]',  'active', 'system@demo', NOW(), NOW()),
+('0f5200f4-0000-4000-8000-0000000000f4', 'currency',          'ISO-4217 currency code',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.currency',         NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance"]',            'active', 'system@demo', NOW(), NOW()),
+('0f5200f5-0000-4000-8000-0000000000f5', 'invoice_date',      'Invoice issue date (partition key)',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.invoice_date',     NULL, '{"data_type": "DATE",      "nullable": false, "partition_key": true}',   '["finance", "partition"]','active','system@demo', NOW(), NOW()),
+
+-- 0f30000b iot-device-telemetry — Kafka topic schema (advertised contract)
+('0f520201-0000-4000-8000-000000000201', 'device_id',         'FK to devices.device_id',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.device_id',         NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming", "fk"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520202-0000-4000-8000-000000000202', 'metric_name',       'Metric name (temperature, humidity, ...)',                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.metric_name',       NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520203-0000-4000-8000-000000000203', 'metric_value',      'Numeric measurement value',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.metric_value',      NULL, '{"data_type": "DECIMAL(10,4)", "nullable": false}',                      '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520204-0000-4000-8000-000000000204', 'unit',              'Unit of measurement (C, %, kPa, ...)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.unit',              NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520205-0000-4000-8000-000000000205', 'reading_timestamp', 'Reading timestamp (UTC)',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.reading_timestamp', NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW())
+
+ON CONFLICT (id) DO NOTHING;
+
+
+-- hasColumn relationships for all the Tables/Views above
+INSERT INTO entity_relationships (id, source_type, source_id, target_type, target_id, relationship_type, properties, created_by, created_at) VALUES
+-- 02500001 Customers Master Table → 5 columns
+('0f620001-0000-4000-8000-000000000001', 'Table', '02500001-0000-4000-8000-000000000001', 'Column', '0f520001-0000-4000-8000-000000000001', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620002-0000-4000-8000-000000000002', 'Table', '02500001-0000-4000-8000-000000000001', 'Column', '0f520002-0000-4000-8000-000000000002', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620003-0000-4000-8000-000000000003', 'Table', '02500001-0000-4000-8000-000000000001', 'Column', '0f520003-0000-4000-8000-000000000003', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620004-0000-4000-8000-000000000004', 'Table', '02500001-0000-4000-8000-000000000001', 'Column', '0f520004-0000-4000-8000-000000000004', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620005-0000-4000-8000-000000000005', 'Table', '02500001-0000-4000-8000-000000000001', 'Column', '0f520005-0000-4000-8000-000000000005', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500002 Snowflake Customers Replica → 4 columns
+('0f620011-0000-4000-8000-000000000011', 'Table', '02500002-0000-4000-8000-000000000002', 'Column', '0f520011-0000-4000-8000-000000000011', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620012-0000-4000-8000-000000000012', 'Table', '02500002-0000-4000-8000-000000000002', 'Column', '0f520012-0000-4000-8000-000000000012', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620013-0000-4000-8000-000000000013', 'Table', '02500002-0000-4000-8000-000000000002', 'Column', '0f520013-0000-4000-8000-000000000013', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620014-0000-4000-8000-000000000014', 'Table', '02500002-0000-4000-8000-000000000002', 'Column', '0f520014-0000-4000-8000-000000000014', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500003 Dev Customers Table → 4 columns
+('0f620021-0000-4000-8000-000000000021', 'Table', '02500003-0000-4000-8000-000000000003', 'Column', '0f520021-0000-4000-8000-000000000021', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620022-0000-4000-8000-000000000022', 'Table', '02500003-0000-4000-8000-000000000003', 'Column', '0f520022-0000-4000-8000-000000000022', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620023-0000-4000-8000-000000000023', 'Table', '02500003-0000-4000-8000-000000000003', 'Column', '0f520023-0000-4000-8000-000000000023', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620024-0000-4000-8000-000000000024', 'Table', '02500003-0000-4000-8000-000000000003', 'Column', '0f520024-0000-4000-8000-000000000024', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500004 Customer Preferences View → 4 columns
+('0f620031-0000-4000-8000-000000000031', 'View',  '02500004-0000-4000-8000-000000000004', 'Column', '0f520031-0000-4000-8000-000000000031', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620032-0000-4000-8000-000000000032', 'View',  '02500004-0000-4000-8000-000000000004', 'Column', '0f520032-0000-4000-8000-000000000032', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620033-0000-4000-8000-000000000033', 'View',  '02500004-0000-4000-8000-000000000004', 'Column', '0f520033-0000-4000-8000-000000000033', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620034-0000-4000-8000-000000000034', 'View',  '02500004-0000-4000-8000-000000000004', 'Column', '0f520034-0000-4000-8000-000000000034', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500005 Device Registry → 4 columns
+('0f620041-0000-4000-8000-000000000041', 'Table', '02500005-0000-4000-8000-000000000005', 'Column', '0f520041-0000-4000-8000-000000000041', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620042-0000-4000-8000-000000000042', 'Table', '02500005-0000-4000-8000-000000000005', 'Column', '0f520042-0000-4000-8000-000000000042', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620043-0000-4000-8000-000000000043', 'Table', '02500005-0000-4000-8000-000000000005', 'Column', '0f520043-0000-4000-8000-000000000043', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620044-0000-4000-8000-000000000044', 'Table', '02500005-0000-4000-8000-000000000005', 'Column', '0f520044-0000-4000-8000-000000000044', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500006 Dev Device Registry → 3 columns
+('0f620051-0000-4000-8000-000000000051', 'Table', '02500006-0000-4000-8000-000000000006', 'Column', '0f520051-0000-4000-8000-000000000051', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620052-0000-4000-8000-000000000052', 'Table', '02500006-0000-4000-8000-000000000006', 'Column', '0f520052-0000-4000-8000-000000000052', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620053-0000-4000-8000-000000000053', 'Table', '02500006-0000-4000-8000-000000000006', 'Column', '0f520053-0000-4000-8000-000000000053', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500007 Device Readings → 4 columns
+('0f620061-0000-4000-8000-000000000061', 'Table', '02500007-0000-4000-8000-000000000007', 'Column', '0f520061-0000-4000-8000-000000000061', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620062-0000-4000-8000-000000000062', 'Table', '02500007-0000-4000-8000-000000000007', 'Column', '0f520062-0000-4000-8000-000000000062', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620063-0000-4000-8000-000000000063', 'Table', '02500007-0000-4000-8000-000000000007', 'Column', '0f520063-0000-4000-8000-000000000063', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620064-0000-4000-8000-000000000064', 'Table', '02500007-0000-4000-8000-000000000007', 'Column', '0f520064-0000-4000-8000-000000000064', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500008 Daily Transactions → 5 columns
+('0f620071-0000-4000-8000-000000000071', 'Table', '02500008-0000-4000-8000-000000000008', 'Column', '0f520071-0000-4000-8000-000000000071', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620072-0000-4000-8000-000000000072', 'Table', '02500008-0000-4000-8000-000000000008', 'Column', '0f520072-0000-4000-8000-000000000072', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620073-0000-4000-8000-000000000073', 'Table', '02500008-0000-4000-8000-000000000008', 'Column', '0f520073-0000-4000-8000-000000000073', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620074-0000-4000-8000-000000000074', 'Table', '02500008-0000-4000-8000-000000000008', 'Column', '0f520074-0000-4000-8000-000000000074', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620075-0000-4000-8000-000000000075', 'Table', '02500008-0000-4000-8000-000000000008', 'Column', '0f520075-0000-4000-8000-000000000075', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500009 Current Inventory (deprecated) → 4 columns
+('0f620081-0000-4000-8000-000000000081', 'Table', '02500009-0000-4000-8000-000000000009', 'Column', '0f520081-0000-4000-8000-000000000081', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620082-0000-4000-8000-000000000082', 'Table', '02500009-0000-4000-8000-000000000009', 'Column', '0f520082-0000-4000-8000-000000000082', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620083-0000-4000-8000-000000000083', 'Table', '02500009-0000-4000-8000-000000000009', 'Column', '0f520083-0000-4000-8000-000000000083', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620084-0000-4000-8000-000000000084', 'Table', '02500009-0000-4000-8000-000000000009', 'Column', '0f520084-0000-4000-8000-000000000084', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 0250000a Customer Addresses → 5 columns
+('0f620091-0000-4000-8000-000000000091', 'Table', '0250000a-0000-4000-8000-000000000010', 'Column', '0f520091-0000-4000-8000-000000000091', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620092-0000-4000-8000-000000000092', 'Table', '0250000a-0000-4000-8000-000000000010', 'Column', '0f520092-0000-4000-8000-000000000092', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620093-0000-4000-8000-000000000093', 'Table', '0250000a-0000-4000-8000-000000000010', 'Column', '0f520093-0000-4000-8000-000000000093', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620094-0000-4000-8000-000000000094', 'Table', '0250000a-0000-4000-8000-000000000010', 'Column', '0f520094-0000-4000-8000-000000000094', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f620095-0000-4000-8000-000000000095', 'Table', '0250000a-0000-4000-8000-000000000010', 'Column', '0f520095-0000-4000-8000-000000000095', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 0250000b Countries Lookup → 3 columns
+('0f6200a1-0000-4000-8000-0000000000a1', 'Table', '0250000b-0000-4000-8000-000000000011', 'Column', '0f5200a1-0000-4000-8000-0000000000a1', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200a2-0000-4000-8000-0000000000a2', 'Table', '0250000b-0000-4000-8000-000000000011', 'Column', '0f5200a2-0000-4000-8000-0000000000a2', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200a3-0000-4000-8000-0000000000a3', 'Table', '0250000b-0000-4000-8000-000000000011', 'Column', '0f5200a3-0000-4000-8000-0000000000a3', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 0250000c Device Types → 4 columns
+('0f6200b1-0000-4000-8000-0000000000b1', 'Table', '0250000c-0000-4000-8000-000000000012', 'Column', '0f5200b1-0000-4000-8000-0000000000b1', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200b2-0000-4000-8000-0000000000b2', 'Table', '0250000c-0000-4000-8000-000000000012', 'Column', '0f5200b2-0000-4000-8000-0000000000b2', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200b3-0000-4000-8000-0000000000b3', 'Table', '0250000c-0000-4000-8000-000000000012', 'Column', '0f5200b3-0000-4000-8000-0000000000b3', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200b4-0000-4000-8000-0000000000b4', 'Table', '0250000c-0000-4000-8000-000000000012', 'Column', '0f5200b4-0000-4000-8000-0000000000b4', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 0250000d Raw Device Data → 4 columns
+('0f6200c1-0000-4000-8000-0000000000c1', 'Table', '0250000d-0000-4000-8000-000000000013', 'Column', '0f5200c1-0000-4000-8000-0000000000c1', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200c2-0000-4000-8000-0000000000c2', 'Table', '0250000d-0000-4000-8000-000000000013', 'Column', '0f5200c2-0000-4000-8000-0000000000c2', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200c3-0000-4000-8000-0000000000c3', 'Table', '0250000d-0000-4000-8000-000000000013', 'Column', '0f5200c3-0000-4000-8000-0000000000c3', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200c4-0000-4000-8000-0000000000c4', 'Table', '0250000d-0000-4000-8000-000000000013', 'Column', '0f5200c4-0000-4000-8000-0000000000c4', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500010 Customer 360 Dashboard view → 4 columns
+('0f6200d1-0000-4000-8000-0000000000d1', 'View',  '02500010-0000-4000-8000-000000000016', 'Column', '0f5200d1-0000-4000-8000-0000000000d1', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200d2-0000-4000-8000-0000000000d2', 'View',  '02500010-0000-4000-8000-000000000016', 'Column', '0f5200d2-0000-4000-8000-0000000000d2', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200d3-0000-4000-8000-0000000000d3', 'View',  '02500010-0000-4000-8000-000000000016', 'Column', '0f5200d3-0000-4000-8000-0000000000d3', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200d4-0000-4000-8000-0000000000d4', 'View',  '02500010-0000-4000-8000-000000000016', 'Column', '0f5200d4-0000-4000-8000-0000000000d4', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 02500011 PowerBI Customer Dataset → 4 columns
+('0f6200e1-0000-4000-8000-0000000000e1', 'View',  '02500011-0000-4000-8000-000000000017', 'Column', '0f5200e1-0000-4000-8000-0000000000e1', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200e2-0000-4000-8000-0000000000e2', 'View',  '02500011-0000-4000-8000-000000000017', 'Column', '0f5200e2-0000-4000-8000-0000000000e2', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200e3-0000-4000-8000-0000000000e3', 'View',  '02500011-0000-4000-8000-000000000017', 'Column', '0f5200e3-0000-4000-8000-0000000000e3', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200e4-0000-4000-8000-0000000000e4', 'View',  '02500011-0000-4000-8000-000000000017', 'Column', '0f5200e4-0000-4000-8000-0000000000e4', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 0f300006 Invoices → 5 columns
+('0f6200f1-0000-4000-8000-0000000000f1', 'Table', '0f300006-0000-4000-8000-000000000006', 'Column', '0f5200f1-0000-4000-8000-0000000000f1', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200f2-0000-4000-8000-0000000000f2', 'Table', '0f300006-0000-4000-8000-000000000006', 'Column', '0f5200f2-0000-4000-8000-0000000000f2', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200f3-0000-4000-8000-0000000000f3', 'Table', '0f300006-0000-4000-8000-000000000006', 'Column', '0f5200f3-0000-4000-8000-0000000000f3', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200f4-0000-4000-8000-0000000000f4', 'Table', '0f300006-0000-4000-8000-000000000006', 'Column', '0f5200f4-0000-4000-8000-0000000000f4', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200f5-0000-4000-8000-0000000000f5', 'Table', '0f300006-0000-4000-8000-000000000006', 'Column', '0f5200f5-0000-4000-8000-0000000000f5', 'hasColumn', NULL, 'system@demo', NOW()),
+
+-- 0f30000b iot-device-telemetry (Stream — Kafka topic) → 5 columns
+('0f6200b1-0000-4000-8000-0000000000b9', 'Stream', '0f30000b-0000-4000-8000-000000000011', 'Column', '0f520201-0000-4000-8000-000000000201', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200b2-0000-4000-8000-0000000000ba', 'Stream', '0f30000b-0000-4000-8000-000000000011', 'Column', '0f520202-0000-4000-8000-000000000202', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200b3-0000-4000-8000-0000000000bb', 'Stream', '0f30000b-0000-4000-8000-000000000011', 'Column', '0f520203-0000-4000-8000-000000000203', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200b4-0000-4000-8000-0000000000bc', 'Stream', '0f30000b-0000-4000-8000-000000000011', 'Column', '0f520204-0000-4000-8000-000000000204', 'hasColumn', NULL, 'system@demo', NOW()),
+('0f6200b5-0000-4000-8000-0000000000bd', 'Stream', '0f30000b-0000-4000-8000-000000000011', 'Column', '0f520205-0000-4000-8000-000000000205', 'hasColumn', NULL, 'system@demo', NOW())
+
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================================
 -- 15d. DATASET SUBSCRIPTIONS → ENTITY SUBSCRIPTIONS
 -- ============================================================================
 
@@ -2154,14 +2500,10 @@ INSERT INTO assets (id, name, description, asset_type_id, platform, location, do
  'active', 'system@demo', NOW(), NOW()),
 
 -- Tables (Customer)
-('0f300005-0000-4000-8000-000000000005',
- 'lakehouse.customer.curated.customer360',
- 'Unified customer profile combining CRM, web, and transaction data.',
- COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.customer.curated.customer360',
- '00000007-0000-4000-8000-000000000007',
- '{"catalog": "lakehouse", "schema": "customer_curated", "table_name": "customer360", "row_count": 850000, "format": "delta"}',
- '["curated", "pii", "customer"]',
- 'active', 'system@demo', NOW(), NOW()),
+-- NOTE: A customer360 / customer master Table previously lived here as 0f300005.
+-- It was deduplicated into 02500001 ("Customers Master Table") in section 15b
+-- since both represented the same business asset. All relationships and
+-- ownership rows that pointed at 0f300005 have been rewired to 02500001.
 
 -- Tables (Finance)
 ('0f300006-0000-4000-8000-000000000006',
@@ -2232,15 +2574,10 @@ INSERT INTO assets (id, name, description, asset_type_id, platform, location, do
  '["ml", "forecasting", "production"]',
  'active', 'system@demo', NOW(), NOW()),
 
--- Deprecated asset
-('0f30000d-0000-4000-8000-000000000013',
- 'legacy.sales.raw.transactions_v1',
- 'Deprecated raw sales table from legacy ETL pipeline. Replaced by POS Transaction Stream.',
- COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'legacy.sales.raw.transactions_v1',
- '00000003-0000-4000-8000-000000000003',
- '{"catalog": "legacy", "schema": "sales_raw", "table_name": "transactions_v1", "row_count": 0, "format": "delta"}',
- '["deprecated", "legacy"]',
- 'deprecated', 'system@demo', NOW() - INTERVAL '180 days', NOW() - INTERVAL '30 days'),
+-- NOTE: A legacy/deprecated stub Table (0f30000d "legacy.sales.raw.transactions_v1")
+-- previously lived here, only used to demo a "replacedBy" relationship. Removed
+-- during dedup — the deprecated/active state demo is already covered by 02500009
+-- ("Current Inventory", status='deprecated') in section 15b.
 
 -- Column assets for pos_transactions table (0f300003)
 ('0f500001-0000-4000-8000-000000000001',
@@ -2577,7 +2914,7 @@ INSERT INTO entity_relationships (id, source_type, source_id, target_type, targe
 -- Tables belong to Databricks Lakehouse system
 ('0f400001-0000-4000-8000-000000000001', 'Table', '0f300003-0000-4000-8000-000000000003', 'System', '0f300001-0000-4000-8000-000000000001', 'belongsToSystem', NULL, 'system@demo', NOW()),
 ('0f400002-0000-4000-8000-000000000002', 'Table', '0f300004-0000-4000-8000-000000000004', 'System', '0f300001-0000-4000-8000-000000000001', 'belongsToSystem', NULL, 'system@demo', NOW()),
-('0f400003-0000-4000-8000-000000000003', 'Table', '0f300005-0000-4000-8000-000000000005', 'System', '0f300001-0000-4000-8000-000000000001', 'belongsToSystem', NULL, 'system@demo', NOW()),
+('0f400003-0000-4000-8000-000000000003', 'Table', '02500001-0000-4000-8000-000000000001', 'System', '0f300001-0000-4000-8000-000000000001', 'belongsToSystem', NULL, 'system@demo', NOW()),
 ('0f400004-0000-4000-8000-000000000004', 'Table', '0f300006-0000-4000-8000-000000000006', 'System', '0f300001-0000-4000-8000-000000000001', 'belongsToSystem', NULL, 'system@demo', NOW()),
 
 -- Dashboards belong to Power BI system
@@ -2586,7 +2923,7 @@ INSERT INTO entity_relationships (id, source_type, source_id, target_type, targe
 
 -- Dashboard consumes table data (business lineage)
 ('0f400007-0000-4000-8000-000000000007', 'Dashboard', '0f300007-0000-4000-8000-000000000007', 'Table', '0f300003-0000-4000-8000-000000000003', 'consumesFrom', '{"lineage_type": "business"}', 'system@demo', NOW()),
-('0f400008-0000-4000-8000-000000000008', 'Dashboard', '0f300008-0000-4000-8000-000000000008', 'Table', '0f300005-0000-4000-8000-000000000005', 'consumesFrom', '{"lineage_type": "business"}', 'system@demo', NOW()),
+('0f400008-0000-4000-8000-000000000008', 'Dashboard', '0f300008-0000-4000-8000-000000000008', 'Table', '02500001-0000-4000-8000-000000000001', 'consumesFrom', '{"lineage_type": "business"}', 'system@demo', NOW()),
 
 -- ML model consumes table
 ('0f400009-0000-4000-8000-000000000009', 'MLModel', '0f30000c-0000-4000-8000-000000000012', 'Table', '0f300003-0000-4000-8000-000000000003', 'consumesFrom', '{"purpose": "training"}', 'system@demo', NOW()),
@@ -2595,8 +2932,10 @@ INSERT INTO entity_relationships (id, source_type, source_id, target_type, targe
 -- Stream feeds into table
 ('0f40000b-0000-4000-8000-000000000011', 'Stream', '0f30000b-0000-4000-8000-000000000011', 'Table', '0f300003-0000-4000-8000-000000000003', 'producesTo', '{"processing": "streaming_ingest"}', 'system@demo', NOW()),
 
--- Deprecated table replaced by new one
-('0f40000c-0000-4000-8000-000000000012', 'Table', '0f30000d-0000-4000-8000-000000000013', 'Table', '0f300003-0000-4000-8000-000000000003', 'replacedBy', '{"reason": "legacy migration"}', 'system@demo', NOW()),
+-- Deprecated table replaced by new one — demonstrates the "replacedBy" pattern.
+-- 02500009 ("Current Inventory", status=deprecated, analytics_catalog.supply_chain.inventory_current)
+-- has been superseded by the curated 0f300004 ("lakehouse.retail.curated.inventory_levels").
+('0f40000c-0000-4000-8000-000000000012', 'Table', '02500009-0000-4000-8000-000000000009', 'Table', '0f300004-0000-4000-8000-000000000004', 'replacedBy', '{"reason": "Migrated from analytics_catalog supply chain table to curated retail inventory_levels"}', 'system@demo', NOW()),
 
 -- DataProducts deployed on systems
 ('0f40000d-0000-4000-8000-000000000013', 'DataProduct', '00700001-0000-4000-8000-000000000001', 'System', '0f300001-0000-4000-8000-000000000001', 'deployedOnSystem', NULL, 'system@demo', NOW()),
@@ -2703,7 +3042,7 @@ INSERT INTO entity_relationships (id, source_type, source_id, target_type, targe
 -- Policy attachments (migrated from policy_attachments table to entity_relationships)
 -- Customer PII Policy → Customer domain, customer360 table, customer search API
 ('0f500001-0000-4000-8000-000000000051', 'Policy', '0f100001-0000-4000-8000-000000000001', 'DataDomain', '00000007-0000-4000-8000-000000000007', 'appliesTo', '{"notes": "Applies to all assets in the Customer domain"}', 'system@demo', NOW()),
-('0f500002-0000-4000-8000-000000000052', 'Table', '0f300005-0000-4000-8000-000000000005', 'Policy', '0f100001-0000-4000-8000-000000000001', 'attachedPolicy', '{"notes": "PII masking required for email, phone columns"}', 'system@demo', NOW()),
+('0f500002-0000-4000-8000-000000000052', 'Table', '02500001-0000-4000-8000-000000000001', 'Policy', '0f100001-0000-4000-8000-000000000001', 'attachedPolicy', '{"notes": "PII masking required for email, phone columns"}', 'system@demo', NOW()),
 ('0f500003-0000-4000-8000-000000000053', 'APIEndpoint', '0f300009-0000-4000-8000-000000000009', 'Policy', '0f100001-0000-4000-8000-000000000001', 'attachedPolicy', '{"notes": "API must enforce PII filtering"}', 'system@demo', NOW()),
 -- Employee Data Access Policy → HR domain
 ('0f500004-0000-4000-8000-000000000054', 'Policy', '0f100002-0000-4000-8000-000000000002', 'DataDomain', '00000009-0000-4000-8000-000000000009', 'appliesTo', NULL, 'system@demo', NOW()),
@@ -2756,8 +3095,8 @@ INSERT INTO business_owners (id, object_type, object_id, user_email, user_name, 
 ('0f60000d-0000-4000-8000-000000000013', 'asset', '0f100007-0000-4000-8000-000000000007', 'alice.chen@example.com',   'Alice Chen',   '0f00000a-0000-4000-8000-000000000010', true,  NOW() - INTERVAL '75 days',  NULL, NULL, 'system@demo', NOW(), NOW()),
 
 -- Asset owners
-('0f60000e-0000-4000-8000-000000000014', 'asset', '0f300005-0000-4000-8000-000000000005', 'alice.chen@example.com',    'Alice Chen',    '0f000001-0000-4000-8000-000000000001', true,  NOW() - INTERVAL '60 days',  NULL, NULL, 'system@demo', NOW(), NOW()),
-('0f60000f-0000-4000-8000-000000000015', 'asset', '0f300005-0000-4000-8000-000000000005', 'frank.lee@example.com',     'Frank Lee',     '0f000005-0000-4000-8000-000000000005', true,  NOW() - INTERVAL '60 days',  NULL, NULL, 'system@demo', NOW(), NOW()),
+('0f60000e-0000-4000-8000-000000000014', 'asset', '02500001-0000-4000-8000-000000000001', 'alice.chen@example.com',    'Alice Chen',    '0f000001-0000-4000-8000-000000000001', true,  NOW() - INTERVAL '60 days',  NULL, NULL, 'system@demo', NOW(), NOW()),
+('0f60000f-0000-4000-8000-000000000015', 'asset', '02500001-0000-4000-8000-000000000001', 'frank.lee@example.com',     'Frank Lee',     '0f000005-0000-4000-8000-000000000005', true,  NOW() - INTERVAL '60 days',  NULL, NULL, 'system@demo', NOW(), NOW()),
 ('0f600010-0000-4000-8000-000000000016', 'asset', '0f300006-0000-4000-8000-000000000006', 'bob.martinez@example.com',  'Bob Martinez',  '0f000001-0000-4000-8000-000000000001', true,  NOW() - INTERVAL '45 days',  NULL, NULL, 'system@demo', NOW(), NOW()),
 ('0f600011-0000-4000-8000-000000000017', 'asset', '0f300007-0000-4000-8000-000000000007', 'hank.analyst@example.com',  'Hank Analyst',  '0f000008-0000-4000-8000-000000000008', true,  NOW() - INTERVAL '30 days',  NULL, NULL, 'system@demo', NOW(), NOW()),
 


### PR DESCRIPTION
## Summary

The demo data packs had three structural gaps that showed up in the UI as empty panels:

- Active `Table` / `View` / `Stream` assets had no `Column` assets, so the asset-detail columns tree was empty (e.g. `Daily Transactions` / `02500008`).
- Several data contracts had `schema_objects` but no `schema_properties` (or no `schema_objects` at all), so contract-detail schemas were empty.
- No `data_contract_quality_checks` existed for any contract, so the DQ surface had nothing to render.

This PR fixes all three across the 5 industry demo packs (`retail`, `auto`, `fsi`, `hls`, `mfg`) and removes a couple of redundant retail rows.

## Changes

### All 5 packs
- **Column assets + `hasColumn` relationships** for every active `Table` / `View` / `Stream` (~145 new columns). Covers Databricks tables, Snowflake replicas, PowerBI semantic models, Kafka topic schemas, dev environments, etc.
- **Backfill `data_contract_schema_objects` and `data_contract_schema_properties`** so every contract schema has 3–10 properties with PK / FK / partition / CDE flags and types.
- **New section `4d. DATA CONTRACT QUALITY CHECKS`** — ~50 representative ODCS checks: `notNull`, `unique`, `regex` (ISO-3166, ISO-4217, ICD-10, CPT, VIN), `enumValues`, `rangeCheck`, and SQL `freshness` / `consistency` rules.

### Retail-only dedup
- Dropped legacy stub `0f30000d` (`legacy.sales.raw.transactions_v1`). The deprecated / `replacedBy` demo is now sourced from `02500009` (`Current Inventory`) replaced by the curated `0f300004` (`inventory_levels`).
- Dropped `0f300005` (`customer360`); its role overlapped with `02500001` (`Customers Master Table`). All `belongsToSystem`, `consumesFrom`, `attachedPolicy`, and `business_owners` rows that pointed at `0f300005` are rewired to `02500001`.

## Test plan

- [x] All 5 SQL files parse cleanly (`sqlparse` paren / string / statement-count check)
- [x] Each pack loads against the running local Postgres (`app_ontos` schema) with `-v ON_ERROR_STOP=1` and commits successfully
- [x] Zero orphan FKs across `data_contract_schema_objects → data_contracts`, `data_contract_schema_properties → data_contract_schema_objects`, `data_contract_quality_checks → data_contract_schema_objects`, and `entity_relationships(hasColumn) → assets`
- [x] Originally-broken asset `02500008` (Daily Transactions) renders 5 columns
- [x] All 28 schema objects across all packs have at least 3 properties
- [ ] Reviewer: load via `POST /api/settings/demo-data/load?preset=<retail|auto|fsi|hls|mfg>` against a clean DB and confirm asset-detail columns trees + contract schemas + DQ checks all render