### PR TITLE
docs(alembic): document <letter><number> revision-id convention

### DIFF
--- a/.cursor/rules/11-database-migrations.mdc
+++ b/.cursor/rules/11-database-migrations.mdc
@@ -1,0 +1,47 @@
+---
+name: Database Migrations
+priority: 65
+scope:
+  globs:
+    - "src/backend/alembic/**"
+    - "src/backend/src/db_models/**"
+---
+
+### Alembic migrations
+
+Full reference: [`docs/notes/database-migrations.md`](../../docs/notes/database-migrations.md).
+
+**Hard rules (CI-enforced)**
+
+- Exactly **one head** at all times. The `check-alembic-heads` job in `.github/workflows/test-coverage.yml` runs `scripts/check-alembic-heads.py` and will fail the PR otherwise.
+- Always **rebase onto the current base branch first**, then run `alembic revision -m '<message>'` so the new revision descends from the live head (`hatch -e dev run alembic heads`).
+- A genuine multi-head merge requires `alembic merge -m 'merge heads' <head_a> <head_b>` plus the `alembic-branch` PR label to bypass the gate.
+
+**Project convention: short revision ids**
+
+Migrations live in `src/backend/alembic/versions/` and use a `<letter><number>_<slug>.py` shorthand instead of Alembic's default 12-char hex slug.
+
+- **Letter** = chronological feature wave. Current waves: `a*` (ontology rewrite), `b*` (cert/publication), `c*` (legacy-dataset cleanup), `d*` (ODCS v3.1.0), `e*` (semantic display), `f*` (merge), `g*` (workflow snapshot), `h*` (consumer principals), `i*` (workflow_version), `j*` (version_family_id).
+- **Number** = order within the wave (`a1`, `a2`, …).
+- Merge revisions: `<next_letter>1_merge_<head_a>_<head_b>.py` (see `f1_merge_aa9_e2_heads.py`).
+
+**Workflow when adding a migration**
+
+1. Rebase the branch onto `main`.
+2. `cd src/backend && hatch -e dev run alembic heads` — note the current head (e.g. `j1_add_version_family_id`).
+3. `hatch -e dev run alembic revision -m '<message>'` (or `--autogenerate` and review).
+4. **Rename the file** from the default `<hex>_<slug>.py` to `<letter><number>_<slug>.py`:
+   - Same wave → bump the number (after `j1_…`, use `j2_…`).
+   - New themed wave → next unused letter (after `j*`, start `k1_…`).
+5. **Inside the file**, update *all three* in lockstep:
+   - `revision = '<letter><number>_<slug>'` (this is what Alembic actually stores)
+   - `down_revision = '<current_head_revision>'`
+   - Docstring header `Revision ID:` and `Revises:` lines
+6. Verify: `hatch -e dev run alembic heads` → must report a single head equal to your new revision; `alembic history` → must show your revision descending from the previous head.
+
+**Common pitfalls**
+
+- The **filename prefix is cosmetic**; only the `revision` string variable matters for chain integrity. Keep them in sync regardless.
+- `down_revision` must point at the **current live head**, not a historical one. A stale `down_revision` (e.g. on a long-running branch) creates a second head after merge and breaks CI.
+- Don't rename historical migrations — descendants reference their `revision` strings and renaming the variable will orphan them.
+- Postgres-specific column types (`from sqlalchemy.dialects.postgresql import JSON`) are fine; the project deploys on Postgres.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Project-specific guidance for Claude Code lives in [`.cursor/rules/`](./.cursor/
 - [`08-testing-and-deployment.mdc`](./.cursor/rules/08-testing-and-deployment.mdc) — local dev, log paths, ports, Playwright MCP
 - [`09-package-management.mdc`](./.cursor/rules/09-package-management.mdc) — yarn (not npm)
 - [`10-entity-panel-matrix.mdc`](./.cursor/rules/10-entity-panel-matrix.mdc) — which polymorphic panels apply to which entity/asset type
+- [`11-database-migrations.mdc`](./.cursor/rules/11-database-migrations.mdc) — Alembic short-revision convention, single-head rule, new-migration workflow
 
 ## Claude-specific
 

--- a/docs/notes/database-migrations.md
+++ b/docs/notes/database-migrations.md
@@ -350,12 +350,81 @@ When `init_db()` runs (application startup):
 
 ### Migration Naming Convention
 
+#### Alembic default
+
 Alembic generates file names like:
 ```
 <revision_id>_<message_slug>.py
 ```
 
 Example: `3135632d55e1_initial_schema_capture.py`
+
+The 12-char hex `<revision_id>` is the value stored in the `revision`
+variable inside the file and recorded in the `alembic_version` table.
+Older migrations in this repo (e.g. `3135632d55e1_*`, `h8355d269ff1_*`,
+`o5022k936mm8_*`) use this default form.
+
+#### Project shorthand: `<letter><number>_<slug>.py`
+
+Starting with the ontology-driven data-model rewrite (`a1_dataset_to_asset_migration.py`),
+this project switched to a human-friendly short-id convention:
+
+```
+<letter><number>_<slug>.py
+```
+
+Examples: `a1_dataset_to_asset_migration.py`, `b2_add_cert_pub_to_contracts.py`,
+`g1_add_workflow_snapshot.py`, `j1_add_version_family_id.py`.
+
+The two parts encode:
+
+- **Letter** (`a`, `b`, `c`, …) — a roughly chronological **cohort / wave**
+  of related migrations. A new letter is picked when a new feature wave
+  starts. Historical waves so far: `a*` = asset/ontology rewrite,
+  `b*` = certification + publication scope, `c*` = legacy-dataset cleanup,
+  `d*` = ODCS v3.1.0 persistence, `e*` = semantic-models display names,
+  `f*` = merge revision (`f1_merge_aa9_e2_heads`), `g*` = workflow
+  snapshot, `h*` = consumer-principals / wizard OBO, `i*` = workflow_version
+  backfill, `j*` = version_family_id.
+- **Number** — order within that wave (`a1`, `a2`, `a3`, …, `a9`).
+
+**Merge revisions** (created via `alembic merge -m '...' <head_a> <head_b>`)
+get the next letter and a `merge_<head_a>_<head_b>` slug. Example:
+`f1_merge_aa9_e2_heads.py` merges `aa9_is_approver` and `e2_semantic_display_name`.
+
+#### What to use for new migrations
+
+When adding a new migration, prefer the project shorthand:
+
+1. Generate the file: `hatch -e dev run alembic revision -m '<message>'`
+2. **Rename** the file from the default `<hex>_<slug>.py` to
+   `<letter><number>_<slug>.py`. Pick the letter:
+   - **Same wave** as the previous head → bump the number
+     (after `j1_add_version_family_id`, the next would be `j2_…`).
+   - **New themed wave** → next unused letter (after `j*`, start `k1_…`).
+3. **Update the `revision` variable** inside the file to match the short
+   id (e.g. `revision = 'j2_my_change'`). The filename prefix is cosmetic,
+   but the `revision` string is what Alembic stores and what `down_revision`
+   in subsequent migrations must reference.
+4. Update the docstring header (`Revision ID: …` and `Revises: …`) to
+   match.
+5. Set `down_revision` to the **current head** (run `hatch -e dev run alembic heads`).
+
+#### Caveats
+
+- **Alembic only cares about `revision` uniqueness.** The `<letter><number>`
+  prefix is purely a project convention; nothing in Alembic, CI, or the
+  app enforces it. The hard rules enforced by CI are:
+  - exactly **one head** at all times (`check-alembic-heads` job in
+    `.github/workflows/test-coverage.yml`), and
+  - every migration's `down_revision` resolves to a known revision.
+- **Filename prefix vs `revision` string must agree.** If you rename the
+  file but forget to update `revision = '...'`, descendants will still
+  work (they reference the string, not the filename), but humans will be
+  badly confused. Keep them in sync.
+- A few historical migrations slipped through with mixed forms
+  (`u1688q602tt5_*`, `r8355n269pp2_*`, etc.) — these are old and
+  intentionally not renamed to avoid breaking the chain.
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary

The project has been using a `<letter><number>_<slug>.py` shorthand for Alembic migrations (e.g. `j1_add_version_family_id.py`) since the ontology-driven data-model rewrite, but the convention was tribal knowledge — neither the migrations doc nor the agent rules described it. That caused PRs to land with stale `down_revision` pointers (most recently #466, where the rebased branch still pointed at `i1_workflow_version` instead of the new head `j1_add_version_family_id`) and forced extra rebase rounds.

This PR codifies the convention so both humans and AI agents pick the right prefix and `down_revision` on the first try.

## Changes

- **`docs/notes/database-migrations.md`** — replace the thin "Migration Naming Convention" stub (which only showed Alembic's default hex form) with a full description of both forms, the letter-cohort meaning, the merge-revision pattern (`f1_merge_aa9_e2_heads`), a step-by-step procedure for adding new migrations, and the key caveat that the filename prefix is cosmetic but the `revision` string variable is what Alembic actually stores.
- **`.cursor/rules/11-database-migrations.mdc`** *(new)* — agent-facing rule scoped to `src/backend/alembic/**` and `src/backend/src/db_models/**`. Codifies the CI-enforced single-head rule, the short-id convention with the current wave map (`a*` ontology rewrite, `b*` cert/publication, …, `j*` version_family_id), the 6-step workflow for adding a migration, and the common pitfalls (stale `down_revision`, filename/variable drift).
- **`CLAUDE.md`** — wire the new rule into the index.

## Test plan

Docs-only change — nothing to execute. Verification steps:

- [ ] Skim `docs/notes/database-migrations.md` § "Migration Naming Convention" — both default + project forms documented, workflow + caveats present.
- [ ] Skim `.cursor/rules/11-database-migrations.mdc` — agent-facing summary is concise and lists the current wave map (`a*` … `j*`).
- [ ] Confirm `CLAUDE.md` index lists `11-database-migrations.mdc`.
- [ ] Confirm CI passes (no code touched, so `check-alembic-heads` and the rest should be green).