### PR TITLE
fix(ui): unify skeleton layouts — full pass (#297)

### DIFF
--- a/src/frontend/src/components/common/list-view-skeleton.tsx
+++ b/src/frontend/src/components/common/list-view-skeleton.tsx
@@ -157,13 +157,32 @@ export function TableSkeleton({
   );
 }
 
+interface DetailHeaderSkeletonProps {
+  /** Number of action buttons on the right side */
+  actionButtons?: number;
+  /**
+   * Number of additional left-side controls to render after the back-button stub.
+   * Useful for pages that include version navigators, view-mode toggles, etc.
+   */
+  leftControls?: number;
+}
+
 /**
  * Skeleton for detail view headers with back button and action buttons.
+ * Optionally renders extra left-side stubs (e.g. version nav, S/M/L toggle).
  */
-export function DetailHeaderSkeleton({ actionButtons = 3 }: { actionButtons?: number }) {
+export function DetailHeaderSkeleton({
+  actionButtons = 3,
+  leftControls = 0,
+}: DetailHeaderSkeletonProps) {
   return (
     <div className="flex items-center justify-between">
-      <Skeleton className="h-9 w-32" />
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-9 w-32" />
+        {[...Array(leftControls)].map((_, i) => (
+          <Skeleton key={i} className="h-9 w-28" />
+        ))}
+      </div>
       <div className="flex items-center gap-2">
         {[...Array(actionButtons)].map((_, i) => (
           <Skeleton key={i} className="h-9 w-24" />
@@ -410,6 +429,8 @@ interface StatCardsSkeletonProps {
   count?: number;
   /** Optional grid override (defaults to responsive 1/3 columns) */
   className?: string;
+  /** Padding for each stat card. Use "p-4" for compact rows. */
+  cardPadding?: string;
 }
 
 /**
@@ -418,11 +439,12 @@ interface StatCardsSkeletonProps {
 export function StatCardsSkeleton({
   count = 3,
   className = 'grid grid-cols-1 sm:grid-cols-3 gap-4',
+  cardPadding = 'p-6',
 }: StatCardsSkeletonProps) {
   return (
     <div className={className}>
       {[...Array(count)].map((_, i) => (
-        <div key={i} className="border rounded-lg p-6">
+        <div key={i} className={`border rounded-lg ${cardPadding}`}>
           <div className="flex items-center gap-3">
             <Skeleton className="h-10 w-10 rounded-lg" />
             <div className="space-y-2 flex-1">
@@ -463,19 +485,44 @@ export function ListItemSkeleton({
   );
 }
 
+interface CatalogColumnsTableSkeletonProps {
+  /** Number of body rows */
+  rows?: number;
+  /**
+   * Number of columns. The first column is rendered as a fixed-width name
+   * cell, the rest are evenly distributed.
+   */
+  columns?: number;
+  /** Render a header row above the body */
+  showHeader?: boolean;
+}
+
 /**
- * Skeleton matching a Card with an icon + title header followed by a
- * pseudo-random horizontal table-row pattern. Useful for "data dictionary" /
- * full-bleed table loading states.
+ * Skeleton matching the Data Catalog page table (columns / data dictionary
+ * style). Renders an optional header row plus configurable body rows.
  */
-export function CatalogColumnsTableSkeleton({ rows = 10 }: { rows?: number }) {
-  // Stable widths matching the rendered Data Catalog columns
-  const colWidths = ['w-32', 'flex-1', 'w-24', 'w-40'];
+export function CatalogColumnsTableSkeleton({
+  rows = 10,
+  columns = 8,
+  showHeader = true,
+}: CatalogColumnsTableSkeletonProps) {
+  // First column gets a fixed name width, remaining columns share flex space
+  const colClasses = Array.from({ length: columns }, (_, i) =>
+    i === 0 ? 'w-40' : 'flex-1'
+  );
+
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-3">
+      {showHeader && (
+        <div className="flex gap-4 pb-2 border-b">
+          {colClasses.map((w, j) => (
+            <Skeleton key={j} className={`h-3 ${w}`} />
+          ))}
+        </div>
+      )}
       {[...Array(rows)].map((_, i) => (
         <div key={i} className="flex gap-4">
-          {colWidths.map((w, j) => (
+          {colClasses.map((w, j) => (
             <Skeleton key={j} className={`h-6 ${w}`} />
           ))}
         </div>
@@ -499,6 +546,597 @@ export function VersionLineageSkeleton({ versions = 2 }: VersionLineageSkeletonP
       {[...Array(versions)].map((_, i) => (
         <Skeleton key={i} className="h-32 w-full" />
       ))}
+    </div>
+  );
+}
+
+interface TabsDetailSkeletonProps {
+  /** Number of tab triggers in the strip */
+  tabs?: number;
+  /** Number of action buttons in the header */
+  actionButtons?: number;
+  /** Number of left-side header controls (after back button) */
+  leftControls?: number;
+  /** Whether to render a hero (icon + title + description) above the tabs */
+  hero?: boolean;
+  /** Layout for the active tab body. 'two-col' renders 2 wide cards + 1 side card. */
+  contentVariant?: 'cards' | 'two-col';
+  /** Number of cards to render in the content area (cards variant only) */
+  contentCards?: number;
+}
+
+/**
+ * Skeleton for a tabbed detail page: header row, hero block, tab strip,
+ * and a content body. Use for asset-detail, data-catalog-details, and
+ * other tabbed entity detail views.
+ */
+export function TabsDetailSkeleton({
+  tabs = 3,
+  actionButtons = 3,
+  leftControls = 0,
+  hero = true,
+  contentVariant = 'cards',
+  contentCards = 2,
+}: TabsDetailSkeletonProps) {
+  return (
+    <div className="py-6 space-y-6">
+      <DetailHeaderSkeleton actionButtons={actionButtons} leftControls={leftControls} />
+
+      {hero && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-10 w-10 rounded" />
+            <Skeleton className="h-8 w-72" />
+            <Skeleton className="h-5 w-20" />
+          </div>
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-3 w-1/3" />
+        </div>
+      )}
+
+      {/* Tab triggers */}
+      <div className="flex gap-2 border-b pb-2">
+        {[...Array(tabs)].map((_, i) => (
+          <Skeleton key={i} className="h-9 w-32" />
+        ))}
+      </div>
+
+      {/* Tab body */}
+      {contentVariant === 'two-col' ? (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <div className="lg:col-span-2 space-y-4">
+            <CardSkeleton titleWidth="w-40" descriptionWidth="w-64" contentRows={4} />
+            <CardSkeleton titleWidth="w-48" descriptionWidth="w-72" contentRows={3} />
+          </div>
+          <div className="space-y-4">
+            <PanelSkeleton rows={3} />
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {[...Array(contentCards)].map((_, i) => (
+            <CardSkeleton key={i} contentRows={3} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SplitPaneSkeletonProps {
+  /** Tailwind width class for the sidebar (e.g. "w-64", "w-1/4") */
+  sidebarWidth?: string;
+  /** Sidebar render style */
+  sidebarVariant?: 'tree' | 'list' | 'cards';
+  /** Number of items in the sidebar list/tree/cards */
+  sidebarItems?: number;
+  /** Main pane render style */
+  main?: 'table' | 'panel' | 'tree' | 'cards';
+  /** Number of columns when main='table' */
+  tableColumns?: number;
+  /** Number of rows when main='table' or items when main is list-like */
+  tableRows?: number;
+  /** Optional toolbar/header row above the split */
+  showHeader?: boolean;
+  /** Total min height (Tailwind class) for the split */
+  minHeight?: string;
+}
+
+/**
+ * Skeleton for split-pane layouts (sidebar + main content). Used by
+ * asset-explorer, entitlements, master-data-management, catalog-commander,
+ * collections, hierarchy-browser, ontology-generator, schema-importer.
+ */
+export function SplitPaneSkeleton({
+  sidebarWidth = 'w-1/4',
+  sidebarVariant = 'list',
+  sidebarItems = 6,
+  main = 'table',
+  tableColumns = 6,
+  tableRows = 6,
+  showHeader = true,
+  minHeight = 'min-h-[400px]',
+}: SplitPaneSkeletonProps) {
+  const renderSidebar = () => {
+    if (sidebarVariant === 'tree') {
+      return <HierarchyTreeSkeleton groups={Math.max(1, Math.floor(sidebarItems / 3))} itemsPerGroup={3} />;
+    }
+    if (sidebarVariant === 'cards') {
+      return (
+        <div className="p-4 space-y-3">
+          {[...Array(sidebarItems)].map((_, i) => (
+            <div key={i} className="border rounded-lg p-3 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          ))}
+        </div>
+      );
+    }
+    return (
+      <div className="p-2">
+        <ListItemSkeleton count={sidebarItems} height="h-10" />
+      </div>
+    );
+  };
+
+  const renderMain = () => {
+    if (main === 'panel') {
+      return <PanelSkeleton rows={tableRows} />;
+    }
+    if (main === 'tree') {
+      return <HierarchyTreeSkeleton groups={3} itemsPerGroup={tableRows} />;
+    }
+    if (main === 'cards') {
+      return (
+        <div className="p-4 space-y-3">
+          {[...Array(tableRows)].map((_, i) => (
+            <CardSkeleton key={i} contentRows={2} />
+          ))}
+        </div>
+      );
+    }
+    return <TableSkeleton columns={tableColumns} rows={tableRows} />;
+  };
+
+  return (
+    <div className={`flex flex-col gap-4 ${minHeight}`.trim()}>
+      {showHeader && (
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-7 w-48" />
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-32" />
+          </div>
+        </div>
+      )}
+      <div className="flex gap-4 flex-1">
+        <div className={`${sidebarWidth} border rounded-lg overflow-hidden`}>
+          {renderSidebar()}
+        </div>
+        <div className="flex-1 border rounded-lg overflow-hidden">
+          {renderMain()}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SettingsFormSkeletonProps {
+  /** Number of form sections */
+  sections?: number;
+  /** Number of fields per section */
+  fieldsPerSection?: number;
+  /** Show a sticky/footer save bar */
+  showSaveBar?: boolean;
+  /** Show the page title block at the top */
+  showTitle?: boolean;
+}
+
+/**
+ * Skeleton for settings form pages (general, delivery, git, etc.).
+ * Renders a title block, N labeled-field sections and an optional save bar.
+ */
+export function SettingsFormSkeleton({
+  sections = 2,
+  fieldsPerSection = 3,
+  showSaveBar = true,
+  showTitle = true,
+}: SettingsFormSkeletonProps) {
+  return (
+    <div className="space-y-6">
+      {showTitle && (
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-96" />
+        </div>
+      )}
+      {[...Array(sections)].map((_, s) => (
+        <div key={s} className="border rounded-lg">
+          <div className="p-6 border-b space-y-2">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-72" />
+          </div>
+          <div className="p-6 space-y-4">
+            {[...Array(fieldsPerSection)].map((_, f) => (
+              <div key={f} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-9 w-full" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+      {showSaveBar && (
+        <div className="flex justify-end gap-2 pt-2">
+          <Skeleton className="h-9 w-24" />
+          <Skeleton className="h-9 w-32" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface HomeDashboardSkeletonProps {
+  /** Number of overview tiles */
+  tileCount?: number;
+  /** Whether to render the My Actions / Quick Actions card */
+  showMyActions?: boolean;
+  /** Whether to render role-specific sections (discovery, curation) */
+  showRoleSections?: boolean;
+}
+
+/**
+ * Skeleton for the personalized Home dashboard. Renders a hero search row,
+ * a stat-tile grid, an optional My Actions block, and optional role sections.
+ */
+export function HomeDashboardSkeleton({
+  tileCount = 4,
+  showMyActions = true,
+  showRoleSections = true,
+}: HomeDashboardSkeletonProps) {
+  return (
+    <div className="py-6 space-y-6">
+      {/* Hero (logo + title + search bar) */}
+      <div className="flex flex-col items-center text-center space-y-3 py-8">
+        <Skeleton className="h-12 w-12 rounded-full" />
+        <Skeleton className="h-8 w-72" />
+        <Skeleton className="h-4 w-96" />
+        <Skeleton className="h-11 w-full max-w-2xl rounded-lg" />
+      </div>
+
+      {/* Tiles */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {[...Array(tileCount)].map((_, i) => (
+          <div key={i} className="border rounded-lg p-5 space-y-3">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded-md" />
+              <Skeleton className="h-5 w-24" />
+            </div>
+            <Skeleton className="h-7 w-12" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        ))}
+      </div>
+
+      {showMyActions && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <PanelSkeleton rows={3} rowHeight="h-12" />
+          <PanelSkeleton rows={3} rowHeight="h-12" />
+        </div>
+      )}
+
+      {showRoleSections && (
+        <div className="space-y-4">
+          <PanelSkeleton rows={3} rowHeight="h-14" />
+          <PanelSkeleton rows={2} rowHeight="h-12" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface TileGridSkeletonProps {
+  /** Number of tiles */
+  count?: number;
+  /** Columns at the largest breakpoint */
+  columns?: 1 | 2 | 3 | 4;
+  /** Render an optional title row above the grid */
+  withHeader?: boolean;
+  /** Tile height class */
+  tileHeight?: string;
+}
+
+/**
+ * Skeleton for tile/card grids (e.g. marketplace product tiles, domain pills).
+ */
+export function TileGridSkeleton({
+  count = 8,
+  columns = 4,
+  withHeader = false,
+  tileHeight = 'h-40',
+}: TileGridSkeletonProps) {
+  // Map columns to a static class so Tailwind's JIT can pick it up
+  const gridClass = {
+    1: 'grid-cols-1',
+    2: 'grid-cols-1 sm:grid-cols-2',
+    3: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+    4: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+  }[columns];
+
+  return (
+    <div className="space-y-4">
+      {withHeader && (
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-9 w-32" />
+        </div>
+      )}
+      <div className={`grid ${gridClass} gap-4`}>
+        {[...Array(count)].map((_, i) => (
+          <div key={i} className={`border rounded-lg p-4 space-y-3 ${tileHeight}`}>
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="h-3 w-2/3" />
+            <div className="flex gap-2 pt-2">
+              <Skeleton className="h-5 w-12" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface DocViewerSkeletonProps {
+  /** Show a Table-of-Contents sidebar */
+  showToc?: boolean;
+  /** Number of prose paragraph rows */
+  proseRows?: number;
+  /** Show a page title above the body */
+  showTitle?: boolean;
+}
+
+/**
+ * Skeleton for documentation / user guide pages with optional TOC sidebar
+ * and a markdown-prose body.
+ */
+export function DocViewerSkeleton({
+  showToc = true,
+  proseRows = 12,
+  showTitle = true,
+}: DocViewerSkeletonProps) {
+  // Cycle through canonical widths so the prose looks varied
+  const widths = ['w-full', 'w-11/12', 'w-5/6', 'w-3/4', 'w-2/3'];
+  return (
+    <div className="space-y-6">
+      {showTitle && (
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-72" />
+          <Skeleton className="h-4 w-96" />
+        </div>
+      )}
+      <div className={`flex gap-6 ${showToc ? '' : 'justify-center'}`}>
+        {showToc && (
+          <div className="w-64 shrink-0 hidden lg:block">
+            <div className="space-y-2 sticky top-4">
+              <Skeleton className="h-4 w-24" />
+              <div className="space-y-1.5 pt-1">
+                {[...Array(8)].map((_, i) => (
+                  <Skeleton
+                    key={i}
+                    className="h-3"
+                    style={{ width: `${Math.round(Math.random() * 40 + 100)}px` }}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+        <div className="flex-1 space-y-3 max-w-4xl">
+          <Skeleton className="h-7 w-1/2 mb-2" />
+          {[...Array(proseRows)].map((_, i) => (
+            <Skeleton key={i} className={`h-3 ${widths[i % widths.length]}`} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface GraphCanvasSkeletonProps {
+  /** Show a left-side filter/legend panel */
+  showFilterPanel?: boolean;
+  /** Show a top toolbar */
+  showToolbar?: boolean;
+  /** Tailwind height for the canvas block */
+  height?: string;
+}
+
+/**
+ * Skeleton for graph / diagram canvases (React Flow, ER diagrams, ontology).
+ */
+export function GraphCanvasSkeleton({
+  showFilterPanel = false,
+  showToolbar = true,
+  height = 'h-[600px]',
+}: GraphCanvasSkeletonProps) {
+  return (
+    <div className="space-y-3">
+      {showToolbar && (
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-9 w-64" />
+            <Skeleton className="h-9 w-24" />
+            <Skeleton className="h-9 w-24" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-9 w-9" />
+            <Skeleton className="h-9 w-9" />
+            <Skeleton className="h-9 w-32" />
+          </div>
+        </div>
+      )}
+      <div className="flex gap-3">
+        {showFilterPanel && (
+          <div className="w-64 shrink-0 border rounded-lg p-4 space-y-3">
+            <Skeleton className="h-5 w-32" />
+            <div className="space-y-2">
+              {[...Array(5)].map((_, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4" />
+                  <Skeleton className="h-4 flex-1" />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        <Skeleton className={`${height} flex-1 rounded-lg`} />
+      </div>
+    </div>
+  );
+}
+
+interface WorkflowCanvasSkeletonProps {
+  /** Show the right-hand inspector panel */
+  showSidebar?: boolean;
+  /** Tailwind height class for the canvas */
+  height?: string;
+}
+
+/**
+ * Skeleton for the Workflow Designer full-height layout.
+ * Renders a top toolbar, a flow canvas and an optional inspector panel.
+ */
+export function WorkflowCanvasSkeleton({
+  showSidebar = true,
+  height = 'h-[calc(100vh-12rem)]',
+}: WorkflowCanvasSkeletonProps) {
+  return (
+    <div className={`flex flex-col gap-3 ${height}`.trim()}>
+      {/* Toolbar */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-9 w-32" />
+          <Skeleton className="h-9 w-9" />
+          <Skeleton className="h-9 w-9" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-9 w-24" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+      </div>
+
+      {/* Canvas + sidebar */}
+      <div className="flex gap-3 flex-1">
+        <Skeleton className="flex-1 rounded-lg" />
+        {showSidebar && (
+          <div className="w-72 shrink-0 border rounded-lg p-4 space-y-3">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-32" />
+            <div className="space-y-2 pt-2">
+              {[...Array(5)].map((_, i) => (
+                <div key={i} className="space-y-1">
+                  <Skeleton className="h-3 w-24" />
+                  <Skeleton className="h-9 w-full" />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface HierarchyDetailSkeletonProps {
+  /** Show the depth / view-mode controls bar */
+  showControls?: boolean;
+  /** Number of tree-row placeholders */
+  treeRows?: number;
+}
+
+/**
+ * Skeleton for the right-hand detail pane of the Hierarchy Browser.
+ * Includes an icon header, badge row, control bar, and tree rows.
+ */
+export function HierarchyDetailSkeleton({
+  showControls = true,
+  treeRows = 6,
+}: HierarchyDetailSkeletonProps) {
+  return (
+    <div className="space-y-4 p-4">
+      {/* Icon + title + badges */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-9 w-9 rounded" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-5 w-56" />
+          <Skeleton className="h-3 w-40" />
+        </div>
+        <Skeleton className="h-9 w-24" />
+      </div>
+
+      <div className="flex gap-2">
+        <Skeleton className="h-5 w-16" />
+        <Skeleton className="h-5 w-20" />
+        <Skeleton className="h-5 w-16" />
+      </div>
+
+      {showControls && (
+        <div className="flex items-center gap-2 border-t pt-3">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-8 w-28" />
+          <div className="ml-auto flex gap-2">
+            <Skeleton className="h-8 w-8" />
+            <Skeleton className="h-8 w-8" />
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        {[...Array(treeRows)].map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-2"
+            style={{ paddingLeft: `${(i % 3) * 16}px` }}
+          >
+            <Skeleton className="h-4 w-4" />
+            <Skeleton
+              className="h-4"
+              style={{ width: `${Math.round(Math.random() * 40 + 140)}px` }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface FilterBarSkeletonProps {
+  /** Number of filter dropdown stubs */
+  filterCount?: number;
+  /** Show a search input on the left */
+  withSearch?: boolean;
+  /** Show a trailing action button (e.g. clear filters) */
+  withAction?: boolean;
+}
+
+/**
+ * Skeleton for a filter row (search + N filter dropdowns + optional action).
+ * Use above tables, hierarchical browsers, etc.
+ */
+export function FilterBarSkeleton({
+  filterCount = 3,
+  withSearch = true,
+  withAction = false,
+}: FilterBarSkeletonProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {withSearch && <Skeleton className="h-9 w-64" />}
+      {[...Array(filterCount)].map((_, i) => (
+        <Skeleton key={i} className="h-9 w-32" />
+      ))}
+      {withAction && <Skeleton className="h-9 w-24 ml-auto" />}
     </div>
   );
 }

--- a/src/frontend/src/components/home/discovery-section.tsx
+++ b/src/frontend/src/components/home/discovery-section.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Loader2, Database, BoxSelect, Star, AlertCircle, Info, Bell } from 'lucide-react';
+import { Database, BoxSelect, Star, AlertCircle, Info, Bell } from 'lucide-react';
 import { CardSkeleton, SkeletonBlock } from '@/components/common/list-view-skeleton';
 import { Link } from 'react-router-dom';
 import EntityInfoDialog from '@/components/metadata/entity-info-dialog';

--- a/src/frontend/src/components/home/discovery-section.tsx
+++ b/src/frontend/src/components/home/discovery-section.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loader2, Database, BoxSelect, Star, AlertCircle, Info, Bell } from 'lucide-react';
+import { CardSkeleton, SkeletonBlock } from '@/components/common/list-view-skeleton';
 import { Link } from 'react-router-dom';
 import EntityInfoDialog from '@/components/metadata/entity-info-dialog';
 import SubscribeDialog from '@/components/data-products/subscribe-dialog';
@@ -257,9 +258,7 @@ export default function DiscoverySection({ maxItems = 12 }: DiscoverySectionProp
         </div>
 
         {domainsLoading || domainLoading ? (
-          <div style={{ height: 220, margin: 'auto' }} className="border rounded-lg overflow-hidden bg-muted/20 w-full flex items-center justify-center">
-            <Loader2 className="h-6 w-6 animate-spin" />
-          </div>
+          <SkeletonBlock height="h-[220px]" className="rounded-lg" />
         ) : domainError ? (
           <div style={{ height: 220, margin: 'auto' }} className="border rounded-lg overflow-hidden bg-muted/20 w-full flex items-center justify-center">
             <Alert variant="destructive" className="m-0 border-0 bg-transparent">
@@ -358,7 +357,11 @@ export default function DiscoverySection({ maxItems = 12 }: DiscoverySectionProp
       <div>
         <div className="flex items-center gap-2 mb-3"><Star className="h-5 w-5 text-primary" /><span className="font-medium">{t('discoverySection.popularProducts')}</span></div>
         {productsLoading ? (
-          <div className="flex items-center justify-center h-32"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {[...Array(4)].map((_, i) => (
+              <CardSkeleton key={i} titleWidth="w-3/4" descriptionWidth="w-1/2" contentRows={2} />
+            ))}
+          </div>
         ) : productsError ? (
           <Alert variant="destructive" className="mb-4"><AlertCircle className="h-4 w-4" /><AlertDescription>{productsError}</AlertDescription></Alert>
         ) : filteredProducts.length === 0 ? (

--- a/src/frontend/src/components/home/quick-actions.tsx
+++ b/src/frontend/src/components/home/quick-actions.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { features, type FeatureGroup } from '@/config/features';
+import { SkeletonLine } from '@/components/common/list-view-skeleton';
 
 interface QuickAction {
   name: string;
@@ -85,7 +86,17 @@ export default function QuickActions() {
   const visibleGroups = groupOrder.filter(group => groupedActions[group]?.length);
 
   if (permissionsLoading) {
-    return <div className="text-sm text-muted-foreground">{t('home:quickActions.loading')}</div>;
+    return (
+      <div className="space-y-4 p-6">
+        <SkeletonLine height="h-3" width="w-24" />
+        <div className="grid grid-cols-2 gap-2">
+          <SkeletonLine height="h-10" />
+          <SkeletonLine height="h-10" />
+          <SkeletonLine height="h-10" />
+          <SkeletonLine height="h-10" />
+        </div>
+      </div>
+    );
   }
 
   if (actions.length === 0) {

--- a/src/frontend/src/components/home/recent-activity.tsx
+++ b/src/frontend/src/components/home/recent-activity.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle, ArrowRightCircle, Loader2 } from 'lucide-react';
+import { AlertCircle, ArrowRightCircle } from 'lucide-react';
+import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -76,7 +77,7 @@ export default function RecentActivity({ limit = 10 }: RecentActivityProps) {
       <Card>
         <CardContent className="p-6">
           {loading ? (
-            <div className="flex items-center justify-center h-24"><Loader2 className="h-6 w-6 animate-spin text-primary" /></div>
+            <ListItemSkeleton count={4} height="h-10" className="space-y-2" />
           ) : error ? (
             <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription>{error}</AlertDescription></Alert>
           ) : entries.length === 0 ? (

--- a/src/frontend/src/components/home/request-role-section.tsx
+++ b/src/frontend/src/components/home/request-role-section.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Loader2, Shield, UserPlus, Info } from 'lucide-react';
+import { Shield, UserPlus, Info } from 'lucide-react';
+import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { usePermissions } from '@/stores/permissions-store';
 import { AppRole } from '@/types/settings';
 import RequestRoleAccessDialog from '@/components/settings/request-role-access-dialog';
@@ -30,8 +31,8 @@ export default function RequestRoleSection({ maxItems = 6 }: RequestRoleSectionP
       <section className="mb-16">
         <h2 className="text-2xl font-semibold mb-4">{t('requestRoleSection.title', 'Roles')}</h2>
         <Card>
-          <CardContent className="flex items-center justify-center py-12">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <CardContent className="py-6">
+            <ListItemSkeleton count={3} height="h-12" className="space-y-2" />
           </CardContent>
         </Card>
       </section>

--- a/src/frontend/src/components/home/required-actions-section.tsx
+++ b/src/frontend/src/components/home/required-actions-section.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { CheckSquare, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { useNotificationsStore } from '@/stores/notifications-store';
 import { Link } from 'react-router-dom';
 import ConfirmRoleRequestDialog from '@/components/settings/confirm-role-request-dialog';
@@ -136,7 +137,9 @@ export default function RequiredActionsSection() {
   return (
     <>
       {loadingApprovals || isLoading ? (
-        <div className="flex justify-center items-center h-32 p-6">{t('requiredActionsSection.loading')}</div>
+        <div className="p-6">
+          <ListItemSkeleton count={4} height="h-12" className="space-y-2" />
+        </div>
       ) : approvalsError ? (
         <div className="text-sm text-destructive p-6">{approvalsError}</div>
       ) : unifiedApprovals.length === 0 && actionItems.length === 0 ? (

--- a/src/frontend/src/components/settings/certification-levels-settings.tsx
+++ b/src/frontend/src/components/settings/certification-levels-settings.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Plus, Pencil, Trash2, Shield, ShieldCheck, Loader2 } from 'lucide-react';
+import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -197,11 +198,7 @@ export default function CertificationLevelsSettings() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[200px]">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <ListItemSkeleton count={3} height="h-20" className="space-y-2" />;
   }
 
   return (

--- a/src/frontend/src/components/settings/delivery-settings.tsx
+++ b/src/frontend/src/components/settings/delivery-settings.tsx
@@ -5,6 +5,7 @@ import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Loader2, Save, Truck } from 'lucide-react';
+import { SettingsFormSkeleton } from '@/components/common/list-view-skeleton';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { useToast } from '@/hooks/use-toast';
@@ -84,6 +85,23 @@ export default function DeliverySettings() {
       setIsSaving(false);
     }
   };
+
+  if (isLoading) {
+    return (
+      <>
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold flex items-center gap-2">
+            <Truck className="w-8 h-8" />
+            {t('settings:delivery.title', 'Delivery Modes')}
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            {t('settings:delivery.description', 'Configure how governance changes are propagated to external systems. Multiple modes can be active simultaneously.')}
+          </p>
+        </div>
+        <SettingsFormSkeleton sections={3} fieldsPerSection={1} showTitle={false} />
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/frontend/src/components/settings/general-settings.tsx
+++ b/src/frontend/src/components/settings/general-settings.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Separator } from '@/components/ui/separator';
 import { Loader2, Save, Settings } from 'lucide-react';
+import { SettingsFormSkeleton } from '@/components/common/list-view-skeleton';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { useToast } from '@/hooks/use-toast';
@@ -107,6 +108,21 @@ export default function GeneralSettings() {
     const { name, value } = e.target;
     setSettings(prev => ({ ...prev, [name]: value }));
   };
+
+  if (isLoading) {
+    return (
+      <>
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold flex items-center gap-2">
+            <Settings className="w-8 h-8" />
+            {t('settings:general.title')}
+          </h1>
+          <p className="text-muted-foreground mt-1">{t('settings:general.description')}</p>
+        </div>
+        <SettingsFormSkeleton sections={3} fieldsPerSection={3} showTitle={false} />
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/frontend/src/components/settings/git-settings.tsx
+++ b/src/frontend/src/components/settings/git-settings.tsx
@@ -6,6 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useToast } from '@/hooks/use-toast';
+import { SettingsFormSkeleton } from '@/components/common/list-view-skeleton';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import {
@@ -268,11 +269,7 @@ export default function GitSettings() {
   };
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-10">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <SettingsFormSkeleton sections={2} fieldsPerSection={3} showTitle={false} />;
   }
 
   return (

--- a/src/frontend/src/components/settings/mcp-tokens-settings.tsx
+++ b/src/frontend/src/components/settings/mcp-tokens-settings.tsx
@@ -64,6 +64,7 @@ import {
   Cpu,
 } from 'lucide-react';
 import { formatDistanceToNow, format } from 'date-fns';
+import { TableSkeleton } from '@/components/common/list-view-skeleton';
 import {
   MCPTokenInfo,
   MCPTokenList,
@@ -289,9 +290,7 @@ export default function MCPTokensSettings() {
 
         {/* Tokens Table */}
         {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          </div>
+          <TableSkeleton columns={6} rows={4} />
         ) : tokens.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
             <Key className="h-12 w-12 mx-auto mb-4 opacity-50" />

--- a/src/frontend/src/components/settings/roles-settings.tsx
+++ b/src/frontend/src/components/settings/roles-settings.tsx
@@ -5,7 +5,7 @@ import { useToast } from '@/hooks/use-toast';
 import { AppRole, FeatureConfig, FeatureAccessLevel } from '@/types/settings'; // Import FeatureAccessLevel
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Loader2, Plus, Pencil, Trash2, AlertCircle, ChevronDown, UserPlus, Shield } from 'lucide-react';
+import { Plus, Pencil, Trash2, AlertCircle, ChevronDown, UserPlus, Shield } from 'lucide-react';
 import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import RoleFormDialog from './role-form-dialog'; // Uncomment and import

--- a/src/frontend/src/components/settings/roles-settings.tsx
+++ b/src/frontend/src/components/settings/roles-settings.tsx
@@ -6,6 +6,7 @@ import { AppRole, FeatureConfig, FeatureAccessLevel } from '@/types/settings'; /
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Loader2, Plus, Pencil, Trash2, AlertCircle, ChevronDown, UserPlus, Shield } from 'lucide-react';
+import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import RoleFormDialog from './role-form-dialog'; // Uncomment and import
 import RequestRoleAccessDialog from './request-role-access-dialog'; // Import role access request dialog
@@ -244,7 +245,7 @@ export default function RolesSettings() {
 
     // --- Render Logic ---
     if (isLoading) {
-        return <div className="flex justify-center items-center h-32"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>;
+        return <ListItemSkeleton count={4} height="h-16" className="space-y-2" />;
     }
 
     if (error) {

--- a/src/frontend/src/components/settings/search-config-editor.tsx
+++ b/src/frontend/src/components/settings/search-config-editor.tsx
@@ -11,6 +11,10 @@ import { Separator } from '@/components/ui/separator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Loader2, Save, RefreshCw, Search, Settings2, Layers, ArrowUpDown, Check, AlertCircle } from 'lucide-react';
+import {
+  CardSkeleton,
+  SkeletonLine,
+} from '@/components/common/list-view-skeleton';
 import { useToast } from '@/hooks/use-toast';
 import { usePermissions } from '@/stores/permissions-store';
 import { 
@@ -292,9 +296,12 @@ export default function SearchConfigEditor() {
   }, [updateConfig]);
 
   if (isLoading) {
+    // Tab strip + 2 config sections
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <div className="space-y-6">
+        <SkeletonLine height="h-10" width="w-96" />
+        <CardSkeleton titleWidth="w-48" descriptionWidth="w-72" contentRows={5} />
+        <CardSkeleton titleWidth="w-40" descriptionWidth="w-60" contentRows={4} />
       </div>
     );
   }

--- a/src/frontend/src/components/settings/settings-page-wrapper.tsx
+++ b/src/frontend/src/components/settings/settings-page-wrapper.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Loader2, ShieldX } from 'lucide-react';
+import { ShieldX } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import usePermissionsStore, { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import { SettingsFormSkeleton } from '@/components/common/list-view-skeleton';
 
 interface SettingsPageWrapperProps {
   title: string;
@@ -48,11 +49,10 @@ export default function SettingsPageWrapper({ title, permissionId, children }: S
   }, [title, setStaticSegments, setDynamicTitle]);
 
   if (permissionsLoading || isInitializing || !initAttempted) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      </div>
-    );
+    // Render a generic settings form skeleton while permissions resolve.
+    // Individual settings pages render their own content-shaped skeletons
+    // afterwards if they have additional async loads.
+    return <SettingsFormSkeleton sections={2} fieldsPerSection={3} />;
   }
 
   if (!hasSettingsAccess) {

--- a/src/frontend/src/components/settings/ui-customization-settings.tsx
+++ b/src/frontend/src/components/settings/ui-customization-settings.tsx
@@ -27,6 +27,10 @@ import {
 } from 'lucide-react';
 import MarkdownViewer from '@/components/ui/markdown-viewer';
 import { useUICustomizationStore } from '@/stores/ui-customization-store';
+import {
+  CardSkeleton,
+  SkeletonLine,
+} from '@/components/common/list-view-skeleton';
 import { DEFAULT_APP_NAME } from '@/lib/branding';
 
 const APP_DISPLAY_NAME_MAX_LEN = 64;
@@ -190,9 +194,13 @@ export default function UICustomizationSettings() {
   const validateLogoUrl = validateImageUrl;
 
   if (isLoading) {
+    // Multi-section skeleton: tab strip + branding/theme/home customization cards
     return (
-      <div className="flex items-center justify-center py-10">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <div className="space-y-6">
+        <SkeletonLine height="h-10" width="w-full" className="max-w-md" />
+        <CardSkeleton titleWidth="w-40" descriptionWidth="w-72" contentRows={4} />
+        <CardSkeleton titleWidth="w-32" descriptionWidth="w-64" contentRows={3} />
+        <CardSkeleton titleWidth="w-48" descriptionWidth="w-80" contentRows={5} />
       </div>
     );
   }

--- a/src/frontend/src/components/workflows/workflow-designer.tsx
+++ b/src/frontend/src/components/workflows/workflow-designer.tsx
@@ -128,6 +128,7 @@ import {
 import { TriggerPicker, type TriggerTypeOption } from './trigger-picker';
 import { EntityTypeMultiselect } from './entity-type-multiselect';
 import { PrincipalPicker } from '@/components/common/principal-picker';
+import { WorkflowCanvasSkeleton } from '@/components/common/list-view-skeleton';
 import {
   joinRoleAndPrincipals,
   splitRoleAndPrincipals,
@@ -1448,8 +1449,8 @@ export default function WorkflowDesigner({ workflowId }: WorkflowDesignerProps) 
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-96">
-        <Loader2 className="h-8 w-8 animate-spin" />
+      <div className="py-6 space-y-4 h-[calc(100vh-120px)] flex flex-col">
+        <WorkflowCanvasSkeleton showSidebar height="flex-1" />
       </div>
     );
   }

--- a/src/frontend/src/views/asset-detail.tsx
+++ b/src/frontend/src/views/asset-detail.tsx
@@ -10,7 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Label } from '@/components/ui/label';
-import { DetailViewSkeleton } from '@/components/common/list-view-skeleton';
+import { TabsDetailSkeleton } from '@/components/common/list-view-skeleton';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { AssetDeleteDialog } from '@/components/assets/asset-delete-dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -179,10 +179,9 @@ export default function AssetDetailView() {
   }, [asset, setStaticSegments, setDynamicTitle]);
 
   if (loading) {
-    // Mirrors the rendered detail view: header with action buttons, core
-    // metadata card, and a few stacked panels (relationships, ownership,
-    // metadata, ratings, costs, quality).
-    return <DetailViewSkeleton cards={4} actionButtons={5} />;
+    // Asset Detail uses a tabbed layout (Overview / Relationships / Lineage /
+    // Impact) above a hero title row. Match that structure.
+    return <TabsDetailSkeleton tabs={4} actionButtons={5} contentVariant="two-col" />;
   }
 
   if (error || !asset) {

--- a/src/frontend/src/views/asset-explorer.tsx
+++ b/src/frontend/src/views/asset-explorer.tsx
@@ -6,7 +6,7 @@ import {
   Table2, Eye, Columns2, LayoutDashboard, Globe, FileCode, Brain, Activity,
   Server, Shield, BookOpen, Database, FolderOpen, Shapes, FileSpreadsheet, FileInput,
 } from 'lucide-react';
-import { ListViewSkeleton } from '@/components/common/list-view-skeleton';
+import { SplitPaneSkeleton } from '@/components/common/list-view-skeleton';
 import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/ui/data-table';
 import { Badge } from '@/components/ui/badge';
@@ -414,9 +414,16 @@ export default function AssetExplorerView() {
   }, [canWrite, canAdmin, navigate, selectedTypeId]);
 
   if (apiIsLoading && assetTypes.length === 0) {
+    // Asset Explorer uses a sidebar (asset type nav) + main DataTable layout
     return (
       <div className="py-6">
-        <ListViewSkeleton columns={5} rows={5} toolbarButtons={1} />
+        <SplitPaneSkeleton
+          sidebarVariant="list"
+          sidebarItems={8}
+          main="table"
+          tableColumns={8}
+          tableRows={6}
+        />
       </div>
     );
   }

--- a/src/frontend/src/views/asset-types.tsx
+++ b/src/frontend/src/views/asset-types.tsx
@@ -185,7 +185,7 @@ export default function AssetTypesView() {
       </div>
 
       {(apiIsLoading || permissionsLoading) ? (
-        <ListViewSkeleton columns={5} rows={5} toolbarButtons={1} />
+        <ListViewSkeleton columns={7} rows={5} toolbarButtons={1} />
       ) : !canRead ? (
         <Alert variant="destructive" className="mb-4">
           <AlertCircle className="h-4 w-4" />

--- a/src/frontend/src/views/audit-trail.tsx
+++ b/src/frontend/src/views/audit-trail.tsx
@@ -37,6 +37,7 @@ import { useToast } from '@/hooks/use-toast';
 import { AuditLog, PaginatedAuditLogResponse, AuditLogFilters } from '@/types/audit-log';
 import { Search, Download, ChevronLeft, ChevronRight, ScrollText } from 'lucide-react';
 import SettingsPageWrapper from '@/components/settings/settings-page-wrapper';
+import { TableSkeleton } from '@/components/common/list-view-skeleton';
 
 const ITEMS_PER_PAGE = 50;
 
@@ -254,7 +255,7 @@ export default function AuditTrail() {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <div className="text-center py-8 text-muted-foreground">{t('results.loading')}</div>
+            <TableSkeleton columns={7} rows={6} bordered={false} showHeader={false} />
           ) : logs.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">{t('results.noLogs')}</div>
           ) : (

--- a/src/frontend/src/views/business-owners.tsx
+++ b/src/frontend/src/views/business-owners.tsx
@@ -126,7 +126,7 @@ export default function BusinessOwnersView() {
       </div>
 
       {(apiIsLoading || permissionsLoading) ? (
-        <ListViewSkeleton columns={5} rows={5} toolbarButtons={0} />
+        <ListViewSkeleton columns={6} rows={5} toolbarButtons={0} />
       ) : !canRead ? (
         <Alert variant="destructive" className="mb-4">
           <AlertCircle className="h-4 w-4" />

--- a/src/frontend/src/views/business-roles.tsx
+++ b/src/frontend/src/views/business-roles.tsx
@@ -178,7 +178,7 @@ export default function BusinessRolesView() {
       </div>
 
       {(apiIsLoading || permissionsLoading) ? (
-        <ListViewSkeleton columns={4} rows={5} toolbarButtons={1} />
+        <ListViewSkeleton columns={6} rows={5} toolbarButtons={1} />
       ) : !canRead ? (
         <Alert variant="destructive" className="mb-4">
           <AlertCircle className="h-4 w-4" />

--- a/src/frontend/src/views/business-terms.tsx
+++ b/src/frontend/src/views/business-terms.tsx
@@ -15,8 +15,11 @@ import {
   Plus,
   ChevronDown,
   Upload,
-  Loader2,
 } from 'lucide-react';
+import {
+  FilterBarSkeleton,
+  HierarchyTreeSkeleton,
+} from '@/components/common/list-view-skeleton';
 import type {
   OntologyConcept,
   KnowledgeCollection,
@@ -384,8 +387,9 @@ export default function BusinessTermsView() {
 
       {/* Loading state */}
       {isLoading ? (
-        <div className="flex-1 flex items-center justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <div className="flex-1 flex flex-col gap-4">
+          <FilterBarSkeleton filterCount={3} />
+          <HierarchyTreeSkeleton groups={4} itemsPerGroup={4} />
         </div>
       ) : (
         <div className="flex-1 flex flex-col gap-4">

--- a/src/frontend/src/views/catalog-commander.tsx
+++ b/src/frontend/src/views/catalog-commander.tsx
@@ -30,6 +30,7 @@ import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DataTable } from '@/components/ui/data-table';
+import { HierarchyTreeSkeleton } from '@/components/common/list-view-skeleton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 // Tabs imports commented out - not currently used
 // import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -791,9 +792,7 @@ const CatalogCommander: React.FC = () => {
             </div>
             <div className="flex-1 min-h-0 overflow-auto border rounded-md bg-muted/20">
               {isLoading ? (
-                <div className="flex items-center justify-center h-full min-h-[200px]">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                </div>
+                <HierarchyTreeSkeleton groups={4} itemsPerGroup={4} />
               ) : error ? (
                 <div className="flex flex-col items-center justify-center h-full min-h-[200px] p-4">
                   <div className="text-destructive text-sm mb-3">{error}</div>
@@ -910,9 +909,7 @@ const CatalogCommander: React.FC = () => {
                     </div>
                     <div className="flex-1 min-h-0 overflow-auto border rounded-md bg-muted/20">
                       {isLoading ? (
-                        <div className="flex items-center justify-center h-full min-h-[200px]">
-                          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                        </div>
+                        <HierarchyTreeSkeleton groups={4} itemsPerGroup={4} />
                       ) : error ? (
                         <div className="flex flex-col items-center justify-center h-full min-h-[200px] p-4">
                           <div className="text-destructive text-sm mb-3">{error}</div>

--- a/src/frontend/src/views/collections.tsx
+++ b/src/frontend/src/views/collections.tsx
@@ -5,8 +5,8 @@ import {
   FolderTree,
   Plus,
   Upload,
-  Loader2,
 } from 'lucide-react';
+import { SplitPaneSkeleton } from '@/components/common/list-view-skeleton';
 import type { KnowledgeCollection } from '@/types/ontology';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { usePermissions } from '@/stores/permissions-store';
@@ -200,9 +200,13 @@ export default function CollectionsView() {
 
       {/* Loading state */}
       {isLoading ? (
-        <div className="flex-1 flex items-center justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </div>
+        <SplitPaneSkeleton
+          sidebarVariant="list"
+          sidebarItems={5}
+          main="panel"
+          tableRows={3}
+          showHeader={false}
+        />
       ) : (
         <CollectionsTab
           collections={collections}

--- a/src/frontend/src/views/compliance-policy-details.tsx
+++ b/src/frontend/src/views/compliance-policy-details.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { AlertCircle, ArrowLeft, PlayCircle, Loader2, Scale, Pencil } from 'lucide-react';
+import { AlertCircle, ArrowLeft, PlayCircle, Scale, Pencil } from 'lucide-react';
 import { DetailViewSkeleton } from '@/components/common/list-view-skeleton';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';

--- a/src/frontend/src/views/compliance-policy-details.tsx
+++ b/src/frontend/src/views/compliance-policy-details.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { AlertCircle, ArrowLeft, PlayCircle, Loader2, Scale, Pencil } from 'lucide-react';
+import { DetailViewSkeleton } from '@/components/common/list-view-skeleton';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
@@ -207,11 +208,7 @@ export default function CompliancePolicyDetails() {
   };
 
   if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <Loader2 className="h-12 w-12 animate-spin text-primary" />
-      </div>
-    );
+    return <DetailViewSkeleton cards={4} actionButtons={3} />;
   }
   if (error || !policy) {
     return (

--- a/src/frontend/src/views/compliance-run-details.tsx
+++ b/src/frontend/src/views/compliance-run-details.tsx
@@ -41,7 +41,7 @@ interface Result {
 }
 
 export default function ComplianceRunDetails() {
-  const { t } = useTranslation(['compliance', 'common']);
+  useTranslation(['compliance', 'common']);
   const { runId } = useParams<{ runId: string }>();
   const navigate = useNavigate();
   const { get } = useApi();

--- a/src/frontend/src/views/compliance-run-details.tsx
+++ b/src/frontend/src/views/compliance-run-details.tsx
@@ -10,6 +10,11 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertCircle, ArrowLeft } from 'lucide-react';
 import { useApi } from '@/hooks/use-api';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import {
+  CardSkeleton,
+  DetailHeaderSkeleton,
+  TableSkeleton,
+} from '@/components/common/list-view-skeleton';
 
 interface Run {
   id: string; // UUID
@@ -99,7 +104,11 @@ export default function ComplianceRunDetails() {
 
   if (loading) {
     return (
-      <div className="container mx-auto py-10 text-center text-muted-foreground">{t('common:labels.loading')}</div>
+      <div className="py-6 space-y-6">
+        <DetailHeaderSkeleton actionButtons={1} />
+        <CardSkeleton titleWidth="w-48" descriptionWidth="w-64" contentRows={3} />
+        <TableSkeleton columns={6} rows={6} />
+      </div>
     );
   }
   if (error || !run) {

--- a/src/frontend/src/views/compliance.tsx
+++ b/src/frontend/src/views/compliance.tsx
@@ -27,6 +27,10 @@ import { ColumnDef } from "@tanstack/react-table";
 import { useApi } from '@/hooks/use-api';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { DataTable } from '@/components/ui/data-table';
+import {
+  ListViewSkeleton,
+  StatCardsSkeleton,
+} from '@/components/common/list-view-skeleton';
 
 interface CompliancePolicy {
   id: string; // UUID
@@ -316,8 +320,9 @@ export default function Compliance() {
       </div>
 
       {apiIsLoading && !isDialogOpen && (
-        <div className="flex justify-center items-center h-64">
-          <p>{t('compliance:loading')}</p>
+        <div className="space-y-4">
+          <StatCardsSkeleton count={4} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4" />
+          <ListViewSkeleton columns={6} rows={5} showToolbar={false} toolbarButtons={0} />
         </div>
       )}
 

--- a/src/frontend/src/views/concept-detail.tsx
+++ b/src/frontend/src/views/concept-detail.tsx
@@ -19,7 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
   SkeletonLine,
-  SkeletonBlock,
+  PanelSkeleton,
 } from '@/components/common/list-view-skeleton';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
@@ -262,8 +262,8 @@ export default function ConceptDetailView() {
     }
   };
 
-  // Loading skeleton mirrors the asset-detail skeleton style for visual
-  // consistency.
+  // Mirrors the rendered concept detail: real back button, title block,
+  // compact definition card, and two side panels (ownership/metadata + links).
   if (isLoading && !concept) {
     return (
       <div className="py-6 space-y-4">
@@ -272,11 +272,15 @@ export default function ConceptDetailView() {
             <ArrowLeft className="mr-2 h-4 w-4" />
             {t('semantic-models:details.backToList', 'Back to Concepts')}
           </Button>
+          <div className="flex items-center gap-2">
+            <SkeletonLine height="h-9" width="w-24" />
+            <SkeletonLine height="h-9" width="w-24" />
+          </div>
         </div>
         <SkeletonLine height="h-9" width="w-2/3" />
         <SkeletonLine height="h-3" width="w-1/2" />
-        <SkeletonBlock height="h-24" className="rounded-lg" />
-        <SkeletonBlock height="h-24" className="rounded-lg" />
+        <PanelSkeleton rows={2} rowHeight="h-10" />
+        <PanelSkeleton rows={3} rowHeight="h-9" />
       </div>
     );
   }

--- a/src/frontend/src/views/data-asset-review-details.tsx
+++ b/src/frontend/src/views/data-asset-review-details.tsx
@@ -19,6 +19,11 @@ import { Label } from '@/components/ui/label';
 // Textarea - unused
 // import { Textarea } from '@/components/ui/textarea';
 import { DataTable } from "@/components/ui/data-table";
+import {
+  CardSkeleton,
+  DetailHeaderSkeleton,
+  TableSkeleton,
+} from '@/components/common/list-view-skeleton';
 import { Toaster } from "@/components/ui/toaster";
 import { RelativeDate } from '@/components/common/relative-date';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -221,7 +226,13 @@ export default function DataAssetReviewDetails() {
 
     // --- Render Logic --- //
     if (loading) {
-        return <div className="flex justify-center items-center h-64"><Loader2 className="h-12 w-12 animate-spin text-primary" /></div>;
+        return (
+            <div className="py-6 space-y-6">
+                <DetailHeaderSkeleton actionButtons={1} />
+                <CardSkeleton titleWidth="w-56" descriptionWidth="w-72" contentRows={4} />
+                <TableSkeleton columns={5} rows={5} />
+            </div>
+        );
     }
     if (error) {
         return <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription>{error}</AlertDescription></Alert>;

--- a/src/frontend/src/views/data-asset-reviews.tsx
+++ b/src/frontend/src/views/data-asset-reviews.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ColumnDef } from "@tanstack/react-table";
-import { Plus, AlertCircle, Loader2, ClipboardCheck, ChevronDown, Trash2 } from 'lucide-react';
+import { Plus, AlertCircle, ClipboardCheck, ChevronDown, Trash2 } from 'lucide-react';
+import { ListViewSkeleton } from '@/components/common/list-view-skeleton';
 
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -209,9 +210,7 @@ export default function DataAssetReviews() {
             )}
 
             {loading ? (
-                <div className="flex justify-center items-center h-64">
-                    <Loader2 className="h-12 w-12 animate-spin text-primary" />
-                </div>
+                <ListViewSkeleton columns={8} rows={5} toolbarButtons={1} />
             ) : (
                 <DataTable
                     columns={columns}

--- a/src/frontend/src/views/data-catalog-details.tsx
+++ b/src/frontend/src/views/data-catalog-details.tsx
@@ -44,7 +44,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { DetailViewSkeleton } from '@/components/common/list-view-skeleton';
+import { TabsDetailSkeleton } from '@/components/common/list-view-skeleton';
 import { Separator } from '@/components/ui/separator';
 import {
   Tooltip,
@@ -243,11 +243,11 @@ const DataCatalogDetails: React.FC = () => {
   };
 
   if (isLoading) {
-    // Mirrors rendered shape: header (back button), title with icon and badge,
-    // tabs row, plus the two-column overview cards (Basic Info + Storage).
+    // Mirrors rendered shape: header (back button), icon+title hero, tabs row
+    // (Overview / Permissions / Lineage), and the two-column overview cards.
     return (
       <div className="flex flex-col h-full p-6">
-        <DetailViewSkeleton cards={3} actionButtons={1} />
+        <TabsDetailSkeleton tabs={3} actionButtons={1} contentVariant="two-col" />
       </div>
     );
   }

--- a/src/frontend/src/views/data-contract-details.tsx
+++ b/src/frontend/src/views/data-contract-details.tsx
@@ -5,7 +5,13 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { AlertCircle, Download, Pencil, Trash2, Loader2, ArrowLeft, FileText, KeyRound, CopyPlus, Plus, Shapes, Columns2, Database, Sparkles, Package, ShieldCheck, Globe, Link2 } from 'lucide-react'
-import { DetailViewSkeleton } from '@/components/common/list-view-skeleton'
+import {
+  DetailHeaderSkeleton,
+  PanelSkeleton,
+  SkeletonBlock,
+  SkeletonLine,
+  TableSkeleton,
+} from '@/components/common/list-view-skeleton'
 import { Badge } from '@/components/ui/badge'
 import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -1576,7 +1582,34 @@ export default function DataContractDetails() {
   }
 
   if (loading) {
-    return <DetailViewSkeleton cards={4} actionButtons={4} />
+    // Mirrors rendered shape: header with back + version navigator + view-mode
+    // toggle on the left, action buttons on the right; body shows ODCS sections
+    // and a schema property table.
+    return (
+      <div className="py-6 space-y-6">
+        <DetailHeaderSkeleton actionButtons={5} leftControls={2} />
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <SkeletonLine height="h-9" width="w-9" className="rounded" />
+            <SkeletonLine height="h-8" width="w-80" />
+            <SkeletonLine height="h-5" width="w-20" />
+          </div>
+          <SkeletonLine height="h-4" width="w-2/3" />
+        </div>
+        <PanelSkeleton rows={3} rowHeight="h-10" />
+        <div className="border rounded-lg">
+          <div className="p-6 border-b">
+            <div className="flex items-center gap-2">
+              <SkeletonLine height="h-5" width="w-5" />
+              <SkeletonLine height="h-5" width="w-32" />
+            </div>
+          </div>
+          <TableSkeleton columns={6} rows={5} bordered={false} />
+        </div>
+        <PanelSkeleton rows={2} rowHeight="h-12" />
+        <PanelSkeleton rows={2} rowHeight="h-10" />
+      </div>
+    )
   }
   if (error || !contract) {
     return (
@@ -1597,7 +1630,7 @@ export default function DataContractDetails() {
     const totalPages = Math.ceil(totalProps / PROPS_PAGE_SIZE)
 
     if (loadingSchemaProps && props.length === 0) {
-      return <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />Loading columns...</div>
+      return <SkeletonBlock height="h-32" className="rounded-md" />
     }
     if (props.length === 0 && totalProps === 0) return null
     return (

--- a/src/frontend/src/views/data-contracts.tsx
+++ b/src/frontend/src/views/data-contracts.tsx
@@ -540,7 +540,7 @@ export default function DataContracts() {
       )}
 
       {loading ? (
-        <ListViewSkeleton columns={6} rows={5} toolbarButtons={3} />
+        <ListViewSkeleton columns={8} rows={5} toolbarButtons={3} />
       ) : (
         <DataTable
           columns={columns}

--- a/src/frontend/src/views/data-domain-details.tsx
+++ b/src/frontend/src/views/data-domain-details.tsx
@@ -24,7 +24,11 @@ import { RelativeDate } from '@/components/common/relative-date';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { AlertCircle } from 'lucide-react';
 // import { Loader2 } from 'lucide-react'; // Unused
-import { DetailViewSkeleton } from '@/components/common/list-view-skeleton';
+import {
+  DetailViewSkeleton,
+  TableSkeleton,
+  SkeletonLine,
+} from '@/components/common/list-view-skeleton';
 import { DataDomainMiniGraph } from '@/components/data-domains/data-domain-mini-graph';
 import { DataDomainFormDialog } from '@/components/data-domains/data-domain-form-dialog';
 import { CommentSidebar } from '@/components/comments';
@@ -540,7 +544,25 @@ export default function DataDomainDetailsView() {
   }, [domain, setDynamicTitle]);
 
   if (isLoading) {
-    return <DetailViewSkeleton cards={4} actionButtons={2} />;
+    // Mirrors rendered shape: header (back + comment + edit), one big metadata
+    // card, hierarchy mini-graph, child domains table, teams table.
+    return (
+      <div className="py-6 space-y-6">
+        <DetailViewSkeleton cards={2} actionButtons={2} />
+        <div className="border rounded-lg">
+          <div className="p-6 border-b">
+            <SkeletonLine height="h-5" width="w-40" />
+          </div>
+          <TableSkeleton columns={4} rows={3} bordered={false} />
+        </div>
+        <div className="border rounded-lg">
+          <div className="p-6 border-b">
+            <SkeletonLine height="h-5" width="w-32" />
+          </div>
+          <TableSkeleton columns={3} rows={3} bordered={false} />
+        </div>
+      </div>
+    );
   }
 
   if (error) {

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -14,7 +14,12 @@ import { useApprovalWizardTrigger } from '@/hooks/use-approval-wizard-trigger';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Loader2, Pencil, Trash2, AlertCircle, Sparkles, CopyPlus, ArrowLeft, Package, KeyRound, Plus, FileText, Download, Bell, BellOff, Users, ShieldCheck, Globe } from 'lucide-react';
-import { DetailViewSkeleton } from '@/components/common/list-view-skeleton';
+import {
+  DetailHeaderSkeleton,
+  PanelSkeleton,
+  SkeletonLine,
+  TableSkeleton,
+} from '@/components/common/list-view-skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import TagChip from '@/components/ui/tag-chip';
@@ -1339,7 +1344,35 @@ export default function DataProductDetails() {
     shouldShowSectionForViewMode(viewMode, section);
 
   if (loading || permissionsLoading) {
-    return <DetailViewSkeleton cards={5} actionButtons={5} />;
+    // Match the rendered shape: header has back + version navigator + S/M/L
+    // view-mode toggle on the left, multiple action buttons on the right;
+    // body has a hero, ODPS metadata panels, and an output-ports table.
+    return (
+      <div className="py-6 space-y-6">
+        <DetailHeaderSkeleton actionButtons={6} leftControls={2} />
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <SkeletonLine height="h-9" width="w-9" className="rounded" />
+            <SkeletonLine height="h-8" width="w-80" />
+            <SkeletonLine height="h-5" width="w-20" />
+          </div>
+          <SkeletonLine height="h-4" width="w-2/3" />
+        </div>
+        <PanelSkeleton rows={3} rowHeight="h-12" />
+        <PanelSkeleton rows={2} rowHeight="h-10" />
+        <div className="border rounded-lg">
+          <div className="p-6 border-b">
+            <div className="flex items-center gap-2">
+              <SkeletonLine height="h-5" width="w-5" />
+              <SkeletonLine height="h-5" width="w-40" />
+            </div>
+          </div>
+          <TableSkeleton columns={5} rows={3} bordered={false} />
+        </div>
+        <PanelSkeleton rows={3} rowHeight="h-10" />
+        <PanelSkeleton rows={2} rowHeight="h-10" />
+      </div>
+    );
   }
 
   if (error) {

--- a/src/frontend/src/views/data-products.tsx
+++ b/src/frontend/src/views/data-products.tsx
@@ -729,7 +729,7 @@ export default function DataProducts() {
 
       {/* 1. Check Permissions Loading */}
       {permissionsLoading ? (
-        <ListViewSkeleton columns={7} rows={5} toolbarButtons={3} />
+        <ListViewSkeleton columns={9} rows={5} toolbarButtons={3} />
       ) : !canRead ? (
         // 2. Check Read Permission (if permissions loaded)
         <Alert variant="destructive" className="mb-4">
@@ -738,7 +738,7 @@ export default function DataProducts() {
         </Alert>
       ) : loading ? (
         // 3. Check Data Loading (if permissions OK)
-        <ListViewSkeleton columns={7} rows={5} toolbarButtons={3} />
+        <ListViewSkeleton columns={9} rows={5} toolbarButtons={3} />
       ) : (
         // 5. Render Content (if permissions OK and data loaded)
         <div className="space-y-4">

--- a/src/frontend/src/views/database-schema.tsx
+++ b/src/frontend/src/views/database-schema.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/popover';
 import { Search, Download, Info } from 'lucide-react';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import { GraphCanvasSkeleton } from '@/components/common/list-view-skeleton';
 
 // Types for our schema data
 interface Column {
@@ -344,14 +345,7 @@ export default function DatabaseSchema() {
   }, [schemaData]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center h-[600px]">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">{t('database-schema:loading')}</p>
-        </div>
-      </div>
-    );
+    return <GraphCanvasSkeleton showToolbar height="h-[600px]" />;
   }
 
   if (error) {

--- a/src/frontend/src/views/delivery-methods.tsx
+++ b/src/frontend/src/views/delivery-methods.tsx
@@ -178,7 +178,7 @@ export default function DeliveryMethodsView() {
       </div>
 
       {(apiIsLoading || permissionsLoading) ? (
-        <ListViewSkeleton columns={4} rows={5} toolbarButtons={1} />
+        <ListViewSkeleton columns={6} rows={5} toolbarButtons={1} />
       ) : !canRead ? (
         <Alert variant="destructive" className="mb-4">
           <AlertCircle className="h-4 w-4" />

--- a/src/frontend/src/views/documentation-viewer.tsx
+++ b/src/frontend/src/views/documentation-viewer.tsx
@@ -34,7 +34,7 @@ function buildToc(markdown: string) {
 }
 
 export default function DocumentationViewer() {
-  const { t } = useTranslation('common');
+  useTranslation('common');
   const { docName } = useParams<{ docName: string }>();
   const [markdown, setMarkdown] = useState<string>('');
   const [title, setTitle] = useState<string>('Documentation');

--- a/src/frontend/src/views/documentation-viewer.tsx
+++ b/src/frontend/src/views/documentation-viewer.tsx
@@ -5,6 +5,7 @@ import { BookOpenCheck, ChevronRight } from 'lucide-react';
 import MarkdownViewer from '@/components/ui/markdown-viewer';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import { DocViewerSkeleton } from '@/components/common/list-view-skeleton';
 
 // Helper function to slugify text for anchor IDs
 function slugify(text: string): string {
@@ -130,7 +131,7 @@ export default function DocumentationViewer() {
           <BookOpenCheck className="w-8 h-8" />
           <h1 className="text-4xl font-bold">{title}</h1>
         </div>
-        <div className="text-muted-foreground">{t('labels.loadingDocumentation')}</div>
+        <DocViewerSkeleton showTitle={false} proseRows={14} />
       </div>
     );
   }

--- a/src/frontend/src/views/entitlements-sync.tsx
+++ b/src/frontend/src/views/entitlements-sync.tsx
@@ -11,6 +11,7 @@ import { ArrowLeftRight, Plus, Trash2, Edit2, Clock, CheckCircle2, XCircle } fro
 import { ColumnDef } from "@tanstack/react-table"
 import useBreadcrumbStore from '@/stores/breadcrumb-store'
 import { DataTable } from '@/components/ui/data-table'
+import { ListViewSkeleton } from '@/components/common/list-view-skeleton'
 
 interface EntitlementsSyncConfig {
   id: string
@@ -355,13 +356,17 @@ export default function EntitlementsSync() {
         </Dialog>
       </div>
 
-      <DataTable
-        columns={columns}
-        data={configs}
-        searchColumn="name"
-        storageKey="entitlements-sync-sort"
-        isLoading={isLoading}
-      />
+      {isLoading && configs.length === 0 ? (
+        <ListViewSkeleton columns={5} rows={5} toolbarButtons={1} />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={configs}
+          searchColumn="name"
+          storageKey="entitlements-sync-sort"
+          isLoading={isLoading}
+        />
+      )}
     </div>
   )
 } 

--- a/src/frontend/src/views/entitlements.tsx
+++ b/src/frontend/src/views/entitlements.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { User, Settings, Plus, Edit2, Trash2, Shield, Loader2 } from 'lucide-react';
+import { User, Settings, Plus, Edit2, Trash2, Shield } from 'lucide-react';
+import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -346,9 +347,7 @@ const Entitlements: React.FC = () => {
           <CardContent>
             <ScrollArea className="h-[70vh]">
               {isLoading ? (
-                <div className="flex justify-center items-center py-10">
-                  <Loader2 className="animate-spin h-8 w-8 text-primary" />
-                </div>
+                <ListItemSkeleton count={5} height="h-16" className="space-y-2" />
               ) : personas.length === 0 ? (
                 <div className="p-4 text-center text-muted-foreground">
                   {t('entitlements:personas.noPersonas')}

--- a/src/frontend/src/views/estate-details.tsx
+++ b/src/frontend/src/views/estate-details.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { ArrowLeft, Globe, Edit3, PlusCircle, Trash2, Share2, Database, Zap, ZapOff, Settings2, ShieldCheck, ListFilter } from 'lucide-react';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import { DetailViewSkeleton } from '@/components/common/list-view-skeleton';
 import AddSharingPolicyDialog from '@/components/estates/add-sharing-policy-dialog';
 
 // --- TypeScript Interfaces (Consider moving to a shared types/estate.ts file later) ---
@@ -179,7 +180,7 @@ export default function EstateDetailsView() {
   };
 
   if (isLoading) {
-    return <div className="flex justify-center items-center h-64">{t('common:labels.loadingEstateDetails')}</div>;
+    return <DetailViewSkeleton cards={3} actionButtons={2} />;
   }
 
   if (error) {

--- a/src/frontend/src/views/estate-details.tsx
+++ b/src/frontend/src/views/estate-details.tsx
@@ -56,7 +56,7 @@ export interface Estate {
 // --- End TypeScript Interfaces ---
 
 export default function EstateDetailsView() {
-  const { t } = useTranslation(['estates', 'common']);
+  useTranslation(['estates', 'common']);
   const { estateId } = useParams<{ estateId: string }>();
   const navigate = useNavigate();
   const { get, put } = useApi();

--- a/src/frontend/src/views/estate-manager.tsx
+++ b/src/frontend/src/views/estate-manager.tsx
@@ -10,6 +10,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { MoreHorizontal, Globe, Plus, Share2, Database, Network } from 'lucide-react';
+import {
+  GraphCanvasSkeleton,
+  ListViewSkeleton,
+} from '@/components/common/list-view-skeleton';
 import { ColumnDef } from "@tanstack/react-table"
 import {
   DropdownMenu,
@@ -78,6 +82,7 @@ export default function EstateManager() {
   const setStaticSegments = useBreadcrumbStore((state) => state.setStaticSegments);
   const setDynamicTitle = useBreadcrumbStore((state) => state.setDynamicTitle);
   const [estates, setEstates] = useState<Estate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const [selectedEstate, setSelectedEstate] = useState<Estate | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [formData, setFormData] = useState<Partial<Estate>>({
@@ -108,6 +113,7 @@ export default function EstateManager() {
 
   const fetchEstates = async () => {
     try {
+      setIsLoading(true);
       const response = await get<Estate[]>('/api/estates');
       setEstates(response.data || []);
     } catch (error) {
@@ -117,6 +123,8 @@ export default function EstateManager() {
         variant: 'destructive',
       });
       setEstates([]);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -384,7 +392,13 @@ export default function EstateManager() {
           />
         </div>
 
-        {viewMode === 'table' ? (
+        {isLoading ? (
+          viewMode === 'table' ? (
+            <ListViewSkeleton columns={8} rows={5} toolbarButtons={1} />
+          ) : (
+            <GraphCanvasSkeleton showToolbar={false} height="h-[calc(100vh-280px)]" />
+          )
+        ) : viewMode === 'table' ? (
           <DataTable
             columns={columns}
             data={estates}

--- a/src/frontend/src/views/hierarchy-browser.tsx
+++ b/src/frontend/src/views/hierarchy-browser.tsx
@@ -14,7 +14,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import {
   HierarchyTreeSkeleton,
-  SkeletonLine,
+  HierarchyDetailSkeleton,
 } from '@/components/common/list-view-skeleton';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
@@ -74,22 +74,6 @@ function getEntityRoute(entityType: string, entityId: string): string {
   return `/assets/${entityId}`;
 }
 
-function DetailSkeleton() {
-  return (
-    <div className="space-y-4 p-6">
-      <SkeletonLine height="h-8" width="w-64" />
-      <SkeletonLine width="w-96" />
-      <div className="space-y-2 mt-6">
-        <SkeletonLine height="h-6" width="w-48" />
-        <div className="pl-4 space-y-1.5">
-          <SkeletonLine height="h-5" width="w-56" />
-          <SkeletonLine height="h-5" width="w-52" />
-          <SkeletonLine height="h-5" width="w-60" />
-        </div>
-      </div>
-    </div>
-  );
-}
 
 interface DetailPanelProps {
   node: InstanceHierarchyNode | null;
@@ -154,7 +138,7 @@ function DetailPanel({
     onVisibleTypesChange(base);
   }, [visibleTypes, allTypes, onVisibleTypesChange]);
 
-  if (loading) return <DetailSkeleton />;
+  if (loading) return <HierarchyDetailSkeleton showControls treeRows={6} />;
 
   if (!node || !displayNode) {
     return (

--- a/src/frontend/src/views/home.tsx
+++ b/src/frontend/src/views/home.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import SearchBar from '@/components/ui/search-bar';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
+import { TileGridSkeleton } from '@/components/common/list-view-skeleton';
 import { UnityCatalogLogo } from '@/components/unity-catalog-logo';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel, HomeSection } from '@/types/settings';
@@ -87,9 +88,7 @@ export default function Home() {
           <div className="mb-8">
             <h2 className="text-2xl font-semibold mb-4">{t('home:overview.title')}</h2>
             {permissionsLoading ? (
-              <div className="flex justify-center items-center h-24 col-span-full">
-                <Loader2 className="h-8 w-8 animate-spin text-primary" />
-              </div>
+              <TileGridSkeleton count={8} columns={4} tileHeight="h-32" />
             ) : availableTiles.length > 0 ? (
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {availableTiles.map((tile) => (

--- a/src/frontend/src/views/master-data-management.tsx
+++ b/src/frontend/src/views/master-data-management.tsx
@@ -16,11 +16,12 @@ import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { RelativeDate } from '@/components/common/relative-date';
 import { 
   GitCompare, Plus, Play, FileCheck, Link2, 
-  Database, AlertCircle, Loader2,
+  Database, AlertCircle,
   // CheckCircle2, // Available for future use
   Clock, Trash2, Settings2, RefreshCw, Users,
   Merge, Eye
 } from 'lucide-react';
+import { SplitPaneSkeleton } from '@/components/common/list-view-skeleton';
 
 import MdmConfigDialog from '@/components/mdm/mdm-config-dialog';
 import LinkSourceDialog from '@/components/mdm/link-source-dialog';
@@ -282,9 +283,14 @@ export default function MasterDataManagement() {
       )}
 
       {loading ? (
-        <div className="flex justify-center items-center h-64">
-          <Loader2 className="h-12 w-12 animate-spin text-primary" />
-        </div>
+        <SplitPaneSkeleton
+          sidebarWidth="w-1/3"
+          sidebarVariant="cards"
+          sidebarItems={4}
+          main="panel"
+          tableRows={4}
+          showHeader={false}
+        />
       ) : (
         <div className="grid grid-cols-12 gap-6">
           {/* MDM Configurations List */}

--- a/src/frontend/src/views/my-products.tsx
+++ b/src/frontend/src/views/my-products.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
-import { Package, ExternalLink, ShoppingBag, Search, X, LayoutList, Network, Database, Grid2X2, Loader2 } from 'lucide-react';
+import { Package, ExternalLink, ShoppingBag, Search, X, LayoutList, Network, Database, Grid2X2 } from 'lucide-react';
 import { CardSkeleton, SkeletonBlock } from '@/components/common/list-view-skeleton';
 import { DataDomainMiniGraph } from '@/components/data-domains/data-domain-mini-graph';
 import { useDomains } from '@/hooks/use-domains';

--- a/src/frontend/src/views/my-products.tsx
+++ b/src/frontend/src/views/my-products.tsx
@@ -9,7 +9,7 @@ import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Package, ExternalLink, ShoppingBag, Search, X, LayoutList, Network, Database, Grid2X2, Loader2 } from 'lucide-react';
-import { CardSkeleton } from '@/components/common/list-view-skeleton';
+import { CardSkeleton, SkeletonBlock } from '@/components/common/list-view-skeleton';
 import { DataDomainMiniGraph } from '@/components/data-domains/data-domain-mini-graph';
 import { useDomains } from '@/hooks/use-domains';
 import { useViewModeStore } from '@/stores/view-mode-store';
@@ -265,10 +265,7 @@ export default function MyProducts() {
           </div>
         </div>
         {domainsLoading || domainDetailsLoading ? (
-          <div className="flex items-center gap-2 text-muted-foreground h-[220px] justify-center border rounded-lg bg-muted/20">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            <span className="text-sm">{t('marketplace.loadingDomains')}</span>
-          </div>
+          <SkeletonBlock height="h-[220px]" className="rounded-lg" />
         ) : domainBrowserStyle === 'pills' ? (
           <div className="flex flex-wrap gap-2">
             <Button variant={selectedDomainId === null ? 'default' : 'outline'} size="sm" onClick={() => setSelectedDomainId(null)} className="rounded-full">

--- a/src/frontend/src/views/my-requests.tsx
+++ b/src/frontend/src/views/my-requests.tsx
@@ -15,7 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent } from '@/components/ui/card';
 import { Inbox, XCircle, Loader2, ShieldCheck, Package, Bell } from 'lucide-react';
 import { RelativeDate } from '@/components/common/relative-date';
-import { ListViewSkeleton } from '@/components/common/list-view-skeleton';
+import { ListViewSkeleton, SkeletonLine } from '@/components/common/list-view-skeleton';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
@@ -194,7 +194,11 @@ export default function MyRequests() {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Pending Requests</p>
-                <p className="text-2xl font-bold">{pendingCount}</p>
+                {requestsLoading ? (
+                  <SkeletonLine height="h-7" width="w-10" className="mt-1" />
+                ) : (
+                  <p className="text-2xl font-bold">{pendingCount}</p>
+                )}
               </div>
             </div>
           </CardContent>
@@ -207,7 +211,11 @@ export default function MyRequests() {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Total Requests</p>
-                <p className="text-2xl font-bold">{rows.length}</p>
+                {requestsLoading ? (
+                  <SkeletonLine height="h-7" width="w-10" className="mt-1" />
+                ) : (
+                  <p className="text-2xl font-bold">{rows.length}</p>
+                )}
               </div>
             </div>
           </CardContent>
@@ -220,7 +228,11 @@ export default function MyRequests() {
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Active Subscriptions</p>
-                <p className="text-2xl font-bold">{subscriptions.length}</p>
+                {subscriptionsLoading ? (
+                  <SkeletonLine height="h-7" width="w-10" className="mt-1" />
+                ) : (
+                  <p className="text-2xl font-bold">{subscriptions.length}</p>
+                )}
               </div>
             </div>
           </CardContent>
@@ -245,7 +257,7 @@ export default function MyRequests() {
 
         <TabsContent value="requests" className="mt-4">
           {requestsLoading ? (
-            <ListViewSkeleton columns={6} rows={5} toolbarButtons={0} showToolbar={false} showPagination={false} />
+            <ListViewSkeleton columns={7} rows={5} toolbarButtons={0} showToolbar={false} showPagination={false} />
           ) : requestsError ? (
             <div className="flex flex-col gap-2">
               <p className="text-destructive">{requestsError}</p>

--- a/src/frontend/src/views/ontology-home.tsx
+++ b/src/frontend/src/views/ontology-home.tsx
@@ -4,8 +4,8 @@ import i18n from 'i18next';
 import { useTranslation } from 'react-i18next';
 import {
   Network,
-  Loader2,
 } from 'lucide-react';
+import { GraphCanvasSkeleton } from '@/components/common/list-view-skeleton';
 import type {
   OntologyConcept,
   GroupedConcepts,
@@ -197,8 +197,8 @@ export default function OntologyHomeView() {
 
       {/* Loading state */}
       {isLoading ? (
-        <div className="flex-1 flex items-center justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <div className="flex-1">
+          <GraphCanvasSkeleton showFilterPanel showToolbar={false} height="h-[600px]" />
         </div>
       ) : (
         <div className="flex-1 flex flex-col">

--- a/src/frontend/src/views/projects.tsx
+++ b/src/frontend/src/views/projects.tsx
@@ -285,7 +285,7 @@ export default function ProjectsView() {
       </div>
 
       {(apiIsLoading || permissionsLoading) ? (
-        <ListViewSkeleton columns={5} rows={5} toolbarButtons={1} />
+        <ListViewSkeleton columns={6} rows={5} toolbarButtons={1} />
       ) : !canRead ? (
          <Alert variant="destructive" className="mb-4">
               <AlertCircle className="h-4 w-4" />

--- a/src/frontend/src/views/security-features.tsx
+++ b/src/frontend/src/views/security-features.tsx
@@ -17,6 +17,7 @@ import {
   TableRow,
 } from "../components/ui/table";
 import { Badge } from '@/components/ui/badge';
+import { ListViewSkeleton } from '@/components/common/list-view-skeleton';
 
 interface SecurityFeature {
   id: string;
@@ -32,6 +33,7 @@ interface SecurityFeature {
 const SecurityFeatures: React.FC = () => {
   const { t } = useTranslation(['security-features', 'common']);
   const [features, setFeatures] = useState<SecurityFeature[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingFeature, setEditingFeature] = useState<SecurityFeature | null>(null);
   const [newFeature, setNewFeature] = useState<Partial<SecurityFeature>>({
@@ -50,6 +52,7 @@ const SecurityFeatures: React.FC = () => {
 
   const fetchFeatures = async () => {
     try {
+      setIsLoading(true);
       const response = await fetch('/api/security-features');
       if (!response.ok) {
         throw new Error('Failed to fetch security features');
@@ -62,6 +65,8 @@ const SecurityFeatures: React.FC = () => {
         description: t('security-features:toast.loadError'),
         variant: 'destructive',
       });
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -242,6 +247,9 @@ const SecurityFeatures: React.FC = () => {
         </Dialog>
       </div>
 
+      {isLoading ? (
+        <ListViewSkeleton columns={7} rows={5} showToolbar={false} toolbarButtons={0} />
+      ) : (
       <div className="rounded-md border">
         <Table>
           <TableHeader>
@@ -304,6 +312,7 @@ const SecurityFeatures: React.FC = () => {
           </TableBody>
         </Table>
       </div>
+      )}
     </div>
   );
 };

--- a/src/frontend/src/views/settings-directory.tsx
+++ b/src/frontend/src/views/settings-directory.tsx
@@ -14,6 +14,10 @@ import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { Loader2, Plug2 } from 'lucide-react';
 
 import SettingsPageWrapper from '@/components/settings/settings-page-wrapper';
+import {
+  SettingsFormSkeleton,
+  SkeletonLine,
+} from '@/components/common/list-view-skeleton';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -213,10 +217,12 @@ export default function SettingsDirectoryView() {
   };
 
   if (loading) {
+    // Provider tabs + dynamic form fields + status row
     return (
       <SettingsPageWrapper title="Directory" permissionId="settings-directory">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        <div className="space-y-4">
+          <SkeletonLine height="h-9" width="w-72" />
+          <SettingsFormSkeleton sections={1} fieldsPerSection={4} showSaveBar={false} showTitle={false} />
         </div>
       </SettingsPageWrapper>
     );

--- a/src/frontend/src/views/teams.tsx
+++ b/src/frontend/src/views/teams.tsx
@@ -298,7 +298,7 @@ export default function TeamsView() {
       </div>
 
       {(apiIsLoading || permissionsLoading) ? (
-        <ListViewSkeleton columns={4} rows={5} toolbarButtons={1} />
+        <ListViewSkeleton columns={5} rows={5} toolbarButtons={1} />
       ) : !canRead ? (
          <Alert variant="destructive" className="mb-4">
               <AlertCircle className="h-4 w-4" />

--- a/src/frontend/src/views/user-guide.tsx
+++ b/src/frontend/src/views/user-guide.tsx
@@ -33,7 +33,7 @@ function buildToc(markdown: string) {
 }
 
 export default function UserGuide() {
-  const { t } = useTranslation('common');
+  useTranslation('common');
   const [markdown, setMarkdown] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/frontend/src/views/user-guide.tsx
+++ b/src/frontend/src/views/user-guide.tsx
@@ -4,6 +4,7 @@ import { BookOpenCheck, ChevronRight } from 'lucide-react';
 import MarkdownViewer from '@/components/ui/markdown-viewer';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
+import { DocViewerSkeleton } from '@/components/common/list-view-skeleton';
 
 // Helper function to slugify text for anchor IDs
 function slugify(text: string): string {
@@ -144,7 +145,7 @@ export default function UserGuide() {
           <BookOpenCheck className="w-8 h-8" />
           <h1 className="text-4xl font-bold">User Guide</h1>
         </div>
-        <div className="text-muted-foreground">{t('labels.loadingUserGuide')}</div>
+        <DocViewerSkeleton showTitle={false} proseRows={14} />
       </div>
     );
   }

--- a/src/frontend/src/views/workflows.tsx
+++ b/src/frontend/src/views/workflows.tsx
@@ -49,6 +49,7 @@ import { ColumnDef, Column } from "@tanstack/react-table";
 import { useApi } from '@/hooks/use-api';
 import SettingsPageWrapper from '@/components/settings/settings-page-wrapper';
 import { DataTable } from '@/components/ui/data-table';
+import { TableSkeleton } from '@/components/common/list-view-skeleton';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import type { 
@@ -1362,9 +1363,7 @@ export default function Workflows() {
         </CardHeader>
         <CardContent>
           {isLoadingWorkflows ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
+            <TableSkeleton columns={5} rows={5} bordered={false} />
           ) : workflows.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               <GitBranch className="h-12 w-12 mx-auto mb-4 opacity-20" />
@@ -1430,9 +1429,7 @@ export default function Workflows() {
         </CardHeader>
         <CardContent>
           {isLoadingExecutions ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
+            <TableSkeleton columns={8} rows={5} bordered={false} />
           ) : executions.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               <Play className="h-12 w-12 mx-auto mb-4 opacity-20" />


### PR DESCRIPTION
## Summary

Full pass over the main views to (a) fix shape mismatches in already-migrated skeletons and (b) replace spinners/loading text/missing states with bespoke layout-matched skeletons. Builds on #297 and is delivered as 4 phased commits + a small cleanup.

### Phase 1 — Library extensions
Extends `src/frontend/src/components/common/list-view-skeleton.tsx` with new helpers and tightens existing ones.

- New: `TabsDetailSkeleton`, `SplitPaneSkeleton`, `SettingsFormSkeleton`, `HomeDashboardSkeleton`, `TileGridSkeleton`, `DocViewerSkeleton`, `GraphCanvasSkeleton`, `WorkflowCanvasSkeleton`, `HierarchyDetailSkeleton`, `FilterBarSkeleton`
- Extended: `DetailHeaderSkeleton` (`leftControls`), `CatalogColumnsTableSkeleton` (`columns`, `showHeader`), `StatCardsSkeleton` (`cardPadding`)
- Grep guard intact: only `list-view-skeleton.tsx` imports from `@/components/ui/skeleton`.

### Phase 2 — Tune migrated views
- Column count fixes on `data-products`, `data-contracts`, `business-roles`, `business-owners`, `teams`, `projects`, `delivery-methods`, `asset-types`, `my-requests` (also adds `SkeletonLine` for the 3 stat cards).
- Tabbed/bespoke detail shapes on `asset-detail`, `data-catalog-details`, `concept-detail`, `hierarchy-browser`, `data-product-details`, `data-contract-details`, `data-domain-details`.

### Phase 3 — Replace spinners/text
Replaces `Loader2`/loading text with layout-matched skeletons on `business-terms`, `collections`, `data-asset-reviews`, `entitlements`, `master-data-management`, `compliance`, `audit-trail`, `workflows`, `asset-explorer`, `catalog-commander`, `my-products`, `security-features`, `estate-manager`, `entitlements-sync`, `compliance-policy-details`, `compliance-run-details`, `data-asset-review-details`, `estate-details`.

### Phase 4 — Settings, home, canvas/graph
Bespoke skeletons for the home dashboard (cascaded into all home subsections), all settings sub-pages (form/table/bespoke split), `ontology-home`, `database-schema`, `workflow-designer`, `documentation-viewer`, `user-guide`.

### Cleanup
Final commit removes dangling `Loader2`/unused `t` imports left over after the migrations.

## Verification

- `yarn type-check`: 0 new errors (only pre-existing `TS6133` warnings in `data-contract-details.tsx` / `data-product-details.tsx` remain, confirmed against baseline `0920f99d`).
- `yarn lint`: 287 errors / 1438 warnings — error count unchanged from baseline; warnings decreased by 8 due to unused-import cleanup.
- `yarn build`: succeeds; bundle size unchanged at sane levels.
- Grep guard intact: `rg \"from '@/components/ui/skeleton'\" src/frontend/src` returns only `list-view-skeleton.tsx`.

## Test plan

- [ ] Throttle network in DevTools (Slow 3G) and walk through every changed route.
- [ ] Confirm skeleton matches loaded shape on each page (no layout shift, no flash of spinner before skeleton).
- [ ] Spot-check home, all settings sub-pages, all detail views, canvas/graph pages.

Refs #297