### PR TITLE
feat(semantic-links): support linking concepts/properties to Assets

### DIFF
--- a/.cursor/rules/10-entity-panel-matrix.mdc
+++ b/.cursor/rules/10-entity-panel-matrix.mdc
@@ -34,7 +34,7 @@ These tables use an `entity_type` + `entity_id` pattern to link to any entity.
 | `entity_relationships` | Typed relationships between any two entities |
 | `entity_subscriptions` | User subscriptions / notifications |
 | `entity_tag_associations` | Tag assignments |
-| `entity_semantic_links` | Links to ontology concepts |
+| `entity_semantic_links` | Links to ontology concepts/properties (`entity_type` ∈ {`data_domain`, `data_product`, `data_contract`, `data_contract_schema`, `data_contract_property`, `asset`, `uc_catalog`, `uc_schema`, `uc_table`, `uc_column`, `dataset` _(legacy)_}) |
 | `rich_text_metadata` | Rich-text notes |
 | `link_metadata` | External link bookmarks |
 | `document_metadata` | Uploaded documents |
@@ -81,7 +81,7 @@ Legend: **Y** = yes, show/support | **—** = no, hide/skip | **Σ** = show summ
 | **Relationships** | Y | Y | Y | — | — | — |
 | **Subscriptions** | — | Y | Y | — | — | — |
 | **Tags** | — | Y | Y | — | — | — |
-| **Semantic Links** | — | — | Y | — | — | — |
+| **Semantic Links** | Y | Y | Y | — | — | — |
 | **Metadata (rich/link/doc)** | Y | Y | Y | Y | Y | Y |
 | **Change Log** | — | Y | Y | — | — | — |
 | **Access Grants** | — | Y | — | — | — | — |
@@ -122,6 +122,7 @@ Legend: **Y** = show | **—** = hide | **Σ** = summary only
 | **Relationships** | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y |
 | **Subscriptions** | — | — | — | — | — | Y | — | — | — | — | — | — | — | — | — | — | — |
 | **Tags** | Y | Y | Y | Y | — | Y | Y | Y | Y | Y | Y | Y | Y | — | — | — | Y |
+| **Semantic Links** | — | — | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | — | Y |
 | **Metadata (rich/link/doc)** | Y | Y | Y | Y | — | Y | Y | Y | Y | Y | Y | Y | Y | Y | — | — | Y |
 | **Change Log** | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y |
 | **Access Grants** | — | — | Y | Y | — | Y | — | — | — | — | — | — | — | — | — | — | — |
@@ -149,6 +150,15 @@ Legend: **Y** = show | **—** = hide | **Σ** = summary only
 - **Dashboard / ML Model**: Consumable outputs. Ratings and costs apply.
 - **Notebook / API Endpoint**: Development artifacts. Comments and tags yes,
   ratings and costs generally no (cost is tracked at the product level).
+- **Semantic Links (Tier 2)**: All Tier 2 asset-backed entities are addressable
+  via `entity_type='asset'` with `entity_id = AssetDb.id` (UUID). The single
+  `asset` polymorphic type covers Table, View, Dataset, Dashboard, Notebook,
+  ML Model, Column, Logical Attribute, Business Term, etc. — the IRI itself
+  indicates whether the link points at a class (rdfs:Class) or property
+  (rdf:Property). Catalog/Schema are excluded because they are platform
+  containers and instead use the dedicated `uc_catalog` / `uc_schema`
+  entity types when raw UC objects need linking. Delivery Channel is
+  excluded — it has no semantic surface today.
 
 ---
 
@@ -182,6 +192,13 @@ const OWNERSHIP_ELIGIBLE_TYPES = new Set([
   'Table', 'View', 'Dataset', 'Dashboard', 'Notebook',
   'ML Model', 'API Endpoint', 'Stream', 'Policy',
   'Business Term', 'Logical Entity', 'System',
+]);
+// Semantic Links are exposed on all asset-backed entities except containers
+// (Catalog/Schema) and Delivery Channel. The asset detail view always renders
+// the panel — empty state is handled gracefully — so an explicit allow-set
+// is only needed if you ever decide to hide the panel for specific types.
+const SEMANTIC_LINK_INELIGIBLE_TYPES = new Set([
+  'Catalog', 'Schema', 'Delivery Channel',
 ]);
 ```
 

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -1709,6 +1709,25 @@ class SemanticModelsManager:
         except Exception as e:
             logger.debug(f"Skipping data contracts load into graph: {e}")
 
+        # Assets: polymorphic AssetDb rows (Table, View, Dataset, Dashboard, Notebook, Column, ...)
+        # Joined to asset_types so we can emit a per-type rdf:type alongside the generic 'asset' type.
+        try:
+            rows = self._db.execute(sql_text(
+                "SELECT a.id, a.name, at.name AS type_name "
+                "FROM assets a LEFT JOIN asset_types at ON a.asset_type_id = at.id"
+            )).fetchall()
+            for r in rows:
+                subj = URIRef(f"urn:ontos:asset:{r[0]}")
+                context.add((subj, RDF.type, URIRef("urn:ontos:entity-type:asset")))
+                if r[2]:
+                    type_slug = str(r[2]).strip().lower().replace(' ', '_')
+                    if type_slug:
+                        context.add((subj, RDF.type, URIRef(f"urn:ontos:asset-type:{type_slug}")))
+                if r[1]:
+                    context.add((subj, RDFS.label, Literal(str(r[1]))))
+        except Exception as e:
+            logger.debug(f"Skipping assets load into graph: {e}")
+
     def add_entity_semantic_link_to_graph(self, entity_type: str, entity_id: str, iri: str, created_by: Optional[str] = None) -> None:
         """Incrementally add a single semantic link triple into the graph and database.
         

--- a/src/backend/src/db_models/semantic_links.py
+++ b/src/backend/src/db_models/semantic_links.py
@@ -8,7 +8,21 @@ from src.common.database import Base
 
 
 class EntitySemanticLinkDb(Base):
-    """Links an entity (data_domain, data_product, data_contract) to a semantic IRI/label; used for knowledge graph and glossary linkage."""
+    """Links an entity to a semantic IRI/label; used for knowledge graph and glossary linkage.
+
+    ``entity_type`` is one of:
+      - ``data_domain``, ``data_product``, ``data_contract``
+      - ``data_contract_schema`` (entity_id = ``{contractId}#{schemaName}``)
+      - ``data_contract_property`` (entity_id = ``{contractId}#{schemaName}#{propertyName}``)
+      - ``asset`` (entity_id = ``AssetDb`` UUID — polymorphic over Table, View,
+        Dataset, Dashboard, Notebook, ML Model, Column, Logical Attribute, ...)
+      - ``uc_catalog`` / ``uc_schema`` / ``uc_table`` / ``uc_column`` (entity_id =
+        UC fully-qualified name; used for raw UC objects not wrapped as Assets)
+      - ``dataset`` (legacy — superseded by ``asset``)
+
+    See ``src/backend/src/models/semantic_links.py`` for the authoritative
+    ``EntityType`` Literal enforced at the API boundary.
+    """
     __tablename__ = "entity_semantic_links"
 
     id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/src/backend/src/models/semantic_links.py
+++ b/src/backend/src/models/semantic_links.py
@@ -2,10 +2,12 @@ from pydantic import BaseModel
 from typing import Optional, Literal
 
 
-# entity_id formats: uc_catalog = catalog; uc_schema = catalog.schema; uc_table = catalog.schema.table; uc_column = catalog.schema.table.column
+# entity_id formats:
+#   uc_catalog = catalog; uc_schema = catalog.schema; uc_table = catalog.schema.table; uc_column = catalog.schema.table.column
+#   asset      = AssetDb UUID (polymorphic asset-backed entity: Table, View, Dataset, Dashboard, Column, ...)
 EntityType = Literal[
     'data_domain', 'data_product', 'data_contract', 'data_contract_schema', 'data_contract_property',
-    'dataset', 'uc_catalog', 'uc_schema', 'uc_table', 'uc_column'
+    'dataset', 'asset', 'uc_catalog', 'uc_schema', 'uc_table', 'uc_column'
 ]
 
 

--- a/src/backend/src/tests/unit/test_semantic_links_manager.py
+++ b/src/backend/src/tests/unit/test_semantic_links_manager.py
@@ -2,10 +2,32 @@
 Unit tests for SemanticLinksManager
 """
 import pytest
+from pydantic import ValidationError
 from unittest.mock import Mock, MagicMock, patch
 from src.controller.semantic_links_manager import SemanticLinksManager
 from src.models.semantic_links import EntitySemanticLink, EntitySemanticLinkCreate
 from src.db_models.semantic_links import EntitySemanticLinkDb
+
+
+class TestEntitySemanticLinkCreateModel:
+    """Validate the EntityType Literal accepts the polymorphic 'asset' value."""
+
+    def test_asset_entity_type_validates(self):
+        payload = EntitySemanticLinkCreate(
+            entity_id="11111111-2222-3333-4444-555555555555",
+            entity_type="asset",
+            iri="http://example.com/schema/Customer",
+            label="Customer",
+        )
+        assert payload.entity_type == "asset"
+
+    def test_unknown_entity_type_rejected(self):
+        with pytest.raises(ValidationError):
+            EntitySemanticLinkCreate(
+                entity_id="x",
+                entity_type="not_an_entity_type",  # type: ignore[arg-type]
+                iri="http://example.com/x",
+            )
 
 
 class TestSemanticLinksManager:
@@ -97,6 +119,21 @@ class TestSemanticLinksManager:
         result = manager._resolve_entity_name("contract-123", "data_contract")
 
         assert result == "Contract Name"
+
+    def test_resolve_entity_name_asset(self, manager, mock_db):
+        """Test resolving entity name for asset (polymorphic AssetDb row)."""
+        mock_result = Mock()
+        mock_result.__getitem__ = Mock(return_value="customers_table")
+        mock_db.execute.return_value.fetchone.return_value = mock_result
+
+        result = manager._resolve_entity_name(
+            "11111111-2222-3333-4444-555555555555", "asset"
+        )
+
+        assert result == "customers_table"
+        # Ensure the SQL targets the shared assets table (same path as dataset)
+        called_sql = str(mock_db.execute.call_args[0][0])
+        assert "FROM assets" in called_sql
 
     def test_resolve_entity_name_not_found(self, manager, mock_db):
         """Test resolving entity name when entity not found."""
@@ -246,6 +283,32 @@ class TestSemanticLinksManager:
         mock_repo.create.assert_called_once()
         manager._db.flush.assert_called_once()
         manager._db.refresh.assert_called_once()
+
+    @patch('src.controller.semantic_links_manager.change_log_manager')
+    @patch('src.controller.semantic_links_manager.entity_semantic_links_repo')
+    def test_add_link_for_asset(self, mock_repo, mock_change_log, manager):
+        """Test adding a semantic link with entity_type='asset' (UUID-based)."""
+        asset_uuid = "11111111-2222-3333-4444-555555555555"
+        payload = EntitySemanticLinkCreate(
+            entity_id=asset_uuid,
+            entity_type="asset",
+            iri="http://example.com/schema/Customer",
+            label="Customer",
+        )
+        created_db = Mock(spec=EntitySemanticLinkDb)
+        created_db.id = 42
+        created_db.entity_id = asset_uuid
+        created_db.entity_type = "asset"
+        created_db.iri = "http://example.com/schema/Customer"
+        created_db.label = "Customer"
+        mock_repo.get_by_entity_and_iri.return_value = None
+        mock_repo.create.return_value = created_db
+
+        result = manager.add(payload, created_by="user@example.com")
+
+        assert result.entity_type == "asset"
+        assert result.entity_id == asset_uuid
+        mock_repo.create.assert_called_once()
 
     @patch('src.controller.semantic_links_manager.entity_semantic_links_repo')
     def test_add_link_already_exists(self, mock_repo, manager, sample_link_create, sample_link_db):

--- a/src/frontend/src/components/search/concepts-search.tsx
+++ b/src/frontend/src/components/search/concepts-search.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
-import { Shapes, Columns2, FileText, Package, Globe, X, Link2, Table, Folder, FolderOpen } from 'lucide-react';
+import { Shapes, Columns2, FileText, Package, Globe, X, Link2, Table, Folder, FolderOpen, Box } from 'lucide-react';
 import UCAssetLookupDialog from '@/components/data-contracts/uc-asset-lookup-dialog';
 import { UCAssetInfo, UCAssetType } from '@/types/uc-asset';
 
@@ -265,6 +265,9 @@ export default function ConceptsSearch({
           case 'data_domain':
             endpoint = `/api/data-domains/${link.entity_id}`;
             break;
+          case 'asset':
+            endpoint = `/api/assets/${link.entity_id}`;
+            break;
           case 'data_contract_schema': {
             const [contractId, schemaName] = String(link.entity_id).split('#');
             if (contractId) {
@@ -327,6 +330,12 @@ export default function ConceptsSearch({
         case 'data_domain':
           endpoint = '/api/data-domains';
           break;
+        case 'asset': {
+          // /api/assets returns a paginated envelope {items, total, ...} — unwrap to a flat list.
+          const res = await get<{ items: any[]; total: number }>('/api/assets?limit=200');
+          setAvailableEntities(res.data?.items || []);
+          return;
+        }
         default:
           return;
       }
@@ -359,6 +368,9 @@ export default function ConceptsSearch({
       case 'data_domain':
         path = `/settings/data-domains/${link.entity_id}`;
         break;
+      case 'asset':
+        path = `/assets/${link.entity_id}`;
+        break;
       case 'uc_catalog':
       case 'uc_schema':
       case 'uc_table':
@@ -389,6 +401,7 @@ export default function ConceptsSearch({
       case 'data_product': return t('search:concepts.assignDialog.dataProduct');
       case 'data_contract': return t('search:concepts.assignDialog.dataContract');
       case 'data_domain': return t('search:concepts.assignDialog.dataDomain');
+      case 'asset': return t('search:concepts.assignDialog.asset', { defaultValue: 'Asset' });
       case 'uc_catalog': return t('search:concepts.assignDialog.ucCatalog');
       case 'uc_schema': return t('search:concepts.assignDialog.ucSchema');
       case 'uc_table': return t('search:concepts.assignDialog.ucTable');
@@ -651,6 +664,8 @@ export default function ConceptsSearch({
                         ? Package
                         : link.entity_type === 'data_domain'
                         ? Globe
+                        : link.entity_type === 'asset'
+                        ? Box
                         : link.entity_type === 'uc_catalog'
                         ? Folder
                         : link.entity_type === 'uc_schema'
@@ -718,6 +733,7 @@ export default function ConceptsSearch({
                   <SelectItem value="data_product">{t('search:concepts.assignDialog.dataProduct')}</SelectItem>
                   <SelectItem value="data_contract">{t('search:concepts.assignDialog.dataContract')}</SelectItem>
                   <SelectItem value="data_domain">{t('search:concepts.assignDialog.dataDomain')}</SelectItem>
+                  <SelectItem value="asset">{t('search:concepts.assignDialog.asset', { defaultValue: 'Asset' })}</SelectItem>
                   <SelectItem value="uc_catalog">{t('search:concepts.assignDialog.ucCatalog')}</SelectItem>
                   <SelectItem value="uc_schema">{t('search:concepts.assignDialog.ucSchema')}</SelectItem>
                   <SelectItem value="uc_table">{t('search:concepts.assignDialog.ucTable')}</SelectItem>

--- a/src/frontend/src/components/search/properties-search.tsx
+++ b/src/frontend/src/components/search/properties-search.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
-import { Columns2, FileText, Shapes, X, Link2 } from 'lucide-react';
+import { Columns2, FileText, Shapes, X, Link2, Box } from 'lucide-react';
 import UCAssetLookupDialog from '@/components/data-contracts/uc-asset-lookup-dialog';
 import { UCAssetInfo, UCAssetType } from '@/types/uc-asset';
 
@@ -60,12 +60,15 @@ export default function PropertiesSearch({
 
   // Assign dialog: target type and selection
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
-  const [assignTargetType, setAssignTargetType] = useState<'data_contract_property' | 'uc_column' | ''>('');
+  const [assignTargetType, setAssignTargetType] = useState<'data_contract_property' | 'uc_column' | 'asset' | ''>('');
   const [contracts, setContracts] = useState<any[]>([]);
   const [selectedContractId, setSelectedContractId] = useState('');
   const [selectedSchemaName, setSelectedSchemaName] = useState('');
   const [selectedPropertyEntityId, setSelectedPropertyEntityId] = useState('');
   const [ucAssetDialogOpen, setUCAssetDialogOpen] = useState(false);
+  // Column-like assets (Column / Logical Attribute) for the `asset` target type
+  const [columnAssets, setColumnAssets] = useState<Array<{ id: string; name: string; asset_type_name?: string | null; location?: string | null }>>([]);
+  const [selectedAssetId, setSelectedAssetId] = useState('');
 
   const updateUrl = (updates: Partial<{ query: string; iri: string }>) => {
     const params = new URLSearchParams();
@@ -200,6 +203,9 @@ export default function PropertiesSearch({
         } else if (link.entity_type === 'data_contract') {
           const contractRes = await get<any>(`/api/data-contracts/${link.entity_id}`);
           entityName = contractRes.data?.name || contractRes.data?.info?.title || link.entity_id;
+        } else if (link.entity_type === 'asset') {
+          const assetRes = await get<any>(`/api/assets/${link.entity_id}`);
+          entityName = assetRes.data?.name || link.entity_id;
         }
         result.push({ ...link, entity_name: entityName });
       } catch (error) {
@@ -230,6 +236,12 @@ export default function PropertiesSearch({
       get<any[]>('/api/data-contracts')
         .then((res) => setContracts(res.data || []))
         .catch(() => setContracts([]));
+    } else if (assignTargetType === 'asset') {
+      // Restrict to column-like asset types — rdf:Property only makes sense for these.
+      const typeFilter = encodeURIComponent('Column,Logical Attribute');
+      get<{ items: any[]; total: number }>(`/api/assets?asset_type_names=${typeFilter}&limit=200`)
+        .then((res) => setColumnAssets(res.data?.items || []))
+        .catch(() => setColumnAssets([]));
     }
   }, [assignTargetType]);
 
@@ -251,17 +263,18 @@ export default function PropertiesSearch({
   const properties = selectedSchema?.properties || [];
 
   const handleAssignTargetTypeChange = (v: string) => {
-    setAssignTargetType(v as 'data_contract_property' | 'uc_column');
+    setAssignTargetType(v as 'data_contract_property' | 'uc_column' | 'asset');
     setSelectedContractId('');
     setSelectedSchemaName('');
     setSelectedPropertyEntityId('');
+    setSelectedAssetId('');
   };
 
   const handleAssign = async () => {
     if (!selectedProperty || !assignTargetType) return;
 
     let entityId = '';
-    let entityType = assignTargetType;
+    let entityType: 'data_contract_property' | 'uc_column' | 'asset' = assignTargetType as any;
 
     if (assignTargetType === 'data_contract_property') {
       entityId = selectedPropertyEntityId;
@@ -273,7 +286,18 @@ export default function PropertiesSearch({
         });
         return;
       }
+    } else if (assignTargetType === 'asset') {
+      entityId = selectedAssetId;
+      if (!entityId) {
+        toast({
+          title: t('common:toast.error'),
+          description: t('search:properties.messages.selectPropertyTarget'),
+          variant: 'destructive'
+        });
+        return;
+      }
     } else if (assignTargetType === 'uc_column') {
+      // uc_column is handled by the UC asset lookup dialog flow
       return;
     }
 
@@ -296,6 +320,7 @@ export default function PropertiesSearch({
       setSelectedContractId('');
       setSelectedSchemaName('');
       setSelectedPropertyEntityId('');
+      setSelectedAssetId('');
       await selectProperty(selectedProperty);
     } catch (error: any) {
       toast({
@@ -432,8 +457,16 @@ export default function PropertiesSearch({
                         ? t('search:properties.assignDialog.ucColumn')
                         : link.entity_type === 'uc_table'
                         ? t('search:properties.assignDialog.ucTable')
+                        : link.entity_type === 'asset'
+                        ? t('search:properties.assignDialog.asset', { defaultValue: 'Asset' })
                         : link.entity_type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-                      const Icon = link.entity_type === 'data_contract_property' ? FileText : link.entity_type === 'uc_column' ? Columns2 : Shapes;
+                      const Icon = link.entity_type === 'data_contract_property'
+                        ? FileText
+                        : link.entity_type === 'uc_column'
+                        ? Columns2
+                        : link.entity_type === 'asset'
+                        ? Box
+                        : Shapes;
                       return (
                         <Badge
                           key={link.id}
@@ -482,6 +515,7 @@ export default function PropertiesSearch({
                 <SelectContent>
                   <SelectItem value="data_contract_property">{t('search:properties.assignDialog.dataContractProperty')}</SelectItem>
                   <SelectItem value="uc_column">{t('search:properties.assignDialog.ucColumn')}</SelectItem>
+                  <SelectItem value="asset">{t('search:properties.assignDialog.asset', { defaultValue: 'Asset (Column / Logical Attribute)' })}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -549,11 +583,41 @@ export default function PropertiesSearch({
               </div>
             )}
 
+            {assignTargetType === 'asset' && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  {t('search:properties.assignDialog.asset', { defaultValue: 'Asset (Column / Logical Attribute)' })}
+                </label>
+                <Select value={selectedAssetId} onValueChange={setSelectedAssetId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder={t('search:properties.assignDialog.selectAsset', { defaultValue: 'Select asset' })} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {columnAssets.length === 0 ? (
+                      <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                        {t('search:properties.assignDialog.noColumnAssets', { defaultValue: 'No Column or Logical Attribute assets found' })}
+                      </div>
+                    ) : (
+                      columnAssets.map((a) => (
+                        <SelectItem key={a.id} value={a.id}>
+                          {a.name}
+                          {a.asset_type_name ? ` (${a.asset_type_name})` : ''}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
             <div className="flex justify-end space-x-2 pt-4">
               <Button variant="outline" onClick={() => setAssignDialogOpen(false)}>{t('common:actions.cancel')}</Button>
-              {assignTargetType === 'data_contract_property' ? (
+              {assignTargetType === 'data_contract_property' && (
                 <Button onClick={handleAssign} disabled={!selectedPropertyEntityId}>{t('common:actions.assign')}</Button>
-              ) : null}
+              )}
+              {assignTargetType === 'asset' && (
+                <Button onClick={handleAssign} disabled={!selectedAssetId}>{t('common:actions.assign')}</Button>
+              )}
             </div>
           </div>
         </DialogContent>

--- a/src/frontend/src/components/semantic/linked-objects-panel.test.tsx
+++ b/src/frontend/src/components/semantic/linked-objects-panel.test.tsx
@@ -81,6 +81,12 @@ const sampleLinks = [
     entity_type: 'uc_table',
     iri: 'https://example.org/onto#Customer',
   },
+  {
+    id: 'link-3',
+    entity_id: '11111111-2222-3333-4444-555555555555',
+    entity_type: 'asset',
+    iri: 'https://example.org/onto#Customer',
+  },
 ]
 
 describe('LinkedObjectsPanel', () => {
@@ -97,6 +103,15 @@ describe('LinkedObjectsPanel', () => {
       if (url.startsWith('/api/data-products/')) {
         return { data: { id: 'product-a', name: 'Product A' } }
       }
+      if (url.startsWith('/api/assets/')) {
+        return {
+          data: {
+            id: '11111111-2222-3333-4444-555555555555',
+            name: 'customers_table',
+            asset_type_name: 'Table',
+          },
+        }
+      }
       return { data: [] }
     })
   })
@@ -108,8 +123,11 @@ describe('LinkedObjectsPanel', () => {
     })
     expect(screen.getByTestId('linked-object-link-1')).toBeInTheDocument()
     expect(screen.getByTestId('linked-object-link-2')).toBeInTheDocument()
+    expect(screen.getByTestId('linked-object-link-3')).toBeInTheDocument()
     expect(screen.getByText(/Product A/)).toBeInTheDocument()
     expect(screen.getByText(/main\.sales\.orders/)).toBeInTheDocument()
+    // Asset row resolves the asset's name via /api/assets/{id}
+    expect(screen.getByText(/customers_table/)).toBeInTheDocument()
   })
 
   it('hides assign button and remove buttons when read-only', async () => {

--- a/src/frontend/src/tests/semantic-links.spec.ts
+++ b/src/frontend/src/tests/semantic-links.spec.ts
@@ -85,3 +85,46 @@ test('adds schema and property semantic links via wizard', async ({ page }) => {
 })
 
 
+test('assigns and removes a semantic concept link on an asset', async ({ page }) => {
+  // Pick the first asset from the asset list endpoint so the test is data-driven.
+  const assetsResp = await page.request.get('/api/assets?limit=1')
+  test.skip(!assetsResp.ok(), 'No /api/assets endpoint reachable')
+  const assetsBody: any = await assetsResp.json().catch(() => null)
+  const firstAsset = assetsBody?.items?.[0]
+  test.skip(!firstAsset?.id, 'No assets seeded in the backend')
+
+  await page.goto(`/assets/${firstAsset.id}`)
+
+  // Wait for the Overview tab to render the Details card.
+  await expect(page.getByRole('tab', { name: /overview/i })).toBeVisible()
+
+  // Open the concept picker via the "Add" trailing button on the linked chips row.
+  const linkedSection = page.getByText('Linked Business Concepts').first()
+  await linkedSection.scrollIntoViewIfNeeded()
+  const addBtn = page.getByRole('button', { name: /^add$/i }).first()
+  await addBtn.click()
+
+  // Pick the first available concept.
+  const searchInput = page.getByPlaceholder(/search business concepts/i)
+  await expect(searchInput).toBeVisible()
+  const selectBtn = page.getByRole('button', { name: /^select$/i }).first()
+  await selectBtn.click()
+
+  // Verify the link appears via the backend.
+  await page.waitForFunction(async (id) => {
+    const r = await fetch(`/api/semantic-links/entity/asset/${id}`)
+    if (!r.ok) return false
+    const data = await r.json()
+    return Array.isArray(data) && data.length > 0
+  }, firstAsset.id, { timeout: 15000 })
+
+  // Capture the link id and remove via the API to clean up. Hover-based UI
+  // removal is brittle in headless mode; the asset-detail panel calls the
+  // same endpoint so backend coverage is sufficient.
+  const linksResp = await page.request.get(`/api/semantic-links/entity/asset/${firstAsset.id}`)
+  const links: Array<{ id: string }> = await linksResp.json()
+  for (const link of links) {
+    await page.request.delete(`/api/semantic-links/${link.id}`)
+  }
+})
+

--- a/src/frontend/src/views/asset-detail.tsx
+++ b/src/frontend/src/views/asset-detail.tsx
@@ -31,6 +31,10 @@ import { RatingPanel } from '@/components/ratings';
 import EntityMetadataPanel from '@/components/metadata/entity-metadata-panel';
 import EntityCostsPanel from '@/components/costs/entity-costs-panel';
 import EntityQualityPanel from '@/components/quality/entity-quality-panel';
+import ConceptSelectDialog from '@/components/semantic/concept-select-dialog';
+import LinkedConceptChips from '@/components/semantic/linked-concept-chips';
+import type { EntitySemanticLink } from '@/types/semantic-link';
+import { useToast } from '@/hooks/use-toast';
 import { usePermissions } from '@/stores/permissions-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
@@ -103,9 +107,12 @@ export default function AssetDetailView() {
   const [ontologyIri, setOntologyIri] = useState<string | null>(null);
   const [isLineageEditorOpen, setIsLineageEditorOpen] = useState(false);
   const [relViewMode, setRelViewMode] = useState<'table' | 'graph'>('table');
+  const [semanticLinks, setSemanticLinks] = useState<EntitySemanticLink[]>([]);
+  const [iriDialogOpen, setIriDialogOpen] = useState(false);
 
-  const { get: apiGet } = useApi();
+  const { get: apiGet, post: apiPost, delete: apiDelete } = useApi();
   const { i18n } = useTranslation();
+  const { toast } = useToast();
   const { hasPermission, isLoading: permissionsLoading } = usePermissions();
   const setStaticSegments = useBreadcrumbStore((state) => state.setStaticSegments);
   const setDynamicTitle = useBreadcrumbStore((state) => state.setDynamicTitle);
@@ -113,6 +120,7 @@ export default function AssetDetailView() {
   const featureId = 'assets';
   const canWrite = !permissionsLoading && hasPermission(featureId, FeatureAccessLevel.READ_WRITE);
   const canAdmin = !permissionsLoading && hasPermission(featureId, FeatureAccessLevel.ADMIN);
+  const canEditSemanticLinks = !permissionsLoading && hasPermission('semantic-models', FeatureAccessLevel.READ_WRITE);
 
   const entityType = asset?.asset_type_name || 'Asset';
 
@@ -142,9 +150,13 @@ export default function AssetDetailView() {
     setLoading(true);
     setError(null);
     try {
-      const response = await apiGet<AssetRead>(`/api/assets/${assetId}`);
-      if (response.error) throw new Error(response.error);
-      setAsset(response.data ?? null);
+      const [assetRes, linksRes] = await Promise.all([
+        apiGet<AssetRead>(`/api/assets/${assetId}`),
+        apiGet<EntitySemanticLink[]>(`/api/semantic-links/entity/asset/${assetId}`),
+      ]);
+      if (assetRes.error) throw new Error(assetRes.error);
+      setAsset(assetRes.data ?? null);
+      setSemanticLinks(Array.isArray(linksRes.data) ? linksRes.data : []);
     } catch (err: any) {
       setError(err.message || 'Failed to load asset');
     } finally {
@@ -155,6 +167,38 @@ export default function AssetDetailView() {
   useEffect(() => {
     fetchAsset();
   }, [fetchAsset]);
+
+  const addSemanticLink = useCallback(async (iri: string) => {
+    if (!assetId) return;
+    try {
+      const res = await apiPost<EntitySemanticLink>(`/api/semantic-links/`, {
+        entity_id: assetId,
+        entity_type: 'asset',
+        iri,
+      });
+      if (res.error) throw new Error(res.error);
+      // Optimistically refresh just the links rather than re-loading the whole asset
+      const refreshed = await apiGet<EntitySemanticLink[]>(`/api/semantic-links/entity/asset/${assetId}`);
+      setSemanticLinks(Array.isArray(refreshed.data) ? refreshed.data : []);
+      setIriDialogOpen(false);
+      toast({ title: 'Linked', description: 'Concept linked to asset.' });
+    } catch (e: any) {
+      toast({ title: 'Error', description: e?.message || 'Failed to link concept', variant: 'destructive' });
+    }
+  }, [assetId, apiPost, apiGet, toast]);
+
+  const removeSemanticLink = useCallback(async (linkId: string) => {
+    if (!assetId) return;
+    try {
+      const res = await apiDelete(`/api/semantic-links/${linkId}`);
+      if (res.error) throw new Error(res.error);
+      const refreshed = await apiGet<EntitySemanticLink[]>(`/api/semantic-links/entity/asset/${assetId}`);
+      setSemanticLinks(Array.isArray(refreshed.data) ? refreshed.data : []);
+      toast({ title: 'Removed', description: 'Concept link removed.' });
+    } catch (e: any) {
+      toast({ title: 'Error', description: e?.message || 'Failed to remove link', variant: 'destructive' });
+    }
+  }, [assetId, apiDelete, apiGet, toast]);
 
   useEffect(() => {
     if (asset) {
@@ -351,6 +395,23 @@ export default function AssetDetailView() {
                         <Badge key={tag} variant="secondary" className="text-xs">{tag}</Badge>
                       ))}
                     </div>
+                  </div>
+                </>
+              )}
+
+              {/* Linked Business Concepts */}
+              {(semanticLinks.length > 0 || canEditSemanticLinks) && (
+                <>
+                  <Separator className="my-4" />
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-2 block">Linked Business Concepts</Label>
+                    <LinkedConceptChips
+                      links={semanticLinks}
+                      onRemove={canEditSemanticLinks ? removeSemanticLink : undefined}
+                      trailing={canEditSemanticLinks ? (
+                        <Button size="sm" variant="outline" onClick={() => setIriDialogOpen(true)} className="h-6 text-xs">Add</Button>
+                      ) : undefined}
+                    />
                   </div>
                 </>
               )}
@@ -568,6 +629,13 @@ export default function AssetDetailView() {
           onDeleted={() => navigate(-1)}
         />
       )}
+
+      {/* Concept linker */}
+      <ConceptSelectDialog
+        isOpen={iriDialogOpen}
+        onOpenChange={setIriDialogOpen}
+        onSelect={addSemanticLink}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Extends the polymorphic `entity_semantic_links` table to accept `entity_type='asset'` (AssetDb UUID) so any asset-backed entity — Table, View, Dataset, Dashboard, Notebook, ML Model, Column, Logical Attribute, Business Term, etc. — can be linked to ontology concepts and properties. Previously only data domains, products, contracts, and raw UC objects were supported, even though the manager was already half-prepared for it.

The Asset detail view gets a Linked Business Concepts row, the Knowledge Graph concept/property search dialogs gain an Asset option, and inferred-link SPARQL queries now find assets because they are seeded into the in-memory RDF graph at startup.

## What's in this PR

**Backend**
- Add `'asset'` to the `EntityType` Literal in [src/backend/src/models/semantic_links.py](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/src/backend/src/models/semantic_links.py) so the API stops rejecting asset-scoped payloads with 422.
- Seed AssetDb rows into the RDF graph as `urn:ontos:asset:{uuid}` with `entity-type:asset` plus a per-type `asset-type:{slug}` rdf:type, plus `rdfs:label` ([semantic_models_manager.py](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/src/backend/src/controller/semantic_models_manager.py) `_load_app_entities_into_graph`).
- Refresh `EntitySemanticLinkDb` docstring with the full entity_type set and `entity_id` format reference.
- New unit tests in [test_semantic_links_manager.py](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/src/backend/src/tests/unit/test_semantic_links_manager.py): Literal validation (accept + reject), `_resolve_entity_name` against the `assets` table, and `add()` round-trip with a UUID payload.

**Frontend**
- [asset-detail.tsx](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/src/frontend/src/views/asset-detail.tsx): render a Linked Business Concepts row in the Details card using `LinkedConceptChips` + `ConceptSelectDialog`, gated by the `semantic-models` READ_WRITE permission. Fetches `/api/semantic-links/entity/asset/{id}` alongside the asset payload.
- [concepts-search.tsx](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/src/frontend/src/components/search/concepts-search.tsx): add `asset` to the assign-dialog entity-type dropdown, loader (unwraps the paginated `/api/assets` envelope), reverse navigation to `/assets/{id}`, label, and Box icon.
- [properties-search.tsx](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/src/frontend/src/components/search/properties-search.tsx): add `asset` as a third `assignTargetType`, scoped to Column / Logical Attribute assets via the `asset_type_names` filter; new picker + assign confirm button.
- Add an `asset` fixture row to the `linked-objects-panel.test.tsx` unit test (the panel already had full asset support).
- Playwright e2e ([semantic-links.spec.ts](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/src/frontend/src/tests/semantic-links.spec.ts)): pick the first asset, assign a concept, verify via API, clean up via DELETE.

**Docs**
- [.cursor/rules/10-entity-panel-matrix.mdc](https://github.com/databrickslabs/ontos/blob/feat/semantic-links-for-assets/.cursor/rules/10-entity-panel-matrix.mdc): fix the Tier 1 Semantic Links row (Y for DataDomain and DataProduct, not just DataContract), add a Tier 2 Semantic Links row (Y for every asset type except Catalog/Schema/Delivery Channel), expand the `entity_semantic_links` row in the polymorphic-tables table with the full enum, and add a `SEMANTIC_LINK_INELIGIBLE_TYPES` snippet to the implementation guidance.

## Design choices

- **Single `asset` entity_type** rather than per-asset-type (e.g. `asset_table`, `asset_column`). Keeps the polymorphic table clean and matches what `EntityCostsPanel` / `EntityQualityPanel` / `EntityMetadataPanel` already do on `asset-detail.tsx`. The IRI itself tells you whether a link points at a class or a property.
- **UC-prefixed types and `asset` coexist by design.** UC entity types remain for raw UC objects that aren't wrapped as Asset rows; no migration in this PR.
- **Permissions reuse.** Gated by the existing `semantic-models` feature permission; no new persona/RBAC plumbing.

## Test plan

- [x] Backend: `hatch -e dev run pytest src/tests/unit/test_semantic_links_manager.py -k 'asset or TestEntitySemanticLinkCreateModel'` — 4/4 pass.
- [x] Frontend: `yarn test --run src/components/semantic/linked-objects-panel.test.tsx` — 6/6 pass.
- [ ] Manual: open an asset detail page, click Add, pick a concept, verify the chip appears; remove the link via the X.
- [ ] Manual: in Knowledge Graph → Concepts, select a concept, open the Assign dialog, choose Asset, pick an asset from the list, confirm; verify the chip appears under Linked Catalog Objects and navigation works.
- [ ] Manual: in Knowledge Graph → Properties, select a property, choose Asset (Column / Logical Attribute) as target type, pick a Column asset, confirm; verify the chip appears.
- [ ] Playwright (against a live backend with seeded assets): `yarn playwright test src/tests/semantic-links.spec.ts`.

## Out of scope

- No bulk migration of existing `uc_table` / `uc_column` links to `asset` links — both coexist.
- No persona/permission rework.
- No SPARQL/KG schema changes beyond the new `urn:ontos:asset:{uuid}` URN format.