### PR TITLE
feat(term-mapping): backend foundation for ontology term suggester (PRD #469)

### DIFF
--- a/src/backend/alembic/versions/k1_add_term_mapping_tables.py
+++ b/src/backend/alembic/versions/k1_add_term_mapping_tables.py
@@ -1,0 +1,93 @@
+"""add term-mapping tables
+
+Revision ID: k1_term_mapping
+Revises: j1_add_version_family_id
+Create Date: 2026-05-29 14:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'k1_term_mapping'
+down_revision: Union[str, None] = 'j1_add_version_family_id'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'term_mapping_runs',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('ontology_contexts', sa.JSON(), nullable=False, server_default='[]'),
+        sa.Column('include_shipped', sa.JSON(), nullable=False, server_default='[]'),
+        sa.Column('target_filter', sa.JSON(), nullable=False, server_default='{}'),
+        sa.Column('engines', sa.JSON(), nullable=False, server_default='[]'),
+        sa.Column('status', sa.String(), nullable=False, server_default='pending'),
+        sa.Column('comment', sa.Text(), nullable=True),
+        sa.Column('stats', sa.JSON(), nullable=False, server_default='{}'),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column('applied_link_ids', sa.JSON(), nullable=False, server_default='[]'),
+        sa.Column('created_by', sa.String(), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('started_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('finished_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('applied_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('undone_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_term_mapping_runs_status', 'term_mapping_runs', ['status'])
+    op.create_index('ix_term_mapping_runs_created_by', 'term_mapping_runs', ['created_by'])
+
+    op.create_table(
+        'term_mapping_suggestions',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('run_id', sa.UUID(), nullable=False),
+        sa.Column('source_entity_type', sa.String(), nullable=False),
+        sa.Column('source_entity_id', sa.String(), nullable=False),
+        sa.Column('source_label', sa.String(), nullable=True),
+        sa.Column('suggestion_kind', sa.String(), nullable=False),
+        sa.Column('target_concept_iri', sa.Text(), nullable=False),
+        sa.Column('target_concept_label', sa.Text(), nullable=True),
+        sa.Column('confidence', sa.Float(), nullable=False, server_default='0.0'),
+        sa.Column('reason', sa.Text(), nullable=False, server_default=''),
+        sa.Column('auto_apply', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('engine', sa.String(), nullable=False, server_default='heuristic'),
+        sa.Column('engine_metadata', sa.JSON(), nullable=True),
+        sa.Column('status', sa.String(), nullable=False, server_default='pending'),
+        sa.Column('decided_by', sa.String(), nullable=True),
+        sa.Column('decided_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('custom_iri', sa.Text(), nullable=True),
+        sa.Column('applied_link_id', sa.UUID(), nullable=True),
+        sa.Column('warnings', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['run_id'], ['term_mapping_runs.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_term_mapping_suggestions_run_id', 'term_mapping_suggestions', ['run_id'])
+    op.create_index('ix_term_mapping_suggestions_status', 'term_mapping_suggestions', ['status'])
+    op.create_index(
+        'ix_term_mapping_suggestions_source',
+        'term_mapping_suggestions',
+        ['source_entity_type', 'source_entity_id'],
+    )
+    op.create_index(
+        'ix_term_mapping_suggestions_run_status',
+        'term_mapping_suggestions',
+        ['run_id', 'status'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_term_mapping_suggestions_run_status', table_name='term_mapping_suggestions')
+    op.drop_index('ix_term_mapping_suggestions_source', table_name='term_mapping_suggestions')
+    op.drop_index('ix_term_mapping_suggestions_status', table_name='term_mapping_suggestions')
+    op.drop_index('ix_term_mapping_suggestions_run_id', table_name='term_mapping_suggestions')
+    op.drop_table('term_mapping_suggestions')
+
+    op.drop_index('ix_term_mapping_runs_created_by', table_name='term_mapping_runs')
+    op.drop_index('ix_term_mapping_runs_status', table_name='term_mapping_runs')
+    op.drop_table('term_mapping_runs')

--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -353,6 +353,8 @@ entity_subscription_routes.register_routes(app)
 business_lineage_routes.register_routes(app)
 readiness_routes.register_routes(app)
 suggestion_routes.register_routes(app)
+from src.routes import term_mapping_routes
+term_mapping_routes.register_routes(app)
 certification_levels_routes.register_routes(app)
 data_asset_reviews_routes.register_routes(app)
 data_catalog_routes.register_routes(app)

--- a/src/backend/src/common/features.py
+++ b/src/backend/src/common/features.py
@@ -136,6 +136,13 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # Users request, admins grant
         'group': GROUP_GOVERN,
     },
+    'term-mapping': {
+        'name': 'Term Mapping',
+        # READ_ONLY views the queue/runs; READ_WRITE creates runs + accepts/
+        # rejects + applies; ADMIN gates the destructive "undo applied run".
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_GOVERN,
+    },
 
     # --- Deploy ---
     'estate-manager': {

--- a/src/backend/src/controller/term_mapping/__init__.py
+++ b/src/backend/src/controller/term_mapping/__init__.py
@@ -1,0 +1,9 @@
+"""Term-mapping engine, adapters, and helpers.
+
+This package houses the deterministic + LLM suggester engines, the per-target
+adapters that translate Ontos entities into a uniform feature shape, and the
+shared scoring/naming helpers ported from the onyx_ontology source repo.
+
+The top-level TermMappingManager (controller/term_mapping_manager.py) orchestrates
+runs, queue persistence, apply, and undo across these components.
+"""

--- a/src/backend/src/controller/term_mapping/adapters/__init__.py
+++ b/src/backend/src/controller/term_mapping/adapters/__init__.py
@@ -1,0 +1,34 @@
+"""Target adapters: translate Ontos entity types into a uniform feature shape.
+
+Each adapter knows how to list candidate target entities from the DB (filtered
+by the run's RunTargetFilter) and how to derive the parent/child relationships
+the engine needs for entity-vs-attribute distinction.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Protocol, TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from src.models.term_mappings import RunTargetFilter
+
+from ..types import TargetEntity
+
+
+class TargetAdapter(Protocol):
+    """Each entity-type-family has one adapter implementation."""
+
+    entity_types: List[str]   # e.g. ["asset"] or ["data_contract_schema", "data_contract_property"]
+
+    def list_targets(self, db: Session, filters: RunTargetFilter) -> Iterable[TargetEntity]:
+        ...
+
+
+from .asset_adapter import AssetAdapter  # noqa: E402
+from .contract_adapter import ContractAdapter  # noqa: E402
+from .product_adapter import ProductAdapter  # noqa: E402
+
+
+def all_adapters() -> List[TargetAdapter]:
+    """Adapter registry; new target families plug in here."""
+    return [AssetAdapter(), ContractAdapter(), ProductAdapter()]

--- a/src/backend/src/controller/term_mapping/adapters/asset_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/asset_adapter.py
@@ -1,0 +1,113 @@
+"""Adapter for Assets (and their Columns) — the polymorphic Asset model.
+
+Columns are first-class AssetDb rows linked to their parent Table/View via
+EntityRelationshipDb(relationship_type="hasColumn"). For term-mapping we list
+target Assets by asset-type name; the default focus is Columns since that's
+where the bulk of vocabulary attachment lives.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+from src.common.logging import get_logger
+from src.db_models.assets import AssetDb, AssetTypeDb
+from src.db_models.entity_relationships import EntityRelationshipDb
+from src.models.term_mappings import RunTargetFilter
+
+from ..types import TargetEntity
+
+logger = get_logger(__name__)
+
+# Sub-entity types we treat as attribute candidates (vs container types).
+_SUB_ENTITY_TYPE_NAMES = {"Column", "Logical Attribute"}
+
+
+class AssetAdapter:
+    entity_types: List[str] = ["asset"]
+
+    def list_targets(self, db: Session, filters: RunTargetFilter) -> Iterable[TargetEntity]:
+        # Default to Columns when caller did not specify asset_type_names —
+        # mapping concepts to entire tables/datasets is supported but rarely
+        # what stewards reach for first.
+        asset_type_names: Optional[List[str]] = filters.asset_type_names
+
+        q = (
+            db.query(AssetDb, AssetTypeDb)
+            .join(AssetTypeDb, AssetDb.asset_type_id == AssetTypeDb.id)
+        )
+
+        if asset_type_names:
+            q = q.filter(AssetTypeDb.name.in_(asset_type_names))
+        else:
+            q = q.filter(AssetTypeDb.name == "Column")
+
+        if filters.domain_ids:
+            q = q.filter(AssetDb.domain_id.in_(filters.domain_ids))
+
+        if filters.limit:
+            q = q.limit(filters.limit)
+
+        # Parent lookup: for Columns, find the hasColumn relationship pointing
+        # AT this asset (target). Bulk-resolve to keep this O(1 query) instead
+        # of N.
+        asset_rows = list(q.all())
+        target_ids = [str(a.id) for a, _ in asset_rows]
+        parents = _bulk_resolve_parents(db, target_ids) if target_ids else {}
+
+        for asset, asset_type in asset_rows:
+            asset_id = str(asset.id)
+            is_sub_entity = asset_type.name in _SUB_ENTITY_TYPE_NAMES
+            props = asset.properties or {}
+
+            parent = parents.get(asset_id)
+            parent_label = parent.get("name") if parent else None
+
+            yield TargetEntity(
+                entity_type="asset",
+                entity_id=asset_id,
+                name=asset.name,
+                label=asset.name,
+                type_label=str(props.get("columnDataType") or props.get("dataType") or ""),
+                parent_entity_type="asset" if is_sub_entity and parent else None,
+                parent_entity_id=parent.get("id") if (is_sub_entity and parent) else None,
+                parent_name=parent_label if is_sub_entity else None,
+                is_pk=bool(props.get("isPrimaryKey")),
+                is_fk=bool(props.get("isForeignKey")),
+                extras={
+                    "asset_type_name": asset_type.name,
+                    "platform": asset.platform,
+                    "location": asset.location,
+                    "classification": props.get("classification"),
+                },
+            )
+
+
+def _bulk_resolve_parents(db: Session, target_asset_ids: List[str]) -> dict:
+    """Map child asset id → {id, name} of its hasColumn parent (if any).
+
+    Uses a single SQL query instead of iterating EntityRelationshipDb +
+    AssetDb joins per row.
+    """
+    if not target_asset_ids:
+        return {}
+    try:
+        rows = db.execute(
+            text(
+                """
+                SELECT er.target_id::text AS child_id,
+                       a.id::text AS parent_id,
+                       a.name AS parent_name
+                FROM entity_relationships er
+                JOIN assets a ON a.id::text = er.source_id
+                WHERE er.relationship_type = 'hasColumn'
+                  AND er.target_id IN :ids
+                """
+            ).bindparams().params(ids=tuple(target_asset_ids))
+        ).fetchall()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Failed to bulk-resolve parents for asset adapter: %s", e)
+        return {}
+    return {row.child_id: {"id": row.parent_id, "name": row.parent_name} for row in rows}

--- a/src/backend/src/controller/term_mapping/adapters/contract_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/contract_adapter.py
@@ -1,0 +1,113 @@
+"""Adapter for Data Contracts and their normalised schema objects/properties.
+
+Yields three flavours of target:
+  * data_contract            — the contract itself (entity_assignment candidate)
+  * data_contract_schema     — each SchemaObjectDb (entity_assignment candidate)
+  * data_contract_property   — each SchemaPropertyDb (attribute_assignment candidate)
+
+entity_id encoding follows the existing semantic-links convention:
+  data_contract            -> contract_id
+  data_contract_schema     -> "{contract_id}#{schema_name}"
+  data_contract_property   -> "{contract_id}#{schema_name}#{property_name}"
+"""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.db_models.data_contracts import DataContractDb, SchemaObjectDb, SchemaPropertyDb
+from src.models.term_mappings import RunTargetFilter
+
+from ..types import TargetEntity
+
+logger = get_logger(__name__)
+
+
+class ContractAdapter:
+    entity_types: List[str] = [
+        "data_contract",
+        "data_contract_schema",
+        "data_contract_property",
+    ]
+
+    def list_targets(self, db: Session, filters: RunTargetFilter) -> Iterable[TargetEntity]:
+        wanted_types = set(filters.entity_types or self.entity_types)
+
+        q = db.query(DataContractDb)
+        if filters.contract_ids:
+            q = q.filter(DataContractDb.id.in_(filters.contract_ids))
+        if filters.domain_ids:
+            q = q.filter(DataContractDb.domain_id.in_(filters.domain_ids))
+
+        contracts = q.all()
+        emitted = 0
+
+        for contract in contracts:
+            contract_id = str(contract.id)
+
+            if "data_contract" in wanted_types:
+                yield TargetEntity(
+                    entity_type="data_contract",
+                    entity_id=contract_id,
+                    name=contract.name or "",
+                    label=contract.name or contract_id,
+                    extras={"version": contract.version, "status": contract.status},
+                )
+                emitted += 1
+                if filters.limit and emitted >= filters.limit:
+                    return
+
+            for schema_obj in contract.schema_objects or []:
+                schema_id = f"{contract_id}#{schema_obj.name}"
+
+                if "data_contract_schema" in wanted_types:
+                    yield TargetEntity(
+                        entity_type="data_contract_schema",
+                        entity_id=schema_id,
+                        name=schema_obj.name,
+                        label=schema_obj.business_name or schema_obj.name,
+                        type_label=schema_obj.logical_type or "object",
+                        parent_entity_type="data_contract",
+                        parent_entity_id=contract_id,
+                        parent_name=contract.name,
+                        extras={
+                            "physical_type": schema_obj.physical_type,
+                            "description": schema_obj.description,
+                        },
+                    )
+                    emitted += 1
+                    if filters.limit and emitted >= filters.limit:
+                        return
+
+                if "data_contract_property" not in wanted_types:
+                    continue
+
+                for prop in schema_obj.properties or []:
+                    # Only top-level properties for v1; nested struct fields
+                    # could be added later by recursing on parent_property_id.
+                    if prop.parent_property_id:
+                        continue
+                    prop_id = f"{contract_id}#{schema_obj.name}#{prop.name}"
+                    yield TargetEntity(
+                        entity_type="data_contract_property",
+                        entity_id=prop_id,
+                        name=prop.name,
+                        label=prop.business_name or prop.name,
+                        type_label=prop.logical_type or prop.physical_type or "",
+                        parent_entity_type="data_contract_schema",
+                        parent_entity_id=schema_id,
+                        parent_name=schema_obj.name,
+                        is_pk=bool(prop.primary_key),
+                        # Note: there is no isForeignKey flag on SchemaPropertyDb;
+                        # the heuristic engine infers FK from the *_id naming
+                        # convention anyway.
+                        extras={
+                            "classification": prop.classification,
+                            "required": prop.required,
+                        },
+                    )
+                    emitted += 1
+                    if filters.limit and emitted >= filters.limit:
+                        return

--- a/src/backend/src/controller/term_mapping/adapters/product_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/product_adapter.py
@@ -1,0 +1,50 @@
+"""Adapter for Data Products.
+
+Data Products are terminal targets — there's no sub-entity to map (ports
+reference contracts/assets that have their own targets via the other
+adapters). One TargetEntity per DataProductDb row.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sqlalchemy.orm import Session
+
+from src.db_models.data_products import DataProductDb
+from src.models.term_mappings import RunTargetFilter
+
+from ..types import TargetEntity
+
+
+class ProductAdapter:
+    entity_types: List[str] = ["data_product"]
+
+    def list_targets(self, db: Session, filters: RunTargetFilter) -> Iterable[TargetEntity]:
+        wanted_types = set(filters.entity_types or self.entity_types)
+        if "data_product" not in wanted_types:
+            return
+
+        q = db.query(DataProductDb)
+        if filters.product_ids:
+            q = q.filter(DataProductDb.id.in_(filters.product_ids))
+        if filters.domain_ids:
+            q = q.filter(DataProductDb.domain.in_(filters.domain_ids))
+
+        if filters.limit:
+            q = q.limit(filters.limit)
+
+        # Look up the latest info record for the display name. The DataProductInfoDb
+        # rows are versioned per-product; for our purposes the product name on
+        # DataProductDb itself is good enough (kept in sync by DataProductsManager).
+        for product in q.all():
+            yield TargetEntity(
+                entity_type="data_product",
+                entity_id=str(product.id),
+                name=product.name or str(product.id),
+                label=product.name or str(product.id),
+                extras={
+                    "version": product.version,
+                    "status": product.status,
+                    "domain": product.domain,
+                },
+            )

--- a/src/backend/src/controller/term_mapping/concept_source.py
+++ b/src/backend/src/controller/term_mapping/concept_source.py
@@ -1,0 +1,286 @@
+"""Concept lookup for the term-mapping suggester.
+
+Concept candidates come ONLY from customer ontologies (rows in the
+``semantic_models`` DB table, mirrored into the RDF graph under
+``urn:semantic-model:*`` contexts) plus any shipped taxonomies the steward has
+explicitly opted into per run.
+
+The internal ``urn:taxonomy:ontos-ontology`` context defines Ontos's own Asset
+typing schema (Table, Column, DataProduct…) and is **never** a valid
+assignment target — this module rejects any caller that tries to include it.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence, Set, TYPE_CHECKING
+
+from rdflib import RDF, RDFS, OWL, Namespace, URIRef
+from rdflib.namespace import SKOS
+
+from src.common.logging import get_logger
+
+from .types import ConceptCandidate
+
+if TYPE_CHECKING:
+    from src.controller.semantic_models_manager import SemanticModelsManager
+
+logger = get_logger(__name__)
+
+
+# Contexts that are NEVER selectable as a concept source for term-mapping.
+# `ontos-ontology` defines internal Asset typing. The remaining `urn:meta:*` /
+# `urn:semantic-links` etc. are internal app indices.
+INTERNAL_BLOCKED_CONTEXTS: Set[str] = {
+    "urn:taxonomy:ontos-ontology",
+    "urn:semantic-links",
+}
+
+# Shipped customer-usable taxonomies. Excluded from defaults but selectable
+# per-run via include_shipped. See PRD concept-source rules.
+SHIPPED_OPT_IN_CONTEXTS: Set[str] = {
+    "urn:taxonomy:databricks_ontology",
+    "urn:taxonomy:odcs-ontology",
+}
+
+CUSTOMER_CONTEXT_PREFIX = "urn:semantic-model:"
+
+
+class InvalidContextError(ValueError):
+    """Raised when a caller tries to use an internal/blocked context."""
+
+
+def is_customer_context(ctx: str) -> bool:
+    return ctx.startswith(CUSTOMER_CONTEXT_PREFIX)
+
+
+def is_shipped_context(ctx: str) -> bool:
+    return ctx in SHIPPED_OPT_IN_CONTEXTS
+
+
+def validate_contexts(
+    ontology_contexts: Sequence[str],
+    include_shipped: Sequence[str],
+) -> List[str]:
+    """Validate the run's selected contexts and return the full effective list.
+
+    Rules:
+      * INTERNAL_BLOCKED_CONTEXTS are rejected outright (HTTP 422 surface).
+      * ontology_contexts items must be customer contexts.
+      * include_shipped items must be in SHIPPED_OPT_IN_CONTEXTS.
+    """
+    seen: List[str] = []
+
+    for ctx in ontology_contexts:
+        if ctx in INTERNAL_BLOCKED_CONTEXTS:
+            raise InvalidContextError(
+                f"Context '{ctx}' is internal to Ontos and not assignable. "
+                f"Use a customer ontology (urn:semantic-model:*) instead."
+            )
+        if ctx in SHIPPED_OPT_IN_CONTEXTS:
+            raise InvalidContextError(
+                f"Context '{ctx}' is a shipped taxonomy. Pass it via "
+                f"include_shipped, not ontology_contexts."
+            )
+        if not is_customer_context(ctx):
+            raise InvalidContextError(
+                f"Context '{ctx}' is not recognised as a customer ontology "
+                f"(must start with '{CUSTOMER_CONTEXT_PREFIX}')."
+            )
+        if ctx not in seen:
+            seen.append(ctx)
+
+    for ctx in include_shipped:
+        if ctx in INTERNAL_BLOCKED_CONTEXTS:
+            raise InvalidContextError(
+                f"Context '{ctx}' is internal to Ontos and not assignable."
+            )
+        if ctx not in SHIPPED_OPT_IN_CONTEXTS:
+            raise InvalidContextError(
+                f"Context '{ctx}' is not on the shipped opt-in list. "
+                f"Allowed shipped contexts: {sorted(SHIPPED_OPT_IN_CONTEXTS)}."
+            )
+        if ctx not in seen:
+            seen.append(ctx)
+
+    return seen
+
+
+class ConceptSource:
+    """Read-side wrapper around SemanticModelsManager that scopes lookups to
+    a fixed set of RDF graph contexts.
+
+    Holds the candidate list in memory (one list per run) — customer
+    ontologies are small enough (hundreds, maybe low thousands of concepts)
+    that pre-loading is faster than re-querying per target.
+    """
+
+    def __init__(
+        self,
+        semantic_models_manager: "SemanticModelsManager",
+        contexts: Sequence[str],
+    ):
+        self._smm = semantic_models_manager
+        self._contexts: List[str] = list(contexts)
+        self._classes: List[ConceptCandidate] = []
+        self._properties: List[ConceptCandidate] = []
+        self._loaded = False
+
+    @property
+    def contexts(self) -> List[str]:
+        return list(self._contexts)
+
+    def load(self) -> None:
+        """Pull all class + property concepts from the configured contexts.
+
+        Iterates over the rdflib ConjunctiveGraph's named graphs directly
+        rather than via SPARQL — gives us context-scoped traversal without
+        depending on the FROM-clause behaviour of every rdflib version.
+        """
+        if self._loaded:
+            return
+
+        graph = self._smm._graph  # ConjunctiveGraph
+
+        wanted: Set[str] = set(self._contexts)
+        classes_seen: dict[str, ConceptCandidate] = {}
+        props_seen: dict[str, ConceptCandidate] = {}
+
+        for context in graph.contexts():
+            ctx_name = str(context.identifier)
+            if ctx_name not in wanted:
+                continue
+
+            for subject in _classes_in_context(context):
+                iri = str(subject)
+                if iri in classes_seen:
+                    continue
+                classes_seen[iri] = ConceptCandidate(
+                    iri=iri,
+                    label=_pick_label(context, subject),
+                    comment=_pick_comment(context, subject),
+                    source_context=ctx_name,
+                    parent_iris=_parents(context, subject),
+                    is_class=True,
+                )
+
+            for subject in _properties_in_context(context):
+                iri = str(subject)
+                if iri in props_seen:
+                    continue
+                props_seen[iri] = ConceptCandidate(
+                    iri=iri,
+                    label=_pick_label(context, subject),
+                    comment=_pick_comment(context, subject),
+                    source_context=ctx_name,
+                    parent_iris=_parents(context, subject),
+                    is_class=False,
+                    range_type=_pick_range(context, subject),
+                )
+
+        self._classes = sorted(classes_seen.values(), key=lambda c: c.iri)
+        self._properties = sorted(props_seen.values(), key=lambda c: c.iri)
+        self._loaded = True
+        logger.info(
+            "ConceptSource loaded %d classes + %d properties from %d contexts: %s",
+            len(self._classes),
+            len(self._properties),
+            len(wanted),
+            sorted(wanted),
+        )
+
+    def classes(self) -> List[ConceptCandidate]:
+        if not self._loaded:
+            self.load()
+        return self._classes
+
+    def properties(self) -> List[ConceptCandidate]:
+        if not self._loaded:
+            self.load()
+        return self._properties
+
+
+def resolve_default_customer_contexts(
+    semantic_models_manager: "SemanticModelsManager",
+) -> List[str]:
+    """Default = every enabled ``urn:semantic-model:*`` context present in
+    the graph. Excludes disabled rows (already filtered by SemanticModelsManager)."""
+    graph = semantic_models_manager._graph
+    contexts: List[str] = []
+    for ctx in graph.contexts():
+        name = str(ctx.identifier)
+        if is_customer_context(name) and name not in contexts:
+            contexts.append(name)
+    return sorted(contexts)
+
+
+# ---------- Helpers (private) ----------
+
+_CLASS_TYPES = (
+    RDFS.Class,
+    OWL.Class,
+    SKOS.Concept,
+)
+
+
+def _classes_in_context(context) -> Iterable[URIRef]:
+    seen: Set[URIRef] = set()
+    for cls_type in _CLASS_TYPES:
+        for s in context.subjects(RDF.type, cls_type):
+            if isinstance(s, URIRef) and s not in seen:
+                seen.add(s)
+                yield s
+    # Also: anything declared as a subClassOf is a class even if rdf:type is
+    # implicit. Matches semantic_models_manager.search_concepts logic.
+    for s in context.subjects(RDFS.subClassOf, None):
+        if isinstance(s, URIRef) and s not in seen:
+            seen.add(s)
+            yield s
+
+
+_PROPERTY_TYPES = (
+    OWL.ObjectProperty,
+    OWL.DatatypeProperty,
+    RDF.Property,
+)
+
+
+def _properties_in_context(context) -> Iterable[URIRef]:
+    seen: Set[URIRef] = set()
+    for prop_type in _PROPERTY_TYPES:
+        for s in context.subjects(RDF.type, prop_type):
+            if isinstance(s, URIRef) and s not in seen:
+                seen.add(s)
+                yield s
+
+
+def _pick_label(context, subject) -> str:
+    for label in context.objects(subject, RDFS.label):
+        return str(label)
+    for label in context.objects(subject, SKOS.prefLabel):
+        return str(label)
+    iri = str(subject)
+    return iri.split("#")[-1].split("/")[-1]
+
+
+def _pick_comment(context, subject) -> str:
+    for c in context.objects(subject, RDFS.comment):
+        return str(c)
+    for c in context.objects(subject, SKOS.definition):
+        return str(c)
+    return ""
+
+
+def _pick_range(context, subject) -> str:
+    for r in context.objects(subject, RDFS.range):
+        return str(r)
+    return ""
+
+
+def _parents(context, subject) -> List[str]:
+    parents: List[str] = []
+    for parent in context.objects(subject, RDFS.subClassOf):
+        if isinstance(parent, URIRef):
+            parents.append(str(parent))
+    for parent in context.objects(subject, RDFS.subPropertyOf):
+        if isinstance(parent, URIRef):
+            parents.append(str(parent))
+    return parents

--- a/src/backend/src/controller/term_mapping/engines/__init__.py
+++ b/src/backend/src/controller/term_mapping/engines/__init__.py
@@ -1,0 +1,7 @@
+"""Suggester engines.
+
+Engine = pluggable callable that turns (targets, concepts) into SuggestionDrafts.
+v1 ships the deterministic HeuristicSuggester; LLMJudgeSuggester is a future
+phase (see PRD).
+"""
+from .heuristic import HeuristicSuggester  # noqa: F401

--- a/src/backend/src/controller/term_mapping/engines/heuristic.py
+++ b/src/backend/src/controller/term_mapping/engines/heuristic.py
@@ -1,0 +1,361 @@
+"""Deterministic heuristic suggester.
+
+Ported from onyx_ontology mapping_suggester.suggest_mappings with three fixes
+called out in the PRD:
+
+  1. Irregular plurals: source's _depluralize only knew the -ies/-s rules and
+     silently dropped tables like 'people' or 'children'. naming.depluralize
+     here checks an irregular table first.
+
+  2. ``label`` similarity is *capped* by ``name`` similarity. The source took
+     ``max(name, label)`` which let a long label string ride to a 0.95
+     auto-accept on a column called "id" by virtue of label "Identifier of
+     the customer", which steward never expected. We now multiply (label
+     similarity is a tiebreaker, not a primary signal).
+
+  3. Skip pairs the steward already rejected in a prior run (see
+     MappingSuggestionRepository.is_pair_already_decided). The source had no
+     persistent queue so it kept re-proposing the same noisy candidates.
+
+The engine ONLY emits SuggestionDraft objects — persistence and concurrency
+are the manager's responsibility.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from ..concept_source import ConceptSource
+from ..naming import (
+    depluralize,
+    normalize,
+    similarity,
+    to_camel,
+    types_compatible,
+)
+from ..scoring import AUTO_ACCEPT, AUTO_REJECT, Signals
+from ..types import ConceptCandidate, SuggestionDraft, TargetEntity
+
+logger = logging.getLogger(__name__)
+
+
+# Predicate for "should I skip this (source, iri) pair because the steward
+# already rejected it before?"
+DecidedFn = Callable[[str, str, str], bool]
+
+
+class HeuristicSuggester:
+    """Configurable heuristic engine; one instance per run.
+
+    Parameters mirror the source's signatures so the well-trodden scoring
+    semantics carry over.
+    """
+
+    name = "heuristic"
+
+    def __init__(
+        self,
+        *,
+        concepts: ConceptSource,
+        already_decided: Optional[DecidedFn] = None,
+        auto_accept: float = AUTO_ACCEPT,
+        auto_reject: float = AUTO_REJECT,
+    ):
+        self._concepts = concepts
+        self._already_decided = already_decided or (lambda *_: False)
+        self._auto_accept = auto_accept
+        self._auto_reject = auto_reject
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    def suggest(self, targets: List[TargetEntity]) -> List[SuggestionDraft]:
+        # Pre-load concepts once per run.
+        classes = self._concepts.classes()
+        properties = self._concepts.properties()
+
+        # Build a stem index so we can resolve FK references in O(1).
+        stem_index: Dict[str, ConceptCandidate] = {}
+        for c in classes:
+            stem = depluralize(normalize(c.label))
+            stem_index.setdefault(stem, c)
+
+        drafts: List[SuggestionDraft] = []
+        for target in targets:
+            kind = self._target_kind(target)
+            if kind == "container":
+                draft = self._suggest_for_container(target, classes)
+            else:
+                draft = self._suggest_for_attribute(
+                    target, classes, properties, stem_index
+                )
+            if draft is None:
+                continue
+            if self._already_decided(
+                draft.source_entity_type,
+                draft.source_entity_id,
+                draft.target_concept_iri,
+            ):
+                # Steward rejected this exact pair before; silently drop it
+                # so it doesn't haunt the queue.
+                continue
+            drafts.append(draft)
+        return drafts
+
+    # ------------------------------------------------------------------
+    # Per-target logic
+    # ------------------------------------------------------------------
+    def _target_kind(self, target: TargetEntity) -> str:
+        if target.entity_type in ("data_contract_property",):
+            return "attribute"
+        if target.entity_type == "asset":
+            return "attribute" if target.parent_entity_id else "container"
+        return "container"
+
+    def _suggest_for_container(
+        self,
+        target: TargetEntity,
+        classes: List[ConceptCandidate],
+    ) -> Optional[SuggestionDraft]:
+        """Pick the best class concept for a top-level target (table-like)."""
+        if not classes:
+            return None
+
+        target_norm = normalize(target.name)
+        target_singular = depluralize(target_norm)
+
+        best: Optional[ConceptCandidate] = None
+        best_score = 0.0
+        for c in classes:
+            label_norm = normalize(c.label)
+            label_singular = depluralize(label_norm)
+            sim_plural = similarity(target_norm, label_norm)
+            sim_singular = similarity(target_singular, label_singular)
+            score = max(sim_plural, sim_singular)
+            if score > best_score:
+                best_score = score
+                best = c
+
+        if best is None or best_score < 0.6:
+            return None
+
+        # Container assignments don't get an explicit type signal, so we
+        # tag type_compatible=True (a class match is type-agnostic).
+        signals = Signals(
+            name_similarity=best_score,
+            type_compatible=True,
+            parts=[
+                f"Name '{target.name}' ~= concept '{best.label}' "
+                f"(similarity {best_score:.2f}) in {_short_ctx(best.source_context)}.",
+            ],
+        )
+        confidence = signals.confidence
+        if confidence <= self._auto_reject:
+            return None
+        return SuggestionDraft(
+            source_entity_type=target.entity_type,
+            source_entity_id=target.entity_id,
+            source_label=target.label,
+            suggestion_kind="entity_assignment",
+            target_concept_iri=best.iri,
+            target_concept_label=best.label,
+            confidence=confidence,
+            reason=signals.render(),
+            auto_apply=confidence >= self._auto_accept,
+            engine=self.name,
+            engine_metadata={
+                "source_context": best.source_context,
+                "stem_match_score": round(best_score, 4),
+            },
+        )
+
+    def _suggest_for_attribute(
+        self,
+        target: TargetEntity,
+        classes: List[ConceptCandidate],
+        properties: List[ConceptCandidate],
+        stem_index: Dict[str, ConceptCandidate],
+    ) -> Optional[SuggestionDraft]:
+        col_lower = (target.name or "").lower()
+        col_norm = normalize(col_lower)
+
+        # ---------- FK heuristic ----------
+        if col_lower.endswith("_id") and col_lower != "id":
+            stem = normalize(col_lower[:-3])
+            stem_singular = depluralize(stem)
+            target_concept = stem_index.get(stem_singular) or stem_index.get(stem)
+            # Skip if the column's parent IS that concept already (would be a
+            # self-FK; almost always means we should have hit the PK path).
+            # Depluralize both sides — parent table 'customers' and concept
+            # 'Customer' must collapse to the same key to recognise the match.
+            parent_norm = depluralize(normalize(target.parent_name or ""))
+            concept_norm = depluralize(normalize(target_concept.label)) if target_concept else ""
+            if target_concept is not None and parent_norm != concept_norm:
+                sim_score = similarity(stem_singular, depluralize(normalize(target_concept.label)))
+                type_ok = (target.type_label or "").lower() in (
+                    "bigint", "long", "int", "integer", "string", "uuid", "varchar"
+                )
+                signals = Signals(
+                    name_similarity=sim_score,
+                    type_compatible=type_ok,
+                    fk_hint=True,
+                    parts=[
+                        f"Column '{target.name}' ends in '_id' and stem '{stem_singular}' matches "
+                        f"concept '{target_concept.label}' (similarity {sim_score:.2f}).",
+                        "Type is identifier-compatible." if type_ok
+                        else f"Type '{target.type_label}' is unusual for an id column — verify.",
+                    ],
+                )
+                confidence = signals.confidence
+                if confidence > self._auto_reject:
+                    return SuggestionDraft(
+                        source_entity_type=target.entity_type,
+                        source_entity_id=target.entity_id,
+                        source_label=target.label,
+                        suggestion_kind="entity_assignment",
+                        target_concept_iri=target_concept.iri,
+                        target_concept_label=target_concept.label,
+                        confidence=confidence,
+                        reason=signals.render(),
+                        auto_apply=confidence >= self._auto_accept,
+                        engine=self.name,
+                        engine_metadata={
+                            "fk_hint": True,
+                            "source_context": target_concept.source_context,
+                        },
+                    )
+
+        # ---------- PK heuristic ----------
+        parent_stem = depluralize(normalize(target.parent_name or ""))
+        looks_like_pk = target.is_pk or col_norm == "id" or (
+            col_lower.endswith("_id") and parent_stem == normalize(col_lower[:-3])
+        )
+        if looks_like_pk:
+            # Try property concepts first (e.g. dcterms:identifier).
+            id_props = [p for p in properties if normalize(p.label) in {"id", "identifier", "uri"}]
+            if id_props:
+                pick = id_props[0]
+                signals = Signals(
+                    name_similarity=1.0,
+                    type_compatible=True,
+                    pk_hint=True,
+                    parts=[
+                        f"Column '{target.name}' is the primary key of '{target.parent_name or 'parent'}'.",
+                        f"Maps to property '{pick.label}' from {_short_ctx(pick.source_context)}.",
+                    ],
+                )
+                confidence = signals.confidence
+                if confidence > self._auto_reject:
+                    return SuggestionDraft(
+                        source_entity_type=target.entity_type,
+                        source_entity_id=target.entity_id,
+                        source_label=target.label,
+                        suggestion_kind="attribute_assignment",
+                        target_concept_iri=pick.iri,
+                        target_concept_label=pick.label,
+                        confidence=confidence,
+                        reason=signals.render(),
+                        auto_apply=confidence >= self._auto_accept,
+                        engine=self.name,
+                        engine_metadata={"pk_hint": True, "source_context": pick.source_context},
+                    )
+
+        # ---------- Generic property match ----------
+        return self._best_property_match(target, properties)
+
+    def _best_property_match(
+        self,
+        target: TargetEntity,
+        properties: List[ConceptCandidate],
+    ) -> Optional[SuggestionDraft]:
+        if not properties:
+            return None
+
+        col_norm = normalize(target.name)
+        col_camel = normalize(to_camel(target.name))
+
+        best: Optional[ConceptCandidate] = None
+        best_name_sim = 0.0
+        best_label_sim = 0.0
+        for prop in properties:
+            prop_norm = normalize(prop.label)
+            name_sim = max(
+                similarity(col_norm, prop_norm),
+                similarity(col_camel, prop_norm),
+            )
+            label_sim = similarity(col_norm, normalize(prop.comment)) if prop.comment else 0.0
+            if name_sim > best_name_sim:
+                best_name_sim = name_sim
+                best_label_sim = label_sim
+                best = prop
+
+        if best is None or best_name_sim < 0.45:
+            return None
+
+        # Bug fix #2: cap label-similarity contribution by name-similarity.
+        # The source's max(name, label) over-rewarded long descriptive labels.
+        combined = best_name_sim + 0.1 * min(best_label_sim, best_name_sim)
+        combined = min(combined, 1.0)
+
+        type_ok = types_compatible(target.type_label, best.range_type)
+        signals = Signals(
+            name_similarity=combined,
+            type_compatible=type_ok,
+            parts=[
+                f"Column '{target.name}' name matches property '{best.label}' "
+                f"(similarity {best_name_sim:.2f}) in {_short_ctx(best.source_context)}.",
+                f"Type '{target.type_label}' is "
+                + ("compatible with" if type_ok else "DIFFERENT from")
+                + f" range '{best.range_type or '?'}'.",
+            ],
+        )
+        confidence = signals.confidence
+        if confidence <= self._auto_reject:
+            return None
+        return SuggestionDraft(
+            source_entity_type=target.entity_type,
+            source_entity_id=target.entity_id,
+            source_label=target.label,
+            suggestion_kind="attribute_assignment",
+            target_concept_iri=best.iri,
+            target_concept_label=best.label,
+            confidence=confidence,
+            reason=signals.render(),
+            auto_apply=confidence >= self._auto_accept,
+            engine=self.name,
+            engine_metadata={
+                "source_context": best.source_context,
+                "name_similarity": round(best_name_sim, 4),
+                "label_similarity": round(best_label_sim, 4),
+                "range_type": best.range_type,
+            },
+        )
+
+
+# ---------- helpers ----------
+
+def _short_ctx(ctx: str) -> str:
+    """Trim 'urn:semantic-model:retail_v1' down to 'retail_v1' for reason strings."""
+    if not ctx:
+        return ""
+    return ctx.rsplit(":", 1)[-1]
+
+
+def build_already_decided_fn(db: Session, repo) -> DecidedFn:
+    """Wire the manager's repo into the engine's decided-pair check.
+
+    Defined here (not in manager.py) so engines stay portable across managers.
+    """
+    def _check(entity_type: str, entity_id: str, iri: str) -> bool:
+        try:
+            return repo.is_pair_already_decided(
+                db,
+                source_entity_type=entity_type,
+                source_entity_id=entity_id,
+                target_concept_iri=iri,
+            )
+        except Exception:  # pragma: no cover
+            return False
+    return _check

--- a/src/backend/src/controller/term_mapping/naming.py
+++ b/src/backend/src/controller/term_mapping/naming.py
@@ -1,0 +1,152 @@
+"""Name normalisation + similarity helpers.
+
+Ported from onyx_ontology/src/databricks_onyx/core/agents/mapping_suggester.py
+(reason strings + scoring kept identical so behaviour stays reproducible
+against the source's regression tests).
+
+Adds an irregular-plurals table the source brief calls out explicitly — without
+it, suggestions for tables named ``people``, ``children``, etc. silently
+drop. See PRD bug 1.
+"""
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+
+_NORM_RE = re.compile(r"[^a-z0-9]+")
+
+# Irregular plurals → singular. Looked up before the generic -ies / -s rules.
+# Keep small and human-curated; this is not meant to be a full inflector.
+_IRREGULAR_PLURALS: dict[str, str] = {
+    "people": "person",
+    "children": "child",
+    "men": "man",
+    "women": "woman",
+    "feet": "foot",
+    "teeth": "tooth",
+    "geese": "goose",
+    "mice": "mouse",
+    "leaves": "leaf",
+    "lives": "life",
+    "knives": "knife",
+    "selves": "self",
+    "wives": "wife",
+    "data": "data",          # mass noun — already singular semantically
+    "criteria": "criterion",
+    "phenomena": "phenomenon",
+    "indices": "index",
+    "matrices": "matrix",
+    "vertices": "vertex",
+}
+
+
+def normalize(s: str) -> str:
+    """Lowercase + strip every non-alphanumeric character.
+
+    Used as the canonical comparable form for table/column/attribute names so
+    snake_case / camelCase / kebab-case all collapse to the same string.
+    """
+    return _NORM_RE.sub("", (s or "").lower())
+
+
+def depluralize(s: str) -> str:
+    """Best-effort singularisation. Checks irregulars first, then the common
+    -ies → -y and -s → '' rules. Never returns an empty string for non-empty
+    input.
+    """
+    if not s:
+        return s
+    irregular = _IRREGULAR_PLURALS.get(s.lower())
+    if irregular is not None:
+        return irregular
+    if len(s) > 3 and s.endswith("ies"):
+        return s[:-3] + "y"
+    if len(s) > 2 and s.endswith("s") and not s.endswith("ss"):
+        return s[:-1]
+    return s
+
+
+def similarity(a: str, b: str) -> float:
+    if not a or not b:
+        return 0.0
+    if a == b:
+        return 1.0
+    return SequenceMatcher(a=a, b=b).ratio()
+
+
+def local_name(uri: str) -> str:
+    """Fragment / last-segment from an IRI. Survives URIs with neither '#' nor
+    '/' by returning the whole string."""
+    if not uri:
+        return ""
+    for sep in ("#", "/"):
+        if sep in uri:
+            return uri.rsplit(sep, 1)[-1]
+    return uri
+
+
+def to_pascal(s: str) -> str:
+    parts = re.split(r"[_\s\-/]+", (s or "").strip())
+    pas = "".join(p[:1].upper() + p[1:] for p in parts if p)
+    return depluralize(pas) or "Entity"
+
+
+def to_camel(s: str) -> str:
+    pas = to_pascal(s)
+    return pas[:1].lower() + pas[1:] if pas else "field"
+
+
+# ---------- Type compatibility ----------
+
+_TYPE_GROUPS: dict[str, set[str]] = {
+    "string": {"string", "varchar", "text", "char", "uuid"},
+    "int": {"int", "integer", "smallint", "bigint", "long", "tinyint", "short"},
+    "float": {"float", "double", "decimal", "numeric", "real"},
+    "bool": {"boolean", "bool"},
+    "date": {"date", "datetime", "timestamp", "time", "datetime2"},
+}
+
+
+def type_group(t: str) -> str:
+    t = (t or "").lower()
+    for group, members in _TYPE_GROUPS.items():
+        if any(t.startswith(m) or t == m for m in members):
+            return group
+    return "string"
+
+
+def simplify_xsd(s: str) -> str:
+    """Drop the ``xsd:`` / namespace prefix from a typed range, leaving the
+    primitive name (string, integer, dateTime…)."""
+    if not s:
+        return ""
+    if "#" in s:
+        return s.rsplit("#", 1)[-1]
+    if ":" in s:
+        return s.rsplit(":", 1)[-1]
+    return s
+
+
+def types_compatible(column_type: str, attr_range: str) -> bool:
+    """Loose type compatibility used by the heuristic engine.
+
+    Returns True when groups match, or when the attribute's declared range is
+    a string (everything can land as a string). Mirrors the source behaviour.
+    """
+    col_group = type_group(column_type)
+    attr_group = type_group(simplify_xsd(attr_range))
+    if attr_group == col_group:
+        return True
+    if attr_group == "string":
+        return True
+    return False
+
+
+def xsd_for_column(column_type: str) -> str:
+    return {
+        "string": "xsd:string",
+        "int": "xsd:long",
+        "float": "xsd:double",
+        "bool": "xsd:boolean",
+        "date": "xsd:dateTime",
+    }[type_group(column_type)]

--- a/src/backend/src/controller/term_mapping/scoring.py
+++ b/src/backend/src/controller/term_mapping/scoring.py
@@ -1,0 +1,43 @@
+"""Confidence-scoring signals + formula.
+
+Lifted from onyx_ontology mapping_suggester._Signals — kept identical (incl.
+the rounding step) so the 0.90 auto-accept threshold lands where stewards
+expect. Don't tweak coefficients without updating the PRD threshold notes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+# Public thresholds (same values as the source so reason strings agree).
+AUTO_ACCEPT = 0.90
+AUTO_REJECT = 0.40
+
+
+@dataclass
+class Signals:
+    """All scoring signals for one source → target candidate pair."""
+    name_similarity: float = 0.0
+    type_compatible: bool = False
+    fk_hint: bool = False
+    pk_hint: bool = False
+    # Human-readable bits glued together in render(); UI shows them verbatim.
+    parts: List[str] = field(default_factory=list)
+
+    @property
+    def confidence(self) -> float:
+        score = 0.0
+        # Name match contributes up to 0.7.
+        score += 0.7 * self.name_similarity
+        # Type compatibility nudges +0.2 or -0.1; -0.1 keeps incompatible
+        # pairs out of the auto-accept band without nuking them outright.
+        score += 0.20 if self.type_compatible else -0.10
+        # PK / FK hint = +0.1; either suffices, never stacks.
+        if self.fk_hint or self.pk_hint:
+            score += 0.10
+        # Round to dodge float drift around AUTO_ACCEPT.
+        return round(max(0.0, min(1.0, score)), 4)
+
+    def render(self) -> str:
+        return " ".join(p for p in self.parts if p) if self.parts else "No strong signal."

--- a/src/backend/src/controller/term_mapping/types.py
+++ b/src/backend/src/controller/term_mapping/types.py
@@ -1,0 +1,81 @@
+"""Internal dataclasses shared by adapters and engines.
+
+These shapes are the contract between the entity-specific adapters and the
+generic suggester engines. The engine never sees Ontos types directly — the
+adapters translate at the boundary.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class TargetEntity:
+    """One thing the suggester can attach concept links to.
+
+    A TargetEntity can be:
+      * a top-level "container" (a Data Product, a Data Contract, an Asset of
+        type Table/Dataset). The engine treats this as an entity_assignment
+        candidate.
+      * a "sub-entity" (a Data Contract property, an Asset of type Column).
+        The engine treats this as an attribute_assignment candidate.
+
+    ``entity_id`` follows the existing semantic-link convention:
+      - data_product / data_contract / asset:  UUID string
+      - data_contract_schema: ``{contract_id}#{schema_name}``
+      - data_contract_property: ``{contract_id}#{schema_name}#{property_name}``
+    """
+    entity_type: str   # one of TargetEntityType from models/term_mappings.py
+    entity_id: str
+    name: str          # short identifier, e.g. column name "cust_email"
+    label: str         # display name, often == name
+    type_label: str = ""   # primitive type for sub-entities (STRING, INT, …)
+    # For sub-entities: pointer to the parent's container target so the engine
+    # can reason about entity-vs-attribute assignment coherently.
+    parent_entity_type: Optional[str] = None
+    parent_entity_id: Optional[str] = None
+    parent_name: Optional[str] = None
+    # Optional pk/fk flags from the source schema.
+    is_pk: bool = False
+    is_fk: bool = False
+    # Free-form extras the adapter can stash (e.g. property classification).
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ConceptCandidate:
+    """One concept from a customer ontology, pulled by ConceptSource."""
+    iri: str
+    label: str
+    comment: str = ""
+    # Which ontology this came from. Carries through into suggestion `reason`
+    # strings so stewards can prefer concepts from the vocabulary they trust.
+    source_context: str = ""
+    # rdfs:subClassOf parents, if known. Used by future semantic engines.
+    parent_iris: List[str] = field(default_factory=list)
+    # True if SKOS concept or rdfs:Class. False for owl:DatatypeProperty /
+    # ObjectProperty (we treat those as attribute candidates).
+    is_class: bool = True
+    # For property concepts, the rdfs:range value (xsd type or class IRI).
+    range_type: str = ""
+
+
+@dataclass
+class SuggestionDraft:
+    """Engine output. The manager turns each draft into a MappingSuggestionDb row.
+
+    Intentionally separate from the DB model so engines stay easily testable.
+    """
+    source_entity_type: str
+    source_entity_id: str
+    source_label: str
+    suggestion_kind: str  # entity_assignment | attribute_assignment
+    target_concept_iri: str
+    target_concept_label: str
+    confidence: float
+    reason: str
+    auto_apply: bool = False
+    engine: str = "heuristic"
+    engine_metadata: Optional[Dict[str, Any]] = None
+    warnings: List[str] = field(default_factory=list)

--- a/src/backend/src/controller/term_mapping_manager.py
+++ b/src/backend/src/controller/term_mapping_manager.py
@@ -1,0 +1,516 @@
+"""TermMappingManager — orchestrates suggestion runs, queue persistence,
+apply (which writes through to entity_semantic_links via SemanticLinksManager),
+and per-run undo.
+
+Architectural notes:
+  * Concept candidates come ONLY from customer ontologies + opted-in shipped
+    taxonomies. The internal ``urn:taxonomy:ontos-ontology`` is permanently
+    blocked (see concept_source.validate_contexts).
+  * One TermMappingManager instance is stored on app.state. Per-request work
+    uses a session passed in by the FastAPI dependency wrapper, not a session
+    held by the manager itself, so request lifecycles stay clean.
+  * Apply uses the existing SemanticLinksManager.add() so all downstream
+    side effects (RDF graph update, change_log entry, search index churn)
+    keep their familiar code path.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.controller.semantic_links_manager import SemanticLinksManager
+from src.db_models.term_mappings import (
+    MappingApplyRunDb,
+    MappingSuggestionDb,
+    RUN_STATUS_APPLIED,
+    RUN_STATUS_APPLYING,
+    RUN_STATUS_FAILED,
+    RUN_STATUS_PENDING,
+    RUN_STATUS_SUGGESTED,
+    RUN_STATUS_SUGGESTING,
+    RUN_STATUS_UNDONE,
+    SUG_STATUS_ACCEPTED,
+    SUG_STATUS_APPLIED,
+    SUG_STATUS_PENDING,
+    SUG_STATUS_REJECTED,
+)
+from src.models.semantic_links import EntitySemanticLinkCreate
+from src.models.term_mappings import (
+    ApplyResult,
+    PendingSuggestionCount,
+    RunCreate,
+    RunRead,
+    RunSummary,
+    SuggestionDecision,
+    SuggestionDecisionBatch,
+    SuggestionDecisionResult,
+    SuggestionRead,
+    UndoResult,
+)
+from src.repositories.term_mapping_repository import (
+    mapping_run_repo,
+    mapping_suggestion_repo,
+)
+
+from .term_mapping.adapters import all_adapters
+from .term_mapping.concept_source import (
+    ConceptSource,
+    InvalidContextError,
+    resolve_default_customer_contexts,
+    validate_contexts,
+)
+from .term_mapping.engines import HeuristicSuggester
+from .term_mapping.engines.heuristic import build_already_decided_fn
+from .term_mapping.types import SuggestionDraft, TargetEntity
+
+if TYPE_CHECKING:
+    from src.controller.semantic_models_manager import SemanticModelsManager
+
+logger = get_logger(__name__)
+
+
+class TermMappingManager:
+    """Stored once on app.state; per-request methods take a Session arg."""
+
+    def __init__(self, semantic_models_manager: "SemanticModelsManager"):
+        self._smm = semantic_models_manager
+
+    # ------------------------------------------------------------------
+    # Run lifecycle
+    # ------------------------------------------------------------------
+    def create_run(
+        self,
+        db: Session,
+        *,
+        payload: RunCreate,
+        created_by: Optional[str],
+    ) -> RunRead:
+        """Create a run row and immediately execute the configured engines.
+
+        For v1 we run synchronously in the request; on larger workloads this
+        moves behind a Databricks job (see PRD Phase 5 follow-up).
+        """
+        # Default contexts to every enabled customer ontology if omitted.
+        contexts = list(payload.ontology_contexts) if payload.ontology_contexts else resolve_default_customer_contexts(self._smm)
+
+        try:
+            effective = validate_contexts(contexts, payload.include_shipped)
+        except InvalidContextError as e:
+            raise ValueError(str(e)) from e
+
+        if not effective:
+            raise ValueError(
+                "No ontology contexts selected. Upload a customer ontology in "
+                "Settings → RDF Sources, or opt into a shipped taxonomy via "
+                "include_shipped."
+            )
+
+        # Persist the run row in 'pending' state first so we have an id to
+        # reference from suggestions and a record even if suggester crashes.
+        run = MappingApplyRunDb(
+            ontology_contexts=[c for c in effective if c not in payload.include_shipped],
+            include_shipped=list(payload.include_shipped),
+            target_filter=payload.target_filter.model_dump(exclude_none=True),
+            engines=list(payload.engines),
+            status=RUN_STATUS_SUGGESTING,
+            comment=payload.comment,
+            stats={},
+            applied_link_ids=[],
+            created_by=created_by,
+            started_at=_utcnow(),
+        )
+        db.add(run)
+        db.flush()
+        run_id = str(run.id)
+
+        # Run the suggester pipeline.
+        try:
+            targets = list(self._list_targets(db, payload))
+            drafts = self._run_engines(db, run, targets, effective)
+            self._persist_drafts(db, run, drafts)
+            run.stats = _stats_from(targets, drafts)
+            run.status = RUN_STATUS_SUGGESTED
+            run.finished_at = _utcnow()
+            db.commit()
+            db.refresh(run)
+        except Exception as e:
+            logger.exception("Term-mapping run %s failed: %s", run_id, e)
+            run.status = RUN_STATUS_FAILED
+            run.error = str(e)
+            run.finished_at = _utcnow()
+            db.commit()
+            db.refresh(run)
+        return RunRead.model_validate(run)
+
+    def get_run(self, db: Session, run_id: str) -> Optional[RunRead]:
+        run = mapping_run_repo.get(db, run_id)
+        return RunRead.model_validate(run) if run else None
+
+    def list_runs(self, db: Session, *, limit: int = 50) -> List[RunSummary]:
+        rows = mapping_run_repo.list_recent(db, limit=limit)
+        return [
+            RunSummary(
+                id=str(r.id),
+                status=r.status,
+                comment=r.comment,
+                stats=r.stats or {},
+                created_by=r.created_by,
+                created_at=r.created_at,
+                finished_at=r.finished_at,
+                applied_at=r.applied_at,
+            )
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Suggestion queue
+    # ------------------------------------------------------------------
+    def list_suggestions(
+        self,
+        db: Session,
+        *,
+        run_id: str,
+        status: Optional[str] = None,
+        source_entity_type: Optional[str] = None,
+        source_entity_id: Optional[str] = None,
+        limit: int = 500,
+        offset: int = 0,
+    ) -> List[SuggestionRead]:
+        rows = mapping_suggestion_repo.list_for_run(
+            db,
+            run_id,
+            status=status,
+            source_entity_type=source_entity_type,
+            source_entity_id=source_entity_id,
+            limit=limit,
+            offset=offset,
+        )
+        return [self._suggestion_to_api(r) for r in rows]
+
+    def list_suggestions_for_entity(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        include_decided: bool = False,
+    ) -> List[SuggestionRead]:
+        statuses = None if include_decided else (SUG_STATUS_PENDING,)
+        rows = mapping_suggestion_repo.list_for_entity(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            statuses=statuses,
+        )
+        return [self._suggestion_to_api(r) for r in rows]
+
+    def pending_count_for_entity(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+    ) -> PendingSuggestionCount:
+        return PendingSuggestionCount(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            pending=mapping_suggestion_repo.count_pending_for_entity(
+                db, entity_type=entity_type, entity_id=entity_id
+            ),
+            auto_apply=mapping_suggestion_repo.count_auto_apply_for_entity(
+                db, entity_type=entity_type, entity_id=entity_id
+            ),
+        )
+
+    def decide(
+        self,
+        db: Session,
+        *,
+        batch: SuggestionDecisionBatch,
+        decided_by: Optional[str],
+    ) -> SuggestionDecisionResult:
+        result = SuggestionDecisionResult(accepted=0, rejected=0, skipped=0)
+        now = _utcnow()
+        for decision in batch.decisions:
+            sug = mapping_suggestion_repo.get(db, decision.id)
+            if sug is None:
+                result.skipped += 1
+                result.errors.append(f"suggestion {decision.id} not found")
+                continue
+            if sug.status not in (SUG_STATUS_PENDING,):
+                # Already accepted/rejected/applied/superseded — refuse to
+                # mutate so audit history stays meaningful.
+                result.skipped += 1
+                continue
+            if decision.decision == "accept":
+                sug.status = SUG_STATUS_ACCEPTED
+                if decision.custom_iri:
+                    sug.custom_iri = decision.custom_iri
+                result.accepted += 1
+            else:
+                sug.status = SUG_STATUS_REJECTED
+                result.rejected += 1
+            sug.decided_by = decided_by
+            sug.decided_at = now
+            db.add(sug)
+        db.commit()
+        return result
+
+    # ------------------------------------------------------------------
+    # Apply / Undo
+    # ------------------------------------------------------------------
+    def apply_run(
+        self,
+        db: Session,
+        *,
+        run_id: str,
+        apply_auto: bool = True,
+        applied_by: Optional[str],
+    ) -> ApplyResult:
+        """Write every accepted (and optionally auto_apply pending) suggestion
+        in the run as an entity_semantic_links row."""
+        run = mapping_run_repo.get(db, run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        run.status = RUN_STATUS_APPLYING
+        db.commit()
+
+        # Bootstrap a SemanticLinksManager bound to this session so add()
+        # plays nicely with the existing RDF graph / change_log flow.
+        sml = SemanticLinksManager(db=db, semantic_models_manager=self._smm)
+
+        result = ApplyResult(run_id=run_id, links_created=0, links_skipped=0)
+        try:
+            statuses = [SUG_STATUS_ACCEPTED]
+            sugs = mapping_suggestion_repo.list_for_run(
+                db, run_id, status=None, limit=10_000
+            )
+            for sug in sugs:
+                if sug.status == SUG_STATUS_ACCEPTED:
+                    target_iri = sug.custom_iri or sug.target_concept_iri
+                elif sug.status == SUG_STATUS_PENDING and apply_auto and sug.auto_apply:
+                    target_iri = sug.target_concept_iri
+                else:
+                    continue
+
+                # Skip engine sentinels (NEW: prefixes etc.) — apply requires a real IRI.
+                if not target_iri or target_iri.startswith("NEW:"):
+                    result.links_skipped += 1
+                    sug.warnings = (sug.warnings or []) + ["orphan_or_new_iri"]
+                    db.add(sug)
+                    continue
+
+                try:
+                    link = sml.add(
+                        EntitySemanticLinkCreate(
+                            entity_id=sug.source_entity_id,
+                            entity_type=sug.source_entity_type,  # type: ignore[arg-type]
+                            iri=target_iri,
+                            label=sug.target_concept_label,
+                        ),
+                        created_by=applied_by,
+                    )
+                except Exception as link_err:
+                    logger.warning(
+                        "Failed to create link for suggestion %s: %s", sug.id, link_err
+                    )
+                    result.errors.append(f"{sug.id}: {link_err}")
+                    result.links_skipped += 1
+                    continue
+
+                sug.status = SUG_STATUS_APPLIED
+                try:
+                    sug.applied_link_id = _coerce_uuid_or_none(link.id)
+                except Exception:
+                    sug.applied_link_id = None
+                db.add(sug)
+                result.links_created += 1
+                run.applied_link_ids = (run.applied_link_ids or []) + [str(link.id)]
+
+            run.status = RUN_STATUS_APPLIED
+            run.applied_at = _utcnow()
+            # Refresh stats with apply numbers
+            stats = dict(run.stats or {})
+            stats["links_created"] = result.links_created
+            stats["links_skipped"] = result.links_skipped
+            run.stats = stats
+            db.commit()
+            db.refresh(run)
+        except Exception as e:
+            logger.exception("Apply run %s failed: %s", run_id, e)
+            run.status = RUN_STATUS_FAILED
+            run.error = str(e)
+            db.commit()
+            raise
+        return result
+
+    def undo_run(
+        self,
+        db: Session,
+        *,
+        run_id: str,
+        undone_by: Optional[str],
+    ) -> UndoResult:
+        run = mapping_run_repo.get(db, run_id)
+        if run is None:
+            raise ValueError(f"Run {run_id} not found")
+        if run.status != RUN_STATUS_APPLIED:
+            raise ValueError(
+                f"Run {run_id} status is '{run.status}'; can only undo an 'applied' run"
+            )
+
+        sml = SemanticLinksManager(db=db, semantic_models_manager=self._smm)
+        result = UndoResult(run_id=run_id, links_removed=0, suggestions_reverted=0)
+
+        for link_id in list(run.applied_link_ids or []):
+            try:
+                removed = sml.remove(link_id, removed_by=undone_by)
+                if removed:
+                    result.links_removed += 1
+                else:
+                    result.errors.append(f"link {link_id} already missing")
+            except Exception as e:
+                logger.warning("Failed to remove link %s during undo: %s", link_id, e)
+                result.errors.append(f"link {link_id}: {e}")
+
+        # Walk all applied suggestions and revert them to 'accepted' so the
+        # steward can re-trigger apply if undo was a mistake.
+        applied_sugs = (
+            db.query(MappingSuggestionDb)
+            .filter(
+                MappingSuggestionDb.run_id == run.id,
+                MappingSuggestionDb.status == SUG_STATUS_APPLIED,
+            )
+            .all()
+        )
+        for sug in applied_sugs:
+            sug.status = SUG_STATUS_ACCEPTED
+            sug.applied_link_id = None
+            db.add(sug)
+            result.suggestions_reverted += 1
+
+        run.status = RUN_STATUS_UNDONE
+        run.undone_at = _utcnow()
+        run.applied_link_ids = []
+        db.commit()
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _list_targets(self, db: Session, payload: RunCreate) -> List[TargetEntity]:
+        wanted_types = set(payload.target_filter.entity_types or [])
+        targets: List[TargetEntity] = []
+        for adapter in all_adapters():
+            # Skip adapters that don't serve any of the wanted entity_types.
+            if wanted_types and not (set(adapter.entity_types) & wanted_types):
+                continue
+            targets.extend(adapter.list_targets(db, payload.target_filter))
+        return targets
+
+    def _run_engines(
+        self,
+        db: Session,
+        run: MappingApplyRunDb,
+        targets: List[TargetEntity],
+        contexts: List[str],
+    ) -> List[SuggestionDraft]:
+        if not targets:
+            return []
+        source = ConceptSource(self._smm, contexts)
+        decided = build_already_decided_fn(db, mapping_suggestion_repo)
+        drafts: List[SuggestionDraft] = []
+        for engine_name in run.engines or ["heuristic"]:
+            if engine_name == "heuristic":
+                engine = HeuristicSuggester(concepts=source, already_decided=decided)
+                drafts.extend(engine.suggest(targets))
+            elif engine_name == "llm_judge":
+                # Out of scope for v1; skip silently with a stats marker.
+                logger.info("llm_judge engine not yet implemented; skipping")
+            else:
+                logger.warning("Unknown engine '%s'; skipping", engine_name)
+        return drafts
+
+    def _persist_drafts(
+        self,
+        db: Session,
+        run: MappingApplyRunDb,
+        drafts: List[SuggestionDraft],
+    ) -> None:
+        rows = [
+            MappingSuggestionDb(
+                run_id=run.id,
+                source_entity_type=d.source_entity_type,
+                source_entity_id=d.source_entity_id,
+                source_label=d.source_label,
+                suggestion_kind=d.suggestion_kind,
+                target_concept_iri=d.target_concept_iri,
+                target_concept_label=d.target_concept_label,
+                confidence=d.confidence,
+                reason=d.reason,
+                auto_apply=d.auto_apply,
+                engine=d.engine,
+                engine_metadata=d.engine_metadata,
+                warnings=d.warnings or None,
+            )
+            for d in drafts
+        ]
+        mapping_suggestion_repo.bulk_insert(db, rows)
+
+    def _suggestion_to_api(self, row: MappingSuggestionDb) -> SuggestionRead:
+        return SuggestionRead(
+            id=str(row.id),
+            run_id=str(row.run_id),
+            source_entity_type=row.source_entity_type,
+            source_entity_id=row.source_entity_id,
+            source_label=row.source_label,
+            suggestion_kind=row.suggestion_kind,  # type: ignore[arg-type]
+            target_concept_iri=row.target_concept_iri,
+            target_concept_label=row.target_concept_label,
+            confidence=row.confidence,
+            reason=row.reason,
+            auto_apply=row.auto_apply,
+            engine=row.engine,  # type: ignore[arg-type]
+            engine_metadata=row.engine_metadata,
+            status=row.status,  # type: ignore[arg-type]
+            decided_by=row.decided_by,
+            decided_at=row.decided_at,
+            custom_iri=row.custom_iri,
+            applied_link_id=str(row.applied_link_id) if row.applied_link_id else None,
+            warnings=row.warnings,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+
+# ---------- module-private helpers ----------
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stats_from(targets: List[TargetEntity], drafts: List[SuggestionDraft]) -> Dict[str, Any]:
+    auto_apply_count = sum(1 for d in drafts if d.auto_apply)
+    return {
+        "targets": len(targets),
+        "suggestions_total": len(drafts),
+        "suggestions_pending": len(drafts),
+        "suggestions_accepted": 0,
+        "suggestions_rejected": 0,
+        "suggestions_auto_apply": auto_apply_count,
+        "links_created": 0,
+    }
+
+
+def _coerce_uuid_or_none(value):
+    from uuid import UUID
+    if value is None:
+        return None
+    try:
+        return UUID(str(value))
+    except Exception:
+        return None

--- a/src/backend/src/db_models/__init__.py
+++ b/src/backend/src/db_models/__init__.py
@@ -43,4 +43,5 @@ from . import certification_levels
 from . import workflow_configurations
 from . import workflow_installations
 from . import workflow_job_runs
+from . import term_mappings
 

--- a/src/backend/src/db_models/term_mappings.py
+++ b/src/backend/src/db_models/term_mappings.py
@@ -1,0 +1,180 @@
+"""Term-mapping persistence: apply-run records and suggestion queue.
+
+The "term mapping" feature bulk-suggests customer-ontology concept links for
+Assets, Data Contract schemas/properties, and Data Products. Applied links are
+written through SemanticLinksManager into the existing entity_semantic_links
+table; these two tables capture the run-level traceability + the persistent
+suggestion queue. See docs/prds/prd-ontology-term-mapping.md.
+"""
+import uuid
+from sqlalchemy import (
+    Column,
+    String,
+    Text,
+    Float,
+    Boolean,
+    Integer,
+    TIMESTAMP,
+    JSON,
+    ForeignKey,
+    Index,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from src.common.database import Base
+
+
+# Run statuses
+RUN_STATUS_PENDING = "pending"          # created but suggester not started
+RUN_STATUS_SUGGESTING = "suggesting"    # suggester executing
+RUN_STATUS_SUGGESTED = "suggested"      # suggester finished; queue ready for review
+RUN_STATUS_APPLYING = "applying"
+RUN_STATUS_APPLIED = "applied"
+RUN_STATUS_UNDONE = "undone"
+RUN_STATUS_FAILED = "failed"
+
+# Suggestion statuses
+SUG_STATUS_PENDING = "pending"
+SUG_STATUS_ACCEPTED = "accepted"
+SUG_STATUS_REJECTED = "rejected"
+SUG_STATUS_APPLIED = "applied"
+SUG_STATUS_SUPERSEDED = "superseded"
+
+# Suggestion kinds
+SUG_KIND_ENTITY = "entity_assignment"
+SUG_KIND_ATTRIBUTE = "attribute_assignment"
+
+# Engines
+ENGINE_HEURISTIC = "heuristic"
+ENGINE_LLM_JUDGE = "llm_judge"
+
+
+class MappingApplyRunDb(Base):
+    """One suggester+apply run. Captures config, stats, and the link ids
+    created on apply (for single-click undo). See PRD."""
+    __tablename__ = "term_mapping_runs"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Concept source scoping. ontology_contexts = customer ontologies
+    # (urn:semantic-model:*). include_shipped = explicit opt-in for shipped
+    # taxonomies (databricks_ontology, odcs-ontology). The internal
+    # urn:taxonomy:ontos-ontology context is rejected by the manager.
+    ontology_contexts = Column(JSON, nullable=False, default=list)
+    include_shipped = Column(JSON, nullable=False, default=list)
+
+    # Target selection filter, e.g.
+    # {"entity_types": ["data_contract_property", "asset"],
+    #  "domain_ids": [...], "contract_ids": [...], "asset_type_names": ["Column"]}
+    target_filter = Column(JSON, nullable=False, default=dict)
+
+    # Enabled engines, e.g. ["heuristic"] or ["heuristic", "llm_judge"]
+    engines = Column(JSON, nullable=False, default=list)
+
+    status = Column(String, nullable=False, default=RUN_STATUS_PENDING, index=True)
+    comment = Column(Text, nullable=True)
+
+    # Runtime stats; merged in as the run progresses.
+    # {"targets": N, "suggestions_total": N, "suggestions_pending": N,
+    #  "suggestions_accepted": N, "suggestions_rejected": N,
+    #  "links_created": N, "llm_calls": N,
+    #  "llm_tokens_in": N, "llm_tokens_out": N}
+    stats = Column(JSON, nullable=False, default=dict)
+    error = Column(Text, nullable=True)
+
+    # IDs of the entity_semantic_links rows this run created. Used by undo
+    # to remove exactly the run's contribution. List[str] of UUIDs.
+    applied_link_ids = Column(JSON, nullable=False, default=list)
+
+    created_by = Column(String, nullable=True, index=True)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    started_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    finished_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    applied_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    undone_at = Column(TIMESTAMP(timezone=True), nullable=True)
+
+    suggestions = relationship(
+        "MappingSuggestionDb",
+        back_populates="run",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self):
+        return f"<MappingApplyRunDb(id={self.id}, status='{self.status}')>"
+
+
+class MappingSuggestionDb(Base):
+    """One proposed assignment of a customer-ontology concept to a single
+    source entity. Persistent queue (pending/accepted/rejected/applied/
+    superseded) so stewards can triage over time and the suggester can
+    skip already-decided pairs on future runs."""
+    __tablename__ = "term_mapping_suggestions"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    run_id = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("term_mapping_runs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Source entity. entity_type matches models/semantic_links.py EntityType
+    # literal (data_product, data_contract, data_contract_schema,
+    # data_contract_property, dataset, asset, uc_*).
+    source_entity_type = Column(String, nullable=False, index=True)
+    source_entity_id = Column(String, nullable=False, index=True)
+    # Denormalised display name to avoid joining back on every read.
+    source_label = Column(String, nullable=True)
+
+    suggestion_kind = Column(String, nullable=False)  # entity_assignment | attribute_assignment
+
+    target_concept_iri = Column(Text, nullable=False)
+    target_concept_label = Column(Text, nullable=True)
+
+    confidence = Column(Float, nullable=False, default=0.0)
+    reason = Column(Text, nullable=False, default="")  # rendered verbatim in UI
+    auto_apply = Column(Boolean, nullable=False, default=False)
+
+    engine = Column(String, nullable=False, default=ENGINE_HEURISTIC)
+    # Engine-specific extras (heuristic signals, LLM rationale, etc.).
+    engine_metadata = Column(JSON, nullable=True)
+
+    # Lifecycle.
+    status = Column(String, nullable=False, default=SUG_STATUS_PENDING, index=True)
+    decided_by = Column(String, nullable=True)
+    decided_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    # Steward override of target_concept_iri at decision time.
+    custom_iri = Column(Text, nullable=True)
+    # Set after apply: the entity_semantic_links.id row this suggestion
+    # produced. Used by undo.
+    applied_link_id = Column(PG_UUID(as_uuid=True), nullable=True)
+
+    # Flags surfaced from engine guards (e.g. orphan_attribute, conflict).
+    warnings = Column(JSON, nullable=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    run = relationship("MappingApplyRunDb", back_populates="suggestions")
+
+    __table_args__ = (
+        Index(
+            "ix_term_mapping_suggestions_source",
+            "source_entity_type",
+            "source_entity_id",
+        ),
+        Index(
+            "ix_term_mapping_suggestions_run_status",
+            "run_id",
+            "status",
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<MappingSuggestionDb(id={self.id}, "
+            f"src={self.source_entity_type}:{self.source_entity_id}, "
+            f"iri={self.target_concept_iri}, status={self.status})>"
+        )

--- a/src/backend/src/models/term_mappings.py
+++ b/src/backend/src/models/term_mappings.py
@@ -1,0 +1,184 @@
+"""Pydantic API models for the term-mapping feature.
+
+Wire-format spec for routes/term_mapping_routes.py. Mirrors the DB shape in
+db_models/term_mappings.py but uses str ids and ISO-format timestamps for the
+HTTP boundary.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------- Enums (literals for the wire) ----------
+
+RunStatus = Literal[
+    "pending",
+    "suggesting",
+    "suggested",
+    "applying",
+    "applied",
+    "undone",
+    "failed",
+]
+
+SuggestionStatus = Literal[
+    "pending",
+    "accepted",
+    "rejected",
+    "applied",
+    "superseded",
+]
+
+SuggestionKind = Literal["entity_assignment", "attribute_assignment"]
+
+Engine = Literal["heuristic", "llm_judge"]
+
+# Subset of entity_semantic_links EntityType valid as a term-mapping target.
+TargetEntityType = Literal[
+    "data_product",
+    "data_contract",
+    "data_contract_schema",
+    "data_contract_property",
+    "dataset",
+    "asset",
+]
+
+
+# ---------- Run shapes ----------
+
+class RunTargetFilter(BaseModel):
+    """Filter that scopes a run's target selection.
+
+    All fields are optional; omitted = no filter on that dimension. When
+    multiple fields are set they AND-combine.
+    """
+    entity_types: Optional[List[TargetEntityType]] = None
+    domain_ids: Optional[List[str]] = None
+    contract_ids: Optional[List[str]] = None
+    product_ids: Optional[List[str]] = None
+    # For asset targets: filter to specific asset_type names (e.g. "Column",
+    # "Table"). When omitted, defaults to ["Column"] in the adapter so we
+    # don't suggest concepts for entire tables by default.
+    asset_type_names: Optional[List[str]] = None
+    # Hard cap on targets per run; defaults applied by manager.
+    limit: Optional[int] = None
+
+
+class RunCreate(BaseModel):
+    """POST /api/term-mappings/runs body.
+
+    ontology_contexts defaults (on the manager side) to every enabled
+    customer ontology (urn:semantic-model:*). The internal
+    urn:taxonomy:ontos-ontology context is rejected.
+    """
+    ontology_contexts: Optional[List[str]] = None
+    include_shipped: List[str] = Field(default_factory=list)
+    target_filter: RunTargetFilter = Field(default_factory=RunTargetFilter)
+    engines: List[Engine] = Field(default_factory=lambda: ["heuristic"])
+    comment: Optional[str] = None
+
+
+class RunRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    ontology_contexts: List[str]
+    include_shipped: List[str]
+    target_filter: Dict[str, Any]
+    engines: List[str]
+    status: RunStatus
+    comment: Optional[str] = None
+    stats: Dict[str, Any]
+    error: Optional[str] = None
+    applied_link_ids: List[str]
+    created_by: Optional[str] = None
+    created_at: datetime
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    applied_at: Optional[datetime] = None
+    undone_at: Optional[datetime] = None
+
+
+class RunSummary(BaseModel):
+    """List-view projection of a run."""
+    id: str
+    status: RunStatus
+    comment: Optional[str] = None
+    stats: Dict[str, Any]
+    created_by: Optional[str] = None
+    created_at: datetime
+    finished_at: Optional[datetime] = None
+    applied_at: Optional[datetime] = None
+
+
+# ---------- Suggestion shapes ----------
+
+class SuggestionRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    run_id: str
+    source_entity_type: str
+    source_entity_id: str
+    source_label: Optional[str] = None
+    suggestion_kind: SuggestionKind
+    target_concept_iri: str
+    target_concept_label: Optional[str] = None
+    confidence: float
+    reason: str
+    auto_apply: bool
+    engine: Engine
+    engine_metadata: Optional[Dict[str, Any]] = None
+    status: SuggestionStatus
+    decided_by: Optional[str] = None
+    decided_at: Optional[datetime] = None
+    custom_iri: Optional[str] = None
+    applied_link_id: Optional[str] = None
+    warnings: Optional[List[str]] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SuggestionDecision(BaseModel):
+    """Single steward decision for bulk POST /suggestions/decisions."""
+    id: str
+    decision: Literal["accept", "reject"]
+    custom_iri: Optional[str] = None  # only meaningful for decision=accept
+
+
+class SuggestionDecisionBatch(BaseModel):
+    decisions: List[SuggestionDecision]
+
+
+class SuggestionDecisionResult(BaseModel):
+    accepted: int
+    rejected: int
+    skipped: int  # suggestions whose id wasn't found or whose status was already terminal
+    errors: List[str] = Field(default_factory=list)
+
+
+# ---------- Apply / Undo result shapes ----------
+
+class ApplyResult(BaseModel):
+    run_id: str
+    links_created: int
+    links_skipped: int  # e.g. orphan attribute, NEW: prefix, duplicate
+    errors: List[str] = Field(default_factory=list)
+
+
+class UndoResult(BaseModel):
+    run_id: str
+    links_removed: int
+    suggestions_reverted: int
+    errors: List[str] = Field(default_factory=list)
+
+
+class PendingSuggestionCount(BaseModel):
+    """Drives the per-entity 'N pending suggestions' badge."""
+    entity_type: str
+    entity_id: str
+    pending: int
+    auto_apply: int

--- a/src/backend/src/repositories/term_mapping_repository.py
+++ b/src/backend/src/repositories/term_mapping_repository.py
@@ -1,0 +1,186 @@
+"""Repositories for the term-mapping feature."""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+from uuid import UUID
+
+from sqlalchemy import desc, func
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.common.logging import get_logger
+from src.common.repository import CRUDBase
+from src.db_models.term_mappings import (
+    MappingApplyRunDb,
+    MappingSuggestionDb,
+    SUG_STATUS_PENDING,
+    SUG_STATUS_REJECTED,
+    SUG_STATUS_ACCEPTED,
+)
+from src.models.term_mappings import RunCreate, RunRead  # update model unused
+
+logger = get_logger(__name__)
+
+
+def _coerce_uuid(value) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    return UUID(str(value))
+
+
+class MappingRunRepository(CRUDBase[MappingApplyRunDb, RunCreate, RunRead]):
+    def list_recent(self, db: Session, *, limit: int = 50) -> List[MappingApplyRunDb]:
+        try:
+            return (
+                db.query(self.model)
+                .order_by(desc(self.model.created_at))
+                .limit(limit)
+                .all()
+            )
+        except SQLAlchemyError as e:
+            logger.error(f"list_recent runs failed: {e}", exc_info=True)
+            db.rollback()
+            raise
+
+
+class MappingSuggestionRepository(CRUDBase[MappingSuggestionDb, MappingSuggestionDb, MappingSuggestionDb]):
+    """Suggestion queue. Uses the model itself as the create/update schema —
+    the manager constructs db_objs directly for bulk inserts, which is faster
+    than per-row Pydantic validation on the suggester hot path."""
+
+    def list_for_run(
+        self,
+        db: Session,
+        run_id,
+        *,
+        status: Optional[str] = None,
+        source_entity_type: Optional[str] = None,
+        source_entity_id: Optional[str] = None,
+        limit: int = 500,
+        offset: int = 0,
+    ) -> List[MappingSuggestionDb]:
+        try:
+            q = db.query(self.model).filter(self.model.run_id == _coerce_uuid(run_id))
+            if status:
+                q = q.filter(self.model.status == status)
+            if source_entity_type:
+                q = q.filter(self.model.source_entity_type == source_entity_type)
+            if source_entity_id:
+                q = q.filter(self.model.source_entity_id == source_entity_id)
+            return q.order_by(self.model.source_entity_type, self.model.source_entity_id).offset(offset).limit(limit).all()
+        except SQLAlchemyError as e:
+            logger.error(f"list_for_run failed: {e}", exc_info=True)
+            db.rollback()
+            raise
+
+    def list_for_entity(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        statuses: Optional[Sequence[str]] = None,
+    ) -> List[MappingSuggestionDb]:
+        try:
+            q = db.query(self.model).filter(
+                self.model.source_entity_type == entity_type,
+                self.model.source_entity_id == entity_id,
+            )
+            if statuses:
+                q = q.filter(self.model.status.in_(list(statuses)))
+            return q.order_by(desc(self.model.created_at)).all()
+        except SQLAlchemyError as e:
+            logger.error(f"list_for_entity failed: {e}", exc_info=True)
+            db.rollback()
+            raise
+
+    def count_pending_for_entity(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+    ) -> int:
+        try:
+            return (
+                db.query(func.count(self.model.id))
+                .filter(
+                    self.model.source_entity_type == entity_type,
+                    self.model.source_entity_id == entity_id,
+                    self.model.status == SUG_STATUS_PENDING,
+                )
+                .scalar()
+                or 0
+            )
+        except SQLAlchemyError as e:
+            logger.error(f"count_pending_for_entity failed: {e}", exc_info=True)
+            db.rollback()
+            raise
+
+    def count_auto_apply_for_entity(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+    ) -> int:
+        try:
+            return (
+                db.query(func.count(self.model.id))
+                .filter(
+                    self.model.source_entity_type == entity_type,
+                    self.model.source_entity_id == entity_id,
+                    self.model.status == SUG_STATUS_PENDING,
+                    self.model.auto_apply.is_(True),
+                )
+                .scalar()
+                or 0
+            )
+        except SQLAlchemyError as e:
+            logger.error(f"count_auto_apply_for_entity failed: {e}", exc_info=True)
+            db.rollback()
+            raise
+
+    def is_pair_already_decided(
+        self,
+        db: Session,
+        *,
+        source_entity_type: str,
+        source_entity_id: str,
+        target_concept_iri: str,
+    ) -> bool:
+        """Has this (source, target_iri) pair been rejected before? Used by
+        the heuristic engine to skip pairs the steward already rejected so
+        they don't reappear on every run."""
+        try:
+            existing = (
+                db.query(self.model.id)
+                .filter(
+                    self.model.source_entity_type == source_entity_type,
+                    self.model.source_entity_id == source_entity_id,
+                    self.model.target_concept_iri == target_concept_iri,
+                    self.model.status == SUG_STATUS_REJECTED,
+                )
+                .first()
+            )
+            return existing is not None
+        except SQLAlchemyError as e:
+            logger.error(f"is_pair_already_decided failed: {e}", exc_info=True)
+            db.rollback()
+            raise
+
+    def bulk_insert(self, db: Session, rows: List[MappingSuggestionDb]) -> int:
+        if not rows:
+            return 0
+        try:
+            db.add_all(rows)
+            db.flush()
+            return len(rows)
+        except SQLAlchemyError as e:
+            logger.error(f"bulk_insert suggestions failed: {e}", exc_info=True)
+            db.rollback()
+            raise
+
+
+mapping_run_repo = MappingRunRepository(model=MappingApplyRunDb)
+mapping_suggestion_repo = MappingSuggestionRepository(model=MappingSuggestionDb)

--- a/src/backend/src/routes/term_mapping_routes.py
+++ b/src/backend/src/routes/term_mapping_routes.py
@@ -1,0 +1,244 @@
+"""FastAPI routes for the Term Mapping feature.
+
+Exposes:
+  POST   /api/term-mappings/runs                    create + execute a run
+  GET    /api/term-mappings/runs                    list recent runs
+  GET    /api/term-mappings/runs/{run_id}           get one run
+  GET    /api/term-mappings/runs/{run_id}/suggestions   list suggestions for run
+  POST   /api/term-mappings/runs/{run_id}/decisions     bulk accept/reject
+  POST   /api/term-mappings/runs/{run_id}/apply         materialise links
+  POST   /api/term-mappings/runs/{run_id}/undo          revert last apply (ADMIN)
+  GET    /api/term-mappings/entities/{type}/{id}/suggestions  per-entity badge data
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy.orm import Session
+
+from ..common.authorization import PermissionChecker
+from ..common.database import get_db
+from ..common.dependencies import CurrentUserDep
+from ..common.features import FeatureAccessLevel
+from ..common.logging import get_logger
+from ..controller.term_mapping_manager import TermMappingManager
+from ..models.term_mappings import (
+    ApplyResult,
+    PendingSuggestionCount,
+    RunCreate,
+    RunRead,
+    RunSummary,
+    SuggestionDecisionBatch,
+    SuggestionDecisionResult,
+    SuggestionRead,
+    UndoResult,
+)
+
+logger = get_logger(__name__)
+router = APIRouter(prefix="/api/term-mappings", tags=["Term Mapping"])
+
+FEATURE_ID = "term-mapping"
+
+
+def _get_manager(request: Request) -> TermMappingManager:
+    mgr: Optional[TermMappingManager] = getattr(request.app.state, "term_mapping_manager", None)
+    if mgr is None:
+        raise HTTPException(
+            status_code=503,
+            detail="TermMappingManager not initialised (semantic models manager unavailable?)",
+        )
+    return mgr
+
+
+# ------------------------------------------------------------------
+# Run lifecycle
+# ------------------------------------------------------------------
+
+@router.post("/runs", response_model=RunRead, status_code=201)
+async def create_run(
+    payload: RunCreate,
+    request: Request,
+    user: CurrentUserDep,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+) -> RunRead:
+    """Create a term-mapping run and execute the configured engines synchronously.
+
+    Returns the persisted run with stats. For large estates this becomes a
+    background-job-backed endpoint in a future phase.
+    """
+    try:
+        return _get_manager(request).create_run(
+            db, payload=payload, created_by=getattr(user, "email", None)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+@router.get("/runs", response_model=List[RunSummary])
+async def list_runs(
+    request: Request,
+    limit: int = Query(50, ge=1, le=500),
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+) -> List[RunSummary]:
+    return _get_manager(request).list_runs(db, limit=limit)
+
+
+@router.get("/runs/{run_id}", response_model=RunRead)
+async def get_run(
+    run_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+) -> RunRead:
+    run = _get_manager(request).get_run(db, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    return run
+
+
+# ------------------------------------------------------------------
+# Suggestion queue
+# ------------------------------------------------------------------
+
+@router.get("/runs/{run_id}/suggestions", response_model=List[SuggestionRead])
+async def list_suggestions(
+    run_id: str,
+    request: Request,
+    status: Optional[str] = Query(None, description="Filter by suggestion status"),
+    source_entity_type: Optional[str] = Query(None),
+    source_entity_id: Optional[str] = Query(None),
+    limit: int = Query(500, ge=1, le=5000),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+) -> List[SuggestionRead]:
+    return _get_manager(request).list_suggestions(
+        db,
+        run_id=run_id,
+        status=status,
+        source_entity_type=source_entity_type,
+        source_entity_id=source_entity_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post(
+    "/runs/{run_id}/decisions",
+    response_model=SuggestionDecisionResult,
+)
+async def decide_suggestions(
+    run_id: str,
+    batch: SuggestionDecisionBatch,
+    request: Request,
+    user: CurrentUserDep,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+) -> SuggestionDecisionResult:
+    # run_id is currently informational — decisions are keyed by suggestion id
+    # (each one already carries its run via the FK), but accepting it in the
+    # path keeps the route hierarchy readable and prevents accidental
+    # cross-run posts from a malformed UI.
+    return _get_manager(request).decide(
+        db, batch=batch, decided_by=getattr(user, "email", None)
+    )
+
+
+# ------------------------------------------------------------------
+# Apply / Undo
+# ------------------------------------------------------------------
+
+@router.post("/runs/{run_id}/apply", response_model=ApplyResult)
+async def apply_run(
+    run_id: str,
+    request: Request,
+    user: CurrentUserDep,
+    apply_auto: bool = Query(
+        True,
+        description="When true, also apply pending suggestions with auto_apply=True.",
+    ),
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+) -> ApplyResult:
+    try:
+        return _get_manager(request).apply_run(
+            db, run_id=run_id, apply_auto=apply_auto, applied_by=getattr(user, "email", None)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+@router.post("/runs/{run_id}/undo", response_model=UndoResult)
+async def undo_run(
+    run_id: str,
+    request: Request,
+    user: CurrentUserDep,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.ADMIN)),
+) -> UndoResult:
+    """ADMIN-only: remove every entity_semantic_links row this run produced
+    and revert applied suggestions back to ``accepted``."""
+    try:
+        return _get_manager(request).undo_run(
+            db, run_id=run_id, undone_by=getattr(user, "email", None)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+# ------------------------------------------------------------------
+# Per-entity badge data
+# ------------------------------------------------------------------
+
+@router.get(
+    "/entities/{entity_type}/{entity_id:path}/suggestions",
+    response_model=List[SuggestionRead],
+)
+async def list_entity_suggestions(
+    entity_type: str,
+    entity_id: str,
+    request: Request,
+    include_decided: bool = Query(False),
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+) -> List[SuggestionRead]:
+    """All term-mapping suggestions for a single entity, across runs.
+
+    Backs the per-entity-panel 'N pending suggestions' panel. entity_id is
+    declared with :path so contract-property compound ids (containing '#')
+    pass through without re-encoding.
+    """
+    return _get_manager(request).list_suggestions_for_entity(
+        db,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        include_decided=include_decided,
+    )
+
+
+@router.get(
+    "/entities/{entity_type}/{entity_id:path}/pending-count",
+    response_model=PendingSuggestionCount,
+)
+async def pending_count(
+    entity_type: str,
+    entity_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+) -> PendingSuggestionCount:
+    return _get_manager(request).pending_count_for_entity(
+        db, entity_type=entity_type, entity_id=entity_id
+    )
+
+
+# ------------------------------------------------------------------
+# Registration
+# ------------------------------------------------------------------
+
+def register_routes(app):
+    app.include_router(router)
+    logger.info("Term-mapping routes registered")

--- a/src/backend/src/tests/unit/test_term_mapping_heuristic.py
+++ b/src/backend/src/tests/unit/test_term_mapping_heuristic.py
@@ -1,0 +1,283 @@
+"""Unit tests for HeuristicSuggester.
+
+Locks in two bug fixes called out in the PRD:
+  * Bug fix #2 — label similarity is capped by name similarity (the source's
+    max(name, label) let descriptive labels push 'id' columns to 0.95
+    auto-accept on the wrong concept).
+  * Bug fix #3 — pairs the steward has rejected before are skipped (the
+    source had no persistent queue and re-proposed the same noise on every
+    run).
+
+And the foundational positive cases: container, FK-by-stem, property-by-name,
+PK-by-property fallback.
+"""
+from typing import List
+
+from src.controller.term_mapping.engines import HeuristicSuggester
+from src.controller.term_mapping.types import ConceptCandidate, TargetEntity
+
+
+class _Source:
+    """Minimal ConceptSource stand-in. The engine only calls .classes() and
+    .properties(), so we don't need the real graph plumbing."""
+
+    def __init__(
+        self,
+        classes: List[ConceptCandidate] | None = None,
+        properties: List[ConceptCandidate] | None = None,
+    ):
+        self._classes = classes or []
+        self._properties = properties or []
+
+    def classes(self):
+        return self._classes
+
+    def properties(self):
+        return self._properties
+
+
+def _customer_class() -> ConceptCandidate:
+    return ConceptCandidate(
+        iri="http://retail.example/Customer",
+        label="Customer",
+        source_context="urn:semantic-model:retail",
+    )
+
+
+def _identifier_prop() -> ConceptCandidate:
+    return ConceptCandidate(
+        iri="http://purl.org/dc/terms/identifier",
+        label="identifier",
+        source_context="urn:semantic-model:retail",
+        is_class=False,
+        range_type="xsd:string",
+    )
+
+
+def _email_prop(label_comment: str = "") -> ConceptCandidate:
+    return ConceptCandidate(
+        iri="http://retail.example/email",
+        label="email",
+        comment=label_comment,
+        source_context="urn:semantic-model:retail",
+        is_class=False,
+        range_type="xsd:string",
+    )
+
+
+class TestContainerMatch:
+    def test_singular_plural_collapse(self):
+        eng = HeuristicSuggester(concepts=_Source(classes=[_customer_class()]))
+        target = TargetEntity(
+            entity_type="asset",
+            entity_id="t1",
+            name="customers",
+            label="customers",
+        )
+        drafts = eng.suggest([target])
+        assert len(drafts) == 1
+        assert drafts[0].target_concept_iri == "http://retail.example/Customer"
+        assert drafts[0].suggestion_kind == "entity_assignment"
+        # Container assignments are type-agnostic → high confidence.
+        assert drafts[0].confidence >= 0.9
+        assert drafts[0].auto_apply is True
+
+    def test_no_match_below_threshold(self):
+        eng = HeuristicSuggester(concepts=_Source(classes=[_customer_class()]))
+        target = TargetEntity(
+            entity_type="asset",
+            entity_id="t-x",
+            name="invoices",
+            label="invoices",
+        )
+        drafts = eng.suggest([target])
+        # similarity('invoice','customer') < 0.6 → no match.
+        assert drafts == []
+
+
+class TestForeignKeyHeuristic:
+    def test_fk_stem_matches_class(self):
+        eng = HeuristicSuggester(concepts=_Source(classes=[_customer_class()]))
+        target = TargetEntity(
+            entity_type="asset",
+            entity_id="c1",
+            name="customer_id",
+            label="customer_id",
+            type_label="bigint",
+            parent_entity_id="orders",
+            parent_name="orders",
+        )
+        drafts = eng.suggest([target])
+        assert len(drafts) == 1
+        d = drafts[0]
+        assert d.target_concept_iri == "http://retail.example/Customer"
+        assert d.engine_metadata and d.engine_metadata.get("fk_hint") is True
+        assert d.confidence == 1.0  # perfect stem + type + fk
+
+    def test_self_fk_is_skipped(self):
+        """When the column lives ON the table that matches the stem, it's a
+        PK candidate, not an FK to itself."""
+        eng = HeuristicSuggester(concepts=_Source(classes=[_customer_class()]))
+        target = TargetEntity(
+            entity_type="asset",
+            entity_id="c1",
+            name="customer_id",
+            label="customer_id",
+            type_label="bigint",
+            parent_entity_id="customers",
+            parent_name="customers",  # parent IS the matched concept
+            is_pk=True,
+        )
+        drafts = eng.suggest([target])
+        # Either zero drafts (no PK property concept) or a PK-flavoured draft
+        # — but never an FK pointing customers → Customer (would be self-FK).
+        for d in drafts:
+            assert d.engine_metadata is None or not d.engine_metadata.get("fk_hint")
+
+    def test_id_only_column_not_fk(self):
+        # `id` alone is the PK heuristic's territory, not FK.
+        eng = HeuristicSuggester(concepts=_Source(classes=[_customer_class()]))
+        target = TargetEntity(
+            entity_type="asset",
+            entity_id="c1",
+            name="id",
+            label="id",
+            type_label="bigint",
+            parent_entity_id="t1",
+            parent_name="customers",
+            is_pk=True,
+        )
+        drafts = eng.suggest([target])
+        # No id/identifier property concept loaded → falls through; that's ok.
+        for d in drafts:
+            assert not (d.engine_metadata and d.engine_metadata.get("fk_hint"))
+
+
+class TestPrimaryKeyHeuristic:
+    def test_pk_maps_to_identifier_property(self):
+        eng = HeuristicSuggester(
+            concepts=_Source(
+                classes=[_customer_class()],
+                properties=[_identifier_prop()],
+            )
+        )
+        target = TargetEntity(
+            entity_type="data_contract_property",
+            entity_id="c#cust#id",
+            name="id",
+            label="id",
+            type_label="bigint",
+            parent_entity_id="c#cust",
+            parent_name="cust",
+            is_pk=True,
+        )
+        drafts = eng.suggest([target])
+        assert any(d.target_concept_iri == _identifier_prop().iri for d in drafts)
+        # PK match gets pk_hint metadata.
+        pk_draft = next(d for d in drafts if d.target_concept_iri == _identifier_prop().iri)
+        assert pk_draft.engine_metadata and pk_draft.engine_metadata.get("pk_hint")
+
+
+class TestPropertyMatch:
+    def test_property_name_match(self):
+        eng = HeuristicSuggester(concepts=_Source(properties=[_email_prop()]))
+        target = TargetEntity(
+            entity_type="data_contract_property",
+            entity_id="c#cust#email",
+            name="email",
+            label="email",
+            type_label="string",
+            parent_entity_id="c#cust",
+            parent_name="cust",
+        )
+        drafts = eng.suggest([target])
+        assert len(drafts) == 1
+        d = drafts[0]
+        assert d.target_concept_iri == _email_prop().iri
+        assert d.suggestion_kind == "attribute_assignment"
+        assert d.confidence >= 0.9
+
+    def test_label_similarity_capped_by_name(self):
+        """Bug fix #2: in the source repo max(name_sim, label_sim) let a long
+        descriptive label drive a column called 'id' to 0.95 against a
+        property literally labelled 'email' (because the label text mentioned
+        'identifier' in passing). We now cap label by name."""
+        # Property whose human label/comment is long and mentions 'id' so
+        # a naïve max would over-reward similarity.
+        chatty = ConceptCandidate(
+            iri="http://retail.example/preferredContactEmail",
+            label="email",
+            comment="The email address used as the primary identifier id key",
+            source_context="urn:semantic-model:retail",
+            is_class=False,
+            range_type="xsd:string",
+        )
+        eng = HeuristicSuggester(concepts=_Source(properties=[chatty]))
+        target = TargetEntity(
+            entity_type="data_contract_property",
+            entity_id="c#cust#id",
+            name="id",
+            label="id",
+            type_label="bigint",
+            parent_entity_id="c#cust",
+            parent_name="cust",
+        )
+        drafts = eng.suggest([target])
+        # The engine may emit 0 drafts (low name_sim below 0.45) or 1 with a
+        # modest confidence well below auto-accept. The bug would have been
+        # emitting a draft with confidence >= 0.9.
+        for d in drafts:
+            assert d.confidence < 0.9, f"label drove past auto-accept: {d}"
+
+
+class TestAlreadyDecidedGuard:
+    """Bug fix #3: the source had no persistent queue, so a rejected pair
+    would reappear on the very next run. We accept a callback the engine
+    invokes per draft to suppress those."""
+
+    def test_rejected_pair_is_pruned(self):
+        eng = HeuristicSuggester(
+            concepts=_Source(classes=[_customer_class()]),
+            already_decided=lambda et, eid, iri: iri.endswith("/Customer"),
+        )
+        target = TargetEntity(
+            entity_type="asset",
+            entity_id="t1",
+            name="customers",
+            label="customers",
+        )
+        drafts = eng.suggest([target])
+        # The only candidate is /Customer, which we said was already rejected.
+        assert drafts == []
+
+    def test_other_pairs_unaffected(self):
+        eng = HeuristicSuggester(
+            concepts=_Source(
+                classes=[_customer_class()],
+                properties=[_email_prop()],
+            ),
+            already_decided=lambda et, eid, iri: iri.endswith("/Customer"),
+        )
+        # /Customer is blocked for the container target,
+        # but /email is fine for the property target.
+        targets = [
+            TargetEntity(
+                entity_type="asset",
+                entity_id="t1",
+                name="customers",
+                label="customers",
+            ),
+            TargetEntity(
+                entity_type="data_contract_property",
+                entity_id="c#cust#email",
+                name="email",
+                label="email",
+                type_label="string",
+                parent_entity_id="c#cust",
+                parent_name="cust",
+            ),
+        ]
+        drafts = eng.suggest(targets)
+        iris = {d.target_concept_iri for d in drafts}
+        assert _email_prop().iri in iris
+        assert "http://retail.example/Customer" not in iris

--- a/src/backend/src/tests/unit/test_term_mapping_naming.py
+++ b/src/backend/src/tests/unit/test_term_mapping_naming.py
@@ -1,0 +1,112 @@
+"""Unit tests for term-mapping naming helpers.
+
+Locks in bug fix #1 from the PRD: the source's _depluralize only knew the
+-ies / trailing-s rules, so 'people', 'children', 'criteria' etc. silently
+dropped (the depluralized form == original, then no entity match).
+"""
+from src.controller.term_mapping.naming import (
+    depluralize,
+    normalize,
+    similarity,
+    simplify_xsd,
+    to_camel,
+    to_pascal,
+    type_group,
+    types_compatible,
+    xsd_for_column,
+)
+
+
+class TestNormalize:
+    def test_strips_separators(self):
+        assert normalize("Cust_Email") == "custemail"
+        assert normalize("customer-id") == "customerid"
+        assert normalize("CustomerID") == "customerid"
+
+    def test_handles_none_and_empty(self):
+        assert normalize("") == ""
+        assert normalize(None) == ""  # type: ignore[arg-type]
+
+
+class TestDepluralize:
+    """Bug fix #1 regression tests — irregular plurals must singularise."""
+
+    def test_irregulars(self):
+        assert depluralize("people") == "person"
+        assert depluralize("children") == "child"
+        assert depluralize("men") == "man"
+        assert depluralize("women") == "woman"
+        assert depluralize("criteria") == "criterion"
+        assert depluralize("indices") == "index"
+
+    def test_standard_ies_rule(self):
+        assert depluralize("categories") == "category"
+        assert depluralize("entities") == "entity"
+
+    def test_standard_s_rule(self):
+        assert depluralize("orders") == "order"
+        assert depluralize("customers") == "customer"
+
+    def test_ss_endings_preserved(self):
+        assert depluralize("address") == "address"
+        assert depluralize("class") == "class"
+
+    def test_short_words_untouched(self):
+        # We only trim 's' on words > 2 chars to avoid mangling 'is', 'as'…
+        assert depluralize("is") == "is"
+        assert depluralize("ts") == "ts"
+
+
+class TestSimilarity:
+    def test_identity(self):
+        assert similarity("abc", "abc") == 1.0
+
+    def test_empty(self):
+        assert similarity("", "abc") == 0.0
+        assert similarity("abc", "") == 0.0
+
+    def test_ordering(self):
+        assert similarity("customer", "customers") > similarity("customer", "orders")
+
+
+class TestCasing:
+    def test_to_pascal(self):
+        assert to_pascal("customer_orders") == "CustomerOrder"
+        assert to_pascal("user-profile") == "UserProfile"
+        assert to_pascal("") == "Entity"
+
+    def test_to_camel(self):
+        assert to_camel("customer_id") == "customerId"
+        # Empty input flows through to_pascal's "Entity" fallback, lower-cased.
+        assert to_camel("") == "entity"
+
+
+class TestTypeCompat:
+    def test_same_group(self):
+        assert types_compatible("varchar", "string")
+        assert types_compatible("bigint", "int")
+        assert types_compatible("decimal", "double")
+
+    def test_string_is_fallback_attr(self):
+        # An attribute declared as string accepts anything (lossy but valid).
+        assert types_compatible("bigint", "string")
+        assert types_compatible("timestamp", "string")
+
+    def test_incompatible(self):
+        # int column → boolean attribute is not a free pass.
+        assert not types_compatible("bigint", "boolean")
+        assert not types_compatible("timestamp", "integer")
+
+    def test_simplify_xsd_strips_prefix(self):
+        assert simplify_xsd("xsd:string") == "string"
+        assert simplify_xsd("http://www.w3.org/2001/XMLSchema#dateTime") == "dateTime"
+
+    def test_xsd_for_column(self):
+        assert xsd_for_column("varchar") == "xsd:string"
+        assert xsd_for_column("bigint") == "xsd:long"
+        assert xsd_for_column("boolean") == "xsd:boolean"
+
+
+def test_type_group_unknown_defaults_to_string():
+    assert type_group("uuidvariant") == "string"
+    assert type_group("") == "string"

--- a/src/backend/src/tests/unit/test_term_mapping_scoring.py
+++ b/src/backend/src/tests/unit/test_term_mapping_scoring.py
@@ -1,0 +1,59 @@
+"""Unit tests for the heuristic scoring formula.
+
+Locks the AUTO_ACCEPT == 0.90 boundary and ensures the rounding step keeps
+borderline-perfect matches inside the auto-apply band.
+"""
+import pytest
+
+from src.controller.term_mapping.scoring import AUTO_ACCEPT, AUTO_REJECT, Signals
+
+
+class TestSignals:
+    def test_perfect_match_with_type_and_pk_caps_at_one(self):
+        s = Signals(name_similarity=1.0, type_compatible=True, pk_hint=True)
+        assert s.confidence == 1.0
+
+    def test_perfect_name_plus_compatible_type_hits_auto_accept(self):
+        # 0.7*1.0 + 0.2 = 0.90 — boundary case.
+        s = Signals(name_similarity=1.0, type_compatible=True)
+        assert s.confidence == AUTO_ACCEPT
+        # Auto-apply candidate confidence comparison uses >= AUTO_ACCEPT.
+        assert s.confidence >= AUTO_ACCEPT
+
+    def test_pk_or_fk_bonus_does_not_stack(self):
+        s_pk = Signals(name_similarity=0.5, type_compatible=True, pk_hint=True)
+        s_fk = Signals(name_similarity=0.5, type_compatible=True, fk_hint=True)
+        s_both = Signals(name_similarity=0.5, type_compatible=True, pk_hint=True, fk_hint=True)
+        assert s_pk.confidence == s_fk.confidence == s_both.confidence
+
+    def test_type_incompat_penalty(self):
+        # 0.7*0.5 + (-0.1) = 0.25
+        s = Signals(name_similarity=0.5, type_compatible=False)
+        assert s.confidence == pytest.approx(0.25)
+
+    def test_floor_at_zero(self):
+        # Pathological case: very low name + type incompat = negative gross,
+        # but the score must clamp at 0.0.
+        s = Signals(name_similarity=0.0, type_compatible=False)
+        assert s.confidence == 0.0
+
+    def test_rounding_avoids_borderline_drift(self):
+        # 0.7 * 0.857142 = 0.5999994 (raw), should round to 0.6 region clean.
+        s = Signals(name_similarity=0.857142, type_compatible=True)
+        # Don't assert exact value; just verify no float drift below the
+        # rejection threshold for a name match that's clearly above noise.
+        assert s.confidence > AUTO_REJECT
+
+    def test_render_falls_back_when_no_parts(self):
+        assert Signals().render() == "No strong signal."
+
+    def test_render_joins_non_empty_parts(self):
+        s = Signals(parts=["one.", "", "two."])
+        assert s.render() == "one. two."
+
+
+def test_threshold_values_locked():
+    """If anyone changes these, dozens of UI assumptions need to be revisited.
+    Treat the constants as part of the public contract."""
+    assert AUTO_ACCEPT == 0.90
+    assert AUTO_REJECT == 0.40

--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -356,6 +356,17 @@ def initialize_managers(app: FastAPI):
         except Exception as e:
             logger.error(f"Failed to initialize OntologyGeneratorManager: {e}", exc_info=True)
 
+        # --- TermMappingManager ---
+        # Singleton (no per-request state); methods take a Session arg.
+        try:
+            from src.controller.term_mapping_manager import TermMappingManager
+            app.state.term_mapping_manager = TermMappingManager(
+                semantic_models_manager=app.state.semantic_models_manager
+            )
+            logger.info("TermMappingManager initialized.")
+        except Exception as e:
+            logger.error(f"Failed to initialize TermMappingManager: {e}", exc_info=True)
+
         # --- EntityRelationshipsManager ---
         try:
             from src.controller.entity_relationships_manager import EntityRelationshipsManager


### PR DESCRIPTION
## Summary

Phase 1 + 2 backend for the **Term Mapping** workbench described in [PRD #469](https://github.com/databrickslabs/ontos/issues/469). Adds an end-to-end backend flow to scope a suggester run, run a deterministic heuristic engine across Assets / Data Contract schemas + properties / Data Products, persist a reviewable suggestion queue, apply accepted suggestions through the existing `SemanticLinksManager` (so the RDF graph + change log + search index all keep their familiar path), and undo on demand.

Concept candidates come strictly from **customer ontologies** (`urn:semantic-model:*`) plus opt-in shipped taxonomies; the internal `urn:taxonomy:ontos-ontology` context is permanently rejected by the manager (would otherwise let stewards map their data to Ontos's own asset-typing schema, which makes no sense).

## What's in

- **DB**: `term_mapping_runs` + `term_mapping_suggestions` tables; Alembic migration `k1_term_mapping` (single head verified).
- **Models**: SQLAlchemy `db_models/term_mappings.py` and Pydantic `models/term_mappings.py` with full `RunCreate` / `RunRead` / `SuggestionDecision` / `ApplyResult` / `UndoResult` shapes.
- **Repository**: `MappingRunRepository` + `MappingSuggestionRepository` with bulk insert and the `is_pair_already_decided` lookup the engine uses to suppress noisy re-proposals.
- **Engine package** `controller/term_mapping/`:
  - `naming.py`, `scoring.py` — pure helpers ported from `onyx_ontology` with three regression-locked bug fixes (see below).
  - `concept_source.py` — context-scoped concept loader; enforces the customer-ontology-only rule.
  - `engines/heuristic.py` — deterministic suggester (container, FK-by-stem, PK, generic property).
  - `adapters/{asset,contract,product}.py` — translate each Ontos entity family into the uniform `TargetEntity` shape.
- **Manager**: `TermMappingManager` stored on `app.state`; methods take a `Session` per request.
- **Routes**: `/api/term-mappings/*` (create/list/get runs, list/decide suggestions, apply, undo, per-entity helpers). Every endpoint gated by `PermissionChecker('term-mapping', …)`; undo is ADMIN-only.
- **Permission**: backend feature ID `term-mapping` registered in `features.py` under the Govern group.
- **Tests**: 37 new unit tests across naming, scoring, and the heuristic engine. Full unit suite still green (1063 passed, 1 skipped).

## Bug fixes inherited from porting

1. **Irregular plurals**: source's `_depluralize` only knew `-ies` / trailing-`s`, so `people` / `children` / `criteria` etc. silently dropped from matching. Added a small irregular table; tested in `test_term_mapping_naming.py`.
2. **Label-similarity cap**: source took `max(name_sim, label_sim)`, letting a long descriptive label drive an `id` column to 0.95 auto-accept against the wrong concept. Label is now a tiebreaker capped by name. Tested in `test_term_mapping_heuristic.py::test_label_similarity_capped_by_name`.
3. **Persistent rejected-pair guard**: source had no queue and re-proposed the same noise every run. The engine now consults `MappingSuggestionRepository.is_pair_already_decided` and skips known-rejected pairs. Tested in `test_term_mapping_heuristic.py::TestAlreadyDecidedGuard`.

Bonus fix found via the test suite: the self-FK guard now depluralises both sides, so a `customer_id` column on a `customers` table doesn't get a bogus FK suggestion pointing at its own concept.

## Deliberately deferred

- **Phase 3 — UI workbench** (run dialog, queue table, apply dialog, per-entity badge): separate PR. Because of that, this PR intentionally does **not** add the `term-mapping` entry to `src/frontend/src/config/features.ts` — no orphan landing-page tile leading nowhere.
- **Phase 4 — `LLMJudgeSuggester` re-ranker** + consent dialog wiring.
- Optional demo SQL seed for a retail customer ontology.

## Test plan

- [x] `hatch -e dev run pytest src/tests/unit -q` → 1063 passed, 1 skipped (locally).
- [x] `hatch -e dev run alembic heads` → single head `k1_term_mapping`.
- [x] No lints on touched files.
- [ ] Smoke-test via curl on a deployed instance:
  - `POST /api/term-mappings/runs` with `target_filter.entity_types=["asset"]` → returns `RunRead` with `status="suggested"` and a non-empty stats blob (against a workspace that has at least one customer ontology loaded).
  - `POST /api/term-mappings/runs` with `ontology_contexts=["urn:taxonomy:ontos-ontology"]` → HTTP 422 (guard fires).
  - `GET /api/term-mappings/runs/{id}/suggestions?status=pending` returns the queue with `confidence`, `reason`, `auto_apply`, `engine_metadata`.
  - `POST /runs/{id}/decisions` flips suggestion statuses.
  - `POST /runs/{id}/apply?apply_auto=true` writes `entity_semantic_links` rows; the same links surface on the affected entity's "Linked Concepts" panel.
  - `POST /runs/{id}/undo` removes exactly those links and reverts suggestion statuses.