### PR TITLE
feat(approvals): surface request details in notifications and approval dialog

### DIFF
--- a/src/backend/src/common/workflow_executor.py
+++ b/src/backend/src/common/workflow_executor.py
@@ -361,6 +361,177 @@ def _resolve_role_to_users(
     return [(role_spec, None)]
 
 
+# Map raw entity_type strings to human-friendly labels used in approval
+# notification subtitles/descriptions. Anything not listed falls back to a
+# title-cased version of the raw string.
+_ENTITY_TYPE_LABELS: Dict[str, str] = {
+    "data_product": "Data Product",
+    "data_contract": "Data Contract",
+    "data_domain": "Data Domain",
+    "data_asset_review": "Data Asset Review",
+    "access_grant": "Access Grant",
+    "asset": "Asset",
+}
+
+
+def _humanize_entity_type(entity_type: Optional[str]) -> str:
+    if not entity_type:
+        return "Entity"
+    label = _ENTITY_TYPE_LABELS.get(entity_type.lower())
+    if label:
+        return label
+    return entity_type.replace("_", " ").title()
+
+
+def _extract_approval_facets(context: "StepContext") -> Dict[str, Any]:
+    """Pull readable request facets out of the trigger entity_data.
+
+    The approval step is generic, but the most common payload — access
+    grant requests — carries the underlying resource + permission/duration/
+    reason inside ``context.entity`` (which is the splatted ``entity_data``
+    from ``AccessGrantsManager.create_request``). We surface these so the
+    notification subtitle/description and the Approve/Reject dialog can
+    show meaningful context instead of bare UUIDs.
+
+    Returns a dict of optional keys. Callers should ``dict.get`` defensively
+    because non-access-grant triggers won't populate any of these.
+    """
+    facets: Dict[str, Any] = {}
+    entity = context.entity if isinstance(context.entity, dict) else {}
+
+    # For ``access_grant`` triggers the proxy ``entity_type`` is
+    # ``access_grant``; the underlying object (data product, contract, …)
+    # is carried inside ``entity_data`` and is what an approver actually
+    # wants to inspect / link to.
+    if context.entity_type and context.entity_type.lower() == "access_grant":
+        underlying_type = entity.get("entity_type")
+        underlying_id = entity.get("entity_id")
+        underlying_name = (
+            entity.get("entity_name")
+            or entity.get("data_product_name")
+        )
+        if underlying_type:
+            facets["underlying_entity_type"] = str(underlying_type)
+        if underlying_id:
+            facets["underlying_entity_id"] = str(underlying_id)
+        if underlying_name:
+            facets["underlying_entity_name"] = str(underlying_name)
+
+        permission = entity.get("permission_level")
+        if permission:
+            facets["permission_level"] = str(permission)
+
+        duration = entity.get("requested_duration_days")
+        if isinstance(duration, (int, float)):
+            facets["requested_duration_days"] = int(duration)
+        elif isinstance(duration, str) and duration.strip().isdigit():
+            facets["requested_duration_days"] = int(duration.strip())
+
+        reason = entity.get("reason")
+        if reason:
+            facets["reason"] = str(reason)
+
+        request_id = entity.get("request_id") or context.entity_id
+        if request_id:
+            facets["request_id"] = str(request_id)
+
+    return facets
+
+
+def _build_approval_subtitle(
+    context: "StepContext",
+    facets: Dict[str, Any],
+    entity_display: str,
+) -> str:
+    """Readable subtitle for the approval notification card.
+
+    Examples:
+        - "Read access to Data Product: Sales Pipeline"
+        - "Data Contract: orders-v1"
+    """
+    if context.entity_type and context.entity_type.lower() == "access_grant":
+        permission = facets.get("permission_level")
+        underlying_type_label = _humanize_entity_type(
+            facets.get("underlying_entity_type")
+        )
+        if permission and facets.get("underlying_entity_name"):
+            return (
+                f"{permission.title()} access to {underlying_type_label}: "
+                f"{facets['underlying_entity_name']}"
+            )
+        if facets.get("underlying_entity_name"):
+            return (
+                f"Access to {underlying_type_label}: "
+                f"{facets['underlying_entity_name']}"
+            )
+        # Fallback: no underlying entity resolved — at least avoid showing
+        # the raw access_grant UUID.
+        return f"Access request from {context.user_email or 'unknown user'}"
+
+    return f"{_humanize_entity_type(context.entity_type)}: {entity_display}"
+
+
+def _build_approval_description(
+    *,
+    context: "StepContext",
+    facets: Dict[str, Any],
+    approval_message: Optional[str],
+) -> str:
+    """Multi-line, label/value description for the approval notification.
+
+    Mirrors what the dialog renders but as plain text so the bell card and
+    email recipients see the same information.
+    """
+    lines: List[str] = []
+
+    requester = context.user_email or "Unknown"
+    lines.append(f"Requester: {requester}")
+
+    underlying_type = facets.get("underlying_entity_type")
+    if underlying_type:
+        resource_label = _humanize_entity_type(underlying_type)
+        resource_name = (
+            facets.get("underlying_entity_name")
+            or facets.get("underlying_entity_id")
+            or ""
+        )
+        if resource_name:
+            lines.append(f"Resource: {resource_label} · {resource_name}")
+        else:
+            lines.append(f"Resource: {resource_label}")
+    elif context.entity_name or context.entity_id:
+        resource_label = _humanize_entity_type(context.entity_type)
+        resource_name = context.entity_name or context.entity_id
+        lines.append(f"Resource: {resource_label} · {resource_name}")
+
+    permission = facets.get("permission_level")
+    if permission:
+        lines.append(f"Permission: {permission}")
+
+    duration = facets.get("requested_duration_days")
+    if isinstance(duration, int):
+        lines.append(f"Duration: {duration} day{'s' if duration != 1 else ''}")
+
+    reason = facets.get("reason")
+    if reason:
+        lines.append(f"Reason: {reason}")
+
+    if approval_message:
+        lines.append(f"Workflow message: {approval_message}")
+
+    # Optional free-form fields carried on the entity. Mirrors the legacy
+    # behaviour for non-access-grant approval payloads.
+    entity = context.entity if isinstance(context.entity, dict) else {}
+    msg = entity.get("message")
+    if msg and msg != approval_message:
+        lines.append(f"Message: {msg}")
+    justification = entity.get("justification")
+    if justification and justification != reason:
+        lines.append(f"Justification: {justification}")
+
+    return "\n".join(lines)
+
+
 class ApprovalStepHandler(StepHandler):
     """Handler for approval steps - creates actionable notifications and pauses workflow."""
 
@@ -384,30 +555,38 @@ class ApprovalStepHandler(StepHandler):
             if not resolved_approvers:
                 return StepResult(passed=False, error="Could not resolve any approvers")
             
-            entity_display = context.entity_name or context.entity_id
-            
+            # Extract human-readable facets from the trigger's entity_data so
+            # the notification + approval dialog can show the underlying
+            # request (requester, resource, permission, duration, reason)
+            # instead of just the proxy ``access_grant`` UUID. Best-effort —
+            # the approval step is generic and only access-grant triggers
+            # populate these fields today.
+            facets = _extract_approval_facets(context)
+
+            entity_display = (
+                facets.get("underlying_entity_name")
+                or context.entity_name
+                or facets.get("underlying_entity_id")
+                or context.entity_id
+            )
+
             # Create actionable notification for each approver
             created_count = 0
             for approver_id, role_uuid in resolved_approvers:
                 try:
-                    # Build description with request details
-                    description = (
-                        f"Approval requested for {context.entity_type} '{entity_display}'.\n\n"
-                        f"Requested by: {context.user_email or 'Unknown'}\n"
+                    subtitle = _build_approval_subtitle(context, facets, entity_display)
+                    description = _build_approval_description(
+                        context=context,
+                        facets=facets,
+                        approval_message=approval_message,
                     )
-                    if approval_message:
-                        description += f"\nMessage: {approval_message}"
-                    if context.entity.get('message'):
-                        description += f"\nMessage: {context.entity.get('message')}"
-                    if context.entity.get('justification'):
-                        description += f"\nJustification: {context.entity.get('justification')}"
-                    
+
                     notification = Notification(
                         id=str(uuid4()),
                         created_at=datetime.utcnow(),
                         type=NotificationType.ACTION_REQUIRED,
                         title="Approval Required",
-                        subtitle=f"{context.entity_type}: {entity_display}",
+                        subtitle=subtitle,
                         description=description,
                         recipient=approver_id,  # Keep for backwards compat / email recipients
                         recipient_role_id=role_uuid,  # Store role UUID if this is a role
@@ -421,6 +600,12 @@ class ApprovalStepHandler(StepHandler):
                             "entity_name": context.entity_name,
                             "requester_email": context.user_email,
                             "timeout_days": timeout_days,
+                            # Structured request context for the approval
+                            # dialog. All optional; only access-grant
+                            # triggers populate the underlying_* / request_*
+                            # fields today.
+                            **facets,
+                            "workflow_message": approval_message or None,
                         },
                         can_delete=False,  # Must respond to this notification
                         read=False,

--- a/src/frontend/src/components/workflows/workflow-approval-response-dialog.tsx
+++ b/src/frontend/src/components/workflows/workflow-approval-response-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   Dialog,
   DialogContent,
@@ -10,9 +11,10 @@ import {
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
-import { Loader2, Check, XCircle } from 'lucide-react';
+import { Loader2, Check, XCircle, ExternalLink } from 'lucide-react';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
+import { getUnderlyingEntityDetailPath } from '@/lib/entity-detail-path';
 
 /** Built from GET /api/workflows/for-trigger/for_approval_response (first step used for dialog). */
 interface DefaultResponseWorkflowStep {
@@ -31,6 +33,22 @@ interface DefaultResponseWorkflowStep {
 export interface WorkflowApprovalResponseDialogPayload {
   execution_id: string;
   entity_name?: string;
+  // Structured request context populated by the backend approval step
+  // (see ApprovalStepHandler in workflow_executor.py). All optional — only
+  // access-grant triggers populate the underlying_* / permission / duration
+  // / reason fields today, but the dialog renders whatever is present.
+  requester_email?: string;
+  entity_type?: string;
+  entity_id?: string;
+  underlying_entity_type?: string;
+  underlying_entity_id?: string;
+  underlying_entity_name?: string;
+  permission_level?: string;
+  requested_duration_days?: number;
+  reason?: string;
+  request_id?: string;
+  workflow_name?: string;
+  workflow_message?: string;
 }
 
 interface WorkflowApprovalResponseDialogProps {
@@ -39,6 +57,97 @@ interface WorkflowApprovalResponseDialogProps {
   payload: WorkflowApprovalResponseDialogPayload | null;
   notificationId?: string;
   onDecisionMade?: () => void;
+}
+
+const ENTITY_TYPE_LABELS: Record<string, string> = {
+  data_product: 'Data Product',
+  data_contract: 'Data Contract',
+  data_domain: 'Data Domain',
+  data_asset_review: 'Data Asset Review',
+  access_grant: 'Access Grant',
+  asset: 'Asset',
+};
+
+function humanizeEntityType(entityType: string | undefined | null): string {
+  if (!entityType) return 'Entity';
+  const key = entityType.toLowerCase();
+  if (ENTITY_TYPE_LABELS[key]) return ENTITY_TYPE_LABELS[key];
+  return entityType
+    .replace(/_/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+interface DetailRow {
+  label: string;
+  value: React.ReactNode;
+}
+
+function buildDetailRows(
+  payload: WorkflowApprovalResponseDialogPayload,
+  onNavigate: () => void,
+): DetailRow[] {
+  const rows: DetailRow[] = [];
+
+  if (payload.requester_email) {
+    rows.push({ label: 'Requester', value: payload.requester_email });
+  }
+
+  const resourceType = payload.underlying_entity_type ?? payload.entity_type;
+  const resourceName =
+    payload.underlying_entity_name ??
+    (resourceType && resourceType.toLowerCase() !== 'access_grant'
+      ? payload.entity_name
+      : undefined);
+  const resourceId = payload.underlying_entity_id ?? payload.entity_id;
+  if (resourceType || resourceName || resourceId) {
+    const typeLabel = humanizeEntityType(resourceType);
+    const displayName = resourceName || resourceId || '—';
+    const detailPath = getUnderlyingEntityDetailPath(
+      payload as unknown as Record<string, unknown>,
+    );
+    const resourceText = `${typeLabel} · ${displayName}`;
+    rows.push({
+      label: 'Resource',
+      value: detailPath ? (
+        <RouterLink
+          to={detailPath}
+          onClick={onNavigate}
+          className="inline-flex items-center gap-1 text-primary hover:underline"
+        >
+          {resourceText}
+          <ExternalLink className="h-3 w-3" />
+        </RouterLink>
+      ) : (
+        resourceText
+      ),
+    });
+  }
+
+  if (payload.permission_level) {
+    rows.push({ label: 'Permission', value: payload.permission_level });
+  }
+
+  if (typeof payload.requested_duration_days === 'number') {
+    const d = payload.requested_duration_days;
+    rows.push({ label: 'Duration', value: `${d} day${d === 1 ? '' : 's'}` });
+  }
+
+  if (payload.reason) {
+    rows.push({ label: 'Reason', value: payload.reason });
+  }
+
+  if (payload.workflow_message) {
+    rows.push({ label: 'Message', value: payload.workflow_message });
+  }
+
+  if (payload.workflow_name) {
+    rows.push({ label: 'Workflow', value: payload.workflow_name });
+  }
+
+  return rows;
 }
 
 export default function WorkflowApprovalResponseDialog({
@@ -145,6 +254,8 @@ export default function WorkflowApprovalResponseDialog({
   const description =
     config.description ?? 'Provide a reason for your approval or rejection decision.';
 
+  const detailRows = payload ? buildDetailRows(payload, () => onOpenChange(false)) : [];
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -158,6 +269,21 @@ export default function WorkflowApprovalResponseDialog({
           </div>
         ) : (
           <>
+            {detailRows.length > 0 && (
+              <div className="rounded-md border bg-muted/30 p-3 space-y-1.5">
+                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Request details
+                </div>
+                <dl className="grid grid-cols-[auto,1fr] gap-x-3 gap-y-1 text-sm">
+                  {detailRows.map((row) => (
+                    <div key={row.label} className="contents">
+                      <dt className="text-muted-foreground">{row.label}</dt>
+                      <dd className="break-words">{row.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            )}
             <div className="space-y-2">
               <Label htmlFor="approval-reason">
                 {reasonField?.label ?? 'Reason for approval or rejection'}

--- a/src/frontend/src/lib/entity-detail-path.ts
+++ b/src/frontend/src/lib/entity-detail-path.ts
@@ -1,0 +1,63 @@
+/**
+ * Resolve the in-app detail route for a notification / workflow payload that
+ * references an entity. Centralised here so the notification bell, approval
+ * dialog, and any future surface that wants to deep-link from a payload all
+ * agree on which entity types are linkable.
+ *
+ * Supported keys (checked in order):
+ *   - `product_id` / `data_product_id` → `/data-products/<id>`
+ *   - `contract_id` / `data_contract_id` → `/data-contracts/<id>`
+ *   - `entity_id` + `entity_type` ∈ {data_product, data_contract}
+ *
+ * Returns `null` when the entity type is not linkable (e.g. the proxy
+ * `access_grant` type — callers should use `underlying_entity_type` /
+ * `underlying_entity_id` instead).
+ */
+export function getEntityDetailPathFromPayload(
+  payload: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const productId = payload.product_id ?? payload.data_product_id;
+  if (typeof productId === 'string' && productId.length > 0) {
+    return `/data-products/${productId}`;
+  }
+
+  const contractId = payload.contract_id ?? payload.data_contract_id;
+  if (typeof contractId === 'string' && contractId.length > 0) {
+    return `/data-contracts/${contractId}`;
+  }
+
+  const entityId = payload.entity_id;
+  const rawType = payload.entity_type;
+  if (typeof entityId !== 'string' || !entityId) return null;
+  const entityType = typeof rawType === 'string' ? rawType.toLowerCase() : '';
+  if (entityType === 'data_product' || entityType === 'dataproduct') {
+    return `/data-products/${entityId}`;
+  }
+  if (entityType === 'data_contract' || entityType === 'datacontract') {
+    return `/data-contracts/${entityId}`;
+  }
+  return null;
+}
+
+/**
+ * Variant that resolves the path for the *underlying* entity carried by a
+ * workflow approval payload. Access-grant approvals have `entity_type` set to
+ * the proxy `access_grant` and the real resource lives under
+ * `underlying_entity_*`.
+ */
+export function getUnderlyingEntityDetailPath(
+  payload: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const underlyingType = payload.underlying_entity_type;
+  const underlyingId = payload.underlying_entity_id;
+  if (typeof underlyingType === 'string' && typeof underlyingId === 'string') {
+    return getEntityDetailPathFromPayload({
+      entity_type: underlyingType,
+      entity_id: underlyingId,
+    });
+  }
+  return getEntityDetailPathFromPayload(payload);
+}


### PR DESCRIPTION
## Summary

Workflow approval notifications and the Approve/Reject dialog now show a readable summary of the request (requester, underlying resource, permission, duration, reason) instead of just the proxy `access_grant` UUID. The dialog also links to the underlying object so an approver can inspect it before deciding.

**Before**

- Notification: `access_grant: 8cdf6fa1-3ebb-…` / `Approval requested for access_grant '8cdf…'. Requested by: lars.george@…`
- Dialog: just a reason textarea — no context at all.

**After**

- Notification subtitle: `Read access to Data Product: Sales Pipeline`
- Notification description: multi-line `Label: value` list (Requester / Resource / Permission / Duration / Reason / …)
- Dialog: "Request details" definition list with a Router `<Link>` to the underlying object, then the existing reason textarea.

## Changes

### Backend — `src/backend/src/common/workflow_executor.py`

- New module helpers next to `_resolve_role_to_users`:
  - `_humanize_entity_type` — `data_product` → `Data Product`, generic title-case fallback.
  - `_extract_approval_facets(context)` — pulls underlying entity + permission / duration / reason / request_id out of `context.entity` (only populated for access-grant triggers; tolerant of missing fields).
  - `_build_approval_subtitle` / `_build_approval_description` — produce the new readable subtitle and multi-line description.
- `ApprovalStepHandler.execute` now merges those facets into the notification `action_payload` (`underlying_entity_*`, `permission_level`, `requested_duration_days`, `reason`, `request_id`, `workflow_message`). Existing top-level keys (`execution_id`, `workflow_id`, `entity_type`, …, `handled`/`decision`) are preserved.

### Frontend

- **New** `src/frontend/src/lib/entity-detail-path.ts` — shared helpers:
  - `getEntityDetailPathFromPayload` (lifted verbatim from `notification-bell.tsx`).
  - `getUnderlyingEntityDetailPath` — prefers `underlying_entity_*` so access-grant payloads link to the actual data product / contract, not the proxy.
- `src/frontend/src/components/workflows/workflow-approval-response-dialog.tsx`
  - Widened `WorkflowApprovalResponseDialogPayload` to include the structured fields.
  - Renders a "Request details" `<dl>` between the description and the reason textarea, only when at least one field is present.
  - Resource row is a `react-router-dom` `<Link>` to the underlying entity when the type maps to a route; falls back to plain text.
  - Closes the dialog when the link is followed so the user doesn't return to a stale modal.
- `src/frontend/src/components/ui/notification-bell.tsx`
  - Imports `getEntityDetailPathFromPayload` from the shared util (removed the duplicate local definition).
  - State type uses `WorkflowApprovalResponseDialogPayload`.
  - `handleOpenWorkflowApprovalDialog` forwards the entire `action_payload` instead of narrowing to `{ execution_id, entity_name }`.

The notification card itself did not need changes — it already renders `notification.subtitle` and `notification.description`, both of which are now backend-formatted into readable text.

## Out of scope

- The `handle_access_grant_request` fallback dialog (separate path that was already readable).
- New REST endpoints for execution context — the existing `action_payload` is the structured contract and carries enough.

## Test plan

- [ ] Trigger a Data Product access request and observe the approver's notification: subtitle reads `<Permission> access to Data Product: <name>`, description shows Requester / Resource / Permission / Duration / Reason.
- [ ] Click Approve/Deny: dialog shows the same details and a clickable Resource link to the data product detail view.
- [ ] Approve with a reason — workflow resumes and the notification's "handled"/"decision" badge still renders correctly (back-compat).
- [ ] Trigger an approval for a non-access-grant workflow (e.g. data contract review) and confirm the dialog still renders sensibly when only a subset of fields is available.
- [ ] No-workflow fallback (`handle_access_grant_request`) is unchanged.