### PR TITLE
feat(asset-reviews): give review requests a human-readable title

### DIFF
--- a/src/backend/alembic/versions/g3_add_title_to_data_asset_review_requests.py
+++ b/src/backend/alembic/versions/g3_add_title_to_data_asset_review_requests.py
@@ -1,0 +1,83 @@
+"""add title column to data_asset_review_requests with backfill
+
+Revision ID: g3_review_title
+Revises: g2_ontology_gen_runs
+Create Date: 2026-06-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "g3_review_title"
+down_revision: Union[str, None] = "g2_ontology_gen_runs"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _short_name(fqn: str) -> str:
+    """Return a compact human-readable label for an asset FQN.
+
+    Mirrors the runtime helper in src/controller/data_asset_reviews_manager.py
+    so backfilled titles match what the manager would produce.
+    """
+    if not fqn:
+        return "asset"
+    if fqn.startswith("mdm://"):
+        tail = fqn[len("mdm://"):].rstrip("/")
+        last = tail.rsplit("/", 1)[-1] if tail else ""
+        return last or "MDM match"
+    if "/" in fqn:
+        last = fqn.rstrip("/").rsplit("/", 1)[-1]
+        return last or fqn
+    return fqn.split(".")[-1] or fqn
+
+
+def upgrade() -> None:
+    op.add_column(
+        "data_asset_review_requests",
+        sa.Column("title", sa.String(length=200), nullable=True),
+    )
+
+    bind = op.get_bind()
+
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, requester_email FROM data_asset_review_requests "
+            "WHERE title IS NULL OR title = ''"
+        )
+    ).fetchall()
+
+    for row in rows:
+        request_id = row[0]
+        requester_email = row[1] or ""
+
+        asset_rows = bind.execute(
+            sa.text(
+                "SELECT asset_fqn FROM reviewed_assets "
+                "WHERE review_request_id = :rid"
+            ),
+            {"rid": request_id},
+        ).fetchall()
+
+        asset_count = len(asset_rows)
+        if asset_count == 1:
+            title = f"Review of {_short_name(asset_rows[0][0])}"
+        elif asset_count > 1:
+            title = f"Review of {_short_name(asset_rows[0][0])} (+{asset_count - 1} more)"
+        else:
+            title = f"Review request by {requester_email}" if requester_email else "Review request"
+
+        title = title[:200]
+
+        bind.execute(
+            sa.text(
+                "UPDATE data_asset_review_requests SET title = :title WHERE id = :rid"
+            ),
+            {"title": title, "rid": request_id},
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("data_asset_review_requests", "title")

--- a/src/backend/src/controller/data_asset_reviews_manager.py
+++ b/src/backend/src/controller/data_asset_reviews_manager.py
@@ -19,6 +19,7 @@ import os
 from src.models.data_asset_reviews import (
     DataAssetReviewRequest as DataAssetReviewRequestApi,
     DataAssetReviewRequestCreate,
+    DataAssetReviewRequestUpdate,
     DataAssetReviewRequestUpdateStatus,
     ReviewedAsset as ReviewedAssetApi,
     ReviewedAssetUpdate,
@@ -43,6 +44,52 @@ from src.common.sanitization import sanitize_markdown_input # Import shared sani
 
 from src.common.logging import get_logger
 logger = get_logger(__name__)
+
+
+def _short_asset_label(fqn: Optional[str]) -> str:
+    """Return a compact human-readable label for an asset FQN.
+
+    - UC objects (``catalog.schema.object``) → last segment (``object``).
+    - Notebook / volume paths → final path segment.
+    - ``mdm://config/run/candidate`` → ``candidate``.
+    - Otherwise → the FQN unchanged.
+    """
+    if not fqn:
+        return "asset"
+    if fqn.startswith("mdm://"):
+        tail = fqn[len("mdm://"):].rstrip("/")
+        last = tail.rsplit("/", 1)[-1] if tail else ""
+        return last or "MDM match"
+    if "/" in fqn:
+        last = fqn.rstrip("/").rsplit("/", 1)[-1]
+        return last or fqn
+    return fqn.split(".")[-1] or fqn
+
+
+def derive_review_title(review: Any) -> str:
+    """Compute a human-readable title for a review request.
+
+    Uses the user-set ``title`` when present (and non-empty); otherwise derives a
+    label from the request contents. Accepts either a Pydantic API model or a
+    SQLAlchemy DB row — anything with ``title``, ``requester_email``, and an
+    ``assets`` iterable of objects exposing ``asset_fqn``.
+    """
+    raw_title = getattr(review, "title", None)
+    if isinstance(raw_title, str) and raw_title.strip():
+        return raw_title.strip()
+
+    assets = list(getattr(review, "assets", None) or [])
+    requester = getattr(review, "requester_email", None) or ""
+
+    if len(assets) == 1:
+        return f"Review of {_short_asset_label(getattr(assets[0], 'asset_fqn', None))}"
+    if len(assets) > 1:
+        first_label = _short_asset_label(getattr(assets[0], "asset_fqn", None))
+        return f"Review of {first_label} (+{len(assets) - 1} more)"
+    if requester:
+        return f"Review request by {requester}"
+    return "Review request"
+
 
 @searchable_asset # Register this manager with the search system
 class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
@@ -159,11 +206,16 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
             if not assets_to_review:
                  raise ValueError("No valid or unique assets provided for review.")
                  
+            # Normalize the user-supplied title: trim whitespace; treat blank as None.
+            raw_title = (request_data.title or "").strip() if request_data.title else None
+            normalized_title = raw_title if raw_title else None
+
             # Prepare the full API model for the repository
             full_request = DataAssetReviewRequestApi(
                 id=request_id,
                 requester_email=request_data.requester_email,
                 reviewer_email=request_data.reviewer_email,
+                title=normalized_title,
                 status=ReviewRequestStatus.QUEUED,
                 notes=request_data.notes,
                 created_at=datetime.utcnow(),
@@ -174,8 +226,12 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
             # Use the repository to create the request and its assets in DB
             created_db_obj = self._repo.create_with_assets(db=db_session, obj_in=full_request)
 
-            # Convert DB object back to API model for response
+            # Convert DB object back to API model for response and ensure `title` is
+            # always populated for downstream consumers (notifications, search, UI).
             created_api_obj = DataAssetReviewRequestApi.from_orm(created_db_obj)
+            if not (created_api_obj.title and created_api_obj.title.strip()):
+                created_api_obj.title = derive_review_title(created_api_obj)
+            display_title = created_api_obj.title
 
             # --- Trigger workflow for review request --- #
             try:
@@ -196,7 +252,7 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
                 executions = trigger_registry.on_request_review(
                     entity_type=EntityType.DATA_ASSET_REVIEW,
                     entity_id=created_api_obj.id,
-                    entity_name=f"Review Request by {created_api_obj.requester_email}",
+                    entity_name=display_title,
                     entity_data=entity_data,
                     user_email=created_api_obj.requester_email,
                     blocking=False,  # Don't block on notification workflows
@@ -209,8 +265,8 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
                     notification = Notification(
                         id=str(uuid.uuid4()),
                         recipient=created_api_obj.reviewer_email,
-                        title="New Data Asset Review Request",
-                        description=f"Review request ({created_api_obj.id}) assigned to you by {created_api_obj.requester_email}.",
+                        title=f"New review request: {display_title}",
+                        description=f"Assigned to you by {created_api_obj.requester_email}.",
                         type=NotificationType.INFO,
                         link=f"/data-asset-reviews/{created_api_obj.id}",
                         created_at=datetime.utcnow(),
@@ -242,7 +298,10 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
         try:
             request_db = self._repo.get(db=self._db, id=request_id)
             if request_db:
-                return DataAssetReviewRequestApi.from_orm(request_db)
+                api_obj = DataAssetReviewRequestApi.from_orm(request_db)
+                if not (api_obj.title and api_obj.title.strip()):
+                    api_obj.title = derive_review_title(api_obj)
+                return api_obj
             return None
         except SQLAlchemyError as e:
             logger.error(f"Database error getting review request {request_id}: {e}")
@@ -259,7 +318,11 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
         try:
             requests_db = self._repo.get_multi(db=self._db, skip=skip, limit=limit)
             # Use parse_obj_as for lists
-            return parse_obj_as(List[DataAssetReviewRequestApi], requests_db)
+            requests_api: List[DataAssetReviewRequestApi] = parse_obj_as(List[DataAssetReviewRequestApi], requests_db)
+            for req in requests_api:
+                if not (req.title and req.title.strip()):
+                    req.title = derive_review_title(req)
+            return requests_api
         except SQLAlchemyError as e:
             logger.error(f"Database error listing review requests: {e}")
             raise
@@ -298,12 +361,14 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
                         "notes": update_data.notes,
                     }
                     
+                    display_title = derive_review_title(updated_db_obj)
+
                     executions = trigger_registry.on_status_change(
                         entity_type=EntityType.DATA_ASSET_REVIEW,
                         entity_id=updated_db_obj.id,
                         from_status=from_status,
                         to_status=to_status,
-                        entity_name=f"Review Request {updated_db_obj.id}",
+                        entity_name=display_title,
                         entity_data=entity_data,
                         user_email=updated_db_obj.reviewer_email,
                         blocking=False,
@@ -313,13 +378,13 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
                         logger.info(f"Triggered {len(executions)} workflow(s) for review status change {updated_db_obj.id}")
                     else:
                         # Fallback to direct notification if no workflow configured
-                        notification_message = f"Data asset review request ({updated_db_obj.id}) status updated to {to_status} by {updated_db_obj.reviewer_email}."
+                        notification_message = f"\"{display_title}\" status updated to {to_status} by {updated_db_obj.reviewer_email}."
                         notification_type = NotificationType.INFO if updated_db_obj.status == ReviewRequestStatus.APPROVED else NotificationType.WARNING
 
                         notification = Notification(
                             id=str(uuid.uuid4()),
                             user_email=updated_db_obj.requester_email,
-                            title=f"Review Request {to_status.capitalize()}",
+                            title=f"Review {to_status.capitalize()}: {display_title}",
                             description=notification_message,
                             type=notification_type,
                             link=f"/data-asset-reviews/{updated_db_obj.id}"
@@ -330,6 +395,8 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
                     logger.error(f"Failed to trigger workflow for review status update {updated_db_obj.id}: {workflow_err}", exc_info=True)
             
             result = DataAssetReviewRequestApi.from_orm(updated_db_obj)
+            if not (result.title and result.title.strip()):
+                result.title = derive_review_title(result)
             self._update_search_index(result)
             return result
         except SQLAlchemyError as e:
@@ -340,6 +407,54 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
              raise ValueError(f"Internal mapping error after update {request_id}: {e}")
         except Exception as e:
             logger.error(f"Unexpected error updating status for request {request_id}: {e}")
+            raise
+
+    def update_review_request(
+        self, request_id: str, update_data: DataAssetReviewRequestUpdate
+    ) -> Optional[DataAssetReviewRequestApi]:
+        """Updates editable fields (title, notes) on a review request.
+
+        Returns ``None`` if the request does not exist.
+        """
+        try:
+            db_obj = self._repo.get(db=self._db, id=request_id)
+            if not db_obj:
+                logger.warning(f"Attempted to update non-existent review request: {request_id}")
+                return None
+
+            payload = update_data.dict(exclude_unset=True)
+            title_set = "title" in payload
+            notes_set = "notes" in payload
+
+            normalized_title: Optional[str] = None
+            if title_set:
+                raw = payload.get("title")
+                if isinstance(raw, str):
+                    raw = raw.strip()
+                normalized_title = raw if raw else None
+
+            updated_db_obj = self._repo.update_request_fields(
+                db=self._db,
+                db_obj=db_obj,
+                title=normalized_title,
+                notes=payload.get("notes") if notes_set else None,
+                title_set=title_set,
+                notes_set=notes_set,
+            )
+
+            api_obj = DataAssetReviewRequestApi.from_orm(updated_db_obj)
+            if not (api_obj.title and api_obj.title.strip()):
+                api_obj.title = derive_review_title(api_obj)
+            self._update_search_index(api_obj)
+            return api_obj
+        except SQLAlchemyError as e:
+            logger.error(f"Database error updating review request {request_id}: {e}")
+            raise
+        except ValidationError as e:
+            logger.error(f"Validation error mapping updated review request {request_id}: {e}")
+            raise ValueError(f"Internal mapping error after update {request_id}: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error updating review request {request_id}: {e}")
             raise
 
     def update_reviewed_asset_status(self, request_id: str, asset_id: str, update_data: ReviewedAssetUpdate) -> Optional[ReviewedAssetApi]:
@@ -664,9 +779,7 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
         if not review.id:
             logger.warning(f"Skipping review due to missing id: {review}")
             return None
-        title = f"Review Request by {review.requester_email} for {review.reviewer_email}"
-        if review.assets:
-            title += f" ({len(review.assets)} assets)"
+        title = derive_review_title(review)
         tags = [review.status.value]
         tags.append(f"reviewer:{review.reviewer_email}")
         tags.append(f"requester:{review.requester_email}")
@@ -684,7 +797,7 @@ class DataAssetReviewManager(SearchableAsset): # Inherit from SearchableAsset
             type="data-asset-review",
             feature_id="data-asset-reviews",
             title=title,
-            description=review.notes or f"Review request {review.id}",
+            description=review.notes or f"Review request by {review.requester_email}",
             link=f"/data-asset-reviews/{review.id}",
             tags=list(set(tags)),
             extra_data=extra_data,

--- a/src/backend/src/db_models/data_asset_reviews.py
+++ b/src/backend/src/db_models/data_asset_reviews.py
@@ -16,6 +16,7 @@ class DataAssetReviewRequestDb(Base):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     requester_email = Column(String, nullable=False, index=True)
     reviewer_email = Column(String, nullable=False, index=True)
+    title = Column(String(200), nullable=True)
     status = Column(String, default=ReviewRequestStatus.QUEUED.value, nullable=False, index=True)
     notes = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)

--- a/src/backend/src/models/data_asset_reviews.py
+++ b/src/backend/src/models/data_asset_reviews.py
@@ -83,6 +83,7 @@ class DataAssetReviewRequestCreate(BaseModel):
     reviewer_email: EmailStr
     asset_fqns: List[str] = Field(..., description="List of fully qualified names of assets to review")
     # We need to determine AssetType based on fqn, perhaps in the manager
+    title: Optional[str] = Field(None, max_length=200, description="Optional human-readable title; auto-derived from contents when empty")
     notes: Optional[str] = Field(None, description="Optional notes for the reviewer")
 
 # Model representing a full data asset review request (including its reviewed assets)
@@ -90,6 +91,7 @@ class DataAssetReviewRequest(BaseModel):
     id: str = Field(..., description="Unique identifier for the review request")
     requester_email: EmailStr
     reviewer_email: EmailStr
+    title: Optional[str] = Field(None, description="Human-readable title; always populated by the API (derived if not set)")
     status: ReviewRequestStatus = Field(default=ReviewRequestStatus.QUEUED, description="Overall status of the review request")
     notes: Optional[str] = Field(None, description="Optional notes for the reviewer")
     created_at: Optional[datetime] = Field(default_factory=datetime.utcnow)
@@ -104,6 +106,11 @@ class DataAssetReviewRequest(BaseModel):
 class DataAssetReviewRequestUpdateStatus(BaseModel):
     status: ReviewRequestStatus
     notes: Optional[str] = None # Allow updating notes when changing status
+
+# Model for partial updates to a review request (e.g. renaming, editing notes)
+class DataAssetReviewRequestUpdate(BaseModel):
+    title: Optional[str] = Field(None, max_length=200)
+    notes: Optional[str] = None
 
 # Model for updating the status of a specific asset within a review (by reviewer)
 class ReviewedAssetUpdate(BaseModel):

--- a/src/backend/src/repositories/data_asset_reviews_repository.py
+++ b/src/backend/src/repositories/data_asset_reviews_repository.py
@@ -28,6 +28,7 @@ class DataAssetReviewRepository(CRUDBase[DataAssetReviewRequestDb, DataAssetRevi
             "id": obj_in.id,
             "requester_email": obj_in.requester_email,
             "reviewer_email": obj_in.reviewer_email,
+            "title": obj_in.title,
             "status": obj_in.status.value,
             "notes": obj_in.notes,
             # created_at/updated_at handled by DB defaults
@@ -91,6 +92,31 @@ class DataAssetReviewRepository(CRUDBase[DataAssetReviewRequestDb, DataAssetRevi
         if notes is not None:
             db_obj.notes = notes
         # updated_at is handled by onupdate trigger
+        db.add(db_obj)
+        db.flush()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update_request_fields(
+        self,
+        db: Session,
+        *,
+        db_obj: DataAssetReviewRequestDb,
+        title: Optional[str] = None,
+        notes: Optional[str] = None,
+        title_set: bool = False,
+        notes_set: bool = False,
+    ) -> DataAssetReviewRequestDb:
+        """Updates editable scalar fields on a review request (title / notes).
+
+        `*_set` flags distinguish "field not in payload" from "field explicitly cleared
+        to null", since `None` alone cannot represent both.
+        """
+        logger.debug(f"Updating fields for DataAssetReviewRequest (DB) id: {db_obj.id}")
+        if title_set:
+            db_obj.title = title
+        if notes_set:
+            db_obj.notes = notes
         db.add(db_obj)
         db.flush()
         db.refresh(db_obj)

--- a/src/backend/src/routes/data_asset_reviews_routes.py
+++ b/src/backend/src/routes/data_asset_reviews_routes.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from src.models.data_asset_reviews import (
     DataAssetReviewRequest as DataAssetReviewRequestApi,
     DataAssetReviewRequestCreate,
+    DataAssetReviewRequestUpdate,
     DataAssetReviewRequestUpdateStatus,
     ReviewedAsset as ReviewedAssetApi,
     ReviewedAssetUpdate,
@@ -139,6 +140,56 @@ def get_review_request(
     except Exception as e:
         logger.exception(f"Error getting review request {request_id}: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error getting review request.")
+
+@router.patch("/data-asset-reviews/{request_id}", response_model=DataAssetReviewRequestApi)
+def update_review_request(
+    request: Request,
+    request_id: str,
+    update: DataAssetReviewRequestUpdate,
+    db: DBSessionDep,
+    audit_manager: AuditManagerDep,
+    audit_user: AuditCurrentUserDep,
+    manager: DataAssetReviewManagerDep,
+    _: bool = Depends(PermissionChecker('data-asset-reviews', FeatureAccessLevel.READ_WRITE))
+):
+    """Update editable fields (title, notes) on a review request."""
+    success = False
+    details: Dict[str, Any] = {
+        "params": {
+            "request_id": request_id,
+            "fields": list(update.dict(exclude_unset=True).keys()),
+        }
+    }
+
+    try:
+        logger.info(f"Updating review request {request_id} fields: {details['params']['fields']}")
+        updated = manager.update_review_request(request_id=request_id, update_data=update)
+        if updated is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review request not found")
+        success = True
+        return updated
+    except ValueError as e:
+        logger.warning("Value error updating review request %s: %s", request_id, e)
+        details["exception"] = {"type": "ValueError", "message": str(e)}
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid update")
+    except HTTPException as e:
+        details["exception"] = {"type": "HTTPException", "status_code": e.status_code, "detail": e.detail}
+        raise
+    except Exception as e:
+        logger.exception("Error updating review request %s", request_id)
+        details["exception"] = {"type": type(e).__name__, "message": str(e)}
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error updating review request.")
+    finally:
+        audit_manager.log_action(
+            db=db,
+            username=audit_user.username,
+            ip_address=request.client.host if request.client else None,
+            feature="data-asset-reviews",
+            action="UPDATE",
+            success=success,
+            details=details,
+        )
+
 
 @router.put("/data-asset-reviews/{request_id}/status", response_model=DataAssetReviewRequestApi)
 def update_review_request_status(

--- a/src/frontend/src/components/data-asset-reviews/create-review-request-dialog.tsx
+++ b/src/frontend/src/components/data-asset-reviews/create-review-request-dialog.tsx
@@ -53,6 +53,7 @@ export default function CreateReviewRequestDialog({ isOpen, onOpenChange, api, o
     const [requesterEmail, setRequesterEmail] = useState<string | null>(null);
     const [_, setIsFetchingUser] = useState(false);
     const [reviewerEmail, setReviewerEmail] = useState('');
+    const [title, setTitle] = useState('');
     const [notes, setNotes] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [formError, setFormError] = useState<string | null>(null);
@@ -118,6 +119,7 @@ export default function CreateReviewRequestDialog({ isOpen, onOpenChange, api, o
             fetchUserInfo();
             fetchCatalogs();
             setReviewerEmail('');
+            setTitle('');
             setNotes('');
             setSelectedAssetFqns(new Set());
             setExpandedNodes(new Set());
@@ -303,10 +305,12 @@ export default function CreateReviewRequestDialog({ isOpen, onOpenChange, api, o
             return;
         }
         setIsSubmitting(true);
+        const trimmedTitle = title.trim();
         const payload: DataAssetReviewRequestCreate = {
             requester_email: requesterEmail,
             reviewer_email: reviewerEmail,
             asset_fqns: Array.from(selectedAssetFqns),
+            title: trimmedTitle || null,
             notes: notes || null,
         };
         try {
@@ -353,6 +357,19 @@ export default function CreateReviewRequestDialog({ isOpen, onOpenChange, api, o
                                 aria-label="Reviewer"
                             />
                         </div>
+                    </div>
+                    <div className="px-1">
+                        <Label htmlFor="review-title">Title (Optional)</Label>
+                        <Input
+                            id="review-title"
+                            value={title}
+                            maxLength={200}
+                            onChange={(e) => {
+                                setTitle(e.target.value);
+                                setFormError(null);
+                            }}
+                            placeholder="Leave empty to auto-generate from selected assets"
+                        />
                     </div>
                     <div className="px-1">
                         <Label htmlFor="notes">Notes (Optional)</Label>

--- a/src/frontend/src/hooks/use-api.ts
+++ b/src/frontend/src/hooks/use-api.ts
@@ -264,6 +264,64 @@ export const useApi = () => {
     }
   }, []);
 
+  const patch = useCallback(async <T>(url: string, body: any): Promise<ApiResponse<T>> => {
+    setLoading(true);
+    try {
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        let errorBody: any;
+        const contentType = response.headers.get('Content-Type');
+        try {
+          if (contentType?.includes('application/json')) {
+            errorBody = await response.json();
+          } else {
+            errorBody = await response.text();
+          }
+        } catch (parseError) {
+          errorBody = response.statusText;
+        }
+
+        let errorMsg: string;
+        if (Array.isArray(errorBody?.detail) && errorBody.detail.length > 0) {
+          errorMsg = errorBody.detail.map((err: any) => {
+            const loc = Array.isArray(err.loc) ? err.loc.join(' → ') : '';
+            return loc ? `${loc}: ${err.msg}` : err.msg;
+          }).join('; ');
+        } else if (errorBody?.detail) {
+          if (typeof errorBody.detail === 'string') {
+            errorMsg = errorBody.detail;
+          } else if (typeof errorBody.detail === 'object') {
+            errorMsg = errorBody.detail.message || JSON.stringify(errorBody.detail);
+          } else {
+            errorMsg = String(errorBody.detail);
+          }
+        } else if (typeof errorBody === 'string') {
+          errorMsg = errorBody;
+        } else {
+          errorMsg = JSON.stringify(errorBody) || `HTTP error! status: ${response.status}`;
+        }
+
+        console.error("[useApi] PATCH error response from", url, "(", response.status, "):", errorBody);
+        return { data: {} as T, error: errorMsg };
+      }
+
+      const data = await response.json();
+      return { data };
+    } catch (error) {
+      console.error("[useApi] PATCH error from", url, ":", error);
+      return { data: {} as T, error: (error as Error).message };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   const delete_ = useCallback(async <T = unknown>(url: string): Promise<ApiResponse<T>> => {
     setLoading(true);
     let responseData: T = {} as T;
@@ -329,5 +387,5 @@ export const useApi = () => {
     return { data: responseData, error: errorMsg };
   }, []);
 
-  return { get, post, put, delete: delete_, loading };
+  return { get, post, put, patch, delete: delete_, loading };
 };

--- a/src/frontend/src/hooks/use-comments.test.ts
+++ b/src/frontend/src/hooks/use-comments.test.ts
@@ -13,6 +13,7 @@ describe('useComments Hook', () => {
   const mockGet = vi.fn();
   const mockPost = vi.fn();
   const mockPut = vi.fn();
+  const mockPatch = vi.fn();
   const mockDelete = vi.fn();
   const mockToast = vi.fn();
 
@@ -24,6 +25,7 @@ describe('useComments Hook', () => {
       get: mockGet,
       post: mockPost,
       put: mockPut,
+      patch: mockPatch,
       delete: mockDelete,
       loading: false,
     });

--- a/src/frontend/src/i18n/locales/de/data-asset-reviews.json
+++ b/src/frontend/src/i18n/locales/de/data-asset-reviews.json
@@ -7,11 +7,21 @@
   "loading": "Überprüfungen werden geladen...",
   "noRequests": "Keine Überprüfungsanfragen gefunden.",
   "toast": {
-    "requestCreated": "Überprüfungsanfrage {{id}} erstellt.",
+    "requestCreated": "Überprüfungsanfrage \"{{title}}\" erstellt.",
     "requestDeleted": "Überprüfungsanfrage gelöscht.",
     "deleteError": "Anfrage konnte nicht gelöscht werden.",
     "bulkDeleted": "{{count}} Anfrage(n) gelöscht.",
-    "bulkDeleteError": "Einige Anfragen konnten nicht gelöscht werden."
+    "bulkDeleteError": "Einige Anfragen konnten nicht gelöscht werden.",
+    "titleUpdated": "Titel aktualisiert.",
+    "idCopied": "ID in die Zwischenablage kopiert."
+  },
+  "form": {
+    "titleLabel": "Titel (Optional)",
+    "titlePlaceholder": "Leer lassen, um automatisch aus ausgewählten Assets zu generieren"
+  },
+  "actions": {
+    "editTitle": "Titel bearbeiten",
+    "copyId": "ID kopieren"
   },
   "confirm": {
     "deleteRequest": "Sind Sie sicher, dass Sie diese Überprüfungsanfrage löschen möchten?",
@@ -24,7 +34,8 @@
     "rejected": "Abgelehnt"
   },
   "table": {
-    "requestId": "Anfrage-ID",
+    "title": "Titel",
+    "untitled": "(ohne Titel)",
     "asset": "Asset",
     "type": "Typ",
     "requester": "Antragsteller",

--- a/src/frontend/src/i18n/locales/en/data-asset-reviews.json
+++ b/src/frontend/src/i18n/locales/en/data-asset-reviews.json
@@ -7,11 +7,21 @@
   "loading": "Loading reviews...",
   "noRequests": "No review requests found.",
   "toast": {
-    "requestCreated": "Review request {{id}} created.",
+    "requestCreated": "Review request \"{{title}}\" created.",
     "requestDeleted": "Review request deleted.",
     "deleteError": "Failed to delete request.",
     "bulkDeleted": "{{count}} request(s) deleted.",
-    "bulkDeleteError": "Some requests could not be deleted."
+    "bulkDeleteError": "Some requests could not be deleted.",
+    "titleUpdated": "Title updated.",
+    "idCopied": "ID copied to clipboard."
+  },
+  "form": {
+    "titleLabel": "Title (Optional)",
+    "titlePlaceholder": "Leave empty to auto-generate from selected assets"
+  },
+  "actions": {
+    "editTitle": "Edit title",
+    "copyId": "Copy ID"
   },
   "confirm": {
     "deleteRequest": "Are you sure you want to delete this review request?",
@@ -24,7 +34,8 @@
     "rejected": "Rejected"
   },
   "table": {
-    "requestId": "Request ID",
+    "title": "Title",
+    "untitled": "(untitled)",
     "asset": "Asset",
     "type": "Type",
     "requester": "Requester",

--- a/src/frontend/src/i18n/locales/es/data-asset-reviews.json
+++ b/src/frontend/src/i18n/locales/es/data-asset-reviews.json
@@ -7,11 +7,21 @@
   "loading": "Cargando revisiones...",
   "noRequests": "No se encontraron solicitudes de revisión.",
   "toast": {
-    "requestCreated": "Solicitud de revisión {{id}} creada.",
+    "requestCreated": "Solicitud de revisión \"{{title}}\" creada.",
     "requestDeleted": "Solicitud de revisión eliminada.",
     "deleteError": "Error al eliminar la solicitud.",
     "bulkDeleted": "{{count}} solicitud(es) eliminada(s).",
-    "bulkDeleteError": "No se pudieron eliminar algunas solicitudes."
+    "bulkDeleteError": "No se pudieron eliminar algunas solicitudes.",
+    "titleUpdated": "Título actualizado.",
+    "idCopied": "ID copiado al portapapeles."
+  },
+  "form": {
+    "titleLabel": "Título (Opcional)",
+    "titlePlaceholder": "Deja vacío para generar automáticamente desde los activos seleccionados"
+  },
+  "actions": {
+    "editTitle": "Editar título",
+    "copyId": "Copiar ID"
   },
   "confirm": {
     "deleteRequest": "¿Está seguro de que desea eliminar esta solicitud de revisión?",
@@ -24,7 +34,8 @@
     "rejected": "Rechazado"
   },
   "table": {
-    "requestId": "ID de Solicitud",
+    "title": "Título",
+    "untitled": "(sin título)",
     "asset": "Activo",
     "type": "Tipo",
     "requester": "Solicitante",

--- a/src/frontend/src/i18n/locales/fr/data-asset-reviews.json
+++ b/src/frontend/src/i18n/locales/fr/data-asset-reviews.json
@@ -7,11 +7,21 @@
   "loading": "Chargement des révisions...",
   "noRequests": "Aucune demande de révision trouvée.",
   "toast": {
-    "requestCreated": "Demande de révision {{id}} créée.",
+    "requestCreated": "Demande de révision « {{title}} » créée.",
     "requestDeleted": "Demande de révision supprimée.",
     "deleteError": "Échec de la suppression de la demande.",
     "bulkDeleted": "{{count}} demande(s) supprimée(s).",
-    "bulkDeleteError": "Certaines demandes n'ont pas pu être supprimées."
+    "bulkDeleteError": "Certaines demandes n'ont pas pu être supprimées.",
+    "titleUpdated": "Titre mis à jour.",
+    "idCopied": "ID copié dans le presse-papiers."
+  },
+  "form": {
+    "titleLabel": "Titre (Optionnel)",
+    "titlePlaceholder": "Laissez vide pour générer automatiquement depuis les actifs sélectionnés"
+  },
+  "actions": {
+    "editTitle": "Modifier le titre",
+    "copyId": "Copier l'ID"
   },
   "confirm": {
     "deleteRequest": "Êtes-vous sûr de vouloir supprimer cette demande de révision ?",
@@ -24,7 +34,8 @@
     "rejected": "Rejeté"
   },
   "table": {
-    "requestId": "ID de Demande",
+    "title": "Titre",
+    "untitled": "(sans titre)",
     "asset": "Actif",
     "type": "Type",
     "requester": "Demandeur",

--- a/src/frontend/src/i18n/locales/it/data-asset-reviews.json
+++ b/src/frontend/src/i18n/locales/it/data-asset-reviews.json
@@ -7,11 +7,21 @@
   "loading": "Caricamento revisioni...",
   "noRequests": "Nessuna richiesta di revisione trovata.",
   "toast": {
-    "requestCreated": "Richiesta di revisione {{id}} creata.",
+    "requestCreated": "Richiesta di revisione \"{{title}}\" creata.",
     "requestDeleted": "Richiesta di revisione eliminata.",
     "deleteError": "Impossibile eliminare la richiesta.",
     "bulkDeleted": "{{count}} richiesta/e eliminata/e.",
-    "bulkDeleteError": "Alcune richieste non sono state eliminate."
+    "bulkDeleteError": "Alcune richieste non sono state eliminate.",
+    "titleUpdated": "Titolo aggiornato.",
+    "idCopied": "ID copiato negli appunti."
+  },
+  "form": {
+    "titleLabel": "Titolo (Opzionale)",
+    "titlePlaceholder": "Lascia vuoto per generare automaticamente dagli asset selezionati"
+  },
+  "actions": {
+    "editTitle": "Modifica titolo",
+    "copyId": "Copia ID"
   },
   "confirm": {
     "deleteRequest": "Sei sicuro di voler eliminare questa richiesta di revisione?",
@@ -24,7 +34,8 @@
     "rejected": "Rifiutato"
   },
   "table": {
-    "requestId": "ID Richiesta",
+    "title": "Titolo",
+    "untitled": "(senza titolo)",
     "asset": "Asset",
     "type": "Tipo",
     "requester": "Richiedente",

--- a/src/frontend/src/i18n/locales/ja/data-asset-reviews.json
+++ b/src/frontend/src/i18n/locales/ja/data-asset-reviews.json
@@ -7,11 +7,21 @@
   "loading": "レビューを読み込み中...",
   "noRequests": "レビューリクエストが見つかりません。",
   "toast": {
-    "requestCreated": "レビューリクエスト {{id}} が作成されました。",
+    "requestCreated": "レビューリクエスト「{{title}}」が作成されました。",
     "requestDeleted": "レビューリクエストが削除されました。",
     "deleteError": "リクエストの削除に失敗しました。",
     "bulkDeleted": "{{count}} 件のリクエストが削除されました。",
-    "bulkDeleteError": "一部のリクエストを削除できませんでした。"
+    "bulkDeleteError": "一部のリクエストを削除できませんでした。",
+    "titleUpdated": "タイトルを更新しました。",
+    "idCopied": "IDをクリップボードにコピーしました。"
+  },
+  "form": {
+    "titleLabel": "タイトル（任意）",
+    "titlePlaceholder": "空欄のままにすると、選択したアセットから自動生成されます"
+  },
+  "actions": {
+    "editTitle": "タイトルを編集",
+    "copyId": "IDをコピー"
   },
   "confirm": {
     "deleteRequest": "このレビューリクエストを削除してもよろしいですか？",
@@ -24,7 +34,8 @@
     "rejected": "却下"
   },
   "table": {
-    "requestId": "リクエストID",
+    "title": "タイトル",
+    "untitled": "（タイトルなし）",
     "asset": "アセット",
     "type": "タイプ",
     "requester": "依頼者",

--- a/src/frontend/src/i18n/locales/nl/data-asset-reviews.json
+++ b/src/frontend/src/i18n/locales/nl/data-asset-reviews.json
@@ -7,11 +7,21 @@
   "loading": "Beoordelingen laden...",
   "noRequests": "Geen beoordelingsverzoeken gevonden.",
   "toast": {
-    "requestCreated": "Beoordelingsverzoek {{id}} aangemaakt.",
+    "requestCreated": "Beoordelingsverzoek \"{{title}}\" aangemaakt.",
     "requestDeleted": "Beoordelingsverzoek verwijderd.",
     "deleteError": "Kon verzoek niet verwijderen.",
     "bulkDeleted": "{{count}} verzoek(en) verwijderd.",
-    "bulkDeleteError": "Sommige verzoeken konden niet worden verwijderd."
+    "bulkDeleteError": "Sommige verzoeken konden niet worden verwijderd.",
+    "titleUpdated": "Titel bijgewerkt.",
+    "idCopied": "ID gekopieerd naar klembord."
+  },
+  "form": {
+    "titleLabel": "Titel (Optioneel)",
+    "titlePlaceholder": "Laat leeg om automatisch te genereren uit geselecteerde assets"
+  },
+  "actions": {
+    "editTitle": "Titel bewerken",
+    "copyId": "ID kopiëren"
   },
   "confirm": {
     "deleteRequest": "Weet je zeker dat je dit beoordelingsverzoek wilt verwijderen?",
@@ -24,7 +34,8 @@
     "rejected": "Afgewezen"
   },
   "table": {
-    "requestId": "Verzoek ID",
+    "title": "Titel",
+    "untitled": "(zonder titel)",
     "asset": "Asset",
     "type": "Type",
     "requester": "Aanvrager",

--- a/src/frontend/src/types/data-asset-review.ts
+++ b/src/frontend/src/types/data-asset-review.ts
@@ -73,6 +73,7 @@ export interface DataAssetReviewRequestCreate {
     requester_email: string;
     reviewer_email: string;
     asset_fqns: string[];
+    title?: string | null;
     notes?: string | null;
 }
 
@@ -81,6 +82,8 @@ export interface DataAssetReviewRequest {
     id: string;
     requester_email: string;
     reviewer_email: string;
+    /** Human-readable title; backend always returns a populated value (derived if not user-set). */
+    title: string;
     status: ReviewRequestStatus;
     notes?: string | null;
     created_at: string; // ISO date string
@@ -91,6 +94,12 @@ export interface DataAssetReviewRequest {
 // Interface for updating the overall request status
 export interface DataAssetReviewRequestUpdateStatus {
     status: ReviewRequestStatus;
+    notes?: string | null;
+}
+
+// Interface for partial updates (PATCH) - title and/or notes
+export interface DataAssetReviewRequestUpdate {
+    title?: string | null;
     notes?: string | null;
 }
 

--- a/src/frontend/src/views/data-asset-review-details.tsx
+++ b/src/frontend/src/views/data-asset-review-details.tsx
@@ -2,19 +2,21 @@ import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ColumnDef } from "@tanstack/react-table";
-import { Loader2, AlertCircle, ArrowLeft, X, ArrowUpDown } from 'lucide-react';
+import { Loader2, AlertCircle, ArrowLeft, X, ArrowUpDown, Pencil, Check, Copy } from 'lucide-react';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from "@/hooks/use-toast";
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import {
     DataAssetReviewRequest, ReviewedAsset, ReviewRequestStatus,
     ReviewedAssetStatus,
+    DataAssetReviewRequestUpdate,
     DataAssetReviewRequestUpdateStatus
 } from '@/types/data-asset-review';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 // Textarea - unused
 // import { Textarea } from '@/components/ui/textarea';
@@ -49,7 +51,7 @@ export default function DataAssetReviewDetails() {
     const { requestId } = useParams<{ requestId: string }>();
     const navigate = useNavigate();
     const api = useApi();
-    const { get, put } = api;
+    const { get, put, patch } = api;
     const { toast } = useToast();
     const setDynamicTitle = useBreadcrumbStore((state) => state.setDynamicTitle);
     const setStaticSegments = useBreadcrumbStore((state) => state.setStaticSegments);
@@ -61,6 +63,9 @@ export default function DataAssetReviewDetails() {
     const [selectedAsset, setSelectedAsset] = useState<ReviewedAsset | null>(null);
     const [selectedAssetIndex, setSelectedAssetIndex] = useState<number>(0);
     const [isEditorOpen, setIsEditorOpen] = useState(false);
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+    const [titleDraft, setTitleDraft] = useState('');
+    const [isSavingTitle, setIsSavingTitle] = useState(false);
 
     // Navigation helpers for asset review
     const pendingAssets = useMemo(() => 
@@ -100,7 +105,7 @@ export default function DataAssetReviewDetails() {
             const response = await get<DataAssetReviewRequest>(`/api/data-asset-reviews/${requestId}`);
             const requestData = checkApiResponse(response, 'Review Request Details');
             setRequest(requestData);
-            setDynamicTitle(`Review: ${requestData.id.substring(0, 8)}...`);
+            setDynamicTitle(requestData.title || `Review ${requestData.id.substring(0, 8)}`);
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : 'Failed to fetch request details';
             setError(errorMessage);
@@ -121,6 +126,52 @@ export default function DataAssetReviewDetails() {
             setDynamicTitle(null);
         };
     }, [requestId, get, toast, setDynamicTitle, setStaticSegments]);
+
+    const beginEditTitle = () => {
+        if (!request) return;
+        setTitleDraft(request.title ?? '');
+        setIsEditingTitle(true);
+    };
+
+    const cancelEditTitle = () => {
+        setIsEditingTitle(false);
+        setTitleDraft('');
+    };
+
+    const handleSaveTitle = async () => {
+        if (!requestId || !request) return;
+        const trimmed = titleDraft.trim();
+        // No-op if unchanged (treat empty draft as "clear / regenerate").
+        if (trimmed === (request.title ?? '').trim()) {
+            cancelEditTitle();
+            return;
+        }
+        setIsSavingTitle(true);
+        const payload: DataAssetReviewRequestUpdate = { title: trimmed || null };
+        try {
+            const response = await patch<DataAssetReviewRequest>(`/api/data-asset-reviews/${requestId}`, payload);
+            const updated = checkApiResponse(response, 'Update Review Title');
+            setRequest(updated);
+            setDynamicTitle(updated.title || `Review ${updated.id.substring(0, 8)}`);
+            toast({ title: t('common:toast.success'), description: t('data-asset-reviews:toast.titleUpdated') });
+            setIsEditingTitle(false);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to update title';
+            toast({ title: 'Error', description: errorMessage, variant: 'destructive' });
+        } finally {
+            setIsSavingTitle(false);
+        }
+    };
+
+    const handleCopyId = async () => {
+        if (!request) return;
+        try {
+            await navigator.clipboard.writeText(request.id);
+            toast({ title: t('data-asset-reviews:toast.idCopied') });
+        } catch {
+            // Silently fail if clipboard is unavailable
+        }
+    };
 
     const handleOverallStatusChange = async (newStatus: ReviewRequestStatus) => {
         if (!requestId || !request || newStatus === request.status) return;
@@ -244,13 +295,80 @@ export default function DataAssetReviewDetails() {
     return (
         <div className="py-6">
             <div className="space-y-6">
-                <div className="flex justify-between items-start mb-4">
-                    <div>
+                <div className="flex justify-between items-start mb-4 gap-4">
+                    <div className="min-w-0 flex-1">
                         <Button variant="outline" size="sm" onClick={() => navigate('/data-asset-reviews')} className="mb-2">
                             <ArrowLeft className="mr-2 h-4 w-4" /> Back to List
                         </Button>
-                        <h1 className="text-3xl font-bold">Review Request Details</h1>
-                        <p className="text-sm text-muted-foreground font-mono">ID: {request.id}</p>
+                        {isEditingTitle ? (
+                            <div className="flex items-center gap-2">
+                                <Input
+                                    autoFocus
+                                    value={titleDraft}
+                                    maxLength={200}
+                                    onChange={(e) => setTitleDraft(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            e.preventDefault();
+                                            handleSaveTitle();
+                                        } else if (e.key === 'Escape') {
+                                            e.preventDefault();
+                                            cancelEditTitle();
+                                        }
+                                    }}
+                                    placeholder={t('data-asset-reviews:form.titlePlaceholder')}
+                                    className="text-2xl font-bold h-auto py-1 px-2"
+                                    disabled={isSavingTitle}
+                                />
+                                <Button
+                                    size="icon"
+                                    variant="default"
+                                    onClick={handleSaveTitle}
+                                    disabled={isSavingTitle}
+                                    aria-label={t('common:actions.save')}
+                                >
+                                    {isSavingTitle ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                                </Button>
+                                <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    onClick={cancelEditTitle}
+                                    disabled={isSavingTitle}
+                                    aria-label={t('common:actions.cancel')}
+                                >
+                                    <X className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-2 group">
+                                <h1 className="text-3xl font-bold truncate">
+                                    {request.title || t('data-asset-reviews:table.untitled')}
+                                </h1>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="opacity-0 group-hover:opacity-100 transition-opacity"
+                                    onClick={beginEditTitle}
+                                    aria-label={t('data-asset-reviews:actions.editTitle')}
+                                    title={t('data-asset-reviews:actions.editTitle')}
+                                >
+                                    <Pencil className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        )}
+                        <div className="flex items-center gap-1 mt-1">
+                            <span className="text-xs text-muted-foreground font-mono">{request.id}</span>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6 text-muted-foreground"
+                                onClick={handleCopyId}
+                                aria-label={t('data-asset-reviews:actions.copyId')}
+                                title={t('data-asset-reviews:actions.copyId')}
+                            >
+                                <Copy className="h-3 w-3" />
+                            </Button>
+                        </div>
                     </div>
                     <div className="flex items-center gap-2">
                         <Label htmlFor="overall-status" className="text-sm font-medium">Overall Status:</Label>

--- a/src/frontend/src/views/data-asset-reviews.tsx
+++ b/src/frontend/src/views/data-asset-reviews.tsx
@@ -78,7 +78,7 @@ export default function DataAssetReviews() {
     };
 
     const handleCreateSuccess = (newRequest: DataAssetReviewRequest) => {
-        toast({ title: t('common:toast.success'), description: t('data-asset-reviews:toast.requestCreated', { id: newRequest.id }) });
+        toast({ title: t('common:toast.success'), description: t('data-asset-reviews:toast.requestCreated', { title: newRequest.title }) });
         fetchRequests(); // Refresh the list
         setIsCreateDialogOpen(false);
         // Optional: Navigate to the new request's details page
@@ -117,13 +117,17 @@ export default function DataAssetReviews() {
     // --- Column Definitions --- //
     const columns = useMemo<ColumnDef<DataAssetReviewRequest>[]>(() => [
         {
-            accessorKey: "id",
+            accessorKey: "title",
             header: ({ column }) => (
                 <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-                    {t('data-asset-reviews:table.requestId')} <ChevronDown className="ml-2 h-4 w-4" />
+                    {t('data-asset-reviews:table.title')} <ChevronDown className="ml-2 h-4 w-4" />
                 </Button>
             ),
-            cell: ({ row }) => <div className="text-xs">{row.original.id}</div>,
+            cell: ({ row }) => (
+                <div className="text-sm font-medium">
+                    {row.original.title || t('data-asset-reviews:table.untitled')}
+                </div>
+            ),
         },
         {
             accessorKey: "status",
@@ -215,7 +219,7 @@ export default function DataAssetReviews() {
                 <DataTable
                     columns={columns}
                     data={requests}
-                    searchColumn="reviewer_email" // Or search by ID, requester, etc.
+                    searchColumn="title"
                     toolbarActions={
                         <>
                             <Button onClick={handleOpenCreateDialog} className="gap-2 h-9">


### PR DESCRIPTION
## Summary

Data asset review requests had no name field, so every surface (list, detail header, breadcrumb, notifications, toasts, search results) fell back to displaying the raw UUID like `00c00001-0000-4000-8000-000000000001`. This PR introduces an optional, user-editable `title` with a smart auto-derived fallback, and surfaces it everywhere a review is named.

**Before**

| Surface | Display |
|---|---|
| List column | `00c00001-0000-4000-...` |
| Detail H1 | `Review Request Details` + UUID |
| Breadcrumb | `Review: 00c00001...` |
| Notification | `Review request (00c00001-...) assigned to you by ...` |
| Search hit | `Review Request by foo@x for bar@y (2 assets)` |

**After**

| Surface | Display |
|---|---|
| List column | `Review of orders (+2 more)` (user-set title takes precedence) |
| Detail H1 | `Review of orders (+2 more)` with inline edit; UUID demoted to small monospace line with copy button |
| Breadcrumb | the title |
| Notification | `New review request: Review of orders (+2 more)` |
| Search hit | the title |

## Derivation rule

Single `derive_review_title()` helper in the manager, used by API responses, workflow `entity_name`, notifications, search index, and the Alembic backfill so all surfaces agree.

1. user-set `title` if non-empty
2. `Review of {short_name(asset_fqn)}` for one asset
3. `Review of {short_name(first)} (+{N-1} more)` for many
4. `Review request by {requester_email}` as last resort

`short_name` understands UC FQNs (`a.b.c` -> `c`), path-style FQNs (notebooks / volumes -> last segment), and `mdm://config/run/candidate` URIs (-> candidate id).

## Backend changes

- New `title VARCHAR(200)` column on `data_asset_review_requests` via Alembic migration `g3_review_title` (descends from `g2_ontology_gen_runs`, single head). Migration backfills existing rows using the same derivation rule the runtime applies.
- Pydantic: `title` added to read + create models; new `DataAssetReviewRequestUpdate` for PATCH.
- Manager always returns a populated title (no `None` reaches consumers). Workflow trigger `entity_name`, fallback notifications (create and status-change), and search-index title all use the derived title; descriptions no longer embed the UUID.
- New `manager.update_review_request()` + repo `update_request_fields()` (uses explicit `*_set` flags so PATCH can distinguish field omitted from field cleared to null).
- New `PATCH /api/data-asset-reviews/{request_id}` route with the same audit-log shape as the other write routes.

## Frontend changes

- Types: `DataAssetReviewRequest.title: string`, `DataAssetReviewRequestCreate.title?`, new `DataAssetReviewRequestUpdate`.
- `useApi` gains a `patch()` method (mirrors `put()`); `useComments` test mock updated to match the expanded return shape.
- Create dialog: optional Title input above Notes (`maxLength=200`), placeholder explains the auto-derived fallback.
- List view: dropped the Request ID column. Title is now the primary column; table search runs against it (placeholder auto-adapts).
- Detail view: breadcrumb and H1 use `request.title`; UUID demoted to small monospace line with a copy-to-clipboard button. Inline title editor (pencil -> input -> PATCH) with Enter/Esc handling.
- i18n: 7 locales updated (en, de, fr, es, it, ja, nl). Renamed `table.requestId` -> `table.title`, added `table.untitled`, `form.titleLabel`, `form.titlePlaceholder`, `actions.editTitle`, `actions.copyId`, `toast.titleUpdated`, `toast.idCopied`. `toast.requestCreated` now interpolates `{{title}}` instead of `{{id}}`.

## Out of scope

- No change to per-asset child rows (still keyed by `asset_fqn`).
- No change to `project_id` exposure.
- No bulk rename UI; backfill happens in the migration only.
- Title is optional, not unique, validated only by length.

## Test plan

- [ ] Run the migration on a populated dev DB; confirm existing rows get sensible titles (one-asset, many-asset, no-asset cases).
- [ ] Create a review request with the Title field left empty; verify the response/list/detail show the auto-derived title.
- [ ] Create a review request with a custom Title; verify it shows everywhere (list, breadcrumb, H1, search, notification).
- [ ] Edit the title via the pencil icon on the detail view; verify PATCH persists and breadcrumb refreshes.
- [ ] Clear the title in the inline editor and save; verify it falls back to the auto-derived value.
- [ ] Copy-ID button copies the UUID to the clipboard.
- [ ] Notifications (create + status change) show the title rather than the UUID.
- [ ] Search results show the derived/user-set title.