### PR TITLE
chore: ignore local docs/research folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ licenses.json
 licenses.csv
 
 .cursor/plans/
+docs/research/


### PR DESCRIPTION
## Summary
- Add `docs/research/` to `.gitignore` so local research notes stay out of version control.

## Test plan
- [x] Verified `.gitignore` diff only adds the new entry.
- [x] Confirmed no other files are included in the commit.