### PR TITLE
chore(tests): scrub obsolete info from test docstrings

### DIFF
--- a/src/backend/src/tests/unit/test_is_user_feature_admin.py
+++ b/src/backend/src/tests/unit/test_is_user_feature_admin.py
@@ -6,7 +6,7 @@ Covers the cascade-bypass admin check used by data-products listing
 1. Short-circuit True when the user belongs to a workspace admin group.
 2. Return True when the user's effective Ontos-role permissions grant
    ``FeatureAccessLevel.ADMIN`` on the named feature, even when they
-   are *not* a workspace admin (the Daimler regression case).
+   are *not* a workspace admin (the dtag regression case).
 3. Return False otherwise.
 4. Honor applied-role overrides (the role-switcher path) when set.
 5. Fail-closed on auth-manager errors — i.e., a transient resolution
@@ -65,10 +65,10 @@ async def test_workspace_admin_short_circuits_true(mock_settings):
 async def test_ontos_role_admin_grants_bypass(mock_settings):
     """Not a workspace admin, but role permissions grant ADMIN → True.
 
-    This is the Daimler / FEVM-Mikhail regression case: the Ontos
-    ``Admin`` role is assigned to a non-``admins`` workspace group
-    (or via email-as-group), and the user's effective permissions
-    include ``ADMIN`` on data-products.
+    This is the dtag regression case: the Ontos ``Admin`` role is
+    assigned to a non-``admins`` workspace group (or via
+    email-as-group), and the user's effective permissions include
+    ``ADMIN`` on data-products.
     """
     from src.common.authorization import is_user_feature_admin
 

--- a/src/backend/src/tests/unit/test_wizard_permission_dispatch.py
+++ b/src/backend/src/tests/unit/test_wizard_permission_dispatch.py
@@ -200,7 +200,7 @@ def test_for_approval_response_user_without_notifications_denied() -> None:
 
 def test_for_approval_response_business_owner_with_read_only_allowed() -> None:
     """PR L — non-admin Business Owner with only `notifications:READ_ONLY`
-    (the typical Data Consumer / Daimler-shaped role) clears the outer
+    (the typical Data Consumer / dtag-shaped role) clears the outer
     gate. Real authorization (caller is the assigned recipient of this
     execution's approval notification) happens INSIDE POST
     /handle-approval (see test_handle_approval_per_execution_check)."""


### PR DESCRIPTION
## Summary

- Replaces residual `....` references in two unit-test docstrings with the neutral code word `dtag`.
- Removes the `FEVM-...` employee handle from `test_is_user_feature_admin.py`.
- Pure docstring / comment edits — no behavior change, no migration impact.

Follow-up to #318 (the replacement of #315), which scrubbed the original feature-PR scope but missed these two later-added unit tests.

## Files changed

- `src/backend/src/tests/unit/test_is_user_feature_admin.py` (module docstring + `test_ontos_role_admin_grants_bypass` docstring)
- `src/backend/src/tests/unit/test_wizard_permission_dispatch.py` (`test_for_approval_response_business_owner_with_read_only_allowed` docstring)

## Test plan

- [x] `grep -ri '...\|FEVM-...' src/ docs/` returns zero matches.
- [x] Affected unit tests still pass locally (`hatch -e dev run pytest src/tests/unit/test_is_user_feature_admin.py src/tests/unit/test_wizard_permission_dispatch.py` → 24 passed).

## Out of scope (flagged for a possible follow-up)

The fixture group name `099_Treasure_DataProducer[_R]` (3 occurrences across `test_is_user_feature_admin.py` and `test_access_grant_dp_enrichment.py`) looks like another customer's SCIM group naming convention. Not touched here; worth a separate scrub PR if confirmed.