### PR TITLE
feat(marketplace): add Go to Details button to info dialog

### DIFF
--- a/src/frontend/src/components/home/marketplace-view.tsx
+++ b/src/frontend/src/components/home/marketplace-view.tsx
@@ -706,6 +706,13 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
           isSubscribed={productIsSubscribed}
           subscriptionLoading={checkingSubscription}
           showBackButton
+          onGoToDetails={() => {
+            const productId = selectedProduct?.id;
+            if (!productId) return;
+            setInfoDialogOpen(false);
+            setSelectedProduct(null);
+            navigate(`/my-products/${productId}`);
+          }}
         />
       )}
 

--- a/src/frontend/src/components/metadata/entity-info-dialog.tsx
+++ b/src/frontend/src/components/metadata/entity-info-dialog.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import MarkdownViewer from '@/components/ui/markdown-viewer';
 import { useEntityMetadata, useMergedMetadata, DocumentItem, LinkItem, EntityKind } from '@/hooks/use-entity-metadata';
-import { Bell, Check, Loader2, ArrowLeft, Share2, Star } from 'lucide-react';
+import { Bell, Check, Loader2, ArrowLeft, Share2, Star, ExternalLink } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { StarRatingInput } from '@/components/ratings/star-rating-input';
 import { RatingSummary } from '@/components/ratings/rating-summary';
@@ -23,6 +23,8 @@ interface Props {
   isSubscribed?: boolean;
   subscriptionLoading?: boolean;
   showBackButton?: boolean;
+  // Navigate to the full entity detail view (optional)
+  onGoToDetails?: () => void;
   // Inheritance support (for Data Products and Datasets)
   contractIds?: string[];
   maxLevelInheritance?: number;
@@ -88,6 +90,7 @@ export default function EntityInfoDialog({
   isSubscribed,
   subscriptionLoading,
   showBackButton = false,
+  onGoToDetails,
   contractIds,
   maxLevelInheritance = 99,
 }: Props) {
@@ -176,6 +179,7 @@ export default function EntityInfoDialog({
   const toc = useMemo(() => buildToc(concatenatedMarkdown), [concatenatedMarkdown]);
 
   const showSubscribeFooter = onSubscribe !== undefined;
+  const showFooter = showSubscribeFooter || onGoToDetails !== undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -348,7 +352,7 @@ export default function EntityInfoDialog({
           )}
         </div>
 
-        {showSubscribeFooter && (
+        {showFooter && (
           <DialogFooter className="px-6 py-4 border-t flex-shrink-0 bg-background">
             <Button
               variant="outline"
@@ -356,28 +360,39 @@ export default function EntityInfoDialog({
             >
               Close
             </Button>
-            {isSubscribed ? (
-              <Button variant="secondary" disabled>
-                <Check className="mr-2 h-4 w-4" />
-                Already Subscribed
-              </Button>
-            ) : (
+            {onGoToDetails && (
               <Button
-                onClick={onSubscribe}
-                disabled={subscriptionLoading}
+                variant="outline"
+                onClick={onGoToDetails}
               >
-                {subscriptionLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Loading...
-                  </>
-                ) : (
-                  <>
-                    <Bell className="mr-2 h-4 w-4" />
-                    Subscribe
-                  </>
-                )}
+                <ExternalLink className="mr-2 h-4 w-4" />
+                Go to Details
               </Button>
+            )}
+            {showSubscribeFooter && (
+              isSubscribed ? (
+                <Button variant="secondary" disabled>
+                  <Check className="mr-2 h-4 w-4" />
+                  Already Subscribed
+                </Button>
+              ) : (
+                <Button
+                  onClick={onSubscribe}
+                  disabled={subscriptionLoading}
+                >
+                  {subscriptionLoading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Loading...
+                    </>
+                  ) : (
+                    <>
+                      <Bell className="mr-2 h-4 w-4" />
+                      Subscribe
+                    </>
+                  )}
+                </Button>
+              )
             )}
           </DialogFooter>
         )}


### PR DESCRIPTION
## Summary

- Add an optional `onGoToDetails` callback prop to `EntityInfoDialog` and render a "Go to Details" button in the footer, using the same `ExternalLink` icon as the marketplace tile's quick-link button.
- Footer now renders whenever either `onSubscribe` or `onGoToDetails` is provided (instead of only for subscribe).
- Wire `onGoToDetails` on the marketplace product info modal (`marketplace-view.tsx`) so users can jump from the preview straight to `/my-products/{id}` — mirroring the tile's icon button.

## Test plan

- [ ] Open the marketplace, click any product tile to open the info modal.
- [ ] Verify a "Go to Details" button appears in the footer between "Close" and "Subscribe" with the ExternalLink icon.
- [ ] Click it and confirm the modal closes and the app navigates to the product detail page.
- [ ] Verify the tile's existing ExternalLink icon button still works.
- [ ] Verify other usages of `EntityInfoDialog` (asset explorer, data products/contracts/domains views, discovery section, metadata panel) still render correctly with no footer change since they don't pass `onGoToDetails`.