### PR TITLE
fix: repair failing CI checks (type-check, backend event loop, pr-title-lint)

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,7 +16,15 @@ permissions:
 jobs:
   validate:
     name: validate title
-    runs-on: ubuntu-latest
+    # Run on the org's self-hosted runner group. The action calls the GitHub
+    # API to read the PR title, and the databrickslabs org enforces an IP
+    # allow list -- GitHub-hosted (ubuntu-latest) runners have dynamic IPs that
+    # are not in the allow list, so every run failed with "your IP address is
+    # not permitted to access this resource". The protected runner group's IPs
+    # are allow-listed, matching the other workflows in this repo.
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:

--- a/src/backend/src/tests/unit/test_trigger_types_endpoint.py
+++ b/src/backend/src/tests/unit/test_trigger_types_endpoint.py
@@ -21,9 +21,12 @@ def _call_endpoint() -> List[Dict[str, Any]]:
     # PermissionChecker is a Depends() — bypassed by calling the underlying
     # coroutine directly with positional args. request is unused by the
     # handler body, so a MagicMock is sufficient.
-    return asyncio.get_event_loop().run_until_complete(
-        get_trigger_types(request=MagicMock(), _=True)
-    )
+    #
+    # asyncio.run() creates and tears down a fresh event loop per call.
+    # asyncio.get_event_loop() is unreliable here: on Python 3.10+ it raises
+    # "There is no current event loop in thread 'MainThread'" when no loop has
+    # been set, which is the case under pytest's default (non-async) runner.
+    return asyncio.run(get_trigger_types(request=MagicMock(), _=True))
 
 
 def test_every_trigger_type_represented_exactly_once() -> None:

--- a/src/frontend/src/views/data-contract-details.tsx
+++ b/src/frontend/src/views/data-contract-details.tsx
@@ -65,8 +65,6 @@ import { DirectCertifyDialog, DirectPublishDialog } from '@/components/common/di
 import type { CertificationLevel, PublicationScope } from '@/types/lifecycle'
 import { userHasApprovalPrivilege } from '@/lib/permissions'
 import { ApprovalEntity } from '@/types/settings'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
 
 // Status-based editability constants
 // Only draft/proposed contracts can be edited in place
@@ -237,7 +235,7 @@ export default function DataContractDetails() {
     availableRoles,
     appliedRoleId,
   } = usePermissions()
-  const { post, get, put } = useApi()
+  const { post, get } = useApi()
   const { userInfo, fetchUserInfo } = useUserStore()
 
   const setStaticSegments = useBreadcrumbStore((state) => state.setStaticSegments)
@@ -281,7 +279,6 @@ export default function DataContractDetails() {
   const [, setTeamMetadata] = useState<{ name?: string; description?: string }>({})
   const [teamMetaName, setTeamMetaName] = useState('')
   const [teamMetaDesc, setTeamMetaDesc] = useState('')
-  const [teamMetaDirty, setTeamMetaDirty] = useState(false)
 
   // Link product dialog state
   const [isLinkProductDialogOpen, setIsLinkProductDialogOpen] = useState(false)
@@ -1067,13 +1064,6 @@ export default function DataContractDetails() {
     setEditingTeamMemberIndex(null)
   }
 
-  const handleDeleteTeamMember = async (index: number) => {
-    if (!contract) return
-    if (!confirm('Remove this team member?')) return
-    const updatedTeam = (contract.team || []).filter((_, i) => i !== index)
-    await updateContract({ team: updatedTeam })
-  }
-
   // Server Config CRUD handlers
   const handleAddServer = async (server: ServerConfig) => {
     if (!contract) return
@@ -1543,21 +1533,6 @@ export default function DataContractDetails() {
     fetchProfileRuns()
   }
 
-
-  const handleSaveTeamMetadata = async () => {
-    if (!contractId) return
-    try {
-      await put(`/api/data-contracts/${contractId}/team-metadata`, {
-        name: teamMetaName || null,
-        description: teamMetaDesc || null
-      })
-      setTeamMetadata({ name: teamMetaName, description: teamMetaDesc })
-      setTeamMetaDirty(false)
-      toast({ title: 'Team metadata saved' })
-    } catch {
-      toast({ title: 'Failed to save team metadata', variant: 'destructive' })
-    }
-  }
 
   // Helper functions for conditional rendering based on view mode
   const shouldShowSection = (section: string): boolean => {

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -1150,33 +1150,6 @@ export default function DataProductDetails() {
     }
   };
 
-  const handleDeleteTeamMember = async (index: number) => {
-    if (!productId || !product) return;
-    if (!confirm('Remove this team member?')) return;
-    try {
-      const updatedMembers = (product.team?.members || []).filter((_, i) => i !== index);
-      const updatedTeam = { ...product.team, members: updatedMembers };
-      const res = await fetch(`/api/data-products/${productId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...product, team: updatedTeam }),
-      });
-      if (!res.ok) throw new Error(`Failed to delete team member (${res.status})`);
-      await fetchProductDetails();
-      toast({
-        title: 'Team Member Removed',
-        description: 'Team member removed successfully.',
-      });
-    } catch (e: any) {
-      toast({
-        title: 'Error',
-        description: e?.message || 'Failed to delete team member',
-        variant: 'destructive',
-      });
-    }
-  };
-
-
   const handleAddSupportChannel = async (channel: Support) => {
     if (!productId || !product) return;
     try {


### PR DESCRIPTION
## Summary

CI on `main` has been failing on every PR across three independent issues. This PR fixes all three so the pipeline goes green.

### 1. TypeScript Type Check (`tsc --noEmit`, TS6133)
`noUnusedLocals`/`noUnusedParameters` were tripping on dead code:

- `src/views/data-contract-details.tsx`: removed unused imports `Input` and `Textarea`, the unused state value `teamMetaDirty`, and two orphaned (never-referenced) handlers `handleDeleteTeamMember` and `handleSaveTeamMetadata`. Removing `handleSaveTeamMetadata` left `put` from `useApi()` unused, so it was dropped from the destructure too.
- `src/views/data-product-details.tsx`: removed the orphaned `handleDeleteTeamMember` handler.

Verified locally: `yarn type-check` and `yarn build` both pass.

### 2. Backend Tests (`test_trigger_types_endpoint.py`)
The 5 failing tests all hit `RuntimeError: There is no current event loop in thread 'MainThread'`. The helper used `asyncio.get_event_loop().run_until_complete(...)`, which raises on Python 3.10+ when no loop has been set (pytest's default sync runner). Switched to `asyncio.run(...)`, the canonical replacement that creates and tears down a fresh loop per call.

### 3. pr-title-lint
This workflow has **never** passed, including on well-formed titles and its own introducing PR. It ran on GitHub-hosted `ubuntu-latest`, whose dynamic runner IPs are blocked by the `databrickslabs` org IP allow list, so the title-validation GitHub API call failed every time (`your IP address is not permitted to access this resource`). Moved the job to the allow-listed self-hosted `databrickslabs-protected-runner-group`, matching every other workflow in the repo.

## Testing
- `yarn type-check` — clean
- `yarn build` — succeeds
- Reproduced the `asyncio.get_event_loop()` failure and confirmed `asyncio.run()` resolves it
- Full backend suite + runner-group behavior validated by this PR's own CI run

This pull request and its description were written by Isaac.