### PR TITLE
fix(ui): interpolate shortName in LLM Search title (refs #240)

### DIFF
--- a/src/frontend/src/components/search/llm-search.tsx
+++ b/src/frontend/src/components/search/llm-search.tsx
@@ -34,6 +34,7 @@ import type {
   SessionSummary,
 } from '@/types/llm-search';
 import { fetchLLMStatus, fetchSessions, sendMessage, deleteSession } from './llm-search-api';
+import { useUICustomizationStore } from '@/stores/ui-customization-store';
 
 
 // ============================================================================
@@ -428,6 +429,7 @@ function ExampleQuestions({ onSelectQuestion }: ExampleQuestionsProps) {
 
 export default function LLMSearch() {
   const { t } = useTranslation(['search', 'common']);
+  const shortName = useUICustomizationStore((s) => s.getShortName());
   const [status, setStatus] = useState<LLMSearchStatus | null>(null);
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [currentSessionId, setCurrentSessionId] = useState<string | undefined>();
@@ -721,7 +723,7 @@ export default function LLMSearch() {
               <div className="w-8 h-8 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center">
                 <Sparkles className="w-4 h-4 text-white" />
               </div>
-              {t('search:llm.title')}
+              {t('search:llm.title', { shortName })}
             </CardTitle>
             <CardDescription className="mt-1">
               {t('search:llm.subtitle')}


### PR DESCRIPTION
## Summary

- The LLM Search card title called `t('search:llm.title')` without passing `{ shortName }`, so the `{{shortName}}` placeholder rendered literally as `Ask {{shortName}}` instead of the configured short name. This was a missed call site from #475.
- Wires `useUICustomizationStore` into `LLMSearch` and passes `shortName` to the title call, mirroring the pattern already used in `copilot-panel.tsx` and `search.tsx` (tab label).
- Re-audited every other locale string containing `{{shortName}}` / `{{appName}}` (`home`, `about`, `schema-importer`, `catalog-commander`, `search.tabs.askOntos`, copilot panel + sidebar button) — all already pass the interpolation variable, nothing else is broken.

## Test plan

Verified against the local dev servers on 2026-06-08 with the mock admin (`lars.george@databricks.com`, group `admins`):

| Check | Result |
| --- | --- |
| Default branding (no overrides) — `/search/llm` card title renders `Ask Ontos` | ✓ |
| After saving `appDisplayName=Acme Catalog`, `appShortName=ACME` via Settings → UI **without reload**: card title becomes `Ask ACME`, tab label becomes `Ask ACME`, right-edge sidebar button becomes `Ask ACME` | ✓ |
| `document.body.textContent` no longer contains `{{shortName}}` or `{{appName}}` anywhere on `/`, `/about`, `/schema-importer`, `/catalog-commander`, `/search/llm` with the copilot panel open | ✓ |
| `/` → `<h1>Welcome to Acme Catalog</h1>` | ✓ |
| `/about` → `<h1>About Acme Catalog</h1>` | ✓ |
| `/schema-importer` description: "…import their structure as Acme Catalog assets." | ✓ |
| Copilot panel: title `Ask ACME`, welcome `Welcome to Ask ACME!`, placeholder `Ask ACME anything...` | ✓ |
| Restoring empty values → all surfaces fall back to `Ontos` | ✓ |
| 0 console errors throughout the flow | ✓ |

Refs #240, follow-up to #475.