### PR TITLE
test: raise frontend coverage past 10% and fix coverage badge resolution

### DIFF
--- a/src/frontend/src/config/features.test.ts
+++ b/src/frontend/src/config/features.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  features,
+  getFeatureByPath,
+  getFeatureNameByPath,
+  getNavigationGroups,
+  getLandingPageFeatures,
+} from './features';
+
+describe('features config', () => {
+  it('defines a non-empty, well-formed feature catalog', () => {
+    expect(features.length).toBeGreaterThan(0);
+    for (const f of features) {
+      expect(f.id).toBeTruthy();
+      expect(f.name).toBeTruthy();
+      expect(f.path.startsWith('/')).toBe(true);
+      expect(['Discover', 'Build', 'Govern', 'Deploy']).toContain(f.group);
+      expect(['ga', 'beta', 'alpha']).toContain(f.maturity);
+    }
+  });
+
+  it('has unique feature ids and paths', () => {
+    expect(new Set(features.map((f) => f.id)).size).toBe(features.length);
+    expect(new Set(features.map((f) => f.path)).size).toBe(features.length);
+  });
+
+  describe('getFeatureByPath', () => {
+    it('finds a feature by its exact path', () => {
+      const first = features[0];
+      expect(getFeatureByPath(first.path)).toEqual(first);
+    });
+
+    it('returns undefined for an unknown path', () => {
+      expect(getFeatureByPath('/definitely-not-a-feature')).toBeUndefined();
+    });
+  });
+
+  describe('getFeatureNameByPath', () => {
+    it('resolves a name from a leading-slash or bare path segment', () => {
+      const first = features[0];
+      const segment = first.path.replace(/^\//, '');
+      expect(getFeatureNameByPath(segment)).toBe(first.name);
+      expect(getFeatureNameByPath(first.path)).toBe(first.name);
+    });
+
+    it('echoes the segment when no feature matches', () => {
+      expect(getFeatureNameByPath('unknown-segment')).toBe('unknown-segment');
+    });
+  });
+
+  describe('getNavigationGroups', () => {
+    it('groups GA features in canonical group order with no empty groups', () => {
+      const groups = getNavigationGroups(['ga']);
+      const order = ['Discover', 'Build', 'Govern', 'Deploy'];
+      const seen = groups.map((g) => g.name);
+      // Names appear in the canonical relative order.
+      expect(seen).toEqual([...order].filter((n) => seen.includes(n)));
+      for (const g of groups) {
+        expect(g.items.length).toBeGreaterThan(0);
+        expect(g.items.every((i) => i.maturity === 'ga')).toBe(true);
+      }
+    });
+
+    it('widens results when more maturities are allowed', () => {
+      const ga = getNavigationGroups(['ga']).reduce((n, g) => n + g.items.length, 0);
+      const all = getNavigationGroups(['ga', 'beta', 'alpha']).reduce(
+        (n, g) => n + g.items.length,
+        0,
+      );
+      expect(all).toBeGreaterThanOrEqual(ga);
+    });
+  });
+
+  describe('getLandingPageFeatures', () => {
+    it('returns only landing GA features', () => {
+      const landing = getLandingPageFeatures(['ga']);
+      expect(landing.every((f) => f.showInLanding && f.maturity === 'ga')).toBe(true);
+    });
+  });
+});

--- a/src/frontend/src/config/features.test.ts
+++ b/src/frontend/src/config/features.test.ts
@@ -52,7 +52,7 @@ describe('features config', () => {
     it('groups GA features in canonical group order with no empty groups', () => {
       const groups = getNavigationGroups(['ga']);
       const order = ['Discover', 'Build', 'Govern', 'Deploy'];
-      const seen = groups.map((g) => g.name);
+      const seen: string[] = groups.map((g) => g.name);
       // Names appear in the canonical relative order.
       expect(seen).toEqual([...order].filter((n) => seen.includes(n)));
       for (const g of groups) {

--- a/src/frontend/src/lib/branding.test.ts
+++ b/src/frontend/src/lib/branding.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_APP_NAME,
+  resolveAppName,
+  resolveShortName,
+  applyBranding,
+} from './branding';
+
+describe('branding', () => {
+  describe('resolveAppName', () => {
+    it('returns the default for non-strings and blank input', () => {
+      expect(resolveAppName(undefined)).toBe(DEFAULT_APP_NAME);
+      expect(resolveAppName(null)).toBe(DEFAULT_APP_NAME);
+      expect(resolveAppName('   ')).toBe(DEFAULT_APP_NAME);
+    });
+
+    it('trims and returns a provided name', () => {
+      expect(resolveAppName('  Acme Data  ')).toBe('Acme Data');
+    });
+  });
+
+  describe('resolveShortName', () => {
+    it('prefers a non-blank short name', () => {
+      expect(resolveShortName('  AD ', 'Acme Data')).toBe('AD');
+    });
+
+    it('falls back to the resolved app name', () => {
+      expect(resolveShortName('   ', 'Acme Data')).toBe('Acme Data');
+      expect(resolveShortName(null, null)).toBe(DEFAULT_APP_NAME);
+    });
+  });
+
+  describe('applyBranding', () => {
+    beforeEach(() => {
+      document.head.innerHTML = '';
+      document.title = '';
+    });
+
+    it('sets the document title from the display name', () => {
+      applyBranding({ displayName: 'My Catalog' });
+      expect(document.title).toBe('My Catalog');
+    });
+
+    it('creates a favicon link and sets a custom href', () => {
+      applyBranding({ displayName: 'X', faviconUrl: 'https://cdn/x.png' });
+      const link = document.querySelector<HTMLLinkElement>('link#app-favicon');
+      expect(link).not.toBeNull();
+      expect(link?.getAttribute('href')).toBe('https://cdn/x.png');
+    });
+
+    it('reuses an existing icon link and falls back to a non-empty href when cleared', () => {
+      const existing = document.createElement('link');
+      existing.rel = 'icon';
+      existing.setAttribute('href', '/original.svg');
+      document.head.appendChild(existing);
+
+      // A blank favicon URL must never leave the href empty; it falls back to
+      // the captured original (module-level, captured on first apply) or the
+      // shipped default. Either way the href stays a usable, non-empty path.
+      applyBranding({ displayName: 'X', faviconUrl: '   ' });
+      expect(existing.id).toBe('app-favicon');
+      expect(existing.getAttribute('href')).toBeTruthy();
+      expect(existing.getAttribute('href')).not.toBe('');
+    });
+  });
+});

--- a/src/frontend/src/lib/entity-detail-path.test.ts
+++ b/src/frontend/src/lib/entity-detail-path.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getEntityDetailPathFromPayload,
+  getUnderlyingEntityDetailPath,
+} from './entity-detail-path';
+
+describe('entity-detail-path', () => {
+  describe('getEntityDetailPathFromPayload', () => {
+    it('returns null for nullish or non-object payloads', () => {
+      expect(getEntityDetailPathFromPayload(null)).toBeNull();
+      expect(getEntityDetailPathFromPayload(undefined)).toBeNull();
+    });
+
+    it('resolves product ids (both key spellings)', () => {
+      expect(getEntityDetailPathFromPayload({ product_id: 'p1' })).toBe('/data-products/p1');
+      expect(getEntityDetailPathFromPayload({ data_product_id: 'p2' })).toBe('/data-products/p2');
+    });
+
+    it('resolves contract ids (both key spellings)', () => {
+      expect(getEntityDetailPathFromPayload({ contract_id: 'c1' })).toBe('/data-contracts/c1');
+      expect(getEntityDetailPathFromPayload({ data_contract_id: 'c2' })).toBe('/data-contracts/c2');
+    });
+
+    it('prefers product id over contract id', () => {
+      expect(getEntityDetailPathFromPayload({ product_id: 'p', contract_id: 'c' })).toBe(
+        '/data-products/p',
+      );
+    });
+
+    it('resolves via entity_type + entity_id', () => {
+      expect(getEntityDetailPathFromPayload({ entity_type: 'data_product', entity_id: 'e1' })).toBe(
+        '/data-products/e1',
+      );
+      expect(
+        getEntityDetailPathFromPayload({ entity_type: 'DataContract', entity_id: 'e2' }),
+      ).toBe('/data-contracts/e2');
+    });
+
+    it('returns null for an unlinkable or incomplete entity', () => {
+      expect(getEntityDetailPathFromPayload({ entity_type: 'access_grant', entity_id: 'g' })).toBeNull();
+      expect(getEntityDetailPathFromPayload({ entity_type: 'data_product' })).toBeNull();
+      expect(getEntityDetailPathFromPayload({ product_id: '' })).toBeNull();
+    });
+  });
+
+  describe('getUnderlyingEntityDetailPath', () => {
+    it('resolves the underlying entity when present', () => {
+      const path = getUnderlyingEntityDetailPath({
+        entity_type: 'access_grant',
+        entity_id: 'g1',
+        underlying_entity_type: 'data_product',
+        underlying_entity_id: 'u1',
+      });
+      expect(path).toBe('/data-products/u1');
+    });
+
+    it('falls back to the top-level payload when no underlying entity', () => {
+      expect(getUnderlyingEntityDetailPath({ product_id: 'p9' })).toBe('/data-products/p9');
+    });
+
+    it('returns null for nullish payloads', () => {
+      expect(getUnderlyingEntityDetailPath(null)).toBeNull();
+    });
+  });
+});

--- a/src/frontend/src/lib/format-label.test.ts
+++ b/src/frontend/src/lib/format-label.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { formatFieldLabel } from './format-label';
+
+describe('formatFieldLabel', () => {
+  it('returns an empty string for falsy input', () => {
+    expect(formatFieldLabel('')).toBe('');
+    expect(formatFieldLabel(null)).toBe('');
+    expect(formatFieldLabel(undefined)).toBe('');
+  });
+
+  describe('English (title case)', () => {
+    it('capitalizes words and lowercases minor words (except first)', () => {
+      expect(formatFieldLabel('owner of the dataset', 'en')).toBe('Owner of the Dataset');
+    });
+
+    it('capitalizes a minor word when it is the first word', () => {
+      expect(formatFieldLabel('the owner')).toBe('The Owner');
+    });
+
+    it('preserves acronyms', () => {
+      expect(formatFieldLabel('API endpoint', 'en')).toBe('API Endpoint');
+    });
+
+    it('defaults to English when no locale is supplied', () => {
+      expect(formatFieldLabel('data product')).toBe('Data Product');
+    });
+  });
+
+  describe('other Latin-script locales (sentence case)', () => {
+    it('capitalizes only the first word', () => {
+      expect(formatFieldLabel('owner of the dataset', 'de')).toBe('Owner of the dataset');
+    });
+
+    it('strips the regional suffix from the locale', () => {
+      expect(formatFieldLabel('hello world', 'fr-FR')).toBe('Hello world');
+    });
+
+    it('preserves acronyms in sentence case too', () => {
+      expect(formatFieldLabel('the API spec', 'es')).toBe('The API spec');
+    });
+  });
+
+  describe('CJK locales (no transformation)', () => {
+    it('returns the label unchanged', () => {
+      expect(formatFieldLabel('オーナー', 'ja')).toBe('オーナー');
+      expect(formatFieldLabel('owner', 'zh')).toBe('owner');
+      expect(formatFieldLabel('owner', 'ko')).toBe('owner');
+    });
+  });
+});

--- a/src/frontend/src/lib/odcs-lifecycle.test.ts
+++ b/src/frontend/src/lib/odcs-lifecycle.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DataContractStatus,
+  ALLOWED_TRANSITIONS,
+  STATUS_CONFIG,
+  canTransitionTo,
+  getAllowedTransitions,
+  getStatusConfig,
+  validateTransition,
+  getRecommendedAction,
+} from './odcs-lifecycle';
+
+describe('odcs-lifecycle', () => {
+  describe('canTransitionTo', () => {
+    it('allows defined transitions', () => {
+      expect(canTransitionTo(DataContractStatus.DRAFT, DataContractStatus.PROPOSED)).toBe(true);
+      expect(canTransitionTo(DataContractStatus.APPROVED, DataContractStatus.ACTIVE)).toBe(true);
+      expect(canTransitionTo(DataContractStatus.DEPRECATED, DataContractStatus.ACTIVE)).toBe(true);
+    });
+
+    it('rejects undefined transitions and same-status', () => {
+      expect(canTransitionTo(DataContractStatus.DRAFT, DataContractStatus.ACTIVE)).toBe(false);
+      expect(canTransitionTo(DataContractStatus.ACTIVE, DataContractStatus.ACTIVE)).toBe(false);
+      expect(canTransitionTo(DataContractStatus.RETIRED, DataContractStatus.DRAFT)).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(canTransitionTo('Draft', 'PROPOSED')).toBe(true);
+    });
+  });
+
+  describe('getAllowedTransitions', () => {
+    it('mirrors the transition table', () => {
+      expect(getAllowedTransitions(DataContractStatus.PROPOSED)).toEqual(
+        ALLOWED_TRANSITIONS[DataContractStatus.PROPOSED],
+      );
+    });
+
+    it('returns [] for terminal and unknown statuses', () => {
+      expect(getAllowedTransitions(DataContractStatus.RETIRED)).toEqual([]);
+      expect(getAllowedTransitions('bogus')).toEqual([]);
+    });
+  });
+
+  describe('getStatusConfig', () => {
+    it('returns config for a known status', () => {
+      expect(getStatusConfig(DataContractStatus.DRAFT)).toEqual(
+        STATUS_CONFIG[DataContractStatus.DRAFT],
+      );
+    });
+
+    it('falls back for an unknown status', () => {
+      const cfg = getStatusConfig('xyz');
+      expect(cfg).toMatchObject({ label: 'xyz', description: 'Unknown status', variant: 'secondary' });
+    });
+  });
+
+  describe('validateTransition', () => {
+    it('accepts a valid transition', () => {
+      expect(validateTransition(DataContractStatus.DRAFT, DataContractStatus.PROPOSED)).toEqual({
+        valid: true,
+      });
+    });
+
+    it('rejects unknown target', () => {
+      const r = validateTransition(DataContractStatus.DRAFT, 'invalid');
+      expect(r.valid).toBe(false);
+      expect(r.error).toContain('Invalid target status');
+    });
+
+    it('rejects same status with contract-specific message', () => {
+      const r = validateTransition(DataContractStatus.ACTIVE, DataContractStatus.ACTIVE);
+      expect(r.valid).toBe(false);
+      expect(r.error).toBe('Contract is already in this status');
+    });
+
+    it('rejects disallowed transition and reports "none" for terminal', () => {
+      const r = validateTransition(DataContractStatus.RETIRED, DataContractStatus.DRAFT);
+      expect(r.valid).toBe(false);
+      expect(r.error).toContain('none');
+    });
+
+    it('lists allowed labels for a non-terminal disallowed transition', () => {
+      const r = validateTransition(DataContractStatus.DRAFT, DataContractStatus.ACTIVE);
+      expect(r.valid).toBe(false);
+      expect(r.error).toContain('Cannot transition');
+      expect(r.error).not.toContain('none');
+    });
+  });
+
+  describe('getRecommendedAction', () => {
+    it('returns guidance for non-terminal statuses', () => {
+      for (const s of [
+        DataContractStatus.DRAFT,
+        DataContractStatus.PROPOSED,
+        DataContractStatus.UNDER_REVIEW,
+        DataContractStatus.APPROVED,
+        DataContractStatus.ACTIVE,
+        DataContractStatus.DEPRECATED,
+      ]) {
+        expect(getRecommendedAction(s)).toBeTruthy();
+      }
+    });
+
+    it('returns null for retired and unknown', () => {
+      expect(getRecommendedAction(DataContractStatus.RETIRED)).toBeNull();
+      expect(getRecommendedAction('unknown')).toBeNull();
+    });
+  });
+});

--- a/src/frontend/src/lib/odps-lifecycle.test.ts
+++ b/src/frontend/src/lib/odps-lifecycle.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { DataProductStatus } from '@/types/data-product';
+import {
+  ALLOWED_TRANSITIONS,
+  STATUS_CONFIG,
+  canTransitionTo,
+  getAllowedTransitions,
+  getStatusConfig,
+  validateTransition,
+  getRecommendedAction,
+} from './odps-lifecycle';
+
+describe('odps-lifecycle', () => {
+  describe('canTransitionTo', () => {
+    it('allows a defined forward transition', () => {
+      expect(canTransitionTo(DataProductStatus.DRAFT, DataProductStatus.PROPOSED)).toBe(true);
+      expect(canTransitionTo(DataProductStatus.APPROVED, DataProductStatus.ACTIVE)).toBe(true);
+    });
+
+    it('rejects an undefined transition', () => {
+      expect(canTransitionTo(DataProductStatus.DRAFT, DataProductStatus.ACTIVE)).toBe(false);
+      expect(canTransitionTo(DataProductStatus.RETIRED, DataProductStatus.ACTIVE)).toBe(false);
+    });
+
+    it('rejects a no-op transition to the same status', () => {
+      expect(canTransitionTo(DataProductStatus.ACTIVE, DataProductStatus.ACTIVE)).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(canTransitionTo('DRAFT', 'Proposed')).toBe(true);
+    });
+
+    it('allows emergency deprecation from draft', () => {
+      expect(canTransitionTo(DataProductStatus.DRAFT, DataProductStatus.DEPRECATED)).toBe(true);
+    });
+  });
+
+  describe('getAllowedTransitions', () => {
+    it('returns the configured targets for a known status', () => {
+      expect(getAllowedTransitions(DataProductStatus.ACTIVE)).toEqual(
+        ALLOWED_TRANSITIONS[DataProductStatus.ACTIVE],
+      );
+    });
+
+    it('returns an empty array for a terminal status', () => {
+      expect(getAllowedTransitions(DataProductStatus.RETIRED)).toEqual([]);
+    });
+
+    it('returns an empty array for an unknown status', () => {
+      expect(getAllowedTransitions('does-not-exist')).toEqual([]);
+    });
+  });
+
+  describe('getStatusConfig', () => {
+    it('returns the configured entry for a known status', () => {
+      expect(getStatusConfig(DataProductStatus.ACTIVE)).toEqual(
+        STATUS_CONFIG[DataProductStatus.ACTIVE],
+      );
+    });
+
+    it('falls back to a secondary config for an unknown status', () => {
+      const cfg = getStatusConfig('mystery');
+      expect(cfg.label).toBe('mystery');
+      expect(cfg.description).toBe('Unknown status');
+      expect(cfg.variant).toBe('secondary');
+    });
+  });
+
+  describe('validateTransition', () => {
+    it('accepts a valid transition', () => {
+      expect(validateTransition(DataProductStatus.DRAFT, DataProductStatus.PROPOSED)).toEqual({
+        valid: true,
+      });
+    });
+
+    it('rejects an unknown target status', () => {
+      const result = validateTransition(DataProductStatus.DRAFT, 'nonsense');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Invalid target status');
+    });
+
+    it('rejects a same-status transition', () => {
+      const result = validateTransition(DataProductStatus.ACTIVE, DataProductStatus.ACTIVE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Product is already in this status');
+    });
+
+    it('rejects a disallowed transition and lists allowed targets', () => {
+      const result = validateTransition(DataProductStatus.RETIRED, DataProductStatus.ACTIVE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Cannot transition');
+      expect(result.error).toContain('none');
+    });
+  });
+
+  describe('getRecommendedAction', () => {
+    it('returns guidance for each non-terminal status', () => {
+      for (const status of [
+        DataProductStatus.DRAFT,
+        DataProductStatus.SANDBOX,
+        DataProductStatus.PROPOSED,
+        DataProductStatus.UNDER_REVIEW,
+        DataProductStatus.APPROVED,
+        DataProductStatus.ACTIVE,
+        DataProductStatus.DEPRECATED,
+      ]) {
+        expect(getRecommendedAction(status)).toBeTruthy();
+      }
+    });
+
+    it('returns null for the terminal retired status', () => {
+      expect(getRecommendedAction(DataProductStatus.RETIRED)).toBeNull();
+    });
+
+    it('returns null for an unknown status', () => {
+      expect(getRecommendedAction('whatever')).toBeNull();
+    });
+  });
+});

--- a/src/frontend/src/lib/ontology-utils.test.ts
+++ b/src/frontend/src/lib/ontology-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import type { OntologyConcept } from '@/types/ontology';
+import {
+  resolveLabel,
+  resolveComment,
+  getAvailableLanguages,
+  getLanguageDisplayName,
+  LANGUAGE_NAMES,
+} from './ontology-utils';
+
+function concept(partial: Partial<OntologyConcept>): OntologyConcept {
+  return {
+    iri: 'http://example.org/onto#Thing',
+    concept_type: 'class',
+    parent_concepts: [],
+    child_concepts: [],
+    properties: [],
+    tagged_assets: [],
+    synonyms: [],
+    examples: [],
+    ...partial,
+  } as OntologyConcept;
+}
+
+describe('ontology-utils', () => {
+  describe('resolveLabel', () => {
+    it('prefers the requested language', () => {
+      const c = concept({ labels: { en: 'Dataset', ja: 'データセット' } });
+      expect(resolveLabel(c, 'ja')).toBe('データセット');
+    });
+
+    it('matches regional variants of the preferred language', () => {
+      const c = concept({ labels: { 'en-US': 'Color' } });
+      expect(resolveLabel(c, 'en')).toBe('Color');
+    });
+
+    it('falls back to English when preferred is missing', () => {
+      const c = concept({ labels: { en: 'Dataset', de: 'Datensatz' } });
+      expect(resolveLabel(c, 'fr')).toBe('Dataset');
+    });
+
+    it('falls back to the no-language-tag label', () => {
+      const c = concept({ labels: { '': 'Untagged' } });
+      expect(resolveLabel(c, 'fr')).toBe('Untagged');
+    });
+
+    it('falls back to the IRI local name when no usable label exists', () => {
+      const c = concept({ iri: 'http://example.org/onto#Widget', labels: {} });
+      expect(resolveLabel(c, 'fr')).toBe('Widget');
+    });
+
+    it('uses the legacy label field when present', () => {
+      const c = concept({ iri: 'urn:noslash', labels: {}, label: 'Legacy' });
+      expect(resolveLabel(c, 'fr')).toBe('Legacy');
+    });
+
+    it('returns any available label as a last resort', () => {
+      const c = concept({ iri: 'urn:noslash', labels: { zz: 'Only' } });
+      expect(resolveLabel(c, 'fr')).toBe('Only');
+    });
+
+    it('returns the IRI itself when nothing else is available', () => {
+      const c = concept({ iri: 'urn:noslash', labels: {} });
+      expect(resolveLabel(c, 'fr')).toBe('urn:noslash');
+    });
+  });
+
+  describe('resolveComment', () => {
+    it('prefers the requested language and its regional variants', () => {
+      expect(resolveComment(concept({ comments: { de: 'Hallo' } }), 'de')).toBe('Hallo');
+      expect(resolveComment(concept({ comments: { 'de-AT': 'Servus' } }), 'de')).toBe('Servus');
+    });
+
+    it('falls back through English, untagged, then any', () => {
+      expect(resolveComment(concept({ comments: { en: 'Hi' } }), 'fr')).toBe('Hi');
+      expect(resolveComment(concept({ comments: { '': 'Untagged' } }), 'fr')).toBe('Untagged');
+      expect(resolveComment(concept({ comments: { zz: 'Other' } }), 'fr')).toBe('Other');
+    });
+
+    it('uses the legacy comment field, else undefined', () => {
+      expect(resolveComment(concept({ comments: {}, comment: 'Legacy' }), 'fr')).toBe('Legacy');
+      expect(resolveComment(concept({ comments: {} }), 'fr')).toBeUndefined();
+    });
+  });
+
+  describe('getAvailableLanguages', () => {
+    it('collects and normalizes language codes with English first', () => {
+      const concepts = [
+        concept({ labels: { 'en-US': 'A', de: 'B' } }),
+        concept({ labels: { ja: 'C', '': 'no-tag' } }),
+      ];
+      expect(getAvailableLanguages(concepts)).toEqual(['en', 'de', 'ja']);
+    });
+
+    it('returns an empty array when there are no labels', () => {
+      expect(getAvailableLanguages([concept({})])).toEqual([]);
+    });
+  });
+
+  describe('getLanguageDisplayName', () => {
+    it('returns the known display name', () => {
+      expect(getLanguageDisplayName('en')).toBe(LANGUAGE_NAMES.en);
+      expect(getLanguageDisplayName('ja')).toBe('日本語');
+    });
+
+    it('uppercases unknown codes', () => {
+      expect(getLanguageDisplayName('xx')).toBe('XX');
+    });
+  });
+});

--- a/src/frontend/src/lib/permissions.test.ts
+++ b/src/frontend/src/lib/permissions.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { ApprovalEntity, AppRole, FeatureAccessLevel } from '@/types/settings';
+import { ACCESS_LEVEL_ORDER, userHasApprovalPrivilege } from './permissions';
+
+function role(partial: Partial<AppRole>): AppRole {
+  return {
+    id: 'r1',
+    name: 'Role',
+    assigned_groups: [],
+    feature_permissions: {},
+    ...partial,
+  } as AppRole;
+}
+
+describe('permissions', () => {
+  describe('ACCESS_LEVEL_ORDER', () => {
+    it('ranks access levels from none up to admin', () => {
+      expect(ACCESS_LEVEL_ORDER[FeatureAccessLevel.NONE]).toBe(0);
+      expect(ACCESS_LEVEL_ORDER[FeatureAccessLevel.ADMIN]).toBe(5);
+      expect(ACCESS_LEVEL_ORDER[FeatureAccessLevel.READ_WRITE]).toBeGreaterThan(
+        ACCESS_LEVEL_ORDER[FeatureAccessLevel.READ_ONLY],
+      );
+    });
+  });
+
+  describe('userHasApprovalPrivilege', () => {
+    const roles: AppRole[] = [
+      role({
+        id: 'stewards',
+        assigned_groups: ['Data-Stewards'],
+        approval_privileges: { [ApprovalEntity.CONTRACTS]: true },
+      }),
+      role({
+        id: 'viewers',
+        assigned_groups: ['viewers'],
+        approval_privileges: { [ApprovalEntity.CONTRACTS]: false },
+      }),
+    ];
+
+    it('uses the applied role override when provided', () => {
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, [], roles, 'stewards')).toBe(true);
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, [], roles, 'viewers')).toBe(false);
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, [], roles, 'missing')).toBe(false);
+    });
+
+    it('grants when the user is in a matching role group (case-insensitive)', () => {
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, ['data-stewards'], roles, null)).toBe(
+        true,
+      );
+    });
+
+    it('denies when no group matches', () => {
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, ['randoms'], roles, null)).toBe(false);
+    });
+
+    it('denies when the matching role lacks the privilege', () => {
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, ['viewers'], roles, null)).toBe(false);
+    });
+
+    it('handles nullish user groups', () => {
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, null, roles, null)).toBe(false);
+      expect(userHasApprovalPrivilege(ApprovalEntity.CONTRACTS, undefined, roles, null)).toBe(false);
+    });
+  });
+});

--- a/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { systemRdfNamespaceDisplayLabel } from './system-rdf-namespace-labels';
+
+describe('systemRdfNamespaceDisplayLabel', () => {
+  // Minimal stand-in for i18next's `t`: echoes the supplied defaultValue.
+  const t = ((key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key) as any;
+
+  it('returns the translated default label for a known system key', () => {
+    expect(systemRdfNamespaceDisplayLabel('urn:meta:sources', t)).toBe('Source registry metadata');
+    expect(systemRdfNamespaceDisplayLabel('urn:semantic-links', t)).toBe('Semantic links');
+    expect(systemRdfNamespaceDisplayLabel('urn:x-rdflib:default', t)).toBe('Default graph');
+    expect(systemRdfNamespaceDisplayLabel('urn:app-entities', t)).toBe('App Entities');
+    expect(systemRdfNamespaceDisplayLabel('urn:demo', t)).toBe('Demo business concepts');
+  });
+
+  it('passes the i18n key and default through to t', () => {
+    const spy = vi.fn((_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? '');
+    systemRdfNamespaceDisplayLabel('urn:demo', spy as any);
+    expect(spy).toHaveBeenCalledWith(
+      'rdfSources.systemNamespaces.demoGraph',
+      expect.objectContaining({ defaultValue: 'Demo business concepts' }),
+    );
+  });
+
+  it('returns the original key for an unknown namespace', () => {
+    expect(systemRdfNamespaceDisplayLabel('urn:something-else', t)).toBe('urn:something-else');
+  });
+});

--- a/src/frontend/src/lib/uc-search-parser.test.ts
+++ b/src/frontend/src/lib/uc-search-parser.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { UCAssetType } from '@/types/uc-asset';
+import {
+  parseSearchQuery,
+  matchesSegment,
+  findFirstMatch,
+  filterBySegment,
+  getTypeFilterDisplayName,
+  buildPathToLevel,
+  getNavigationLevel,
+  getCurrentLevelFilter,
+  isTypeAllowed,
+} from './uc-search-parser';
+
+describe('uc-search-parser', () => {
+  describe('parseSearchQuery', () => {
+    it('parses a plain dotted path into segments', () => {
+      const r = parseSearchQuery('lars.te.taa');
+      expect(r.typeFilter).toBeNull();
+      expect(r.segments).toEqual(['lars', 'te', 'taa']);
+      expect(r.endsWithDot).toBe(false);
+      expect(r.rawQuery).toBe('lars.te.taa');
+    });
+
+    it('extracts a type prefix', () => {
+      const r = parseSearchQuery('t:main.def');
+      expect(r.typeFilter).toBe(UCAssetType.TABLE);
+      expect(r.pathQuery).toBe('main.def');
+      expect(r.segments).toEqual(['main', 'def']);
+    });
+
+    it('detects a trailing dot as expansion intent', () => {
+      const r = parseSearchQuery('main.');
+      expect(r.endsWithDot).toBe(true);
+      expect(r.segments).toEqual(['main']);
+    });
+
+    it('ignores an unknown prefix and treats the colon text as path', () => {
+      const r = parseSearchQuery('zzz:foo');
+      expect(r.typeFilter).toBeNull();
+      // No known prefix matched, so the whole string stays as the path query.
+      expect(r.pathQuery).toBe('zzz:foo');
+    });
+
+    it('handles a bare type prefix with no path', () => {
+      const r = parseSearchQuery('v:');
+      expect(r.typeFilter).toBe(UCAssetType.VIEW);
+      expect(r.segments).toEqual([]);
+    });
+  });
+
+  describe('matchesSegment', () => {
+    it('matches prefixes case-insensitively', () => {
+      expect(matchesSegment('Lars_George', 'lars')).toBe(true);
+      expect(matchesSegment('orders', 'ord')).toBe(true);
+    });
+
+    it('does not match a non-prefix', () => {
+      expect(matchesSegment('orders', 'xyz')).toBe(false);
+    });
+
+    it('matches everything for an empty segment', () => {
+      expect(matchesSegment('anything', '')).toBe(true);
+    });
+  });
+
+  describe('findFirstMatch / filterBySegment', () => {
+    const items = [{ name: 'alpha' }, { name: 'apple' }, { name: 'beta' }];
+
+    it('finds the first matching item', () => {
+      expect(findFirstMatch(items, 'a')?.name).toBe('alpha');
+      expect(findFirstMatch(items, 'be')?.name).toBe('beta');
+    });
+
+    it('returns the first item when the segment is empty', () => {
+      expect(findFirstMatch(items, '')?.name).toBe('alpha');
+    });
+
+    it('filters items by segment', () => {
+      expect(filterBySegment(items, 'a').map((i) => i.name)).toEqual(['alpha', 'apple']);
+      expect(filterBySegment(items, '')).toEqual(items);
+    });
+  });
+
+  describe('getTypeFilterDisplayName', () => {
+    it('returns "All types" for null', () => {
+      expect(getTypeFilterDisplayName(null)).toBe('All types');
+    });
+
+    it('returns readable names per type', () => {
+      expect(getTypeFilterDisplayName(UCAssetType.TABLE)).toBe('Tables');
+      expect(getTypeFilterDisplayName(UCAssetType.MATERIALIZED_VIEW)).toBe('Materialized Views');
+      expect(getTypeFilterDisplayName(UCAssetType.FUNCTION)).toBe('Functions');
+      expect(getTypeFilterDisplayName(UCAssetType.VOLUME)).toBe('Volumes');
+      expect(getTypeFilterDisplayName(UCAssetType.METRIC)).toBe('Metrics');
+    });
+  });
+
+  describe('buildPathToLevel', () => {
+    it('joins segments up to the requested level', () => {
+      const segs = ['a', 'b', 'c'];
+      expect(buildPathToLevel(segs, 0)).toBe('a');
+      expect(buildPathToLevel(segs, 1)).toBe('a.b');
+      expect(buildPathToLevel(segs, 2)).toBe('a.b.c');
+    });
+  });
+
+  describe('getNavigationLevel', () => {
+    it('is 0 at the catalog level', () => {
+      expect(getNavigationLevel(parseSearchQuery(''))).toBe(0);
+    });
+
+    it('goes one level deeper after a trailing dot (capped at 2)', () => {
+      expect(getNavigationLevel(parseSearchQuery('a.'))).toBe(1);
+      expect(getNavigationLevel(parseSearchQuery('a.b.c.'))).toBe(2);
+    });
+
+    it('stays at the filtering level without a trailing dot', () => {
+      expect(getNavigationLevel(parseSearchQuery('a'))).toBe(0);
+      expect(getNavigationLevel(parseSearchQuery('a.b'))).toBe(1);
+    });
+  });
+
+  describe('getCurrentLevelFilter', () => {
+    it('returns the last segment when filtering', () => {
+      expect(getCurrentLevelFilter(parseSearchQuery('a.b'))).toBe('b');
+    });
+
+    it('returns empty after a trailing dot or with no segments', () => {
+      expect(getCurrentLevelFilter(parseSearchQuery('a.'))).toBe('');
+      expect(getCurrentLevelFilter(parseSearchQuery(''))).toBe('');
+    });
+  });
+
+  describe('isTypeAllowed', () => {
+    const allowed = [UCAssetType.TABLE, UCAssetType.VIEW];
+
+    it('rejects types not in the allowed list', () => {
+      expect(isTypeAllowed(UCAssetType.FUNCTION, null, allowed)).toBe(false);
+    });
+
+    it('honors an active type filter', () => {
+      expect(isTypeAllowed(UCAssetType.TABLE, UCAssetType.VIEW, allowed)).toBe(false);
+      expect(isTypeAllowed(UCAssetType.TABLE, UCAssetType.TABLE, allowed)).toBe(true);
+    });
+
+    it('allows any allowed type when no filter is set', () => {
+      expect(isTypeAllowed(UCAssetType.VIEW, null, allowed)).toBe(true);
+    });
+  });
+});

--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -30,8 +30,14 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
+      // Restrict the coverage universe to first-party source. Without an
+      // explicit include, `all: true` lets v8 instrument runtime-imported
+      // deps (e.g. @babel/runtime), which polluted lcov.info with ~1.3k
+      // node_modules entries and made Codecov unable to resolve the
+      // `frontend` flag (badge showed "unknown").
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
-        'node_modules/',
+        '**/node_modules/**',
         'src/test/',
         '**/*.d.ts',
         '**/*.config.*',
@@ -45,13 +51,15 @@ export default defineConfig({
         'vite.config.ts',
       ],
       all: true,
-      // Gates set to current baseline floors to prevent regressions.
-      // Ratchet up as coverage improves toward the 80% goal.
+      // Gates set to current baseline floors (just under measured coverage)
+      // to prevent regressions. Ratchet up as coverage improves toward the
+      // 80% goal. Measured at time of writing: lines/statements 10.2%,
+      // functions 36.1%, branches 72.1%.
       thresholds: {
-        lines: 3,
-        functions: 25,
-        branches: 55,
-        statements: 3,
+        lines: 10,
+        functions: 35,
+        branches: 70,
+        statements: 10,
       },
     },
   },

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -92,6 +92,12 @@ asyncio_mode = "strict"
 
 [tool.coverage.run]
 source = ["backend/src"]
+# Record repo-relative file paths (e.g. "backend/src/app.py") instead of paths
+# relative to the source root ("app.py"). Codecov's path fix in codecov.yml
+# (`backend/::src/backend/`) only matches paths that start with "backend/", so
+# without this the backend files never resolve against the repo tree and the
+# `backend` flag badge reported a diluted number instead of the real coverage.
+relative_files = true
 omit = [
     "*/tests/*",
     "*/test_*.py",


### PR DESCRIPTION
## What & why

The README coverage badges were not reporting correctly: the **backend** flag badge showed ~6% (the diluted overall blend, not the real ~34%) and the **frontend** flag badge showed `unknown`. Both turned out to be coverage-report path/scoping bugs rather than badge-markup issues. This PR fixes the root causes and, while in the coverage tooling, raises real frontend line coverage past the 10% floor.

## Badge fixes

**Backend flag resolved against the repo tree.** `coverage.xml` recorded file paths relative to the source root (`app.py`), but `codecov.yml`'s path fix `backend/::src/backend/` only matches paths that start with `backend/`. So backend files never mapped onto the repo tree and the `backend` flag reported a diluted number. Setting `relative_files = true` in `[tool.coverage.run]` makes coverage emit repo-relative paths (`backend/src/app.py`), which the existing fix then rewrites to `src/backend/src/app.py` as intended.

**Frontend flag stopped being polluted by node_modules.** With `all: true` and no explicit `include`, v8 instrumented runtime-imported deps, adding ~1,300 `node_modules/**` entries to `lcov.info`. Scoping coverage to `include: ['src/**/*.{ts,tsx}']` (and tightening the node_modules exclude glob) yields a clean, source-only report so Codecov can resolve the `frontend` flag.

No changes to the README badge URLs were needed — they are correct and will populate once the next run uploads cleanly-scoped reports.

## Coverage to 10%

- Frontend line coverage: **9.08% → 10.22%** via focused unit tests on pure `lib`/`config` modules: ODPS/ODCS lifecycle state machines, UC search parser, ontology label resolution, entity detail-path resolution, branding, format-label, permissions, system RDF namespace labels, and the feature catalog. 61 new tests, all green (845 passing total).
- Ratcheted the vitest gates from their old floors to the new baseline: `lines`/`statements` 3 → **10**, `functions` 25 → **35**, `branches` 55 → **70**.
- Backend is already at **33.7%** with the CI gate at `--fail-under=30` — already a stronger floor than 10%, so it is left unchanged.

## Testing

`vitest run --coverage` passes with all thresholds met (lines 10.22%). Backend path format verified by inspecting the regenerated `coverage.xml` (`<source>backend/src</source>` + `filename="app.py"` → resolves to `backend/src/app.py`).

This pull request and its description were written by Isaac.