### PR TITLE
fix: clear quick-win and test-cleanup SonarQube criticals

### DIFF
--- a/src/backend/src/common/unity_catalog_utils.py
+++ b/src/backend/src/common/unity_catalog_utils.py
@@ -59,7 +59,7 @@ def is_valid_uuid(identifier: str) -> bool:
         return False
 
 
-def sanitize_uc_identifier(identifier: str, max_length: int = 255) -> str:
+def sanitize_uc_identifier(identifier: Optional[str], max_length: int = 255) -> str:
     """Sanitize and validate a Unity Catalog identifier.
     
     Unity Catalog identifiers (catalog, schema, table, column names) must:
@@ -184,7 +184,7 @@ def sanitize_postgres_identifier(identifier: str, max_length: int = 63) -> str:
     return identifier
 
 
-def map_logical_type_to_column_type(logical_type: str) -> ColumnTypeName:
+def map_logical_type_to_column_type(logical_type: Optional[str]) -> ColumnTypeName:
     """Map a logical type string to Databricks ColumnTypeName enum.
     
     Args:

--- a/src/backend/src/controller/semantic_links_manager.py
+++ b/src/backend/src/controller/semantic_links_manager.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Union, TYPE_CHECKING
+from uuid import UUID
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 import re
@@ -239,7 +240,7 @@ class SemanticLinksManager:
             logger.warning(f"Failed to log change for semantic link add: {log_err}")
         return self._to_api(db_obj)
 
-    def remove(self, link_id: str, removed_by: Optional[str] = None) -> bool:
+    def remove(self, link_id: Union[str, UUID], removed_by: Optional[str] = None) -> bool:
         removed = entity_semantic_links_repo.remove(self._db, id=link_id)
         try:
             manager = None

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -2965,7 +2965,7 @@ class SemanticModelsManager:
         try:
             coll_context = self._graph.get_context(URIRef(collection_iri))
             self._graph.remove_context(coll_context)
-        except:
+        except Exception:
             pass
         
         self._db.commit()

--- a/src/backend/src/tests/unit/test_audit_log_repository.py
+++ b/src/backend/src/tests/unit/test_audit_log_repository.py
@@ -39,7 +39,6 @@ class TestAuditLogRepository:
         db_session.refresh(log_db)
 
         # Assert
-        assert log_db is not None
         assert log_db.username == "test-user"
 
     def test_get_audit_log_by_id(self, repository, db_session):

--- a/src/backend/src/tests/unit/test_change_log_repository.py
+++ b/src/backend/src/tests/unit/test_change_log_repository.py
@@ -37,7 +37,6 @@ class TestChangeLogRepository:
         db_session.refresh(log_db)
 
         # Assert
-        assert log_db is not None
         assert log_db.entity_type == "data_product"
 
     def test_get_change_log_by_id(self, repository, db_session):

--- a/src/backend/src/tests/unit/test_data_products_manager.py
+++ b/src/backend/src/tests/unit/test_data_products_manager.py
@@ -602,8 +602,8 @@ class TestDataProductsManager:
         manager = DataProductsManager(db=db_session, ws_client=None)
 
         # Assert
-        # Should initialize but log warning
-        assert manager is not None
+        # Should initialize but log warning; ws_client stored as None
+        assert manager._ws_client is None
         # SDK operations should handle missing client gracefully
 
     def test_manager_without_notifications(self, db_session):
@@ -616,5 +616,5 @@ class TestDataProductsManager:
         )
 
         # Assert
-        assert manager is not None
+        assert manager._notifications_manager is None
         # Should work but notifications won't be sent

--- a/src/backend/src/tests/unit/test_data_profiling_runs_repository.py
+++ b/src/backend/src/tests/unit/test_data_profiling_runs_repository.py
@@ -43,7 +43,6 @@ class TestDataProfilingRunsRepository:
         db_session.refresh(run_db)
 
         # Assert
-        assert run_db is not None
         assert run_db.contract_id == sample_contract_id
 
     def test_get_profiling_run_by_id(self, repository, db_session, sample_contract_id):

--- a/src/backend/src/tests/unit/test_notification_repository.py
+++ b/src/backend/src/tests/unit/test_notification_repository.py
@@ -37,7 +37,6 @@ class TestNotificationRepository:
         db_session.refresh(notification_db)
 
         # Assert
-        assert notification_db is not None
         assert notification_db.title == "Test Notification"
 
     def test_get_notification_by_id(self, repository, db_session):

--- a/src/backend/src/tests/unit/test_projects_repository.py
+++ b/src/backend/src/tests/unit/test_projects_repository.py
@@ -43,7 +43,6 @@ class TestProjectRepository:
         db_session.refresh(project_db)
 
         # Assert
-        assert project_db is not None
         assert project_db.name == "Test Project"
 
     # =====================================================================

--- a/src/backend/src/tests/unit/test_semantic_models_repository.py
+++ b/src/backend/src/tests/unit/test_semantic_models_repository.py
@@ -36,7 +36,6 @@ class TestSemanticModelsRepository:
         db_session.refresh(model_db)
 
         # Assert
-        assert model_db is not None
         assert model_db.name == "Test Model"
 
     def test_get_semantic_model_by_id(self, repository, db_session):

--- a/src/backend/src/tests/unit/test_teams_repository.py
+++ b/src/backend/src/tests/unit/test_teams_repository.py
@@ -51,7 +51,6 @@ class TestTeamRepository:
         db_session.refresh(team_db)
 
         # Assert
-        assert team_db is not None
         assert team_db.name == "Test Team"
 
     # =====================================================================

--- a/src/backend/src/tests/unit/test_workflow_installations_repository.py
+++ b/src/backend/src/tests/unit/test_workflow_installations_repository.py
@@ -37,7 +37,6 @@ class TestWorkflowInstallationRepository:
         db_session.refresh(installation_db)
 
         # Assert
-        assert installation_db is not None
         assert installation_db.workflow_id == "test-workflow"
 
     def test_get_installation_by_id(self, repository, db_session):

--- a/src/backend/src/tests/unit/test_workflow_job_runs_repository.py
+++ b/src/backend/src/tests/unit/test_workflow_job_runs_repository.py
@@ -51,7 +51,6 @@ class TestWorkflowJobRunRepository:
         db_session.refresh(job_run_db)
 
         # Assert
-        assert job_run_db is not None
         assert job_run_db.run_id == 98765
 
     def test_get_job_run_by_id(self, repository, db_session, sample_installation):

--- a/src/backend/src/utils/contract_cloner.py
+++ b/src/backend/src/utils/contract_cloner.py
@@ -21,9 +21,6 @@ class ContractCloner:
     - Sets version metadata (version_family_id, parent_contract_id, change_summary)
     """
 
-    def __init__(self):
-        pass
-
     def clone_for_new_version(
         self,
         source_contract_db,


### PR DESCRIPTION
## What & why

Follow-up to #507 (blockers). This clears the low-volume, bug-adjacent **CRITICAL** code smells flagged by SonarQube. The bulk maintainability criticals (`S1192` duplicated literals ×309, `S3776` cognitive complexity ×279) are intentionally **out of scope** — they're a separate deliberate refactor effort, not quick wins. No production behavior changes here.

## Fixes by rule

**`python:S5754` — bare `except` (1)**
- `controller/semantic_models_manager.py`: a bare `except:` around KG context removal also swallowed `KeyboardInterrupt`/`SystemExit`. Narrowed to `except Exception:`.

**`python:S1186` — empty method (1)**
- `utils/contract_cloner.py`: removed a no-op `def __init__(self): pass` (class has no base requiring it).

**`python:S5655` — argument type mismatch (3)**
These were flagged in tests that deliberately pass `None`/`UUID` to exercise edge cases. Rather than weaken the tests, the input type hints were widened to reflect what the code already accepts:
- `sanitize_uc_identifier(identifier: Optional[str])` — it validates and rejects `None` with a `ValueError`.
- `map_logical_type_to_column_type(logical_type: Optional[str])` — it already does `(logical_type or '')`.
- `SemanticLinksManager.remove(link_id: Union[str, UUID])` — passes the id straight to the repo, which the integration test exercises with a `UUID`.

**`python:S5727` — identity check always true (11)**
- Redundant `assert x is not None` on freshly-created objects in unit tests. Removed where a stronger assertion follows (9). For the two `test_data_products_manager` init tests where it was the sole assertion, replaced with a meaningful degraded-state check (`assert manager._ws_client is None` / `assert manager._notifications_manager is None`).

## Testing

- Affected unit tests pass.
- The 7 pre-existing `test_data_products_manager` failures (SQLite integrity quirks, `DID NOT RAISE`) are unchanged from `main` — verified by stashing this branch's changes and re-running.

## SonarQube rescan

Local rescan (9.9.8 LTS) of this branch confirms all four targeted rules drop to **0**:

| Rule | Before | After |
|---|---|---|
| S5754 | 1 | 0 |
| S1186 | 1 | 0 |
| S5655 | 3 | 0 |
| S5727 | 11 | 0 |
| **Critical total** | 612 | **596** |

This pull request and its description were written by Isaac.