### PR TITLE
feat(auth): add DATABRICKS_CONFIG_PROFILE OAuth U2M fallback for local dev

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -26,8 +26,15 @@ Create a `.env` file in the project root (see `.env.example` for a complete temp
 | `DATABRICKS_SCHEMA` | Default Unity Catalog schema | `default` | No |
 | `DATABRICKS_VOLUME` | Volume for storing app-related files | `app_volume` | Yes |
 | `DATABRICKS_TOKEN` | Personal access token (optional - SDK can use other auth methods) | `dapi1234567890abcdef` | No |
+| `DATABRICKS_CONFIG_PROFILE` | Profile name in `~/.databrickscfg` for OAuth U2M auth (auto-refreshes). Used only when `DATABRICKS_TOKEN` is not set. | `DEFAULT` | No |
 
 **Note:** `DATABRICKS_HTTP_PATH` is derived automatically from `DATABRICKS_WAREHOUSE_ID` and does not need to be set manually.
+
+**Databricks auth resolution order (local dev):**
+
+1. `DATABRICKS_TOKEN` — Personal Access Token (PAT). Highest priority; useful for workspaces that still issue PATs.
+2. `DATABRICKS_CONFIG_PROFILE` — named profile in `~/.databrickscfg`. The Databricks SDK uses OAuth U2M and auto-refreshes the token, so this works even when admins disable PATs (run `databricks auth login --profile <name>` once to seed the profile).
+3. SDK implicit auth — used in Databricks Apps where the platform injects credentials.
 
 ### Database Configuration
 

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -18,6 +18,9 @@ APP_DB_ECHO=False            # Log SQLAlchemy generated SQL statements (True/Fal
 DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
 # DATABRICKS_TOKEN=dapi123... # Optional: Databricks Personal Access Token.
                              # If not set, SDK will try other auth methods (CLI profile, OAuth).
+# DATABRICKS_CONFIG_PROFILE=DEFAULT  # Optional: profile name in ~/.databrickscfg
+                                    # Used for OAuth U2M auth (auto-refreshes). Takes effect
+                                    # only when DATABRICKS_TOKEN is not set.
 
 # --- Databricks Volume for App Data ---
 # Required for features like audit logs, data contract outputs, etc.

--- a/src/backend/src/common/config.py
+++ b/src/backend/src/common/config.py
@@ -55,6 +55,9 @@ class Settings(BaseSettings):
     DATABRICKS_SCHEMA: str = Field("app_ontos", env='DATABRICKS_SCHEMA')  # Default schema
     DATABRICKS_VOLUME: Optional[str] = Field(None, env='DATABRICKS_VOLUME')  # Full volume path (injected by Databricks Apps)
     DATABRICKS_TOKEN: Optional[str] = None  # Optional since handled by SDK
+    DATABRICKS_CONFIG_PROFILE: Optional[str] = Field(
+        None, env='DATABRICKS_CONFIG_PROFILE'
+    )  # Local dev: name of profile in ~/.databrickscfg (OAuth U2M with auto-refresh)
     DATABRICKS_HTTP_PATH: Optional[str] = None # Will be computed by validator
     DATABRICKS_APP_NAME: str = Field("ontos", env='DATABRICKS_APP_NAME')  # Name of the Databricks App
 

--- a/src/backend/src/common/llm_client.py
+++ b/src/backend/src/common/llm_client.py
@@ -52,13 +52,22 @@ def create_openai_client(
         try:
             from databricks.sdk.core import Config
 
-            config = Config()
+            config_kwargs = {}
+            if settings.DATABRICKS_CONFIG_PROFILE:
+                # pydantic doesn't push .env values to os.environ; pass profile explicitly
+                config_kwargs["profile"] = settings.DATABRICKS_CONFIG_PROFILE
+            config = Config(**config_kwargs)
             headers = config.authenticate()
             if headers and "Authorization" in headers:
                 auth_header = headers["Authorization"]
                 if auth_header.startswith("Bearer "):
                     token = auth_header[7:]
-                    logger.info("Using token from Databricks SDK (default config)")
+                    logger.info(
+                        "Using token from Databricks SDK (%s)",
+                        f"profile={settings.DATABRICKS_CONFIG_PROFILE}"
+                        if settings.DATABRICKS_CONFIG_PROFILE
+                        else "default config",
+                    )
         except Exception as sdk_err:
             logger.debug("Could not get token from SDK config: %s", sdk_err)
 

--- a/src/backend/src/common/workspace_client.py
+++ b/src/backend/src/common/workspace_client.py
@@ -316,7 +316,9 @@ def get_workspace_client(settings: Optional[Settings] = None, timeout: int = 30)
 
     # Determine authentication mode and cache key
     token = settings.DATABRICKS_TOKEN
-    
+    profile = settings.DATABRICKS_CONFIG_PROFILE
+    skip_cluster_check = False
+
     if token:
         # Explicit token authentication (e.g., local development)
         token_hash = _get_token_hash(token)
@@ -346,6 +348,29 @@ def get_workspace_client(settings: Optional[Settings] = None, timeout: int = 30)
         )
         
         cache_identifier = token_hash
+    elif profile:
+        # CLI profile authentication (OAuth U2M from ~/.databrickscfg, auto-refreshes)
+        cache_key = f"profile_{profile}"
+
+        if cache_key in _CLIENT_CACHE:
+            cached_client, cached_identifier, _ = _CLIENT_CACHE[cache_key]
+            _CLIENT_CACHE[cache_key] = (cached_client, cached_identifier, time.time())
+            logger.info(f"Reusing cached profile workspace client (profile={profile})")
+            return cached_client
+
+        logger.info(f"Initializing NEW profile workspace client (profile={profile}, timeout={timeout}s)")
+
+        # Don't pass host explicitly: profile carries it; passing both can make the SDK
+        # ignore the profile's auth and fall back to env-based auth.
+        client = WorkspaceClient(
+            profile=profile,
+            product="ontos",
+            product_version=__version__,
+        )
+
+        cache_identifier = profile
+        # U2M tokens commonly lack clusters:read; use lighter verification
+        skip_cluster_check = True
     else:
         # Implicit authentication (e.g., Databricks Apps)
         cache_key = "implicit_auth"
@@ -370,7 +395,7 @@ def get_workspace_client(settings: Optional[Settings] = None, timeout: int = 30)
         cache_identifier = "implicit"
 
     # Verify connectivity and set telemetry headers
-    verified_client = _verify_workspace_client(client)
+    verified_client = _verify_workspace_client(client, skip_cluster_check=skip_cluster_check)
 
     caching_client = CachingWorkspaceClient(verified_client, timeout=timeout)
 


### PR DESCRIPTION
## Summary

Adds a CLI-profile auth path so local startup keeps working when admins revoke PATs. The Databricks SDK reads `~/.databrickscfg` and auto-refreshes the OAuth token — no manual hourly repaste.

Local auth resolution order after this change:
1. `DATABRICKS_TOKEN` set -> existing PAT path (workspaces that still issue PATs keep working)
2. `DATABRICKS_CONFIG_PROFILE` set -> new profile path (`WorkspaceClient(profile=...)`)
3. Neither set -> existing Databricks Apps implicit-auth path

### Why

Field-eng admins disabled PATs for the local user, which crashed `startup_event` in `src/backend/src/app.py` with `PermissionDenied: API tokens are disabled for user 8432093917481966`. The Databricks CLI already has a working OAuth U2M session for the affected workspace, so wiring the SDK to that profile is the cleanest fix.

### Changes

- `src/backend/src/common/config.py` — new `DATABRICKS_CONFIG_PROFILE: Optional[str]` setting next to `DATABRICKS_TOKEN`.
- `src/backend/src/common/workspace_client.py` — profile branch in `get_workspace_client()`, cached as `profile_<name>`, verified with `skip_cluster_check=True` (U2M tokens commonly lack `clusters:read`). Builds `WorkspaceClient(profile=..., product=...)` without passing `host` so the profile's auth wins.
- `src/backend/src/common/llm_client.py` — passes `profile=settings.DATABRICKS_CONFIG_PROFILE` to `Config()` in the SDK token fallback (pydantic doesn't push `.env` values to `os.environ`, so the SDK wouldn't see them otherwise).
- `src/backend/.env.example`, `CONFIGURING.md` — document the new env var and the resolution order.

### What is intentionally NOT changed

- `databricks.sql` warehouse connector / `DATABRICKS_HTTP_PATH` — not on the failing startup path; revisit only if a SQL-warehouse code path also breaks.
- `get_obo_workspace_client` — Databricks Apps OBO flow is unaffected.
- Tests under `src/backend/src/tests/` — they hard-code `DATABRICKS_TOKEN`, which still works under the PAT branch.

## Test plan

- [x] Local backend starts cleanly with `DATABRICKS_CONFIG_PROFILE=e2-demo-field-eng` and PAT commented out. `/tmp/backend.log` shows:
  - `Initializing NEW profile workspace client (profile=e2-demo-field-eng, timeout=30s)`
  - `loading e2-demo-field-eng profile from ~/.databrickscfg: host, auth_type, account_id, workspace_id`
  - `Workspace connectivity verified successfully (OBO mode)`
  - `Initializing Grant Manager... -> Grant Manager initialized` (previous failure point)
  - `Application startup complete`
  - No `PermissionDenied: API tokens are disabled` errors.
- [ ] Reviewer: confirm a workspace that still has `DATABRICKS_TOKEN=dapi...` set continues to use the PAT branch (`Initializing NEW service principal workspace client ...`).
- [ ] Reviewer: confirm Databricks Apps deployment (no `DATABRICKS_TOKEN`, no `DATABRICKS_CONFIG_PROFILE`) still hits the implicit-auth branch.