### PR TITLE
feat(semantic-models): humanize RDF source labels across UI

### DIFF
--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -39,6 +39,7 @@ from src.common.sparql_validator import SPARQLQueryValidator
 from src.utils.semantic_model_title_candidates import (
     best_display_title_from_graph,
     extract_title_candidates,
+    humanize_rdf_filename,
 )
 from src.utils.rdf_serialization_display import serialization_label_for_stored_model
 from src.owl.owl_parser import clean_truncated_turtle
@@ -238,11 +239,30 @@ class SemanticModelsManager:
         return self._to_api(updated)
 
     def get_title_candidates(self, model_id: str) -> Optional[List[dict]]:
-        """Return suggested titles from ontology header resources, or None if model not found."""
+        """Return suggested titles for a model, or None if the model is not found.
+
+        Sources, in priority order:
+          1. ``owl:Ontology`` / ``skos:ConceptScheme`` header literals
+             (``rdfs:label``, ``skos:prefLabel``, ``dcterms:title``, ``dc:title``).
+          2. A humanized version of the original filename
+             (``pizza.owl`` → ``Pizza``) so the user always has a sensible
+             non-custom option in the title-edit dialog.
+        """
         db_obj = semantic_models_repo.get(self._db, id=model_id)
         if not db_obj:
             return None
-        return extract_title_candidates(db_obj.content_text or "", db_obj.format)
+        candidates = extract_title_candidates(db_obj.content_text or "", db_obj.format)
+        source_filename = db_obj.original_filename or db_obj.name
+        humanized = humanize_rdf_filename(source_filename) if source_filename else ""
+        if humanized and humanized != source_filename and not any(
+            (c.get("text") or "").strip() == humanized for c in candidates
+        ):
+            candidates.append({
+                "iri": f"file:{source_filename}",
+                "kind": "filename",
+                "text": humanized,
+            })
+        return candidates
 
     def replace_content(self, model_id: str, content_text: str, original_filename: Optional[str], content_type: Optional[str], size_bytes: Optional[int], updated_by: Optional[str]) -> Optional[SemanticModelApi]:
         db_obj = semantic_models_repo.get(self._db, id=model_id)
@@ -780,7 +800,20 @@ class SemanticModelsManager:
             existing_collections.add(str(subj))
         
         registered_count = 0
-        
+
+        # Pre-build a map of sanitized model name -> stored display_name so we
+        # can honor explicit titles set on uploaded models when registering
+        # their `urn:semantic-model:*` contexts as collections.
+        semantic_model_display_names: Dict[str, str] = {}
+        try:
+            for m in semantic_models_repo.get_multi(self._db, skip=0, limit=10_000):
+                if not m.display_name:
+                    continue
+                sanitized = _sanitize_context_name(m.name)
+                semantic_model_display_names[f"urn:semantic-model:{sanitized}"] = m.display_name.strip()
+        except Exception as e:
+            logger.debug(f"Could not preload semantic model display names: {e}")
+
         # Scan all contexts and register missing ones
         for context in self._graph.contexts():
             context_name = str(context.identifier)
@@ -793,23 +826,33 @@ class SemanticModelsManager:
             if context_name in existing_collections:
                 continue
             
-            # Infer collection type and label from context name
+            # Infer collection type and label from context name. Labels are
+            # produced by `humanize_rdf_filename`, which strips known RDF
+            # extensions and preserves common acronyms (FIBO, GS1, ...).
             if context_name.startswith("urn:taxonomy:"):
                 coll_type = "taxonomy"
-                label = context_name.replace("urn:taxonomy:", "").replace("-", " ").replace("_", " ").title()
+                suffix = context_name[len("urn:taxonomy:"):]
+                label = humanize_rdf_filename(suffix) or suffix
             elif context_name.startswith("urn:glossary:"):
                 coll_type = "glossary"
-                label = context_name.replace("urn:glossary:", "").replace("-", " ").replace("_", " ").title()
+                suffix = context_name[len("urn:glossary:"):]
+                label = humanize_rdf_filename(suffix) or suffix
             elif context_name.startswith("urn:ontology:"):
                 coll_type = "ontology"
-                label = context_name.replace("urn:ontology:", "").replace("-", " ").replace("_", " ").title()
+                suffix = context_name[len("urn:ontology:"):]
+                label = humanize_rdf_filename(suffix) or suffix
             elif context_name.startswith("urn:semantic-model:"):
                 coll_type = "ontology"
-                label = context_name.replace("urn:semantic-model:", "").replace("-", " ").replace("_", " ").title()
+                explicit = semantic_model_display_names.get(context_name)
+                if explicit:
+                    label = explicit
+                else:
+                    suffix = context_name[len("urn:semantic-model:"):]
+                    label = humanize_rdf_filename(suffix) or suffix
             else:
                 coll_type = "ontology"
-                # Extract label from last segment
-                label = context_name.split(":")[-1].replace("-", " ").replace("_", " ").title()
+                suffix = context_name.split(":")[-1]
+                label = humanize_rdf_filename(suffix) or suffix
             
             # Count concepts in this context
             concept_count = len(list(context.subjects(RDF.type, SKOS.Concept)))
@@ -860,10 +903,89 @@ class SemanticModelsManager:
                 )
             
             registered_count += 1
-        
-        if registered_count > 0:
+
+        # Second pass: refresh labels of *existing* imported/system collections
+        # whose stored `rdfs:label` no longer matches what the current humanizer
+        # would produce. Skips user-editable collections so any manual edits via
+        # the Collections tab are never overwritten.
+        refreshed_count = 0
+        managed_prefixes = (
+            "urn:taxonomy:",
+            "urn:glossary:",
+            "urn:ontology:",
+            "urn:semantic-model:",
+        )
+        for coll_iri in existing_collections:
+            if not coll_iri.startswith(managed_prefixes):
+                continue
+            coll_uri = URIRef(coll_iri)
+            is_editable_raw = self._get_literal(meta_context, coll_uri, ONTOS.isEditable)
+            is_editable = (is_editable_raw or "").strip().lower() in {"true", "1"}
+            if is_editable:
+                continue
+
+            # Compute expected label using the same priority chain as new rows.
+            if coll_iri.startswith("urn:semantic-model:"):
+                explicit = semantic_model_display_names.get(coll_iri)
+                if explicit:
+                    expected = explicit
+                else:
+                    suffix = coll_iri[len("urn:semantic-model:"):]
+                    expected = humanize_rdf_filename(suffix) or suffix
+            else:
+                for prefix in managed_prefixes:
+                    if coll_iri.startswith(prefix):
+                        suffix = coll_iri[len(prefix):]
+                        break
+                expected = humanize_rdf_filename(suffix) or suffix
+
+            current = self._get_literal(meta_context, coll_uri, RDFS.label)
+            if not expected or current == expected:
+                continue
+
+            # Update in-memory graph
+            meta_context.remove((coll_uri, RDFS.label, None))
+            meta_context.add((coll_uri, RDFS.label, Literal(expected)))
+
+            # Update persisted triple (delete old literal, insert new one)
+            try:
+                if current is not None:
+                    rdf_triples_repo.remove_triple(
+                        self._db,
+                        subject_uri=coll_iri,
+                        predicate_uri=str(RDFS.label),
+                        object_value=current,
+                        context_name=META_CONTEXT,
+                    )
+                rdf_triples_repo.add_triple(
+                    self._db,
+                    subject_uri=coll_iri,
+                    predicate_uri=str(RDFS.label),
+                    object_value=expected,
+                    object_is_uri=False,
+                    context_name=META_CONTEXT,
+                    source_type="collection",
+                    source_identifier=coll_iri,
+                    created_by="system",
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to persist refreshed label for %s: %s", coll_iri, e
+                )
+                continue
+
+            logger.info(
+                "Refreshed collection label %s: %r -> %r",
+                coll_iri, current, expected,
+            )
+            refreshed_count += 1
+
+        if registered_count > 0 or refreshed_count > 0:
             self._db.commit()
-            logger.info(f"Auto-registered {registered_count} sources as collections")
+            if registered_count > 0:
+                logger.info(f"Auto-registered {registered_count} sources as collections")
+            if refreshed_count > 0:
+                logger.info(f"Refreshed labels for {refreshed_count} imported collections")
 
     def rebuild_graph_from_enabled(self) -> None:
         """Rebuild the in-memory RDF graph from database and dynamic sources.

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -12,7 +12,11 @@ from src.models.ontology import (
     ConceptSearchResult
 )
 from src.models.semantic_models import SemanticModelCreate, SemanticModelUpdate
-from src.utils.semantic_model_title_candidates import extract_title_candidates, pick_auto_display_name
+from src.utils.semantic_model_title_candidates import (
+    extract_title_candidates,
+    humanize_rdf_filename,
+    pick_auto_display_name,
+)
 from src.utils.rdf_serialization_display import serialization_label_for_graph_taxonomy
 from src.common.dependencies import CurrentUserDep, AuditManagerDep, DBSessionDep, AuditCurrentUserDep
 from src.common.authorization import PermissionChecker
@@ -257,9 +261,16 @@ async def upload_semantic_model(
                 detail=f"Failed to parse ontology file. Please check the file format and syntax. Error: {str(parse_error)}"
             )
         
-        # Create semantic model in database (optional display title from ontology header)
+        # Create semantic model in database.
+        # Display title priority:
+        #   1. owl:Ontology / skos:ConceptScheme header literal (rdfs:label, dcterms:title, ...)
+        #   2. Humanized filename fallback (strip extension, prettify casing)
         title_candidates = extract_title_candidates(content_text, format_type)
         auto_display_name = pick_auto_display_name(title_candidates)
+        if not auto_display_name:
+            humanized = humanize_rdf_filename(safe_filename)
+            if humanized and humanized != safe_filename:
+                auto_display_name = humanized
         create_data = SemanticModelCreate(
             name=safe_filename,
             display_name=auto_display_name,

--- a/src/backend/src/tests/unit/test_register_sources_collection_labels.py
+++ b/src/backend/src/tests/unit/test_register_sources_collection_labels.py
@@ -1,0 +1,150 @@
+"""Tests for label backfill in `_register_sources_as_collections`.
+
+The auto-registration step also refreshes the `rdfs:label` of already-
+registered, system-managed (`isEditable = "false"`) `ontos:KnowledgeCollection`
+rows when the current humanizer would produce a different result. Editable
+collections must be left untouched so user edits in the Collections tab never
+get clobbered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from rdflib import Literal, Namespace, RDF, RDFS, URIRef
+
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.repositories.rdf_triples_repository import rdf_triples_repo
+
+ONTOS = Namespace("http://ontos.app/ontology#")
+META_CONTEXT = "urn:meta:sources"
+
+
+@pytest.fixture
+def manager_no_rebuild(db_session, tmp_path):
+    """Manager with the heavy graph rebuild step stubbed out."""
+    with patch.object(SemanticModelsManager, "rebuild_graph_from_enabled", lambda self: None):
+        yield SemanticModelsManager(db_session, data_dir=tmp_path)
+
+
+def _seed_collection(
+    manager: SemanticModelsManager,
+    coll_iri: str,
+    label: str,
+    is_editable: bool,
+) -> None:
+    """Insert an `ontos:KnowledgeCollection` row directly into the meta graph and DB."""
+    meta_context = manager._graph.get_context(URIRef(META_CONTEXT))
+    coll_uri = URIRef(coll_iri)
+    meta_context.add((coll_uri, RDF.type, ONTOS.KnowledgeCollection))
+    meta_context.add((coll_uri, RDFS.label, Literal(label)))
+    meta_context.add((coll_uri, ONTOS.isEditable, Literal("true" if is_editable else "false")))
+
+    triples = [
+        (coll_iri, str(RDF.type), str(ONTOS.KnowledgeCollection), True),
+        (coll_iri, str(RDFS.label), label, False),
+        (coll_iri, str(ONTOS.isEditable), "true" if is_editable else "false", False),
+    ]
+    for subj, pred, obj, is_uri in triples:
+        rdf_triples_repo.add_triple(
+            manager._db,
+            subject_uri=subj,
+            predicate_uri=pred,
+            object_value=obj,
+            object_is_uri=is_uri,
+            context_name=META_CONTEXT,
+            source_type="collection",
+            source_identifier=coll_iri,
+            created_by="test",
+        )
+    manager._db.commit()
+
+
+def _current_label(manager: SemanticModelsManager, coll_iri: str) -> str | None:
+    meta_context = manager._graph.get_context(URIRef(META_CONTEXT))
+    return manager._get_literal(meta_context, URIRef(coll_iri), RDFS.label)
+
+
+def _persisted_label_count(manager: SemanticModelsManager, coll_iri: str, value: str) -> int:
+    """Count `rdfs:label` triples in the DB for a collection with the given object value."""
+    from src.db_models.rdf_triples import RdfTripleDb
+
+    return manager._db.query(RdfTripleDb).filter(
+        RdfTripleDb.subject_uri == coll_iri,
+        RdfTripleDb.predicate_uri == str(RDFS.label),
+        RdfTripleDb.object_value == value,
+        RdfTripleDb.context_name == META_CONTEXT,
+    ).count()
+
+
+def test_imported_collection_with_stale_label_is_refreshed(manager_no_rebuild):
+    coll_iri = "urn:semantic-model:pizza.owl"
+    _seed_collection(manager_no_rebuild, coll_iri, "Pizza.Owl", is_editable=False)
+
+    manager_no_rebuild._register_sources_as_collections()
+
+    assert _current_label(manager_no_rebuild, coll_iri) == "Pizza"
+    assert _persisted_label_count(manager_no_rebuild, coll_iri, "Pizza") == 1
+    assert _persisted_label_count(manager_no_rebuild, coll_iri, "Pizza.Owl") == 0
+
+
+def test_imported_collection_with_legacy_titlecase_is_refreshed(manager_no_rebuild):
+    """Pre-existing `Odcs Ontology` should become `ODCS Ontology` after acronyms were added."""
+    coll_iri = "urn:taxonomy:odcs-ontology"
+    _seed_collection(manager_no_rebuild, coll_iri, "Odcs Ontology", is_editable=False)
+
+    manager_no_rebuild._register_sources_as_collections()
+
+    assert _current_label(manager_no_rebuild, coll_iri) == "ODCS Ontology"
+
+
+def test_editable_collection_label_is_left_untouched(manager_no_rebuild):
+    coll_iri = "urn:taxonomy:user-edited-glossary"
+    _seed_collection(
+        manager_no_rebuild, coll_iri, "Pretty Glossary Title", is_editable=True
+    )
+
+    manager_no_rebuild._register_sources_as_collections()
+
+    assert _current_label(manager_no_rebuild, coll_iri) == "Pretty Glossary Title"
+
+
+def test_label_already_correct_is_noop(manager_no_rebuild):
+    coll_iri = "urn:taxonomy:databricks_ontology"
+    _seed_collection(manager_no_rebuild, coll_iri, "Databricks Ontology", is_editable=False)
+
+    manager_no_rebuild._register_sources_as_collections()
+
+    assert _current_label(manager_no_rebuild, coll_iri) == "Databricks Ontology"
+    # Still exactly one persisted row for the (unchanged) label.
+    assert _persisted_label_count(manager_no_rebuild, coll_iri, "Databricks Ontology") == 1
+
+
+def test_uploaded_model_display_name_wins_over_humanized_suffix(manager_no_rebuild, db_session):
+    """If the corresponding semantic model has an explicit display_name set, use it."""
+    from src.db_models.semantic_models import SemanticModelDb
+    import uuid
+
+    db_session.add(
+        SemanticModelDb(
+            id=str(uuid.uuid4()),
+            name="pizza.owl",
+            display_name="My Custom Pizza Title",
+            format="rdfs",
+            content_text="",
+            original_filename="pizza.owl",
+            content_type=None,
+            size_bytes="0",
+            enabled=True,
+            created_by="test",
+        )
+    )
+    db_session.commit()
+
+    coll_iri = "urn:semantic-model:pizza.owl"
+    _seed_collection(manager_no_rebuild, coll_iri, "Pizza.Owl", is_editable=False)
+
+    manager_no_rebuild._register_sources_as_collections()
+
+    assert _current_label(manager_no_rebuild, coll_iri) == "My Custom Pizza Title"

--- a/src/backend/src/tests/unit/test_semantic_model_title_candidates.py
+++ b/src/backend/src/tests/unit/test_semantic_model_title_candidates.py
@@ -8,6 +8,7 @@ from src.utils.semantic_model_title_candidates import (
     best_display_title_from_graph,
     collect_title_candidates_from_graph,
     extract_title_candidates,
+    humanize_rdf_filename,
     pick_auto_display_name,
 )
 
@@ -92,6 +93,38 @@ def test_collect_and_best_from_in_memory_skos_scheme():
     cands = collect_title_candidates_from_graph(g)
     assert any(c["text"] == "Industry Codes" for c in cands)
     assert best_display_title_from_graph(g) == "Industry Codes"
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("pizza.owl", "Pizza"),
+        ("PIZZA.OWL", "Pizza"),
+        ("my_ontology.ttl", "My Ontology"),
+        ("my-ontology-v2.ttl", "My Ontology V2"),
+        ("databricks_ontology.ttl", "Databricks Ontology"),
+        ("fibo-quick-fix.rdf", "FIBO Quick Fix"),
+        ("gs1_taxonomy.skos", "GS1 Taxonomy"),
+        ("Schema.org.jsonld", "Schema Org"),
+        ("foo.bar.baz.owl", "Foo Bar Baz"),
+        ("/tmp/uploads/some_file.rdfs", "Some File"),
+        ("nodot", "Nodot"),
+        ("ALLCAPS.TTL", "Allcaps"),
+        ("abc.TTL", "Abc"),
+    ],
+)
+def test_humanize_rdf_filename(filename, expected):
+    assert humanize_rdf_filename(filename) == expected
+
+
+def test_humanize_rdf_filename_empty():
+    assert humanize_rdf_filename("") == ""
+
+
+def test_humanize_rdf_filename_only_extension():
+    # Stripping everything would leave an empty name; helper should return
+    # the original input unchanged so callers can fall back gracefully.
+    assert humanize_rdf_filename(".ttl") == ".ttl"
 
 
 def test_graph_title_matches_string_parse_path():

--- a/src/backend/src/utils/semantic_model_title_candidates.py
+++ b/src/backend/src/utils/semantic_model_title_candidates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -15,6 +16,32 @@ _TITLE_PREDICATES: Tuple[URIRef, ...] = (
     SKOS.prefLabel,
     DCTERMS.title,
     DC.title,
+)
+
+_RDF_FILE_EXTENSIONS: Tuple[str, ...] = (
+    ".ttl",
+    ".owl",
+    ".rdf",
+    ".xml",
+    ".skos",
+    ".rdfs",
+    ".nt",
+    ".n3",
+    ".trig",
+    ".trix",
+    ".jsonld",
+    ".json-ld",
+    ".json",
+)
+
+# Tokens that should keep their original casing instead of being title-cased
+# (acronyms / brand names common in RDF source filenames).
+_PRESERVED_CASE_TOKENS: frozenset[str] = frozenset(
+    {
+        "FIBO", "GS1", "OWL", "RDF", "RDFS", "SKOS", "ODCS", "ODPS",
+        "W3C", "OBO", "GO", "DCAT", "PROV", "SHACL", "QUDT", "FOAF",
+        "DBpedia", "DC", "VOID", "SIOC", "OAI", "ISO",
+    }
 )
 
 
@@ -126,6 +153,45 @@ def extract_title_candidates(content_text: str, format_field: str) -> List[dict]
     graph = Graph()
     graph.parse(data=content_text, format=fmt)
     return collect_title_candidates_from_graph(graph)
+
+
+def humanize_rdf_filename(filename: str) -> str:
+    """Turn an RDF source filename into a human-readable title.
+
+    Steps:
+      1. Take the basename (drop any directory parts).
+      2. Strip a single known RDF extension if present (case-insensitive).
+      3. Replace ``_``, ``-`` and ``.`` with spaces.
+      4. Collapse whitespace.
+      5. Title-case word-by-word, preserving common acronyms (FIBO, GS1, ...).
+
+    Returns the original filename unchanged if it ends up empty after cleaning.
+    """
+    if not filename:
+        return ""
+
+    name = filename.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    lower = name.lower()
+    for ext in _RDF_FILE_EXTENSIONS:
+        if lower.endswith(ext):
+            name = name[: -len(ext)]
+            break
+
+    cleaned = re.sub(r"[._\-]+", " ", name)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if not cleaned:
+        return filename
+
+    parts: List[str] = []
+    for word in cleaned.split(" "):
+        upper = word.upper()
+        if upper in _PRESERVED_CASE_TOKENS:
+            parts.append(upper)
+        elif word.isupper() and len(word) <= 4 and word.isalpha():
+            parts.append(word)
+        else:
+            parts.append(word[:1].upper() + word[1:].lower() if word else word)
+    return " ".join(parts)
 
 
 def pick_auto_display_name(candidates: List[dict]) -> Optional[str]:

--- a/src/frontend/src/lib/rdf-filename.test.ts
+++ b/src/frontend/src/lib/rdf-filename.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { humanizeRdfFilename } from './rdf-filename';
+
+/**
+ * Parity tests for the backend `humanize_rdf_filename` helper.
+ *
+ * Keep in lockstep with
+ * `src/backend/src/tests/unit/test_semantic_model_title_candidates.py`.
+ */
+describe('humanizeRdfFilename', () => {
+  const cases: Array<[string, string]> = [
+    ['pizza.owl', 'Pizza'],
+    ['PIZZA.OWL', 'Pizza'],
+    ['my_ontology.ttl', 'My Ontology'],
+    ['my-ontology-v2.ttl', 'My Ontology V2'],
+    ['databricks_ontology.ttl', 'Databricks Ontology'],
+    ['fibo-quick-fix.rdf', 'FIBO Quick Fix'],
+    ['gs1_taxonomy.skos', 'GS1 Taxonomy'],
+    ['Schema.org.jsonld', 'Schema Org'],
+    ['foo.bar.baz.owl', 'Foo Bar Baz'],
+    ['/tmp/uploads/some_file.rdfs', 'Some File'],
+    ['nodot', 'Nodot'],
+    ['ALLCAPS.TTL', 'Allcaps'],
+    ['abc.TTL', 'Abc'],
+    ['odcs-ontology', 'ODCS Ontology'],
+    ['ontos-ontology', 'Ontos Ontology'],
+  ];
+
+  it.each(cases)('humanizes %s -> %s', (input, expected) => {
+    expect(humanizeRdfFilename(input)).toBe(expected);
+  });
+
+  it('returns empty string when input is empty', () => {
+    expect(humanizeRdfFilename('')).toBe('');
+  });
+
+  it('returns input unchanged when cleaning would yield empty', () => {
+    // Stripping the only RDF extension leaves no name to humanize, so we
+    // fall back to the raw input so callers can gracefully handle it.
+    expect(humanizeRdfFilename('.ttl')).toBe('.ttl');
+  });
+});

--- a/src/frontend/src/lib/rdf-filename.ts
+++ b/src/frontend/src/lib/rdf-filename.ts
@@ -1,0 +1,78 @@
+/**
+ * Frontend mirror of the backend `humanize_rdf_filename` helper in
+ * `src/backend/src/utils/semantic_model_title_candidates.py`.
+ *
+ * Used to derive a human-readable label from an RDF source filename / slug
+ * (for example `pizza.owl` -> `Pizza`, `gs1_taxonomy.skos` -> `GS1 Taxonomy`).
+ *
+ * Keep the algorithm in sync with the Python version when changing acronym
+ * lists or extension lists.
+ */
+
+const RDF_FILE_EXTENSIONS: readonly string[] = [
+  '.ttl',
+  '.owl',
+  '.rdf',
+  '.xml',
+  '.skos',
+  '.rdfs',
+  '.nt',
+  '.n3',
+  '.trig',
+  '.trix',
+  '.jsonld',
+  '.json-ld',
+  '.json',
+];
+
+const PRESERVED_CASE_TOKENS: ReadonlySet<string> = new Set([
+  'FIBO', 'GS1', 'OWL', 'RDF', 'RDFS', 'SKOS', 'ODCS', 'ODPS',
+  'W3C', 'OBO', 'GO', 'DCAT', 'PROV', 'SHACL', 'QUDT', 'FOAF',
+  'DBpedia', 'DC', 'VOID', 'SIOC', 'OAI', 'ISO',
+]);
+
+function stripRdfExtension(name: string): string {
+  const lower = name.toLowerCase();
+  for (const ext of RDF_FILE_EXTENSIONS) {
+    if (lower.endsWith(ext)) {
+      return name.slice(0, name.length - ext.length);
+    }
+  }
+  return name;
+}
+
+/**
+ * Turn an RDF source filename / slug into a human-readable title.
+ *
+ * Steps mirror the backend:
+ *   1. Take the basename (drop directory parts).
+ *   2. Strip a single known RDF extension if present (case-insensitive).
+ *   3. Replace `_`, `-`, `.` with spaces and collapse whitespace.
+ *   4. Title-case word-by-word, preserving common acronyms (FIBO, GS1, ...).
+ *
+ * Returns the original input unchanged when cleaning would yield an empty
+ * string so callers can fall back to the raw key.
+ */
+export function humanizeRdfFilename(filename: string): string {
+  if (!filename) return '';
+
+  const basename = filename.split(/[\\/]/).pop() ?? filename;
+  const withoutExt = stripRdfExtension(basename);
+  const cleaned = withoutExt.replace(/[._\-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!cleaned) return filename;
+
+  const parts = cleaned.split(' ').map((word) => {
+    if (!word) return word;
+    const upper = word.toUpperCase();
+    if (PRESERVED_CASE_TOKENS.has(upper)) return upper;
+    if (
+      word === upper &&
+      word.length <= 4 &&
+      /^[A-Z]+$/.test(word)
+    ) {
+      return word;
+    }
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  });
+  return parts.join(' ');
+}

--- a/src/frontend/src/lib/system-rdf-namespace-labels.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.ts
@@ -1,5 +1,7 @@
 import type { TFunction } from 'i18next';
 
+import { humanizeRdfFilename } from '@/lib/rdf-filename';
+
 /**
  * Known internal graph names / API pseudo-row `name` values (not user taxonomies).
  * Keys use the semantic-models namespace as default when calling `t`.
@@ -37,6 +39,6 @@ export function systemRdfNamespaceDisplayLabel(
   t: TFunction<'semantic-models', undefined> | TFunction,
 ): string {
   const entry = SYSTEM_RDF_NAMESPACE_KEYS[graphKey];
-  if (!entry) return graphKey;
-  return t(entry.i18nKey, { defaultValue: entry.defaultLabel });
+  if (entry) return t(entry.i18nKey, { defaultValue: entry.defaultLabel });
+  return humanizeRdfFilename(graphKey) || graphKey;
 }


### PR DESCRIPTION
## Summary

Make uploaded RDF sources display human-readable titles consistently across **RDF Sources**, **Collections**, and **Concepts** views.

Previously, an ontology like `pizza.owl` that ships without an `rdfs:label` / `dcterms:title` on its `owl:Ontology` header showed up as the raw filename or a half-prettified slug (`Pizza.Owl`, `Odcs Ontology`) depending on which surface you were looking at.

A single humanizer now powers all three:

- Strips known RDF extensions (`.owl`, `.ttl`, `.rdf`, `.xml`, `.skos`, `.rdfs`, `.nt`, `.n3`, `.trig`, `.trix`, `.jsonld`, `.json-ld`, `.json`).
- Replaces `_` / `-` / `.` with spaces and title-cases word-by-word.
- Preserves common ontology acronyms: `FIBO`, `GS1`, `ODCS`, `ODPS`, `OWL`, `RDF`, `RDFS`, `SKOS`, `DCAT`, `SHACL`, `QUDT`, `FOAF`, `W3C`, `OBO`, `DBpedia`, ...

### Where it shows up

- **RDF Sources** upload path: when `extract_title_candidates` finds no header literal, `humanize_rdf_filename(safe_filename)` is saved as `display_name`. The pencil-edit dialog also surfaces the humanized name as a one-click candidate alongside ontology-header titles, so existing rows can be fixed with a single click.
- **Collections** tab: `_register_sources_as_collections` uses the same helper when creating rows, and now also runs a second pass that re-derives the `rdfs:label` for already-registered, non-editable collections whose stored label drifts from the current humanizer output. User-editable collections are explicitly skipped so manual edits via the Collections UI are never clobbered.
- **Concepts** views (filter pills, group headers, collection hints): `systemRdfNamespaceDisplayLabel` falls back through a TypeScript port of the backend humanizer when the source key isn't one of the known `urn:*` system labels.

### Examples (covered by tests)

| Input | Output |
| --- | --- |
| `pizza.owl` | `Pizza` |
| `databricks_ontology.ttl` | `Databricks Ontology` |
| `fibo-quick-fix.rdf` | `FIBO Quick Fix` |
| `gs1_taxonomy.skos` | `GS1 Taxonomy` |
| `odcs-ontology` | `ODCS Ontology` |
| `my-ontology-v2.ttl` | `My Ontology V2` |

### Backfill behaviour

On the next graph rebuild (or backend startup), already-registered imported collections whose labels were written by the old logic are quietly refreshed. Verified locally:

```
INFO - Refreshed collection label urn:taxonomy:odcs-ontology: 'Odcs Ontology' -> 'ODCS Ontology'
INFO - Refreshed collection label urn:semantic-model:pizza.owl: 'Pizza.Owl' -> 'Pizza'
```

## Files

- `src/backend/src/utils/semantic_model_title_candidates.py` - new `humanize_rdf_filename` helper, extension list, preserved-acronym set.
- `src/backend/src/routes/semantic_models_routes.py` - upload-time fallback wiring.
- `src/backend/src/controller/semantic_models_manager.py` - second pass in `_register_sources_as_collections` for backfill; humanizer used in new-collection registration; humanized filename surfaced via `get_title_candidates`.
- `src/frontend/src/lib/rdf-filename.ts` - TS port of the backend helper.
- `src/frontend/src/lib/system-rdf-namespace-labels.ts` - fallback to `humanizeRdfFilename`.

## Test plan

- [x] `cd src/backend && hatch -e dev run pytest src/tests/unit/test_semantic_model_title_candidates.py src/tests/unit/test_register_sources_collection_labels.py src/tests/unit/test_semantic_models_bundled_size.py` -> 33 passed
- [x] `cd src/frontend && yarn vitest run src/lib/rdf-filename.test.ts` -> 17 passed
- [x] Manual: upload `pizza.owl`, confirm row shows `Pizza` on RDF Sources, `Pizza` on Collections, `Pizza` on Concepts (filter pills + group headers).
- [x] Manual: edit a Collection label via the Collections tab, verify the backfill leaves it alone on next rebuild.