### PR TITLE
ci: fix coverage badges (CODECOV_TOKEN + shields.io labels)

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -57,6 +57,12 @@ jobs:
           files: ./src/coverage.xml
           flags: backend
           name: backend-coverage
+          # Required for uploads to protected branches (main/develop). Without
+          # it Codecov rejects the upload ("Token required because branch is
+          # protected") while the step stays green due to fail_ci_if_error:false,
+          # which silently froze the coverage badges. Forks have no access to the
+          # secret and fall back to tokenless PR uploads, so this is safe there.
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Upload HTML coverage report
@@ -111,6 +117,9 @@ jobs:
           files: ./src/frontend/coverage/lcov.info
           flags: frontend
           name: frontend-coverage
+          # See note on the backend upload step above: required so uploads to
+          # protected branches are accepted instead of silently rejected.
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Upload HTML coverage report


### PR DESCRIPTION
## Problem

The coverage badges in the README (`codecov`, `backend coverage`, `frontend coverage`) are stale/broken — frontend shows **"unknown"**, and the overall + backend badges both show a frozen **~6%** (indistinguishable from each other) — even though CI is green and the generated reports are healthy.

Root cause: **coverage uploads to the protected `main`/`develop` branches have been silently rejected since ~2026-03-16.** The Codecov step in each upload job logs:

```
Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

The `codecov/codecov-action` steps pass **no token**, and `fail_ci_if_error: false`, so the jobs stay green while Codecov ingests nothing. Codecov's last processed commit on `main` is from March, which is why the badges no longer reflect reality. (Verified: the frontend `lcov.info` produced in CI measures ~10.2% with correct `src/` paths — the data is fine; it just never lands.) The overall and backend badges read identically because, with frontend missing, the overall total collapses to the backend-only number.

## Changes

1. **`ci`:** pass `token: ${{ secrets.CODECOV_TOKEN }}` on both the backend and frontend Codecov upload steps so uploads to protected branches are accepted. Fork PRs have no access to the secret and fall back to tokenless PR uploads, so this is a no-op there.
2. **`docs`:** render the three Codecov badges through shields.io so each carries a distinct label (`coverage` / `backend` / `frontend`) instead of all showing the word "codecov".

## Required follow-up (admin)

The token fix needs the **`CODECOV_TOKEN`** repository secret to be set:

1. Copy the upload token from https://app.codecov.io/gh/databrickslabs/ontos/config/general (Repository Upload Token).
2. Add it under **Settings → Secrets and variables → Actions** as `CODECOV_TOKEN`.
3. Re-run the `Test Coverage` workflow on `main`. Once one upload lands, the `frontend` flag populates (~10.2%) and the badge stops showing "unknown."

This pull request and its description were written by Isaac.