### PR TITLE
fix(concepts): remove duplicate Create buttons and dead Upload button

### DIFF
--- a/src/frontend/src/components/knowledge/collections-tab.tsx
+++ b/src/frontend/src/components/knowledge/collections-tab.tsx
@@ -19,7 +19,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import {
   FolderTree,
-  Plus,
   Pencil,
   Trash2,
   Download,
@@ -44,7 +43,6 @@ interface CollectionsTabProps {
   collections: KnowledgeCollection[];
   selectedCollection: KnowledgeCollection | null;
   onSelectCollection: (collection: KnowledgeCollection | null) => void;
-  onCreateCollection: () => void;
   onEditCollection: (collection: KnowledgeCollection) => void;
   onDeleteCollection: (collection: KnowledgeCollection) => void;
   onExportCollection: (collection: KnowledgeCollection, format: 'turtle' | 'rdfxml') => void;
@@ -85,7 +83,6 @@ export const CollectionsTab: React.FC<CollectionsTabProps> = ({
   collections,
   selectedCollection,
   onSelectCollection,
-  onCreateCollection,
   onEditCollection,
   onDeleteCollection,
   onExportCollection,
@@ -263,14 +260,6 @@ export const CollectionsTab: React.FC<CollectionsTabProps> = ({
           data={collections}
           searchColumn="label"
           storageKey="knowledge-collections-sort"
-          toolbarActions={
-            canEdit && (
-              <Button onClick={onCreateCollection}>
-                <Plus className="h-4 w-4 mr-2" />
-                {t('semantic-models:actions.createCollection')}
-              </Button>
-            )
-          }
           onRowClick={(row) => onSelectCollection(
             selectedCollection?.iri === row.original.iri ? null : row.original
           )}

--- a/src/frontend/src/components/knowledge/concepts-tab.tsx
+++ b/src/frontend/src/components/knowledge/concepts-tab.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useMemo, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import {
   Search,
-  Plus,
   ChevronRight,
   ChevronDown,
   Layers,
@@ -30,13 +28,11 @@ interface ConceptsTabProps {
   filteredConcepts: OntologyConcept[];
   selectedConcept?: OntologyConcept | null;
   onSelectConcept: (concept: OntologyConcept) => void;
-  onCreateConcept: () => void;
   // Display options (from unified filter panel)
   groupBySource: boolean;
   showProperties: boolean;
   groupByDomain: boolean;
   selectedLanguage: string;
-  canEdit: boolean;
 }
 
 const typeIcons: Record<string, React.ReactNode> = {
@@ -75,12 +71,10 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
   filteredConcepts,
   selectedConcept,
   onSelectConcept,
-  onCreateConcept,
   groupBySource,
   showProperties: _showProperties,
   groupByDomain,
   selectedLanguage,
-  canEdit,
 }) => {
   const { t } = useTranslation(['semantic-models', 'common']);
   const expandedGroups = useGlossaryPreferencesStore((s) => s.expandedConceptGroups);
@@ -425,16 +419,6 @@ export const ConceptsTab: React.FC<ConceptsTabProps> = ({
             className="pl-9"
           />
         </div>
-        {canEdit && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onCreateConcept}
-          >
-            <Plus className="h-4 w-4 mr-2" />
-            {t('semantic-models:actions.createConcept')}
-          </Button>
-        )}
       </div>
 
       <div

--- a/src/frontend/src/views/business-terms.tsx
+++ b/src/frontend/src/views/business-terms.tsx
@@ -421,8 +421,6 @@ export default function BusinessTermsView() {
             filteredConcepts={filteredConcepts}
             selectedConcept={null}
             onSelectConcept={handleSelectConcept}
-            onCreateConcept={handleCreateConcept}
-            canEdit={canWrite}
             groupBySource={groupBySource}
             showProperties={showProperties}
             groupByDomain={groupByDomain}

--- a/src/frontend/src/views/collections.tsx
+++ b/src/frontend/src/views/collections.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/components/ui/button';
 import {
   FolderTree,
   Plus,
-  Upload,
 } from 'lucide-react';
 import { SplitPaneSkeleton } from '@/components/common/list-view-skeleton';
 import type { KnowledgeCollection } from '@/types/ontology';
@@ -191,10 +190,6 @@ export default function CollectionsView() {
               {t('semantic-models:actions.createCollection')}
             </Button>
           )}
-
-          <Button variant="outline" size="icon" title={t('common:actions.import')}>
-            <Upload className="h-4 w-4" />
-          </Button>
         </div>
       </div>
 
@@ -212,7 +207,6 @@ export default function CollectionsView() {
           collections={collections}
           selectedCollection={selectedCollection}
           onSelectCollection={setSelectedCollection}
-          onCreateCollection={handleCreateCollection}
           onEditCollection={handleEditCollection}
           onDeleteCollection={handleDeleteCollection}
           onExportCollection={handleExportCollection}


### PR DESCRIPTION
## Summary

The **Concepts** (`/concepts/browser`) and **Collections** (`/concepts/collections`) pages each rendered their primary action twice — once in the page header and again inside the embedded tab/table toolbar. The Collections page also had an `Upload` icon button with no `onClick` handler (clicks did nothing, no console error). This PR removes the duplicates and the dead button so each page has a single create entry point in the header.

### Before / After

- **Collections page:** had `+ Create Collection` in the header *and* in the DataTable toolbar, plus a non-functional Upload icon button → now has just `+ Create Collection` in the header.
- **Concepts page:** had `+ Create ▾` dropdown in the header *and* a separate `+ Create Concept` button next to the tree search input → now has just the `+ Create ▾` dropdown in the header.

### Why two existed

`concepts-tab.tsx` and `collections-tab.tsx` were originally self-contained tab components in the older `business-terms` page (when Concepts / Collections / Search were tabs rather than separate routes). Each tab needed its own inline create button because it didn't have a page header. When the views were refactored into the dedicated `Concepts` / `Collections` routes with their own headers, the inline create buttons were never removed.

## Changes

- `src/frontend/src/views/collections.tsx`
  - Remove the dead `Upload` icon button and its lucide import.
  - Stop passing `onCreateCollection` to `<CollectionsTab />`.
- `src/frontend/src/components/knowledge/collections-tab.tsx`
  - Remove the duplicate `+ Create Collection` from the `DataTable` `toolbarActions`.
  - Drop the now-unused `onCreateCollection` prop and `Plus` lucide import.
- `src/frontend/src/components/knowledge/concepts-tab.tsx`
  - Remove the inline `+ Create Concept` button next to the search input.
  - Drop the now-unused `onCreateConcept` and `canEdit` props and the `Button` / `Plus` imports.
- `src/frontend/src/views/business-terms.tsx`
  - Stop passing `onCreateConcept` and `canEdit` to `<ConceptsTab />`.

Header dropdowns/buttons still call the existing `handleCreateConcept` / `handleCreateCollection` handlers — no behavior change beyond the de-duplication.

Net diff: **4 files changed, 35 deletions(-)**.

## Test plan

- [x] `/concepts/collections` renders one `+ Create Collection` in the header, no Upload button, no duplicate inside the table toolbar.
- [x] Clicking the header `+ Create Collection` opens the `CollectionEditorDialog` (verified via Playwright).
- [x] `/concepts/browser` renders the `+ Create ▾` dropdown only in the header (no inline button next to the search input).
- [x] `+ Create ▾ → Create Concept` and `+ Create ▾ → Create Collection` continue to work.
- [x] No new TypeScript / lint errors in the touched files.

## Notes

- If we later want a real collection-import flow on this page, the existing `ImportConceptsDialog` (`src/frontend/src/components/knowledge/import-concepts-dialog.tsx`) already supports importing into a collection — re-introducing a wired Upload button here would just be: import that dialog, add `importDialogOpen` state, and wire `onClick`, mirroring the pattern in `business-terms.tsx`.