### PR TITLE
feat(copilot): make Ask Ontos sidebar resizable and align header

### DIFF
--- a/src/frontend/src/components/copilot/copilot-panel.tsx
+++ b/src/frontend/src/components/copilot/copilot-panel.tsx
@@ -16,7 +16,12 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import LLMConsentDialog, { hasLLMConsent } from '@/components/common/llm-consent-dialog';
 import { fetchLLMStatus, fetchSessions, sendMessage, deleteSession } from '@/components/search/llm-search-api';
-import { useCopilotStore, type CopilotPageContext } from '@/stores/copilot-store';
+import {
+  useCopilotStore,
+  type CopilotPageContext,
+  COPILOT_MIN_WIDTH,
+  COPILOT_MAX_WIDTH,
+} from '@/stores/copilot-store';
 import { useCopilotQuestions } from '@/hooks/use-copilot-questions';
 import { useUICustomizationStore } from '@/stores/ui-customization-store';
 import type { LLMConfig } from '@/types/llm';
@@ -37,23 +42,23 @@ function CopilotMessage({ message }: { message: ChatMessage }) {
   const isUser = message.role === 'user';
 
   return (
-    <div className={`flex gap-2 ${isUser ? 'flex-row-reverse' : ''}`}>
+    <div className={`flex gap-2 min-w-0 ${isUser ? 'flex-row-reverse' : ''}`}>
       {!isUser && (
         <div className="w-6 h-6 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center shrink-0">
           <Sparkles className="w-3 h-3 text-white" />
         </div>
       )}
       <div className={`
-        max-w-[85%] rounded-lg px-3 py-2 text-sm
+        max-w-[85%] min-w-0 rounded-lg px-3 py-2 text-sm break-words
         ${isUser
           ? 'bg-sky-100 dark:bg-sky-900/50 text-sky-900 dark:text-sky-100'
           : 'bg-muted'
         }
       `}>
         {isUser ? (
-          <p className="whitespace-pre-wrap">{message.content}</p>
+          <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{message.content}</p>
         ) : (
-          <div className="prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+          <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] [&_code]:break-all [&_a]:break-all [&_pre]:whitespace-pre-wrap [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
@@ -71,7 +76,7 @@ function CopilotMessage({ message }: { message: ChatMessage }) {
                 code: ({ className, children, ...props }) => {
                   const isInline = !className;
                   return isInline ? (
-                    <code className="bg-muted-foreground/20 px-1 py-0.5 rounded text-xs" {...props}>{children}</code>
+                    <code className="bg-muted-foreground/20 px-1 py-0.5 rounded text-xs break-all" {...props}>{children}</code>
                   ) : (
                     <code className={`${className} block bg-zinc-900 text-zinc-100 p-2 rounded-md overflow-x-auto text-xs`} {...props}>{children}</code>
                   );
@@ -92,8 +97,55 @@ export default function CopilotPanel() {
   const shortName = useUICustomizationStore((s) => s.getShortName());
   const isOpen = useCopilotStore((s) => s.isOpen);
   const pageContext = useCopilotStore((s) => s.pageContext);
-  const { closePanel } = useCopilotStore((s) => s.actions);
+  const panelWidth = useCopilotStore((s) => s.panelWidth);
+  const { closePanel, setPanelWidth } = useCopilotStore((s) => s.actions);
   const questionGroups = useCopilotQuestions();
+
+  // Drag-to-resize: attach window-level listeners only while dragging so the
+  // pointer can leave the thin handle without losing the drag. We throttle
+  // width updates to animation frames to avoid storming the store.
+  const isResizingRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
+
+  const startResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isResizingRef.current = true;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+
+    const onMove = (ev: MouseEvent) => {
+      if (!isResizingRef.current) return;
+      if (rafIdRef.current !== null) return;
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null;
+        const next = window.innerWidth - ev.clientX;
+        setPanelWidth(next);
+      });
+    };
+
+    const onUp = () => {
+      isResizingRef.current = false;
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, [setPanelWidth]);
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+    };
+  }, []);
 
   const [status, setStatus] = useState<LLMSearchStatus | null>(null);
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
@@ -261,9 +313,23 @@ export default function CopilotPanel() {
       />
 
       {/* Panel container — fixed right side, no overlay */}
-      <div className="fixed inset-y-0 right-0 z-50 w-[400px] border-l bg-background shadow-lg flex flex-col animate-in slide-in-from-right duration-300">
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+      <div
+        className="fixed inset-y-0 right-0 z-50 border-l bg-background shadow-lg flex flex-col animate-in slide-in-from-right duration-300"
+        style={{ width: panelWidth }}
+      >
+        {/* Resize handle — thin strip on the left edge */}
+        <div
+          onMouseDown={startResize}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t('search:copilot.resizeHandle', { defaultValue: 'Resize Ask Ontos panel' })}
+          aria-valuemin={COPILOT_MIN_WIDTH}
+          aria-valuemax={COPILOT_MAX_WIDTH}
+          aria-valuenow={panelWidth}
+          className="absolute inset-y-0 -left-0.5 w-1.5 cursor-col-resize z-10 hover:bg-violet-500/40 active:bg-violet-500/60 transition-colors"
+        />
+        {/* Header — h-16 matches the app header so the bottom border aligns */}
+        <div className="flex h-16 items-center justify-between gap-2 px-4 border-b shrink-0">
           <div className="flex items-center gap-2">
             <div className="w-7 h-7 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center">
               <Sparkles className="w-3.5 h-3.5 text-white" />

--- a/src/frontend/src/components/layout/layout.tsx
+++ b/src/frontend/src/components/layout/layout.tsx
@@ -31,6 +31,7 @@ export default function Layout({ children }: LayoutProps) {
   const isSidebarCollapsed = useLayoutStore((state) => state.isSidebarCollapsed);
   const { toggleSidebar } = useLayoutStore((state) => state.actions);
   const isCopilotOpen = useCopilotStore((s) => s.isOpen);
+  const copilotPanelWidth = useCopilotStore((s) => s.panelWidth);
   const { togglePanel } = useCopilotStore((s) => s.actions);
   const [health, setHealth] = useState<HealthState | null>(null);
   const [isRetrying, setIsRetrying] = useState(false);
@@ -99,11 +100,13 @@ export default function Layout({ children }: LayoutProps) {
       {/* Sidebar/copilot offsets use padding (not margin) so the column
           stays at 100vw and never overflows horizontally. The Sidebar is
           position:fixed and contributes no flex/inline width. */}
-      <div className={cn(
-        "flex flex-col min-h-screen min-w-0 transition-[padding] duration-300 ease-in-out",
-        isSidebarCollapsed ? "pl-[56px]" : "pl-[240px]",
-        isCopilotOpen && "pr-[400px]"
-      )}>
+      <div
+        className={cn(
+          "flex flex-col min-h-screen min-w-0 transition-[padding] duration-300 ease-in-out",
+          isSidebarCollapsed ? "pl-[56px]" : "pl-[240px]"
+        )}
+        style={{ paddingRight: isCopilotOpen ? copilotPanelWidth : undefined }}
+      >
         <Header onToggleSidebar={toggleSidebar} isSidebarCollapsed={isSidebarCollapsed} />
         {/* Alerts wrapped in padded containers (not mx-6 on the Alert itself):
             shadcn Alert is `w-full`, so mx-6 would expand it past the

--- a/src/frontend/src/stores/copilot-store.ts
+++ b/src/frontend/src/stores/copilot-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 export interface CopilotEntity {
   type: string;
@@ -13,35 +14,63 @@ export interface CopilotPageContext {
   selectedEntity?: CopilotEntity;
 }
 
+export const COPILOT_MIN_WIDTH = 320;
+export const COPILOT_MAX_WIDTH = 900;
+export const COPILOT_DEFAULT_WIDTH = 400;
+
 interface CopilotState {
   isOpen: boolean;
   pageContext: CopilotPageContext | null;
+  panelWidth: number;
   actions: {
     togglePanel: () => void;
     openPanel: () => void;
     closePanel: () => void;
+    setPanelWidth: (w: number) => void;
     setContext: (pageName: string, pageUrl: string, selectedEntity?: CopilotEntity, featureId?: string) => void;
     clearContext: () => void;
   };
 }
 
+// `isOpen` is intentionally kept on its own legacy localStorage key
+// (`copilot-sidebar-visited`) so the first-run "auto-open until dismissed"
+// behavior is preserved. Only the resizable width is persisted via zustand.
 const VISITED_KEY = 'copilot-sidebar-visited';
 
-export const useCopilotStore = create<CopilotState>()((set) => ({
-  isOpen: localStorage.getItem(VISITED_KEY) !== 'true',
-  pageContext: null,
-  actions: {
-    togglePanel: () => set((state) => {
-      if (state.isOpen) localStorage.setItem(VISITED_KEY, 'true');
-      return { isOpen: !state.isOpen };
+const clampWidth = (w: number): number =>
+  Math.min(COPILOT_MAX_WIDTH, Math.max(COPILOT_MIN_WIDTH, Math.round(w)));
+
+export const useCopilotStore = create<CopilotState>()(
+  persist(
+    (set) => ({
+      isOpen: localStorage.getItem(VISITED_KEY) !== 'true',
+      pageContext: null,
+      panelWidth: COPILOT_DEFAULT_WIDTH,
+      actions: {
+        togglePanel: () => set((state) => {
+          if (state.isOpen) localStorage.setItem(VISITED_KEY, 'true');
+          return { isOpen: !state.isOpen };
+        }),
+        openPanel: () => set({ isOpen: true }),
+        closePanel: () => {
+          localStorage.setItem(VISITED_KEY, 'true');
+          set({ isOpen: false });
+        },
+        setPanelWidth: (w) => set({ panelWidth: clampWidth(w) }),
+        setContext: (pageName, pageUrl, selectedEntity, featureId) =>
+          set({ pageContext: { pageName, pageUrl, featureId, selectedEntity } }),
+        clearContext: () => set({ pageContext: null }),
+      },
     }),
-    openPanel: () => set({ isOpen: true }),
-    closePanel: () => {
-      localStorage.setItem(VISITED_KEY, 'true');
-      set({ isOpen: false });
-    },
-    setContext: (pageName, pageUrl, selectedEntity, featureId) =>
-      set({ pageContext: { pageName, pageUrl, featureId, selectedEntity } }),
-    clearContext: () => set({ pageContext: null }),
-  },
-}));
+    {
+      name: 'copilot-panel-storage',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ panelWidth: state.panelWidth }),
+      merge: (persisted, current) => {
+        const p = (persisted ?? {}) as Partial<CopilotState>;
+        const width = typeof p.panelWidth === 'number' ? clampWidth(p.panelWidth) : current.panelWidth;
+        return { ...current, panelWidth: width };
+      },
+    }
+  )
+);


### PR DESCRIPTION
## Summary

- Persist Ask Ontos (Copilot) panel width to `localStorage` via zustand, clamped to 320-900px (default 400px). Adds `COPILOT_MIN/MAX/DEFAULT_WIDTH` constants and a `setPanelWidth` action; `isOpen` continues to use its legacy `copilot-sidebar-visited` key so the first-run auto-open behaviour is preserved.
- Add a drag handle on the panel's left edge with `requestAnimationFrame`-throttled width updates and proper `userSelect`/`cursor` handling during drag.
- Drive the main layout's right padding from the live panel width instead of the static `pr-[400px]`, so the content column always matches the panel as the user drags.
- Align the panel header to `h-16` (it was `px-4 py-3`, ~52px) so its bottom border lines up with the main app header's border.
- Fix message text wrapping so long inline code, URLs, and unbreakable tokens (e.g. ``compliance/hazmat``) no longer push the bubble past the panel width — adds `min-w-0`, `break-words`, `[overflow-wrap:anywhere]`, and `break-all` on inline code and links.

## Files

- ``src/frontend/src/stores/copilot-store.ts``
- ``src/frontend/src/components/copilot/copilot-panel.tsx``
- ``src/frontend/src/components/layout/layout.tsx``

## Test plan

- [ ] Open the Ask Ontos panel; drag the left edge — the panel and main content reflow live, with no text selection or cursor flicker.
- [ ] Reload the page — the panel reopens at the previously dragged width.
- [ ] Inspect the panel header — its bottom border lines up with the main app header's bottom border.
- [ ] Send a message containing a long unbreakable token (e.g. ``compliance/hazmat`` or a long URL) — the bubble no longer overflows horizontally.
- [ ] Resize the window narrow enough that the clamp kicks in — width stays within 320-900px.
- [ ] Toggle the panel closed and reopen — width is preserved.