### PR TITLE
fix(databricks): return enum values for column types

### DIFF
--- a/src/backend/src/connectors/databricks.py
+++ b/src/backend/src/connectors/databricks.py
@@ -650,10 +650,11 @@ class DatabricksConnector(AssetConnector):
             if table.columns:
                 columns = []
                 for col in table.columns:
+                    type_name_value = col.type_name.value if col.type_name else None
                     columns.append(ColumnInfo(
                         name=col.name,
-                        data_type=col.type_text or str(col.type_name) if col.type_name else "unknown",
-                        logical_type=str(col.type_name) if col.type_name else None,
+                        data_type=col.type_text or type_name_value or "unknown",
+                        logical_type=type_name_value,
                         nullable=col.nullable if col.nullable is not None else True,
                         description=col.comment,
                         is_partition_key=col.partition_index is not None,
@@ -727,7 +728,7 @@ class DatabricksConnector(AssetConnector):
                     columns.append(ColumnInfo(
                         name=param.name,
                         data_type=param.type_text or "unknown",
-                        logical_type=str(param.type_name) if param.type_name else None,
+                        logical_type=param.type_name.value if param.type_name else None,
                         description=param.comment,
                     ))
                 schema_info = SchemaInfo(columns=columns)

--- a/src/backend/src/controller/data_catalog_manager.py
+++ b/src/backend/src/controller/data_catalog_manager.py
@@ -721,10 +721,11 @@ class DataCatalogManager:
             columns = []
             if table.columns:
                 for idx, col in enumerate(table.columns):
+                    type_name_value = col.type_name.value if col.type_name else None
                     columns.append(ColumnInfo(
                         name=col.name,
-                        type_text=col.type_text or str(col.type_name) if col.type_name else "UNKNOWN",
-                        type_name=str(col.type_name) if col.type_name else None,
+                        type_text=col.type_text or type_name_value or "UNKNOWN",
+                        type_name=type_name_value,
                         position=idx,
                         nullable=col.nullable if col.nullable is not None else True,
                         comment=col.comment,

--- a/src/backend/src/tests/unit/test_data_catalog_manager.py
+++ b/src/backend/src/tests/unit/test_data_catalog_manager.py
@@ -13,10 +13,12 @@ logic without spinning up a DB.
 """
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import List
 from unittest.mock import MagicMock
 
 import pytest
+from databricks.sdk.service.catalog import ColumnTypeName
 
 from src.controller.data_catalog_manager import DataCatalogManager
 from src.models.data_catalog import ColumnDictionaryEntry
@@ -325,3 +327,41 @@ class TestPaginationAndFilters:
         assert resp.total_count == 9
         assert len(resp.columns) == 3
         assert resp.has_more is True
+
+
+class TestTableDetailsTypeNameFormatting:
+    def test_get_table_details_uses_enum_value_and_preserves_type_text(self, manager):
+        manager.client.tables.get.return_value = SimpleNamespace(
+            columns=[
+                SimpleNamespace(
+                    name="amount",
+                    type_text=None,
+                    type_name=ColumnTypeName.DOUBLE,
+                    nullable=True,
+                    comment=None,
+                    partition_index=None,
+                ),
+                SimpleNamespace(
+                    name="price",
+                    type_text="decimal(10,2)",
+                    type_name=None,
+                    nullable=False,
+                    comment=None,
+                    partition_index=None,
+                ),
+            ],
+            tags=[],
+            table_type=None,
+            owner=None,
+            comment=None,
+            storage_location=None,
+        )
+
+        table = manager.get_table_details("main.sales.orders")
+
+        assert table is not None
+        assert len(table.columns) == 2
+        assert table.columns[0].type_name == "DOUBLE"
+        assert table.columns[0].type_text == "DOUBLE"
+        assert table.columns[1].type_name is None
+        assert table.columns[1].type_text == "decimal(10,2)"

--- a/src/backend/src/tests/unit/test_databricks_connector_types.py
+++ b/src/backend/src/tests/unit/test_databricks_connector_types.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from databricks.sdk.service.catalog import ColumnTypeName
+
+from src.connectors.databricks import DatabricksConnector
+
+
+def _table_with_column(column: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        table_type=None,
+        columns=[column],
+        table_constraints=[],
+        owner="owner@example.com",
+        comment="test table",
+        properties={},
+        full_name="main.sales.orders",
+        name="orders",
+        storage_location=None,
+        catalog_name="main",
+        schema_name="sales",
+    )
+
+
+def test_get_table_metadata_uses_enum_value_for_logical_type():
+    ws = MagicMock()
+    ws.tables.get.return_value = _table_with_column(
+        SimpleNamespace(
+            name="amount_usd",
+            type_text=None,
+            type_name=ColumnTypeName.DOUBLE,
+            nullable=True,
+            comment="Amount",
+            partition_index=None,
+        )
+    )
+
+    connector = DatabricksConnector(workspace_client=ws)
+    metadata = connector._get_table_metadata(ws, "main.sales.orders")
+
+    assert metadata is not None
+    assert metadata.schema_info is not None
+    col = metadata.schema_info.columns[0]
+    assert col.logical_type == "DOUBLE"
+    assert col.logical_type != "ColumnTypeName.DOUBLE"
+    assert col.data_type == "DOUBLE"
+
+
+def test_get_table_metadata_keeps_type_text_when_type_name_missing():
+    ws = MagicMock()
+    ws.tables.get.return_value = _table_with_column(
+        SimpleNamespace(
+            name="price",
+            type_text="decimal(10,2)",
+            type_name=None,
+            nullable=False,
+            comment=None,
+            partition_index=None,
+        )
+    )
+
+    connector = DatabricksConnector(workspace_client=ws)
+    metadata = connector._get_table_metadata(ws, "main.sales.orders")
+
+    assert metadata is not None
+    assert metadata.schema_info is not None
+    col = metadata.schema_info.columns[0]
+    assert col.data_type == "decimal(10,2)"
+    assert col.logical_type is None


### PR DESCRIPTION
## Summary
- replace `str(type_name)` with `type_name.value` in Databricks connector and data catalog manager table detail mapping
- fix fallback precedence so `type_text` is preserved when `type_name` is missing
- add focused unit tests for enum value serialization and `type_text` fallback behavior

## Test plan
- [x] `hatch -e dev run pytest src/tests/unit/test_databricks_connector_types.py src/tests/unit/test_data_catalog_manager.py -q`