### PR TITLE
feat(maturity): configurable multi-level maturity assessment

### DIFF
--- a/src/backend/alembic/versions/c1_add_maturity_tables.py
+++ b/src/backend/alembic/versions/c1_add_maturity_tables.py
@@ -1,0 +1,86 @@
+"""Add maturity_levels, maturity_gates, maturity_snapshots tables and entity columns
+
+Revision ID: c1_maturity
+Revises: b3_cert_ds_asset
+Create Date: 2026-06-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+
+revision: str = "c1_maturity"
+down_revision: Union[str, None] = "g2_ontology_gen_runs"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- maturity_levels ---
+    op.create_table(
+        "maturity_levels",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column("level_order", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("icon", sa.String(100), nullable=True),
+        sa.Column("color", sa.String(50), nullable=True),
+        sa.Column("entity_type", sa.String(50), nullable=False, server_default="all"),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("entity_type", "level_order", name="uq_maturity_level_entity_order"),
+        sa.UniqueConstraint("entity_type", "name", name="uq_maturity_level_entity_name"),
+    )
+    op.create_index("ix_maturity_levels_entity_type", "maturity_levels", ["entity_type"])
+
+    # --- maturity_gates ---
+    op.create_table(
+        "maturity_gates",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column("maturity_level_id", PG_UUID(as_uuid=True),
+                   sa.ForeignKey("maturity_levels.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("compliance_policy_id", sa.String(),
+                   sa.ForeignKey("compliance_policies.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("required", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("maturity_level_id", "compliance_policy_id",
+                            name="uq_maturity_gate_level_policy"),
+    )
+    op.create_index("ix_maturity_gates_level_id", "maturity_gates", ["maturity_level_id"])
+    op.create_index("ix_maturity_gates_policy_id", "maturity_gates", ["compliance_policy_id"])
+
+    # --- maturity_snapshots ---
+    op.create_table(
+        "maturity_snapshots",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column("entity_type", sa.String(50), nullable=False),
+        sa.Column("entity_id", sa.String(), nullable=False),
+        sa.Column("achieved_level_order", sa.Integer(), nullable=True),
+        sa.Column("achieved_level_name", sa.String(255), nullable=True),
+        sa.Column("total_levels", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("gates_passed", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("gates_total", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("gate_results_json", sa.Text(), nullable=True),
+        sa.Column("evaluated_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("evaluated_by", sa.String(), nullable=True),
+    )
+    op.create_index("ix_maturity_snapshots_entity", "maturity_snapshots",
+                     ["entity_type", "entity_id"])
+
+    # --- Cached maturity columns on entity tables ---
+    for table_name in ("data_products", "data_contracts"):
+        op.add_column(table_name, sa.Column("maturity_level_order", sa.Integer(), nullable=True))
+        op.add_column(table_name, sa.Column("maturity_evaluated_at", sa.TIMESTAMP(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    for table_name in ("data_products", "data_contracts"):
+        op.drop_column(table_name, "maturity_evaluated_at")
+        op.drop_column(table_name, "maturity_level_order")
+
+    op.drop_table("maturity_snapshots")
+    op.drop_table("maturity_gates")
+    op.drop_table("maturity_levels")

--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -75,6 +75,7 @@ from src.routes import (
     readiness_routes,
     suggestion_routes,
     certification_levels_routes,
+    maturity_routes,
     directory_routes,
 )
 
@@ -354,6 +355,7 @@ business_lineage_routes.register_routes(app)
 readiness_routes.register_routes(app)
 suggestion_routes.register_routes(app)
 certification_levels_routes.register_routes(app)
+maturity_routes.register_routes(app)
 data_asset_reviews_routes.register_routes(app)
 data_catalog_routes.register_routes(app)
 

--- a/src/backend/src/common/features.py
+++ b/src/backend/src/common/features.py
@@ -194,6 +194,11 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
+    'settings-maturity-levels': {
+        'name': 'Settings — Maturity Levels',
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_SETTINGS,
+    },
 
     # --- Settings: Configuration sub-pages ---
     'settings-general': {

--- a/src/backend/src/common/workflow_triggers.py
+++ b/src/backend/src/common/workflow_triggers.py
@@ -516,6 +516,40 @@ class TriggerRegistry:
         return self.fire_trigger(event, blocking=blocking)
 
     # =========================================================================
+    # Maturity Triggers
+    # =========================================================================
+
+    def on_maturity_change(
+        self,
+        entity_type: EntityType,
+        entity_id: str,
+        entity_name: Optional[str] = None,
+        entity_data: Optional[Dict[str, Any]] = None,
+        user_email: Optional[str] = None,
+        *,
+        from_level: Optional[int] = None,
+        to_level: Optional[int] = None,
+        blocking: bool = False,
+    ) -> List[WorkflowExecution]:
+        """Fire when an entity's maturity level changes."""
+        data = dict(entity_data or {})
+        data["from_maturity_level"] = from_level
+        data["to_maturity_level"] = to_level
+        event = TriggerEvent(
+            trigger_type=TriggerType.ON_MATURITY_CHANGE,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            entity_name=entity_name,
+            entity_data=data,
+            user_email=user_email,
+        )
+        logger.info(
+            f"on_maturity_change fired for {entity_type.value} '{entity_id}': "
+            f"level {from_level} -> {to_level}"
+        )
+        return self.fire_trigger(event, blocking=blocking)
+
+    # =========================================================================
     # Request Triggers
     # =========================================================================
 

--- a/src/backend/src/controller/entity_dict_builder.py
+++ b/src/backend/src/controller/entity_dict_builder.py
@@ -1,0 +1,227 @@
+"""Build enriched entity dictionaries for compliance DSL evaluation.
+
+Produces a flat dict with raw entity fields + computed relationship/governance
+counts so that maturity gate rules can use simple assertions like
+``obj.business_term_count > 0`` or ``obj.certification_level >= 2``.
+"""
+from typing import Dict, Any, Optional
+
+from sqlalchemy.orm import Session
+from sqlalchemy import func, and_, or_
+
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def build_data_product_dict(db: Session, product_id: str) -> Optional[Dict[str, Any]]:
+    """Build an enriched dict for a DataProduct."""
+    from src.db_models.data_products import DataProductDb
+    product = db.get(DataProductDb, product_id)
+    if not product:
+        return None
+
+    base = _extract_base_fields(product)
+    base["entity_type"] = "DataProduct"
+
+    # Description fields
+    desc = product.description
+    base["has_description"] = bool(desc and (desc.purpose or desc.usage))
+    base["has_purpose"] = bool(desc and desc.purpose)
+    base["has_usage"] = bool(desc and desc.usage)
+
+    # Owner
+    base["owner_team_id"] = product.owner_team_id
+    base["has_owner"] = bool(product.owner_team_id)
+
+    # Output ports / contracts
+    output_ports = product.output_ports or []
+    base["output_port_count"] = len(output_ports)
+    contract_count = sum(
+        len(getattr(op, "input_contracts", None) or [])
+        for op in output_ports
+    )
+    base["contract_count"] = contract_count
+    base["has_contract"] = contract_count > 0
+
+    # Certification
+    base["certification_level"] = product.certification_level or 0
+    base["inherited_certification_level"] = product.inherited_certification_level or 0
+    base["is_certified"] = bool(product.certification_level)
+    base["effective_certification"] = max(
+        product.certification_level or 0,
+        product.inherited_certification_level or 0,
+    )
+
+    # Publication
+    pub_scope = getattr(product, "publication_scope", "none") or "none"
+    base["publication_scope"] = pub_scope
+    base["is_published"] = pub_scope != "none"
+
+    # Relationship counts
+    _add_relationship_counts(db, base, "DataProduct", product_id)
+    _add_tag_count(db, base, product_id, "DataProduct")
+    _add_quality_check_count(db, base, "DataProduct", product_id)
+
+    return base
+
+
+def build_data_contract_dict(db: Session, contract_id: str) -> Optional[Dict[str, Any]]:
+    """Build an enriched dict for a DataContract."""
+    from src.db_models.data_contracts import DataContractDb
+    contract = db.get(DataContractDb, contract_id)
+    if not contract:
+        return None
+
+    base = _extract_base_fields(contract)
+    base["entity_type"] = "DataContract"
+
+    # Description
+    base["has_description"] = bool(contract.description_purpose or contract.description_usage)
+    base["has_purpose"] = bool(contract.description_purpose)
+
+    # Owner
+    base["owner_team_id"] = contract.owner_team_id
+    base["has_owner"] = bool(contract.owner_team_id)
+
+    # Certification
+    base["certification_level"] = contract.certification_level or 0
+    base["inherited_certification_level"] = contract.inherited_certification_level or 0
+    base["is_certified"] = bool(contract.certification_level)
+    base["effective_certification"] = max(
+        contract.certification_level or 0,
+        contract.inherited_certification_level or 0,
+    )
+
+    # Publication
+    pub_scope = getattr(contract, "publication_scope", "none") or "none"
+    base["publication_scope"] = pub_scope
+    base["is_published"] = pub_scope != "none"
+
+    # Schema objects count
+    schema_objs = getattr(contract, "schema_objects", None) or []
+    base["schema_object_count"] = len(schema_objs) if hasattr(schema_objs, '__len__') else 0
+
+    # Relationship counts
+    _add_relationship_counts(db, base, "DataContract", contract_id)
+    _add_tag_count(db, base, contract_id, "DataContract")
+    _add_quality_check_count(db, base, "DataContract", contract_id)
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract_base_fields(db_obj) -> Dict[str, Any]:
+    """Extract common scalar fields from a SQLAlchemy model."""
+    d: Dict[str, Any] = {}
+    for col in db_obj.__table__.columns:
+        val = getattr(db_obj, col.name, None)
+        d[col.name] = val
+    return d
+
+
+def _add_relationship_counts(db: Session, d: Dict[str, Any],
+                              entity_type: str, entity_id: str) -> None:
+    """Count relationships by type and add to dict."""
+    from src.db_models.entity_relationships import EntityRelationshipDb
+
+    rels = (
+        db.query(EntityRelationshipDb)
+        .filter(
+            or_(
+                and_(EntityRelationshipDb.source_type == entity_type,
+                     EntityRelationshipDb.source_id == entity_id),
+                and_(EntityRelationshipDb.target_type == entity_type,
+                     EntityRelationshipDb.target_id == entity_id),
+            )
+        )
+        .all()
+    )
+
+    # Count by relationship type
+    outgoing = [r for r in rels if r.source_id == entity_id]
+    incoming = [r for r in rels if r.target_id == entity_id]
+
+    d["relationship_count"] = len(rels)
+
+    # Specific relationship counts
+    d["dataset_count"] = sum(1 for r in outgoing if r.relationship_type == "hasDataset")
+    d["business_term_count"] = (
+        sum(1 for r in outgoing if r.relationship_type == "hasTerm") +
+        sum(1 for r in incoming if r.relationship_type in ("relatesTo", "hasTerm"))
+    )
+    d["upstream_system_count"] = sum(
+        1 for r in outgoing if r.relationship_type == "deployedOnSystem"
+    )
+    d["upstream_product_count"] = sum(
+        1 for r in outgoing if r.relationship_type == "dependsOn"
+    )
+    d["delivery_channel_count"] = sum(
+        1 for r in outgoing if r.relationship_type == "exposes"
+    )
+    d["has_business_terms"] = d["business_term_count"] > 0
+    d["has_upstream_lineage"] = (d["upstream_system_count"] + d["upstream_product_count"]) > 0
+    d["has_delivery_channels"] = d["delivery_channel_count"] > 0
+
+    # Logical attribute mappings (via datasets)
+    logical_attr_count = 0
+    for dr in [r for r in outgoing if r.relationship_type == "hasDataset"]:
+        ds_rels = (
+            db.query(EntityRelationshipDb)
+            .filter(
+                or_(
+                    and_(EntityRelationshipDb.source_type == "Dataset",
+                         EntityRelationshipDb.source_id == dr.target_id),
+                    and_(EntityRelationshipDb.target_type == "Dataset",
+                         EntityRelationshipDb.target_id == dr.target_id),
+                )
+            )
+            .all()
+        )
+        for dsr in ds_rels:
+            if dsr.relationship_type == "implementedBy" and dsr.source_type == "LogicalAttribute":
+                logical_attr_count += 1
+    d["logical_attribute_mapping_count"] = logical_attr_count
+    d["has_logical_attribute_mappings"] = logical_attr_count > 0
+
+
+def _add_tag_count(db: Session, d: Dict[str, Any],
+                    entity_id: str, entity_type: str) -> None:
+    """Count tags assigned to entity."""
+    from src.db_models.tags import EntityTagAssociationDb
+    count = (
+        db.query(func.count(EntityTagAssociationDb.id))
+        .filter(
+            and_(
+                EntityTagAssociationDb.entity_id == entity_id,
+                EntityTagAssociationDb.entity_type == entity_type,
+            )
+        )
+        .scalar()
+    ) or 0
+    d["tag_count"] = count
+    d["has_tags"] = count > 0
+
+
+def _add_quality_check_count(db: Session, d: Dict[str, Any],
+                              entity_type: str, entity_id: str) -> None:
+    """Count quality items for entity."""
+    try:
+        from src.db_models.quality import QualityItemDb
+        count = (
+            db.query(func.count(QualityItemDb.id))
+            .filter(
+                and_(
+                    QualityItemDb.entity_type == entity_type,
+                    QualityItemDb.entity_id == entity_id,
+                )
+            )
+            .scalar()
+        ) or 0
+    except Exception:
+        count = 0
+    d["quality_check_count"] = count
+    d["has_quality_checks"] = count > 0

--- a/src/backend/src/controller/maturity_evaluator.py
+++ b/src/backend/src/controller/maturity_evaluator.py
@@ -1,0 +1,283 @@
+"""Maturity evaluation engine.
+
+Evaluates an entity against admin-configured maturity levels.
+Levels are cumulative: evaluation stops at the first level where a required gate fails.
+"""
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.controller.entity_dict_builder import (
+    build_data_product_dict,
+    build_data_contract_dict,
+)
+from src.models.maturity import (
+    MaturityReport,
+    LevelResult,
+    GateResult,
+)
+from src.repositories.maturity_repository import maturity_repo
+
+logger = get_logger(__name__)
+
+_ENTITY_DICT_BUILDERS = {
+    "DataProduct": build_data_product_dict,
+    "DataContract": build_data_contract_dict,
+}
+
+
+class MaturityEvaluator:
+    """Evaluates maturity for Data Products and Data Contracts."""
+
+    def evaluate(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        persist: bool = True,
+        evaluated_by: Optional[str] = None,
+    ) -> Optional[MaturityReport]:
+        """Evaluate maturity for an entity.
+
+        Returns None if the entity is not found.
+        """
+        builder = _ENTITY_DICT_BUILDERS.get(entity_type)
+        if not builder:
+            logger.warning(f"No entity dict builder for type: {entity_type}")
+            return None
+
+        entity_dict = builder(db, entity_id)
+        if entity_dict is None:
+            return None
+
+        entity_name = entity_dict.get("name")
+
+        # Load levels applicable to this entity type
+        levels = maturity_repo.get_all_ordered(db, entity_type=entity_type)
+        if not levels:
+            return MaturityReport(
+                entity_type=entity_type,
+                entity_id=entity_id,
+                entity_name=entity_name,
+                evaluated_at=datetime.now(timezone.utc),
+                evaluated_by=evaluated_by,
+            )
+
+        level_results = []
+        achieved_order = None
+        achieved_name = None
+        total_gates_passed = 0
+        total_gates = 0
+
+        for level in levels:
+            gates = level.gates or []
+            gate_results = []
+            all_required_pass = True
+
+            for gate in gates:
+                total_gates += 1
+                policy = gate.compliance_policy
+                if not policy:
+                    gate_results.append(GateResult(
+                        gate_id=str(gate.id),
+                        policy_id=gate.compliance_policy_id,
+                        policy_name="(missing policy)",
+                        required=gate.required,
+                        passed=False,
+                        message="Compliance policy not found",
+                    ))
+                    if gate.required:
+                        all_required_pass = False
+                    continue
+
+                passed, message = self._evaluate_gate(policy.rule, entity_dict)
+                if passed:
+                    total_gates_passed += 1
+                elif gate.required:
+                    all_required_pass = False
+
+                gate_results.append(GateResult(
+                    gate_id=str(gate.id),
+                    policy_id=gate.compliance_policy_id,
+                    policy_name=policy.name,
+                    required=gate.required,
+                    passed=passed,
+                    message=message if not passed else None,
+                ))
+
+            level_results.append(LevelResult(
+                level_order=level.level_order,
+                level_name=level.name,
+                level_icon=level.icon,
+                level_color=level.color,
+                achieved=all_required_pass,
+                gates=gate_results,
+            ))
+
+            if all_required_pass:
+                achieved_order = level.level_order
+                achieved_name = level.name
+            else:
+                # Cumulative: stop evaluating higher levels
+                break
+
+        now = datetime.now(timezone.utc)
+        report = MaturityReport(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            entity_name=entity_name,
+            achieved_level_order=achieved_order,
+            achieved_level_name=achieved_name,
+            total_levels=len(levels),
+            gates_passed=total_gates_passed,
+            gates_total=total_gates,
+            levels=level_results,
+            evaluated_at=now,
+            evaluated_by=evaluated_by,
+        )
+
+        if persist:
+            # Detect level change for trigger / change log
+            prev_snapshot = maturity_repo.get_latest_snapshot(
+                db, entity_type=entity_type, entity_id=entity_id
+            )
+            prev_level = prev_snapshot.achieved_level_order if prev_snapshot else None
+
+            self._persist(db, report)
+
+            if achieved_order != prev_level:
+                self._log_change(
+                    db,
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    from_level=prev_level,
+                    to_level=achieved_order,
+                    entity_name=entity_name,
+                    evaluated_by=evaluated_by,
+                )
+
+        return report
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _evaluate_gate(rule: str, entity_dict: dict) -> tuple[bool, Optional[str]]:
+        """Evaluate a compliance DSL rule against an entity dict."""
+        try:
+            from src.common.compliance_dsl import evaluate_rule_on_object
+            return evaluate_rule_on_object(rule, entity_dict)
+        except Exception as e:
+            logger.error(f"Gate evaluation error: {e}", exc_info=True)
+            return False, str(e)
+
+    @staticmethod
+    def _persist(db: Session, report: MaturityReport) -> None:
+        """Persist a snapshot and update the cached maturity level on the entity."""
+        gate_results_data = []
+        for lr in report.levels:
+            for gr in lr.gates:
+                gate_results_data.append({
+                    "level_order": lr.level_order,
+                    "level_name": lr.level_name,
+                    "gate_id": gr.gate_id,
+                    "policy_id": gr.policy_id,
+                    "policy_name": gr.policy_name,
+                    "required": gr.required,
+                    "passed": gr.passed,
+                    "message": gr.message,
+                })
+
+        maturity_repo.create_snapshot(
+            db,
+            entity_type=report.entity_type,
+            entity_id=report.entity_id,
+            achieved_level_order=report.achieved_level_order,
+            achieved_level_name=report.achieved_level_name,
+            total_levels=report.total_levels,
+            gates_passed=report.gates_passed,
+            gates_total=report.gates_total,
+            gate_results_json=json.dumps(gate_results_data),
+            evaluated_by=report.evaluated_by,
+        )
+
+        # Update cached maturity on entity table
+        _update_entity_cache(
+            db,
+            entity_type=report.entity_type,
+            entity_id=report.entity_id,
+            level_order=report.achieved_level_order,
+        )
+
+        db.commit()
+
+
+    @staticmethod
+    def _log_change(
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        from_level: Optional[int],
+        to_level: Optional[int],
+        entity_name: Optional[str] = None,
+        evaluated_by: Optional[str] = None,
+    ) -> None:
+        """Log maturity change to change log and fire workflow trigger."""
+        try:
+            from src.controller.change_log_manager import ChangeLogManager
+            cl = ChangeLogManager()
+            cl.log_change_with_details(
+                db,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                action="MATURITY_CHANGED",
+                username=evaluated_by or "system",
+                details={
+                    "from_maturity_level": from_level,
+                    "to_maturity_level": to_level,
+                },
+            )
+        except Exception as e:
+            logger.warning(f"Failed to log maturity change: {e}")
+
+        try:
+            from src.common.workflow_triggers import TriggerRegistry
+            from src.models.process_workflows import EntityType
+            et_map = {"DataProduct": EntityType.DATA_PRODUCT, "DataContract": EntityType.DATA_CONTRACT}
+            et_enum = et_map.get(entity_type)
+            if et_enum:
+                registry = TriggerRegistry(db)
+                registry.on_maturity_change(
+                    entity_type=et_enum,
+                    entity_id=entity_id,
+                    entity_name=entity_name,
+                    from_level=from_level,
+                    to_level=to_level,
+                    user_email=evaluated_by,
+                )
+        except Exception as e:
+            logger.warning(f"Failed to fire maturity trigger: {e}")
+
+
+def _update_entity_cache(db: Session, *, entity_type: str, entity_id: str,
+                          level_order: Optional[int]) -> None:
+    """Update the cached maturity_level_order on the entity table."""
+    now = datetime.now(timezone.utc)
+    if entity_type == "DataProduct":
+        from src.db_models.data_products import DataProductDb
+        db.query(DataProductDb).filter(DataProductDb.id == entity_id).update(
+            {"maturity_level_order": level_order, "maturity_evaluated_at": now},
+            synchronize_session=False,
+        )
+    elif entity_type == "DataContract":
+        from src.db_models.data_contracts import DataContractDb
+        db.query(DataContractDb).filter(DataContractDb.id == entity_id).update(
+            {"maturity_level_order": level_order, "maturity_evaluated_at": now},
+            synchronize_session=False,
+        )

--- a/src/backend/src/data/demo_data_auto.sql
+++ b/src/backend/src/data/demo_data_auto.sql
@@ -343,19 +343,19 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO compliance_policies (id, name, description, failure_message, rule, category, severity, is_active, created_at, updated_at) VALUES
 ('01100001-0004-4000-8000-000000000001', 'UNECE R155 Cybersecurity', 'Verify vehicle data pipelines meet UNECE WP.29 R155 cybersecurity management system requirements',
 'Vehicle data pipeline lacks cybersecurity controls. UNECE R155 requires documented threat analysis and risk assessment (TARA) for all vehicle data interfaces.',
-'MATCH (d:DataPipeline) WHERE d.domain IN [''Connected Vehicles'', ''Autonomous Driving''] ASSERT d.has_tara = true AND d.encryption_in_transit = true', 'security', 'critical', true, NOW(), NOW()),
+'MATCH (d:DataPipeline) WHERE d.domain IN [''Connected Vehicles'', ''Autonomous Driving''] ASSERT d.has_tara = true AND d.encryption_in_transit = true', 'Security', 'critical', true, NOW(), NOW()),
 
 ('01100002-0004-4000-8000-000000000002', 'IATF 16949 PPAP Compliance', 'Ensure all production parts have approved PPAP submissions at the required level',
 'Part is in production without approved PPAP. IATF 16949 Section 8.3.4.4 requires PPAP approval before production shipment. Interim approval requires documented containment plan.',
-'MATCH (p:Part) WHERE p.production_status = ''active'' ASSERT p.ppap_status IN [''approved'', ''interim_approved'']', 'quality', 'critical', true, NOW(), NOW()),
+'MATCH (p:Part) WHERE p.production_status = ''active'' ASSERT p.ppap_status IN [''approved'', ''interim_approved'']', 'Data Quality', 'critical', true, NOW(), NOW()),
 
 ('01100003-0004-4000-8000-000000000003', 'GDPR Vehicle Data Privacy', 'Verify that vehicle telematics data containing PII is processed in compliance with GDPR/CCPA',
 'Telematics dataset contains PII without proper consent tracking or anonymization. Vehicle location traces, driving behavior, and diagnostic data linked to VIN require explicit consent or pseudonymization.',
-'MATCH (d:Dataset) WHERE d.contains_vehicle_pii = true ASSERT d.consent_mechanism IS NOT NULL AND d.retention_days <= 730', 'governance', 'high', true, NOW(), NOW()),
+'MATCH (d:Dataset) WHERE d.contains_vehicle_pii = true ASSERT d.consent_mechanism IS NOT NULL AND d.retention_days <= 730', 'Governance', 'high', true, NOW(), NOW()),
 
 ('01100004-0004-4000-8000-000000000004', 'ISO 26262 Data Integrity', 'Ensure ADAS training and validation datasets meet ISO 26262 functional safety data integrity requirements',
 'ADAS dataset lacks functional safety traceability. ISO 26262 Part 8 requires documented data management plans, integrity checks, and traceability for safety-relevant data used in ASIL-rated systems.',
-'MATCH (d:Dataset) WHERE d.domain = ''Autonomous Driving'' AND d.safety_relevant = true ASSERT d.asil_rating IS NOT NULL AND d.integrity_checksum IS NOT NULL', 'governance', 'critical', true, NOW(), NOW())
+'MATCH (d:Dataset) WHERE d.domain = ''Autonomous Driving'' AND d.safety_relevant = true ASSERT d.asil_rating IS NOT NULL AND d.integrity_checksum IS NOT NULL', 'Governance', 'critical', true, NOW(), NOW())
 
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/data/demo_data_fsi.sql
+++ b/src/backend/src/data/demo_data_fsi.sql
@@ -342,19 +342,19 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO compliance_policies (id, name, description, failure_message, rule, category, severity, is_active, created_at, updated_at) VALUES
 ('01100001-0002-4000-8000-000000000001', 'BCBS 239 Data Lineage', 'Verify all risk data has documented end-to-end lineage per BCBS 239 Principle 4',
 'Risk dataset lacks documented data lineage. BCBS 239 requires complete, documented lineage from source to report for all material risk data.',
-'MATCH (d:Dataset) WHERE d.domain IN [''Risk Management'', ''Capital Markets''] ASSERT d.has_lineage = true AND d.lineage_validated = true', 'governance', 'critical', true, NOW(), NOW()),
+'MATCH (d:Dataset) WHERE d.domain IN [''Risk Management'', ''Capital Markets''] ASSERT d.has_lineage = true AND d.lineage_validated = true', 'Governance', 'critical', true, NOW(), NOW()),
 
 ('01100002-0002-4000-8000-000000000002', 'AML Transaction Monitoring Coverage', 'Ensure all customer accounts are covered by AML transaction monitoring',
 'Account not covered by AML monitoring. All retail and commercial accounts must be monitored for suspicious activity per BSA requirements.',
-'MATCH (a:Account) ASSERT a.aml_monitoring_enabled = true', 'security', 'critical', true, NOW(), NOW()),
+'MATCH (a:Account) ASSERT a.aml_monitoring_enabled = true', 'Security', 'critical', true, NOW(), NOW()),
 
 ('01100003-0002-4000-8000-000000000003', 'KYC Periodic Review', 'Verify KYC profiles are reviewed within regulatory timelines based on risk rating',
 'KYC review overdue. High-risk customers must be reviewed annually, medium-risk every 2 years, and low-risk every 3 years.',
-'MATCH (c:Customer) ASSERT c.days_since_kyc_review <= CASE c.risk_rating WHEN ''high'' THEN 365 WHEN ''medium'' THEN 730 ELSE 1095 END', 'governance', 'high', true, NOW(), NOW()),
+'MATCH (c:Customer) ASSERT c.days_since_kyc_review <= CASE c.risk_rating WHEN ''high'' THEN 365 WHEN ''medium'' THEN 730 ELSE 1095 END', 'Governance', 'high', true, NOW(), NOW()),
 
 ('01100004-0002-4000-8000-000000000004', 'Market Data Timeliness', 'Ensure market data feeds are within acceptable staleness thresholds',
 'Market data feed is stale. Real-time feeds must be within 500ms and end-of-day feeds must be available by T+1 06:00 UTC.',
-'MATCH (f:MarketDataFeed) WHERE f.feed_type = ''realtime'' ASSERT f.latency_ms <= 500', 'freshness', 'high', true, NOW(), NOW())
+'MATCH (f:MarketDataFeed) WHERE f.feed_type = ''realtime'' ASSERT f.latency_ms <= 500', 'Data Quality', 'high', true, NOW(), NOW())
 
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/data/demo_data_hls.sql
+++ b/src/backend/src/data/demo_data_hls.sql
@@ -345,19 +345,19 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO compliance_policies (id, name, description, failure_message, rule, category, severity, is_active, created_at, updated_at) VALUES
 ('01100001-0001-4000-8000-000000000001', 'HIPAA PHI De-identification', 'Verify all patient data is de-identified per HIPAA Safe Harbor method',
 'Protected Health Information (PHI) detected in dataset. All 18 HIPAA identifiers must be removed or generalized per the Safe Harbor method before analytical use.',
-'MATCH (d:Dataset) WHERE d.domain IN [''Clinical'', ''Research''] AND d.contains_phi = true ASSERT d.deidentification_method = ''safe_harbor''', 'security', 'critical', true, NOW(), NOW()),
+'MATCH (d:Dataset) WHERE d.domain IN [''Clinical'', ''Research''] AND d.contains_phi = true ASSERT d.deidentification_method = ''safe_harbor''', 'Security', 'critical', true, NOW(), NOW()),
 
 ('01100002-0001-4000-8000-000000000002', '21 CFR Part 11 Audit Trail', 'Ensure electronic records have complete audit trails per FDA regulations',
 'Dataset lacks required audit trail for 21 CFR Part 11 compliance. All clinical trial electronic records must have timestamped, user-attributed audit trails that cannot be modified.',
-'MATCH (d:Dataset) WHERE d.domain = ''Research'' ASSERT d.has_audit_trail = true AND d.audit_trail_immutable = true', 'governance', 'critical', true, NOW(), NOW()),
+'MATCH (d:Dataset) WHERE d.domain = ''Research'' ASSERT d.has_audit_trail = true AND d.audit_trail_immutable = true', 'Governance', 'critical', true, NOW(), NOW()),
 
 ('01100003-0001-4000-8000-000000000003', 'CDISC Standards Compliance', 'Verify clinical trial data conforms to CDISC SDTM/ADaM standards',
 'Clinical trial dataset does not conform to CDISC standards. All submission-ready datasets must follow SDTM or ADaM data models.',
-'MATCH (d:Dataset) WHERE d.domain = ''Research'' AND d.is_submission_ready = true ASSERT d.cdisc_standard IN [''SDTM'', ''ADaM'']', 'quality', 'high', true, NOW(), NOW()),
+'MATCH (d:Dataset) WHERE d.domain = ''Research'' AND d.is_submission_ready = true ASSERT d.cdisc_standard IN [''SDTM'', ''ADaM'']', 'Data Quality', 'high', true, NOW(), NOW()),
 
 ('01100004-0001-4000-8000-000000000004', 'Adverse Event Reporting Timeliness', 'Ensure serious adverse events are reported within regulatory timelines',
 'Serious adverse event reporting exceeds 15-day regulatory deadline. Expedited ICSRs must be submitted within 15 calendar days of initial receipt.',
-'MATCH (ae:AdverseEvent) WHERE ae.seriousness = ''serious'' ASSERT ae.days_to_report <= 15', 'governance', 'critical', true, NOW(), NOW())
+'MATCH (ae:AdverseEvent) WHERE ae.seriousness = ''serious'' ASSERT ae.days_to_report <= 15', 'Governance', 'critical', true, NOW(), NOW())
 
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/data/demo_data_mfg.sql
+++ b/src/backend/src/data/demo_data_mfg.sql
@@ -348,19 +348,19 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO compliance_policies (id, name, description, failure_message, rule, category, severity, is_active, created_at, updated_at) VALUES
 ('01100001-0003-4000-8000-000000000001', 'ISO 9001 Traceability', 'Verify lot/serial traceability from raw material to finished goods per ISO 9001:2015',
 'Product lot lacks complete material traceability. ISO 9001 Section 8.5.2 requires lot-level traceability for all manufactured products.',
-'MATCH (p:Product) ASSERT p.has_lot_traceability = true AND p.genealogy_complete = true', 'quality', 'critical', true, NOW(), NOW()),
+'MATCH (p:Product) ASSERT p.has_lot_traceability = true AND p.genealogy_complete = true', 'Data Quality', 'critical', true, NOW(), NOW()),
 
 ('01100002-0003-4000-8000-000000000002', 'SPC Out-of-Control Detection', 'Flag processes where SPC control charts indicate out-of-control conditions',
 'Process characteristic is out of statistical control. Western Electric rules violations detected. Production hold and engineering review required.',
-'MATCH (c:Characteristic) ASSERT c.spc_status = ''in_control''', 'quality', 'high', true, NOW(), NOW()),
+'MATCH (c:Characteristic) ASSERT c.spc_status = ''in_control''', 'Data Quality', 'high', true, NOW(), NOW()),
 
 ('01100003-0003-4000-8000-000000000003', 'Equipment Calibration Currency', 'Ensure all measurement equipment has current calibration certification',
 'Measurement equipment calibration is overdue. All gages, CMMs, and test equipment must have valid calibration certificates per the calibration schedule.',
-'MATCH (e:Equipment) WHERE e.type = ''measurement'' ASSERT e.calibration_due_date > datetime()', 'governance', 'critical', true, NOW(), NOW()),
+'MATCH (e:Equipment) WHERE e.type = ''measurement'' ASSERT e.calibration_due_date > datetime()', 'Governance', 'critical', true, NOW(), NOW()),
 
 ('01100004-0003-4000-8000-000000000004', 'OSHA Recordable Reporting', 'Ensure OSHA recordable incidents are documented within 7 calendar days',
 'OSHA recordable incident not documented within required timeframe. Per 29 CFR 1904, OSHA 300 log must be updated within 7 calendar days of incident.',
-'MATCH (i:Incident) WHERE i.is_osha_recordable = true ASSERT i.days_to_document <= 7', 'governance', 'high', true, NOW(), NOW())
+'MATCH (i:Incident) WHERE i.is_osha_recordable = true ASSERT i.days_to_document <= 7', 'Governance', 'high', true, NOW(), NOW())
 
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/data/demo_data_retail.sql
+++ b/src/backend/src/data/demo_data_retail.sql
@@ -562,19 +562,19 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO compliance_policies (id, name, description, failure_message, rule, category, severity, is_active, created_at, updated_at) VALUES
 ('01100001-0000-4000-8000-000000000001', 'Naming Conventions', 'Verify that all objects follow corporate naming conventions', 
 'Names must use snake_case format (lowercase letters with underscores). For example: "customer_orders" is valid, but "CustomerOrders" or "customer-orders" are not. Views must be prefixed with "v_".', 
-E'MATCH (obj:Object)\nWHERE obj.type IN [''catalog'', ''schema'', ''table'', ''view'']\nASSERT \n  CASE obj.type\n    WHEN ''catalog'' THEN obj.name MATCHES ''^[a-z][a-z0-9_]*$''\n    WHEN ''schema'' THEN obj.name MATCHES ''^[a-z][a-z0-9_]*$''\n    WHEN ''table'' THEN obj.name MATCHES ''^[a-z][a-z0-9_]*$''\n    WHEN ''view'' THEN obj.name MATCHES ''^v_[a-z][a-z0-9_]*$''\n  END', 'governance', 'high', true, NOW(), NOW()),
+E'MATCH (obj:Object)\nWHERE obj.type IN [''catalog'', ''schema'', ''table'', ''view'']\nASSERT \n  CASE obj.type\n    WHEN ''catalog'' THEN obj.name MATCHES ''^[a-z][a-z0-9_]*$''\n    WHEN ''schema'' THEN obj.name MATCHES ''^[a-z][a-z0-9_]*$''\n    WHEN ''table'' THEN obj.name MATCHES ''^[a-z][a-z0-9_]*$''\n    WHEN ''view'' THEN obj.name MATCHES ''^v_[a-z][a-z0-9_]*$''\n  END', 'Governance', 'high', true, NOW(), NOW()),
 ('01100002-0000-4000-8000-000000000002', 'PII Data Encryption', 'Ensure all PII data is encrypted at rest', 
 'All datasets containing Personally Identifiable Information (PII) must be encrypted using AES-256 encryption. Please enable encryption on the table or contact your security team for assistance.',
-'MATCH (d:Dataset) WHERE d.contains_pii = true ASSERT d.encryption = ''AES256''', 'security', 'critical', true, NOW(), NOW()),
+'MATCH (d:Dataset) WHERE d.contains_pii = true ASSERT d.encryption = ''AES256''', 'Security', 'critical', true, NOW(), NOW()),
 ('01100003-0000-4000-8000-000000000003', 'Data Quality Thresholds', 'Maintain data quality metrics above defined thresholds', 
 'Data quality must meet minimum standards: completeness > 95% and accuracy > 98%. Review the data pipeline for missing or incorrect values before publishing.',
-'MATCH (d:Dataset) ASSERT d.completeness > 0.95 AND d.accuracy > 0.98', 'quality', 'high', true, NOW(), NOW()),
+'MATCH (d:Dataset) ASSERT d.completeness > 0.95 AND d.accuracy > 0.98', 'Data Quality', 'high', true, NOW(), NOW()),
 ('01100004-0000-4000-8000-000000000004', 'Access Control', 'Verify proper access controls on sensitive data', 
 'High-sensitivity datasets must have restricted access controls configured. Please set access_level to "restricted" and ensure only authorized groups have access.',
-'MATCH (d:Dataset) WHERE d.sensitivity = ''high'' ASSERT d.access_level = ''restricted''', 'security', 'critical', true, NOW(), NOW()),
+'MATCH (d:Dataset) WHERE d.sensitivity = ''high'' ASSERT d.access_level = ''restricted''', 'Security', 'critical', true, NOW(), NOW()),
 ('01100005-0000-4000-8000-000000000005', 'Data Freshness', 'Ensure data is updated within defined timeframes', 
 'Data appears to be stale (not updated within the last 24 hours). Check the data pipeline status and ensure scheduled jobs are running correctly.',
-'MATCH (d:Dataset) ASSERT d.last_updated > datetime() - duration(''P1D'')', 'freshness', 'medium', true, NOW(), NOW())
+'MATCH (d:Dataset) ASSERT d.last_updated > datetime() - duration(''P1D'')', 'Data Quality', 'medium', true, NOW(), NOW())
 
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/db_models/__init__.py
+++ b/src/backend/src/db_models/__init__.py
@@ -40,6 +40,7 @@ from . import delivery_methods
 from . import entity_relationships
 from . import entity_subscriptions
 from . import certification_levels
+from . import maturity
 from . import workflow_configurations
 from . import workflow_installations
 from . import workflow_job_runs

--- a/src/backend/src/db_models/data_contracts.py
+++ b/src/backend/src/db_models/data_contracts.py
@@ -70,6 +70,10 @@ class DataContractDb(Base):
     certification_expires_at = Column(DateTime(timezone=True), nullable=True)
     certification_notes = Column(Text, nullable=True)
 
+    # ==================== Maturity ====================
+    maturity_level_order = Column(Integer, nullable=True)
+    maturity_evaluated_at = Column(DateTime(timezone=True), nullable=True)
+
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
     created_by = Column(String, nullable=True)

--- a/src/backend/src/db_models/data_products.py
+++ b/src/backend/src/db_models/data_products.py
@@ -86,6 +86,10 @@ class DataProductDb(Base):
     certification_expires_at = Column(DateTime(timezone=True), nullable=True)
     certification_notes = Column(Text, nullable=True)
 
+    # ==================== Maturity ====================
+    maturity_level_order = Column(Integer, nullable=True)
+    maturity_evaluated_at = Column(DateTime(timezone=True), nullable=True)
+
     # ==================== ODPS v1.0.0 Relationships ====================
     description = relationship("DescriptionDb", back_populates="product", uselist=False, cascade="all, delete-orphan", lazy="selectin")
     authoritative_definitions = relationship("AuthoritativeDefinitionDb", back_populates="product", cascade="all, delete-orphan", lazy="selectin")

--- a/src/backend/src/db_models/maturity.py
+++ b/src/backend/src/db_models/maturity.py
@@ -1,0 +1,98 @@
+"""Database models for configurable maturity levels."""
+import uuid
+from sqlalchemy import (
+    Column, String, Integer, Text, Boolean, TIMESTAMP, ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from src.common.database import Base
+
+
+class MaturityLevelDb(Base):
+    """Admin-configurable ordered maturity levels, scoped per entity type.
+
+    Example seed: Accessible (1), Described (2), Defined (3), Monitored (4), Trusted (5).
+    """
+    __tablename__ = "maturity_levels"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    level_order = Column(Integer, nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    icon = Column(String(100), nullable=True)
+    color = Column(String(50), nullable=True)
+    # "DataProduct", "DataContract", or "all"
+    entity_type = Column(String(50), nullable=False, default="all", index=True)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    gates = relationship("MaturityGateDb", back_populates="maturity_level",
+                         cascade="all, delete-orphan", lazy="selectin",
+                         order_by="MaturityGateDb.display_order")
+
+    __table_args__ = (
+        UniqueConstraint("entity_type", "level_order", name="uq_maturity_level_entity_order"),
+        UniqueConstraint("entity_type", "name", name="uq_maturity_level_entity_name"),
+    )
+
+    def __repr__(self):
+        return f"<MaturityLevelDb(order={self.level_order}, name='{self.name}', entity_type='{self.entity_type}')>"
+
+
+class MaturityGateDb(Base):
+    """Links a maturity level to a compliance policy that must pass for level achievement."""
+    __tablename__ = "maturity_gates"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    maturity_level_id = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("maturity_levels.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    compliance_policy_id = Column(
+        String,
+        ForeignKey("compliance_policies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    required = Column(Boolean, nullable=False, default=True)
+    display_order = Column(Integer, nullable=False, default=0)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+
+    maturity_level = relationship("MaturityLevelDb", back_populates="gates")
+    compliance_policy = relationship("CompliancePolicyDb", lazy="selectin")
+
+    __table_args__ = (
+        UniqueConstraint("maturity_level_id", "compliance_policy_id",
+                         name="uq_maturity_gate_level_policy"),
+    )
+
+    def __repr__(self):
+        return f"<MaturityGateDb(level={self.maturity_level_id}, policy={self.compliance_policy_id})>"
+
+
+class MaturitySnapshotDb(Base):
+    """Timestamped evaluation result for maturity tracking over time."""
+    __tablename__ = "maturity_snapshots"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    entity_type = Column(String(50), nullable=False, index=True)
+    entity_id = Column(String, nullable=False, index=True)
+    achieved_level_order = Column(Integer, nullable=True)
+    achieved_level_name = Column(String(255), nullable=True)
+    total_levels = Column(Integer, nullable=False, default=0)
+    gates_passed = Column(Integer, nullable=False, default=0)
+    gates_total = Column(Integer, nullable=False, default=0)
+    gate_results_json = Column(Text, nullable=True)
+    evaluated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    evaluated_by = Column(String, nullable=True)
+
+    def __repr__(self):
+        return (
+            f"<MaturitySnapshotDb(entity={self.entity_type}:{self.entity_id}, "
+            f"level={self.achieved_level_order})>"
+        )

--- a/src/backend/src/models/maturity.py
+++ b/src/backend/src/models/maturity.py
@@ -1,0 +1,129 @@
+"""Pydantic models for maturity levels API."""
+from datetime import datetime
+from typing import Optional, List, Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Maturity Level CRUD
+# ---------------------------------------------------------------------------
+
+class MaturityLevelBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = None
+    icon: Optional[str] = Field(None, max_length=100)
+    color: Optional[str] = Field(None, max_length=50)
+    entity_type: str = Field("all", description="DataProduct, DataContract, or all")
+
+
+class MaturityLevelCreate(MaturityLevelBase):
+    level_order: int = Field(..., ge=1)
+
+
+class MaturityLevelUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = None
+    icon: Optional[str] = Field(None, max_length=100)
+    color: Optional[str] = Field(None, max_length=50)
+    entity_type: Optional[str] = None
+    level_order: Optional[int] = Field(None, ge=1)
+
+
+class MaturityGateRead(BaseModel):
+    id: UUID
+    maturity_level_id: UUID
+    compliance_policy_id: str
+    compliance_policy_name: Optional[str] = None
+    compliance_policy_rule: Optional[str] = None
+    required: bool = True
+    display_order: int = 0
+    created_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+class MaturityLevelRead(MaturityLevelBase):
+    id: UUID
+    level_order: int
+    gates: List[MaturityGateRead] = Field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+class MaturityLevelReorder(BaseModel):
+    """Bulk reorder: list of id -> new level_order mappings."""
+    levels: list[dict] = Field(
+        ...,
+        description="List of {id, level_order} dicts",
+        examples=[[{"id": "...", "level_order": 1}, {"id": "...", "level_order": 2}]],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Maturity Gate CRUD
+# ---------------------------------------------------------------------------
+
+class MaturityGateCreate(BaseModel):
+    compliance_policy_id: str = Field(..., description="ID of the compliance policy to gate on")
+    required: bool = Field(True, description="If False, treated as advisory (warn, not block)")
+    display_order: int = Field(0, ge=0)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation Results
+# ---------------------------------------------------------------------------
+
+class GateResult(BaseModel):
+    """Result of evaluating a single gate."""
+    gate_id: str
+    policy_id: str
+    policy_name: str
+    required: bool
+    passed: bool
+    message: Optional[str] = None
+
+
+class LevelResult(BaseModel):
+    """Evaluation result for a single maturity level."""
+    level_order: int
+    level_name: str
+    level_icon: Optional[str] = None
+    level_color: Optional[str] = None
+    achieved: bool
+    gates: List[GateResult] = Field(default_factory=list)
+
+
+class MaturityReport(BaseModel):
+    """Full maturity evaluation report for an entity."""
+    entity_type: str
+    entity_id: str
+    entity_name: Optional[str] = None
+    achieved_level_order: Optional[int] = None
+    achieved_level_name: Optional[str] = None
+    total_levels: int = 0
+    gates_passed: int = 0
+    gates_total: int = 0
+    levels: List[LevelResult] = Field(default_factory=list)
+    evaluated_at: datetime = Field(default_factory=datetime.utcnow)
+    evaluated_by: Optional[str] = None
+
+
+class MaturitySnapshotRead(BaseModel):
+    """Historical maturity snapshot."""
+    id: UUID
+    entity_type: str
+    entity_id: str
+    achieved_level_order: Optional[int] = None
+    achieved_level_name: Optional[str] = None
+    total_levels: int = 0
+    gates_passed: int = 0
+    gates_total: int = 0
+    gate_results_json: Optional[str] = None
+    evaluated_at: datetime
+    evaluated_by: Optional[str] = None
+
+    model_config = {"from_attributes": True}

--- a/src/backend/src/models/process_workflows.py
+++ b/src/backend/src/models/process_workflows.py
@@ -50,6 +50,9 @@ class TriggerType(str, Enum):
     ON_PUBLISH = "on_publish"  # When an entity is published to marketplace
     ON_UNPUBLISH = "on_unpublish"  # When an entity is unpublished from marketplace
 
+    # Maturity triggers
+    ON_MATURITY_CHANGE = "on_maturity_change"  # When maturity level changes (up or down)
+
     # Access lifecycle triggers
     ON_EXPIRING = "on_expiring"  # When access/entity is about to expire
     ON_REVOKE = "on_revoke"  # When access is revoked

--- a/src/backend/src/repositories/maturity_repository.py
+++ b/src/backend/src/repositories/maturity_repository.py
@@ -1,0 +1,289 @@
+"""Repository for maturity levels, gates, and snapshots."""
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import func, select, and_
+from sqlalchemy.orm import Session
+
+from src.db_models.maturity import MaturityLevelDb, MaturityGateDb, MaturitySnapshotDb
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class MaturityLevelRepository:
+
+    # ------------------------------------------------------------------
+    # Levels
+    # ------------------------------------------------------------------
+
+    def get_all_ordered(self, db: Session, *, entity_type: Optional[str] = None) -> List[MaturityLevelDb]:
+        """Return levels ordered by level_order, optionally filtered by entity_type."""
+        q = db.query(MaturityLevelDb)
+        if entity_type:
+            q = q.filter(
+                MaturityLevelDb.entity_type.in_([entity_type, "all"])
+            )
+        return q.order_by(MaturityLevelDb.level_order).all()
+
+    def get_by_id(self, db: Session, level_id: UUID) -> Optional[MaturityLevelDb]:
+        return db.query(MaturityLevelDb).filter(MaturityLevelDb.id == level_id).first()
+
+    def get_by_order(self, db: Session, level_order: int, entity_type: str) -> Optional[MaturityLevelDb]:
+        return db.query(MaturityLevelDb).filter(
+            and_(
+                MaturityLevelDb.level_order == level_order,
+                MaturityLevelDb.entity_type == entity_type,
+            )
+        ).first()
+
+    def create(self, db: Session, *, name: str, level_order: int,
+               entity_type: str = "all", description: Optional[str] = None,
+               icon: Optional[str] = None, color: Optional[str] = None) -> MaturityLevelDb:
+        obj = MaturityLevelDb(
+            name=name,
+            level_order=level_order,
+            entity_type=entity_type,
+            description=description,
+            icon=icon,
+            color=color,
+        )
+        db.add(obj)
+        db.flush()
+        db.refresh(obj)
+        logger.info(f"Created maturity level '{name}' (order={level_order}, entity_type={entity_type})")
+        return obj
+
+    def update(self, db: Session, *, db_obj: MaturityLevelDb, update_data: dict) -> MaturityLevelDb:
+        for field, value in update_data.items():
+            if hasattr(db_obj, field) and field != "id":
+                setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.flush()
+        db.refresh(db_obj)
+        logger.info(f"Updated maturity level '{db_obj.name}'")
+        return db_obj
+
+    def delete(self, db: Session, *, db_obj: MaturityLevelDb) -> None:
+        db.delete(db_obj)
+        db.flush()
+        logger.info(f"Deleted maturity level '{db_obj.name}' (order={db_obj.level_order})")
+
+    def reorder(self, db: Session, *, order_map: dict[str, int]) -> List[MaturityLevelDb]:
+        """Bulk reorder: order_map = {str(uuid): new_order, ...}.
+        Two-pass to avoid unique constraint violations.
+        """
+        all_levels = self.get_all_ordered(db)
+        changed = []
+        for level in all_levels:
+            new_order = order_map.get(str(level.id))
+            if new_order is not None and new_order != level.level_order:
+                changed.append((level, new_order))
+
+        if not changed:
+            return all_levels
+
+        for i, (level, _) in enumerate(changed):
+            level.level_order = -(i + 1)
+            db.add(level)
+        db.flush()
+
+        for level, new_order in changed:
+            level.level_order = new_order
+            db.add(level)
+        db.flush()
+
+        return self.get_all_ordered(db)
+
+    def count_snapshots_for_level(self, db: Session, level_order: int) -> int:
+        return db.query(func.count(MaturitySnapshotDb.id)).filter(
+            MaturitySnapshotDb.achieved_level_order == level_order
+        ).scalar() or 0
+
+    def is_empty(self, db: Session, entity_type: Optional[str] = None) -> bool:
+        q = db.query(MaturityLevelDb)
+        if entity_type:
+            q = q.filter(MaturityLevelDb.entity_type == entity_type)
+        return q.count() == 0
+
+    # ------------------------------------------------------------------
+    # Gates
+    # ------------------------------------------------------------------
+
+    def add_gate(self, db: Session, *, maturity_level_id: UUID,
+                 compliance_policy_id: str, required: bool = True,
+                 display_order: int = 0) -> MaturityGateDb:
+        gate = MaturityGateDb(
+            maturity_level_id=maturity_level_id,
+            compliance_policy_id=compliance_policy_id,
+            required=required,
+            display_order=display_order,
+        )
+        db.add(gate)
+        db.flush()
+        db.refresh(gate)
+        logger.info(f"Added gate: level={maturity_level_id}, policy={compliance_policy_id}")
+        return gate
+
+    def get_gate_by_id(self, db: Session, gate_id: UUID) -> Optional[MaturityGateDb]:
+        return db.query(MaturityGateDb).filter(MaturityGateDb.id == gate_id).first()
+
+    def remove_gate(self, db: Session, *, db_obj: MaturityGateDb) -> None:
+        db.delete(db_obj)
+        db.flush()
+        logger.info(f"Removed gate {db_obj.id}")
+
+    # ------------------------------------------------------------------
+    # Snapshots
+    # ------------------------------------------------------------------
+
+    def create_snapshot(self, db: Session, **kwargs) -> MaturitySnapshotDb:
+        snap = MaturitySnapshotDb(**kwargs)
+        db.add(snap)
+        db.flush()
+        db.refresh(snap)
+        return snap
+
+    def list_snapshots(self, db: Session, *, entity_type: str,
+                       entity_id: str, limit: int = 50) -> List[MaturitySnapshotDb]:
+        return (
+            db.query(MaturitySnapshotDb)
+            .filter(
+                and_(
+                    MaturitySnapshotDb.entity_type == entity_type,
+                    MaturitySnapshotDb.entity_id == entity_id,
+                )
+            )
+            .order_by(MaturitySnapshotDb.evaluated_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def get_latest_snapshot(self, db: Session, *, entity_type: str,
+                            entity_id: str) -> Optional[MaturitySnapshotDb]:
+        return (
+            db.query(MaturitySnapshotDb)
+            .filter(
+                and_(
+                    MaturitySnapshotDb.entity_type == entity_type,
+                    MaturitySnapshotDb.entity_id == entity_id,
+                )
+            )
+            .order_by(MaturitySnapshotDb.evaluated_at.desc())
+            .first()
+        )
+
+
+    def seed_defaults(self, db: Session) -> List[MaturityLevelDb]:
+        """Seed default 5-level maturity model with compliance policy gates.
+
+        Only seeds if no maturity levels exist yet. Creates compliance policies
+        for each gate and wires them up.
+        """
+        if not self.is_empty(db):
+            return self.get_all_ordered(db)
+
+        from src.db_models.compliance import CompliancePolicyDb
+        import uuid as _uuid
+
+        # Define the 5-level model
+        LEVELS = [
+            {
+                "level_order": 1, "name": "Accessible", "entity_type": "all",
+                "description": "Data can be found and requested through clear procedures",
+                "icon": "lock-keyhole", "color": "blue",
+                "gates": [
+                    {"name": "Owner is known", "rule": "ASSERT obj.has_owner = True",
+                     "severity": "high", "category": "Maturity"},
+                    {"name": "Name is defined", "rule": "ASSERT obj.name != ''",
+                     "severity": "high", "category": "Maturity"},
+                ],
+            },
+            {
+                "level_order": 2, "name": "Described", "entity_type": "all",
+                "description": "Purpose and usage are properly documented",
+                "icon": "file-text", "color": "cyan",
+                "gates": [
+                    {"name": "Description present", "rule": "ASSERT obj.has_description = True",
+                     "severity": "high", "category": "Maturity"},
+                    {"name": "Tags assigned", "rule": "ASSERT obj.tag_count > 0",
+                     "severity": "medium", "category": "Maturity", "required": False},
+                ],
+            },
+            {
+                "level_order": 3, "name": "Defined", "entity_type": "all",
+                "description": "Business definitions and governance roles are established",
+                "icon": "book-open", "color": "green",
+                "gates": [
+                    {"name": "Business terms linked",
+                     "rule": "ASSERT obj.business_term_count > 0",
+                     "severity": "high", "category": "Maturity"},
+                    {"name": "Upstream lineage defined",
+                     "rule": "ASSERT obj.has_upstream_lineage = True",
+                     "severity": "high", "category": "Maturity"},
+                ],
+            },
+            {
+                "level_order": 4, "name": "Monitored", "entity_type": "all",
+                "description": "Data quality is actively monitored and issues are followed up",
+                "icon": "activity", "color": "amber",
+                "gates": [
+                    {"name": "Quality checks active",
+                     "rule": "ASSERT obj.quality_check_count > 0",
+                     "severity": "high", "category": "Maturity"},
+                ],
+            },
+            {
+                "level_order": 5, "name": "Trusted", "entity_type": "all",
+                "description": "Certified, reusable data product with complete governance",
+                "icon": "shield-check", "color": "purple",
+                "gates": [
+                    {"name": "Entity is certified",
+                     "rule": "ASSERT obj.effective_certification >= 1",
+                     "severity": "high", "category": "Maturity"},
+                    {"name": "Delivery channels defined",
+                     "rule": "ASSERT obj.has_delivery_channels = True",
+                     "severity": "medium", "category": "Maturity", "required": False},
+                    {"name": "Has output contracts",
+                     "rule": "ASSERT obj.has_contract = True",
+                     "severity": "high", "category": "Maturity"},
+                ],
+            },
+        ]
+
+        created_levels = []
+        for level_def in LEVELS:
+            gate_defs = level_def.pop("gates")
+            level = self.create(db, **level_def)
+
+            for idx, gate_def in enumerate(gate_defs):
+                is_required = gate_def.pop("required", True)
+                policy = CompliancePolicyDb(
+                    id=str(_uuid.uuid4()),
+                    slug=f"maturity-{level_def['level_order']}-{gate_def['name'].lower().replace(' ', '-')}",
+                    name=f"[Maturity L{level_def['level_order']}] {gate_def['name']}",
+                    description=f"Maturity gate for level '{level_def.get('name', level_def['level_order'])}': {gate_def['name']}",
+                    failure_message=f"Gate failed: {gate_def['name']}",
+                    rule=gate_def["rule"],
+                    category=gate_def.get("category", "Maturity"),
+                    severity=gate_def.get("severity", "medium"),
+                    is_active=True,
+                )
+                db.add(policy)
+                db.flush()
+
+                self.add_gate(
+                    db,
+                    maturity_level_id=level.id,
+                    compliance_policy_id=policy.id,
+                    required=is_required,
+                    display_order=idx,
+                )
+
+            created_levels.append(level)
+
+        logger.info("Seeded default 5-level maturity model with compliance policy gates")
+        return created_levels
+
+
+maturity_repo = MaturityLevelRepository()

--- a/src/backend/src/routes/maturity_routes.py
+++ b/src/backend/src/routes/maturity_routes.py
@@ -1,0 +1,360 @@
+"""API routes for maturity levels management and evaluation."""
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from src.common.dependencies import DBSessionDep
+from src.common.authorization import PermissionChecker
+from src.common.features import FeatureAccessLevel
+from src.models.maturity import (
+    MaturityLevelCreate,
+    MaturityLevelRead,
+    MaturityLevelUpdate,
+    MaturityLevelReorder,
+    MaturityGateCreate,
+    MaturityGateRead,
+    MaturityReport,
+    MaturitySnapshotRead,
+)
+from src.repositories.maturity_repository import maturity_repo
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api", tags=["Maturity Levels"])
+SETTINGS_FEATURE_ID = "settings"
+DP_FEATURE_ID = "data-products"
+DC_FEATURE_ID = "data-contracts"
+
+
+# ---------------------------------------------------------------------------
+# Helper: map DB gate to read model with policy name
+# ---------------------------------------------------------------------------
+
+def _gate_to_read(gate) -> MaturityGateRead:
+    policy_name = None
+    policy_rule = None
+    if gate.compliance_policy:
+        policy_name = gate.compliance_policy.name
+        policy_rule = gate.compliance_policy.rule
+    return MaturityGateRead(
+        id=gate.id,
+        maturity_level_id=gate.maturity_level_id,
+        compliance_policy_id=gate.compliance_policy_id,
+        compliance_policy_name=policy_name,
+        compliance_policy_rule=policy_rule,
+        required=gate.required,
+        display_order=gate.display_order,
+        created_at=gate.created_at,
+    )
+
+
+def _level_to_read(level) -> MaturityLevelRead:
+    return MaturityLevelRead(
+        id=level.id,
+        level_order=level.level_order,
+        name=level.name,
+        description=level.description,
+        icon=level.icon,
+        color=level.color,
+        entity_type=level.entity_type,
+        gates=[_gate_to_read(g) for g in (level.gates or [])],
+        created_at=level.created_at,
+        updated_at=level.updated_at,
+    )
+
+
+# ===================================================================
+# Admin CRUD for Maturity Levels
+# ===================================================================
+
+@router.get("/maturity-levels", response_model=List[MaturityLevelRead])
+async def list_maturity_levels(
+    db: DBSessionDep,
+    entity_type: Optional[str] = None,
+):
+    """List all maturity levels, optionally filtered by entity_type."""
+    levels = maturity_repo.get_all_ordered(db, entity_type=entity_type)
+    return [_level_to_read(l) for l in levels]
+
+
+@router.post(
+    "/maturity-levels",
+    response_model=MaturityLevelRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_maturity_level(
+    body: MaturityLevelCreate,
+    db: DBSessionDep,
+    _: bool = Depends(PermissionChecker(SETTINGS_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Create a new maturity level. Admin only."""
+    existing = maturity_repo.get_by_order(db, body.level_order, body.entity_type)
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A maturity level with order {body.level_order} already exists for entity_type '{body.entity_type}'.",
+        )
+    try:
+        level = maturity_repo.create(
+            db,
+            name=body.name,
+            level_order=body.level_order,
+            entity_type=body.entity_type,
+            description=body.description,
+            icon=body.icon,
+            color=body.color,
+        )
+        db.commit()
+        db.refresh(level)
+        return _level_to_read(level)
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error creating maturity level: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to create maturity level")
+
+
+@router.put("/maturity-levels/reorder", response_model=List[MaturityLevelRead])
+async def reorder_maturity_levels(
+    body: MaturityLevelReorder,
+    db: DBSessionDep,
+    _: bool = Depends(PermissionChecker(SETTINGS_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Bulk reorder maturity levels. Admin only."""
+    order_map = {item["id"]: item["level_order"] for item in body.levels}
+    try:
+        result = maturity_repo.reorder(db, order_map=order_map)
+        db.commit()
+        return [_level_to_read(l) for l in result]
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error reordering maturity levels: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to reorder maturity levels")
+
+
+@router.put("/maturity-levels/{level_id}", response_model=MaturityLevelRead)
+async def update_maturity_level(
+    level_id: UUID,
+    body: MaturityLevelUpdate,
+    db: DBSessionDep,
+    _: bool = Depends(PermissionChecker(SETTINGS_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Update a maturity level. Admin only."""
+    db_obj = maturity_repo.get_by_id(db, level_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Maturity level not found")
+
+    update_data = body.model_dump(exclude_unset=True)
+    if not update_data:
+        return _level_to_read(db_obj)
+
+    if "level_order" in update_data:
+        et = update_data.get("entity_type", db_obj.entity_type)
+        existing = maturity_repo.get_by_order(db, update_data["level_order"], et)
+        if existing and existing.id != level_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Order {update_data['level_order']} is already taken for entity_type '{et}'.",
+            )
+
+    try:
+        updated = maturity_repo.update(db, db_obj=db_obj, update_data=update_data)
+        db.commit()
+        db.refresh(updated)
+        return _level_to_read(updated)
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error updating maturity level: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to update maturity level")
+
+
+@router.delete("/maturity-levels/{level_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_maturity_level(
+    level_id: UUID,
+    db: DBSessionDep,
+    _: bool = Depends(PermissionChecker(SETTINGS_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Delete a maturity level. Blocked if snapshots reference it."""
+    db_obj = maturity_repo.get_by_id(db, level_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Maturity level not found")
+
+    ref_count = maturity_repo.count_snapshots_for_level(db, db_obj.level_order)
+    if ref_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Cannot delete: {ref_count} snapshot(s) reference level order {db_obj.level_order}.",
+        )
+
+    try:
+        maturity_repo.delete(db, db_obj=db_obj)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error deleting maturity level: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to delete maturity level")
+
+
+# ===================================================================
+# Gate Management
+# ===================================================================
+
+@router.post(
+    "/maturity-levels/{level_id}/gates",
+    response_model=MaturityGateRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_gate(
+    level_id: UUID,
+    body: MaturityGateCreate,
+    db: DBSessionDep,
+    _: bool = Depends(PermissionChecker(SETTINGS_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Add a compliance policy gate to a maturity level. Admin only."""
+    level = maturity_repo.get_by_id(db, level_id)
+    if not level:
+        raise HTTPException(status_code=404, detail="Maturity level not found")
+
+    from src.db_models.compliance import CompliancePolicyDb
+    policy = db.get(CompliancePolicyDb, body.compliance_policy_id)
+    if not policy:
+        raise HTTPException(status_code=404, detail="Compliance policy not found")
+
+    try:
+        gate = maturity_repo.add_gate(
+            db,
+            maturity_level_id=level_id,
+            compliance_policy_id=body.compliance_policy_id,
+            required=body.required,
+            display_order=body.display_order,
+        )
+        db.commit()
+        db.refresh(gate)
+        return _gate_to_read(gate)
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error adding gate: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to add gate")
+
+
+@router.delete(
+    "/maturity-levels/{level_id}/gates/{gate_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_gate(
+    level_id: UUID,
+    gate_id: UUID,
+    db: DBSessionDep,
+    _: bool = Depends(PermissionChecker(SETTINGS_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Remove a gate from a maturity level. Admin only."""
+    gate = maturity_repo.get_gate_by_id(db, gate_id)
+    if not gate or gate.maturity_level_id != level_id:
+        raise HTTPException(status_code=404, detail="Gate not found on this level")
+
+    try:
+        maturity_repo.remove_gate(db, db_obj=gate)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error removing gate: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to remove gate")
+
+
+# ===================================================================
+# Evaluation Endpoints
+# ===================================================================
+
+def _get_evaluator(request: Request):
+    from src.controller.maturity_evaluator import MaturityEvaluator
+    evaluator = getattr(request.app.state, "maturity_evaluator", None)
+    if not evaluator:
+        evaluator = MaturityEvaluator()
+    return evaluator
+
+
+@router.get(
+    "/data-products/{product_id}/maturity",
+    response_model=MaturityReport,
+    dependencies=[Depends(PermissionChecker(DP_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+def get_product_maturity(product_id: str, db: DBSessionDep, request: Request):
+    """Get current maturity assessment for a data product."""
+    evaluator = _get_evaluator(request)
+    report = evaluator.evaluate(db, entity_type="DataProduct", entity_id=product_id)
+    if not report:
+        raise HTTPException(status_code=404, detail=f"Data product {product_id} not found")
+    return report
+
+
+@router.post(
+    "/data-products/{product_id}/maturity/evaluate",
+    response_model=MaturityReport,
+    dependencies=[Depends(PermissionChecker(DP_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+def evaluate_product_maturity(product_id: str, db: DBSessionDep, request: Request):
+    """Force re-evaluate maturity for a data product."""
+    evaluator = _get_evaluator(request)
+    report = evaluator.evaluate(db, entity_type="DataProduct", entity_id=product_id, persist=True)
+    if not report:
+        raise HTTPException(status_code=404, detail=f"Data product {product_id} not found")
+    return report
+
+
+@router.get(
+    "/data-products/{product_id}/maturity/history",
+    response_model=List[MaturitySnapshotRead],
+    dependencies=[Depends(PermissionChecker(DP_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+def get_product_maturity_history(product_id: str, db: DBSessionDep, limit: int = 50):
+    """Get maturity evaluation history for a data product."""
+    return maturity_repo.list_snapshots(db, entity_type="DataProduct", entity_id=product_id, limit=limit)
+
+
+@router.get(
+    "/data-contracts/{contract_id}/maturity",
+    response_model=MaturityReport,
+    dependencies=[Depends(PermissionChecker(DC_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+def get_contract_maturity(contract_id: str, db: DBSessionDep, request: Request):
+    """Get current maturity assessment for a data contract."""
+    evaluator = _get_evaluator(request)
+    report = evaluator.evaluate(db, entity_type="DataContract", entity_id=contract_id)
+    if not report:
+        raise HTTPException(status_code=404, detail=f"Data contract {contract_id} not found")
+    return report
+
+
+@router.post(
+    "/data-contracts/{contract_id}/maturity/evaluate",
+    response_model=MaturityReport,
+    dependencies=[Depends(PermissionChecker(DC_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+def evaluate_contract_maturity(contract_id: str, db: DBSessionDep, request: Request):
+    """Force re-evaluate maturity for a data contract."""
+    evaluator = _get_evaluator(request)
+    report = evaluator.evaluate(db, entity_type="DataContract", entity_id=contract_id, persist=True)
+    if not report:
+        raise HTTPException(status_code=404, detail=f"Data contract {contract_id} not found")
+    return report
+
+
+@router.get(
+    "/data-contracts/{contract_id}/maturity/history",
+    response_model=List[MaturitySnapshotRead],
+    dependencies=[Depends(PermissionChecker(DC_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+)
+def get_contract_maturity_history(contract_id: str, db: DBSessionDep, limit: int = 50):
+    """Get maturity evaluation history for a data contract."""
+    return maturity_repo.list_snapshots(db, entity_type="DataContract", entity_id=contract_id, limit=limit)
+
+
+# ===================================================================
+# Registration
+# ===================================================================
+
+def register_routes(app):
+    app.include_router(router)
+    logger.info("Maturity routes registered")

--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -470,10 +470,12 @@ async def startup_event_handler(app: FastAPI):
         # seed_defaults() calls below are idempotent — they no-op if rows exist.
         try:
             from src.repositories.certification_levels_repository import certification_levels_repo
+            from src.repositories.maturity_repository import maturity_repo
 
             session_factory = get_session_factory()
             with session_factory() as db_session:
                 certification_levels_repo.seed_defaults(db_session)
+                maturity_repo.seed_defaults(db_session)
                 db_session.commit()
             logger.info("Reference data seed step complete.")
         except Exception as e:

--- a/src/frontend/src/app.tsx
+++ b/src/frontend/src/app.tsx
@@ -101,6 +101,7 @@ import SettingsConnectorsView from './views/settings-connectors';
 import SettingsDirectoryView from './views/settings-directory';
 import SettingsSemanticModelsView from './views/settings-semantic-models';
 import SettingsCertificationLevelsView from './views/settings-certification-levels';
+import SettingsMaturityLevelsView from './views/settings-maturity-levels';
 
 export default function App() {
   const fetchUserInfo = useUserStore((state: any) => state.fetchUserInfo);
@@ -252,6 +253,7 @@ export default function App() {
                 <Route path="directory" element={<SettingsDirectoryView />} />
                 <Route path="semantic-models" element={<SettingsSemanticModelsView />} />
                 <Route path="certification-levels" element={<SettingsCertificationLevelsView />} />
+                <Route path="maturity-levels" element={<SettingsMaturityLevelsView />} />
                 <Route path="workflows" element={<Workflows />} />
                 <Route path="workflows/new" element={<WorkflowDesignerView />} />
                 <Route path="workflows/:workflowId" element={<WorkflowDesignerView />} />

--- a/src/frontend/src/components/common/maturity-badge.tsx
+++ b/src/frontend/src/components/common/maturity-badge.tsx
@@ -1,0 +1,62 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  LockKeyhole, FileText, BookOpen, Activity, ShieldCheck,
+} from 'lucide-react';
+
+const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+  'lock-keyhole': LockKeyhole,
+  'file-text': FileText,
+  'book-open': BookOpen,
+  'activity': Activity,
+  'shield-check': ShieldCheck,
+};
+
+const COLOR_CLASSES: Record<string, string> = {
+  blue: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  cyan: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200',
+  green: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  amber: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  purple: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+  red: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  emerald: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+  slate: 'bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
+};
+
+interface MaturityBadgeProps {
+  levelName: string | null;
+  levelIcon?: string | null;
+  levelColor?: string | null;
+  levelOrder?: number | null;
+  totalLevels?: number;
+  className?: string;
+}
+
+export function MaturityBadge({
+  levelName,
+  levelIcon,
+  levelColor,
+  levelOrder,
+  totalLevels,
+  className,
+}: MaturityBadgeProps) {
+  if (!levelName) {
+    return (
+      <Badge variant="outline" className={`text-muted-foreground ${className || ''}`}>
+        Not assessed
+      </Badge>
+    );
+  }
+
+  const Icon = ICON_MAP[levelIcon || 'shield-check'] || ShieldCheck;
+  const colorClass = COLOR_CLASSES[levelColor || 'blue'] || COLOR_CLASSES.blue;
+
+  return (
+    <Badge variant="outline" className={`${colorClass} ${className || ''}`}>
+      <Icon className="h-3 w-3 mr-1" />
+      {levelName}
+      {levelOrder != null && totalLevels ? (
+        <span className="ml-1 opacity-70">({levelOrder}/{totalLevels})</span>
+      ) : null}
+    </Badge>
+  );
+}

--- a/src/frontend/src/components/common/maturity-inline.tsx
+++ b/src/frontend/src/components/common/maturity-inline.tsx
@@ -1,0 +1,193 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
+import { useToast } from '@/hooks/use-toast';
+import {
+  CheckCircle2, XCircle, AlertTriangle, Loader2, RefreshCw,
+} from 'lucide-react';
+import { MaturityBadge } from '@/components/common/maturity-badge';
+import type { MaturityReport, LevelResult } from '@/types/maturity';
+
+interface MaturityInlineProps {
+  entityType: 'DataProduct' | 'DataContract';
+  entityId: string;
+  /** Render as a compact column (for header badges area) vs inline row */
+  compact?: boolean;
+}
+
+const API_PREFIX: Record<string, string> = {
+  DataProduct: '/api/data-products',
+  DataContract: '/api/data-contracts',
+};
+
+const GATE_ICON: Record<string, { icon: typeof CheckCircle2; cls: string }> = {
+  pass: { icon: CheckCircle2, cls: 'text-green-600 dark:text-green-400' },
+  fail: { icon: XCircle, cls: 'text-red-600 dark:text-red-400' },
+  warn: { icon: AlertTriangle, cls: 'text-amber-600 dark:text-amber-400' },
+};
+
+export function MaturityInline({ entityType, entityId, compact = false }: MaturityInlineProps) {
+  const [report, setReport] = useState<MaturityReport | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEvaluating, setIsEvaluating] = useState(false);
+  const { toast } = useToast();
+
+  const prefix = API_PREFIX[entityType] || API_PREFIX.DataProduct;
+
+  const fetchReport = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`${prefix}/${entityId}/maturity`);
+      if (res.ok) setReport(await res.json());
+    } catch { /* silent */ }
+    setIsLoading(false);
+  }, [entityId, prefix]);
+
+  const evaluate = useCallback(async () => {
+    setIsEvaluating(true);
+    try {
+      const res = await fetch(`${prefix}/${entityId}/maturity/evaluate`, { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json();
+        setReport(data);
+        const passed = data.gates_passed ?? 0;
+        const total = data.gates_total ?? 0;
+        const level = data.achieved_level_name || 'Not assessed';
+        toast({
+          title: 'Maturity evaluated',
+          description: `${level} — ${passed}/${total} gates passed`,
+        });
+      } else {
+        toast({ title: 'Evaluation failed', description: `Server returned ${res.status}`, variant: 'destructive' });
+      }
+    } catch (e) {
+      toast({ title: 'Evaluation failed', description: String(e), variant: 'destructive' });
+    }
+    setIsEvaluating(false);
+  }, [entityId, prefix, toast]);
+
+  useEffect(() => { fetchReport(); }, [fetchReport]);
+
+  if (isLoading) {
+    return <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />;
+  }
+
+  if (!report) {
+    return <span className="text-xs text-muted-foreground">—</span>;
+  }
+
+  const achievedLevel = report.levels.find(l => l.achieved && l.level_order === report.achieved_level_order);
+  const levelName = report.achieved_level_name || 'Not assessed';
+  const passed = report.gates_passed ?? 0;
+  const total = report.gates_total ?? 0;
+
+  if (compact) {
+    return (
+      <HoverCard openDelay={200}>
+        <HoverCardTrigger asChild>
+          <div className="flex flex-col items-center gap-1 cursor-default group" role="button" tabIndex={0}>
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-semibold leading-none text-muted-foreground group-hover:text-foreground transition-colors">
+                {levelName}
+              </span>
+              <button
+                className="inline-flex items-center justify-center h-4 w-4 rounded-sm hover:bg-muted transition-colors"
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); evaluate(); }}
+                title="Re-evaluate maturity"
+              >
+                {isEvaluating
+                  ? <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                  : <RefreshCw className="h-3 w-3 text-muted-foreground hover:text-foreground" />}
+              </button>
+            </div>
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Maturity</span>
+          </div>
+        </HoverCardTrigger>
+        <HoverCardContent className="w-72" side="bottom" align="end">
+          <HoverDetail report={report} levelName={levelName} passed={passed} total={total} />
+        </HoverCardContent>
+      </HoverCard>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <HoverCard openDelay={200}>
+        <HoverCardTrigger asChild>
+          <button className="flex items-center gap-1.5 cursor-default">
+            <MaturityBadge
+              levelName={report.achieved_level_name}
+              levelIcon={achievedLevel?.level_icon}
+              levelColor={achievedLevel?.level_color}
+              levelOrder={report.achieved_level_order}
+              totalLevels={report.total_levels}
+            />
+          </button>
+        </HoverCardTrigger>
+        <HoverCardContent className="w-72" side="bottom" align="start">
+          <HoverDetail report={report} levelName={levelName} passed={passed} total={total} />
+        </HoverCardContent>
+      </HoverCard>
+      <span className="text-[10px] text-muted-foreground">
+        {passed}/{total}
+      </span>
+      <Button
+        variant="ghost" size="icon"
+        className="h-5 w-5"
+        onClick={evaluate}
+        disabled={isEvaluating}
+        title="Re-evaluate maturity"
+      >
+        {isEvaluating
+          ? <Loader2 className="h-3 w-3 animate-spin" />
+          : <RefreshCw className="h-3 w-3" />}
+      </Button>
+    </div>
+  );
+}
+
+function HoverDetail({ report, levelName, passed, total }: {
+  report: MaturityReport; levelName: string; passed: number; total: number;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold">Maturity: {levelName}</p>
+        <span className="text-xs text-muted-foreground">
+          {passed}/{total} gates
+        </span>
+      </div>
+      <div className="space-y-1 max-h-48 overflow-y-auto">
+        {report.levels.map((level: LevelResult) => (
+          <LevelRow key={level.level_order} level={level} />
+        ))}
+      </div>
+      {report.evaluated_at && (
+        <p className="text-[10px] text-muted-foreground pt-1 border-t">
+          Evaluated {new Date(report.evaluated_at).toLocaleString()}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function LevelRow({ level }: { level: LevelResult }) {
+  const hasFails = level.gates.some(g => !g.passed && g.required);
+  const hasWarns = level.gates.some(g => !g.passed && !g.required);
+  const status = hasFails ? 'fail' : hasWarns ? 'warn' : 'pass';
+  const { icon: Icon, cls } = GATE_ICON[status];
+  const passed = level.gates.filter(g => g.passed).length;
+
+  return (
+    <div className="flex items-center gap-2 py-0.5">
+      <Icon className={`h-3 w-3 shrink-0 ${cls}`} />
+      <span className="font-mono text-[10px] text-muted-foreground w-3">{level.level_order}</span>
+      <span className={`text-xs flex-1 truncate ${level.achieved ? 'font-medium' : 'text-muted-foreground'}`}>
+        {level.level_name}
+      </span>
+      <span className="text-[10px] text-muted-foreground">
+        {passed}/{level.gates.length}
+      </span>
+    </div>
+  );
+}

--- a/src/frontend/src/components/data-products/maturity-panel.tsx
+++ b/src/frontend/src/components/data-products/maturity-panel.tsx
@@ -1,0 +1,195 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  CheckCircle2, XCircle, AlertTriangle, Loader2, RefreshCw, TrendingUp,
+  ChevronDown, ChevronRight,
+} from 'lucide-react';
+import { MaturityBadge } from '@/components/common/maturity-badge';
+import type { MaturityReport, LevelResult, MaturitySnapshot } from '@/types/maturity';
+
+interface MaturityPanelProps {
+  entityType: 'DataProduct' | 'DataContract';
+  entityId: string;
+}
+
+const STATUS_CONFIG = {
+  pass: { icon: CheckCircle2, color: 'text-green-600 dark:text-green-400', bg: 'bg-green-50 dark:bg-green-950/30' },
+  fail: { icon: XCircle, color: 'text-red-600 dark:text-red-400', bg: 'bg-red-50 dark:bg-red-950/30' },
+  warn: { icon: AlertTriangle, color: 'text-amber-600 dark:text-amber-400', bg: 'bg-amber-50 dark:bg-amber-950/30' },
+};
+
+const API_PREFIX: Record<string, string> = {
+  DataProduct: '/api/data-products',
+  DataContract: '/api/data-contracts',
+};
+
+export function MaturityPanel({ entityType, entityId }: MaturityPanelProps) {
+  const [report, setReport] = useState<MaturityReport | null>(null);
+  const [history, setHistory] = useState<MaturitySnapshot[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedLevel, setExpandedLevel] = useState<number | null>(null);
+
+  const prefix = API_PREFIX[entityType] || API_PREFIX.DataProduct;
+
+  const fetchReport = useCallback(async (evaluate = false) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const url = evaluate
+        ? `${prefix}/${entityId}/maturity/evaluate`
+        : `${prefix}/${entityId}/maturity`;
+      const method = evaluate ? 'POST' : 'GET';
+      const res = await fetch(url, { method });
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      setReport(await res.json());
+    } catch (e: any) {
+      setError(e.message || 'Failed to load maturity report');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [entityId, prefix]);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      const res = await fetch(`${prefix}/${entityId}/maturity/history?limit=10`);
+      if (res.ok) setHistory(await res.json());
+    } catch { /* non-critical */ }
+  }, [entityId, prefix]);
+
+  useEffect(() => { fetchReport(); fetchHistory(); }, [fetchReport, fetchHistory]);
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          <span className="ml-2 text-sm text-muted-foreground">Evaluating maturity...</span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-center">
+          <p className="text-sm text-destructive">{error || 'Unable to load maturity report'}</p>
+          <Button variant="outline" size="sm" className="mt-2" onClick={() => fetchReport()}>
+            <RefreshCw className="mr-2 h-3.5 w-3.5" /> Retry
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Maturity
+          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-normal text-muted-foreground">
+              {report.gates_passed}/{report.gates_total} gates passed
+            </span>
+            <MaturityBadge
+              levelName={report.achieved_level_name}
+              levelOrder={report.achieved_level_order}
+              totalLevels={report.total_levels}
+            />
+            <Button variant="ghost" size="icon" className="h-7 w-7"
+              onClick={() => { fetchReport(true); fetchHistory(); }}
+              title="Re-evaluate maturity">
+              <RefreshCw className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Level progression */}
+        {report.levels.map((level: LevelResult) => {
+          const isExpanded = expandedLevel === level.level_order;
+          const allPassed = level.achieved;
+          const hasWarnings = level.gates.some(g => !g.passed && !g.required);
+          const hasFails = level.gates.some(g => !g.passed && g.required);
+
+          let levelStatus: 'pass' | 'fail' | 'warn' = 'pass';
+          if (hasFails) levelStatus = 'fail';
+          else if (hasWarnings) levelStatus = 'warn';
+
+          const cfg = STATUS_CONFIG[levelStatus];
+          const LevelIcon = cfg.icon;
+
+          return (
+            <div key={level.level_order} className="rounded-md border overflow-hidden">
+              <button
+                className={`flex items-center gap-3 w-full px-3 py-2.5 text-left ${cfg.bg}`}
+                onClick={() => setExpandedLevel(isExpanded ? null : level.level_order)}
+              >
+                <LevelIcon className={`h-4 w-4 flex-shrink-0 ${cfg.color}`} />
+                {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                <span className="font-mono text-xs text-muted-foreground w-4">{level.level_order}</span>
+                <span className="text-sm font-medium flex-1">{level.level_name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {level.gates.filter(g => g.passed).length}/{level.gates.length} gates
+                </span>
+              </button>
+
+              {isExpanded && level.gates.length > 0 && (
+                <div className="px-3 py-2 space-y-1 bg-background">
+                  {level.gates.map((gate, gi) => {
+                    const gStatus = gate.passed ? 'pass' : (gate.required ? 'fail' : 'warn');
+                    const gCfg = STATUS_CONFIG[gStatus];
+                    const GateIcon = gCfg.icon;
+                    return (
+                      <div key={gi} className="flex items-start gap-2 py-1">
+                        <GateIcon className={`h-3.5 w-3.5 mt-0.5 flex-shrink-0 ${gCfg.color}`} />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs font-medium">{gate.policy_name}</p>
+                          {gate.message && (
+                            <p className="text-xs text-muted-foreground">{gate.message}</p>
+                          )}
+                        </div>
+                        <Badge variant="outline" className="text-[10px]">
+                          {gate.required ? 'Required' : 'Advisory'}
+                        </Badge>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* History mini-chart */}
+        {history.length > 1 && (
+          <div className="pt-2 border-t">
+            <p className="text-xs text-muted-foreground mb-2">Maturity over time</p>
+            <div className="flex items-end gap-0.5 h-8">
+              {history.slice().reverse().map((snap, i) => {
+                const maxLevel = snap.total_levels || 5;
+                const pct = snap.achieved_level_order != null
+                  ? Math.max(10, (snap.achieved_level_order / maxLevel) * 100)
+                  : 5;
+                return (
+                  <div
+                    key={snap.id || i}
+                    className="bg-primary/60 rounded-t flex-1 min-w-1"
+                    style={{ height: `${pct}%` }}
+                    title={`${snap.achieved_level_name || 'None'} (${new Date(snap.evaluated_at).toLocaleDateString()})`}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/frontend/src/components/settings/maturity-levels-settings.tsx
+++ b/src/frontend/src/components/settings/maturity-levels-settings.tsx
@@ -1,0 +1,495 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  Plus, Pencil, Trash2, Loader2, ChevronDown, ChevronRight,
+  LockKeyhole, FileText, BookOpen, Activity, ShieldCheck, ExternalLink, Info,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
+import { useToast } from '@/hooks/use-toast';
+import { useApi } from '@/hooks/use-api';
+import type { MaturityLevel, MaturityGate } from '@/types/maturity';
+
+interface CompliancePolicy {
+  id: string;
+  name: string;
+  category: string | null;
+  rule: string | null;
+  severity: string | null;
+  description: string | null;
+}
+
+const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+  'lock-keyhole': LockKeyhole,
+  'file-text': FileText,
+  'book-open': BookOpen,
+  'activity': Activity,
+  'shield-check': ShieldCheck,
+};
+const ICON_OPTIONS = Object.keys(ICON_MAP);
+
+const COLOR_OPTIONS = ['blue', 'cyan', 'green', 'amber', 'purple', 'red', 'emerald', 'slate'];
+
+const ENTITY_TYPE_OPTIONS = [
+  { value: 'all', label: 'All Entity Types' },
+  { value: 'DataProduct', label: 'Data Products' },
+  { value: 'DataContract', label: 'Data Contracts' },
+];
+
+const COLOR_CLASSES: Record<string, string> = {
+  blue: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  cyan: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200',
+  green: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  amber: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  purple: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+  red: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  emerald: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+  slate: 'bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-200',
+};
+
+export default function MaturityLevelsSettings() {
+  const { toast } = useToast();
+  const { get, post, put, delete: apiDelete } = useApi();
+
+  const [levels, setLevels] = useState<MaturityLevel[]>([]);
+  const [policies, setPolicies] = useState<CompliancePolicy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [editingLevel, setEditingLevel] = useState<MaturityLevel | null>(null);
+  const [deletingLevel, setDeletingLevel] = useState<MaturityLevel | null>(null);
+  const [expandedLevel, setExpandedLevel] = useState<string | null>(null);
+  const [addingGateToLevel, setAddingGateToLevel] = useState<string | null>(null);
+  const [selectedPolicyId, setSelectedPolicyId] = useState('');
+  const [gateRequired, setGateRequired] = useState(true);
+  const [formData, setFormData] = useState({
+    name: '', description: '', icon: 'shield-check', color: 'blue', entity_type: 'all',
+  });
+  const [saving, setSaving] = useState(false);
+  const hasFetched = useRef(false);
+
+  const fetchLevels = useCallback(async () => {
+    try {
+      setLoading(true);
+      const { data, error } = await get<MaturityLevel[]>('/api/maturity-levels');
+      if (error) throw new Error(error);
+      const sorted = Array.isArray(data) ? [...data].sort((a, b) => b.level_order - a.level_order) : [];
+      setLevels(sorted);
+    } catch {
+      // silent on initial
+    } finally {
+      setLoading(false);
+    }
+  }, [get]);
+
+  const fetchPolicies = useCallback(async () => {
+    try {
+      const { data } = await get<any>('/api/compliance/policies');
+      const list = Array.isArray(data) ? data : (data?.policies ?? data?.items ?? []);
+      setPolicies(list);
+    } catch { /* non-critical */ }
+  }, [get]);
+
+  useEffect(() => {
+    if (!hasFetched.current) {
+      hasFetched.current = true;
+      fetchLevels();
+      fetchPolicies();
+    }
+  }, [fetchLevels, fetchPolicies]);
+
+  const handleOpenCreate = () => {
+    setEditingLevel(null);
+    setFormData({ name: '', description: '', icon: 'shield-check', color: 'blue', entity_type: 'all' });
+    setDialogOpen(true);
+  };
+
+  const handleOpenEdit = (level: MaturityLevel) => {
+    setEditingLevel(level);
+    setFormData({
+      name: level.name,
+      description: level.description || '',
+      icon: level.icon || 'shield-check',
+      color: level.color || 'blue',
+      entity_type: level.entity_type || 'all',
+    });
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!formData.name.trim()) return;
+    setSaving(true);
+    try {
+      if (editingLevel) {
+        const { error } = await put(`/api/maturity-levels/${editingLevel.id}`, {
+          name: formData.name,
+          description: formData.description || null,
+          icon: formData.icon,
+          color: formData.color,
+          entity_type: formData.entity_type,
+        });
+        if (error) throw new Error(error);
+        toast({ title: 'Updated', description: `Maturity level "${formData.name}" updated.` });
+      } else {
+        const maxOrder = levels.length > 0 ? Math.max(...levels.map(l => l.level_order)) : 0;
+        const { error } = await post('/api/maturity-levels', {
+          name: formData.name,
+          description: formData.description || null,
+          icon: formData.icon,
+          color: formData.color,
+          entity_type: formData.entity_type,
+          level_order: maxOrder + 1,
+        });
+        if (error) throw new Error(error);
+        toast({ title: 'Created', description: `Maturity level "${formData.name}" created.` });
+      }
+      setDialogOpen(false);
+      fetchLevels();
+    } catch (err: any) {
+      toast({ title: 'Error', description: err?.message || 'Failed to save', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deletingLevel) return;
+    const { error } = await apiDelete(`/api/maturity-levels/${deletingLevel.id}`);
+    if (error) {
+      toast({ title: 'Cannot delete', description: error, variant: 'destructive' });
+    } else {
+      toast({ title: 'Deleted', description: `Maturity level "${deletingLevel.name}" deleted.` });
+      setDeletingLevel(null);
+      fetchLevels();
+    }
+    setDeleteDialogOpen(false);
+  };
+
+  const handleMoveUp = async (index: number) => {
+    if (index <= 0) return;
+    const newLevels = [...levels];
+    const prevOrder = newLevels[index - 1].level_order;
+    const currOrder = newLevels[index].level_order;
+    newLevels[index - 1].level_order = currOrder;
+    newLevels[index].level_order = prevOrder;
+    const { error } = await put('/api/maturity-levels/reorder', {
+      levels: newLevels.map(l => ({ id: l.id, level_order: l.level_order })),
+    });
+    if (!error) fetchLevels();
+  };
+
+  const handleMoveDown = async (index: number) => {
+    if (index >= levels.length - 1) return;
+    const newLevels = [...levels];
+    const nextOrder = newLevels[index + 1].level_order;
+    const currOrder = newLevels[index].level_order;
+    newLevels[index + 1].level_order = currOrder;
+    newLevels[index].level_order = nextOrder;
+    const { error } = await put('/api/maturity-levels/reorder', {
+      levels: newLevels.map(l => ({ id: l.id, level_order: l.level_order })),
+    });
+    if (!error) fetchLevels();
+  };
+
+  const handleAddGate = async (levelId: string) => {
+    if (!selectedPolicyId) return;
+    const level = levels.find(l => l.id === levelId);
+    const maxOrder = level?.gates?.length ? Math.max(...level.gates.map(g => g.display_order)) + 1 : 0;
+    const { error } = await post(`/api/maturity-levels/${levelId}/gates`, {
+      compliance_policy_id: selectedPolicyId,
+      required: gateRequired,
+      display_order: maxOrder,
+    });
+    if (error) {
+      toast({ title: 'Error', description: error, variant: 'destructive' });
+    } else {
+      setAddingGateToLevel(null);
+      setSelectedPolicyId('');
+      setGateRequired(true);
+      fetchLevels();
+    }
+  };
+
+  const handleRemoveGate = async (levelId: string, gateId: string) => {
+    const { error } = await apiDelete(`/api/maturity-levels/${levelId}/gates/${gateId}`);
+    if (!error) fetchLevels();
+  };
+
+  const getColorClass = (color: string | null) => COLOR_CLASSES[color || 'blue'] || COLOR_CLASSES.blue;
+  const getIcon = (iconName: string | null) => ICON_MAP[iconName || 'shield-check'] || ShieldCheck;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[200px]">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Maturity Levels</h2>
+          <p className="text-sm text-muted-foreground">
+            Define the maturity ladder for data products and contracts. Each level is gated by compliance policies.
+          </p>
+        </div>
+        <Button onClick={handleOpenCreate} size="sm">
+          <Plus className="h-4 w-4 mr-1" /> Add Level
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        {levels.map((level, index) => {
+          const IconComponent = getIcon(level.icon);
+          const isExpanded = expandedLevel === level.id;
+          return (
+            <div key={level.id} className="border rounded-lg">
+              <div className="flex items-center gap-3 px-4 py-3">
+                <div className="flex flex-col gap-0.5">
+                  <button onClick={() => handleMoveUp(index)} disabled={index === 0}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-20 text-xs">▲</button>
+                  <button onClick={() => handleMoveDown(index)} disabled={index === levels.length - 1}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-20 text-xs">▼</button>
+                </div>
+                <button onClick={() => setExpandedLevel(isExpanded ? null : level.id)}
+                  className="flex items-center gap-2 flex-1 text-left">
+                  {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                  <span className="font-mono text-sm text-muted-foreground w-6">{level.level_order}</span>
+                  <Badge variant="outline" className={getColorClass(level.color)}>
+                    <IconComponent className="h-3 w-3 mr-1" />
+                    {level.name}
+                  </Badge>
+                  <span className="text-sm text-muted-foreground flex-1">{level.description || ''}</span>
+                  <Badge variant="secondary" className="text-xs">
+                    {level.entity_type === 'all' ? 'All types' : level.entity_type}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">{level.gates?.length || 0} gate(s)</span>
+                </button>
+                <div className="flex gap-1">
+                  <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => handleOpenEdit(level)}>
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive"
+                    onClick={() => { setDeletingLevel(level); setDeleteDialogOpen(true); }}>
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+
+              {isExpanded && (
+                <div className="border-t px-4 py-3 bg-muted/30 space-y-2">
+                  <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    Compliance Policy Gates
+                  </div>
+                  {(level.gates || []).map((gate: MaturityGate) => {
+                    const policy = policies.find(p => p.id === gate.compliance_policy_id);
+                    return (
+                      <div key={gate.id} className="flex items-center gap-3 pl-4 py-1.5 border-b last:border-b-0 border-border/40">
+                        <span className={`h-2 w-2 rounded-full shrink-0 ${gate.required ? 'bg-red-500' : 'bg-amber-500'}`} />
+                        <HoverCard openDelay={200}>
+                          <HoverCardTrigger asChild>
+                            <button className="text-sm font-medium flex-1 text-left hover:underline underline-offset-2 decoration-dashed inline-flex items-center gap-1.5">
+                              {gate.compliance_policy_name || gate.compliance_policy_id}
+                              <Info className="h-3 w-3 text-muted-foreground" />
+                            </button>
+                          </HoverCardTrigger>
+                          <HoverCardContent className="w-80" side="right" align="start">
+                            <div className="space-y-2">
+                              <p className="text-sm font-semibold">{gate.compliance_policy_name}</p>
+                              {(policy?.description || gate.compliance_policy_rule) && (
+                                <p className="text-xs text-muted-foreground">
+                                  {policy?.description || 'No description'}
+                                </p>
+                              )}
+                              {gate.compliance_policy_rule && (
+                                <code className="block text-xs bg-muted px-2 py-1.5 rounded font-mono whitespace-pre-wrap">
+                                  {gate.compliance_policy_rule}
+                                </code>
+                              )}
+                              <div className="flex items-center gap-2 pt-1">
+                                {policy?.severity && (
+                                  <Badge variant="outline" className="text-xs capitalize">{policy.severity}</Badge>
+                                )}
+                                <Badge variant="outline" className="text-xs">
+                                  {gate.required ? 'Required' : 'Advisory'}
+                                </Badge>
+                              </div>
+                              <a href={`/compliance?policy=${gate.compliance_policy_id}`}
+                                className="inline-flex items-center gap-1 text-xs text-primary hover:underline pt-1">
+                                <ExternalLink className="h-3 w-3" />
+                                View in Compliance
+                              </a>
+                            </div>
+                          </HoverCardContent>
+                        </HoverCard>
+                        <Badge variant="outline" className="text-xs shrink-0">
+                          {gate.required ? 'Required' : 'Advisory'}
+                        </Badge>
+                        <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive shrink-0"
+                          onClick={() => handleRemoveGate(level.id, gate.id)}>
+                          <Trash2 className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    );
+                  })}
+
+                  {addingGateToLevel === level.id ? (
+                    <div className="flex items-center gap-2 pl-4 pt-2">
+                      <Select value={selectedPolicyId} onValueChange={setSelectedPolicyId}>
+                        <SelectTrigger className="flex-1 h-8 text-sm">
+                          <SelectValue placeholder="Select compliance policy..." />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {policies.map(p => (
+                            <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <div className="flex items-center gap-1.5">
+                        <Switch checked={gateRequired} onCheckedChange={setGateRequired} id="gate-req" />
+                        <Label htmlFor="gate-req" className="text-xs">Required</Label>
+                      </div>
+                      <Button size="sm" variant="outline" className="h-8"
+                        onClick={() => handleAddGate(level.id)} disabled={!selectedPolicyId}>Add</Button>
+                      <Button size="sm" variant="ghost" className="h-8"
+                        onClick={() => { setAddingGateToLevel(null); setSelectedPolicyId(''); }}>Cancel</Button>
+                    </div>
+                  ) : (
+                    <Button variant="ghost" size="sm" className="ml-4 text-xs"
+                      onClick={() => { setAddingGateToLevel(level.id); setSelectedPolicyId(''); setGateRequired(true); }}>
+                      <Plus className="h-3 w-3 mr-1" /> Add Gate
+                    </Button>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {levels.length === 0 && (
+          <div className="text-center text-muted-foreground py-8 border rounded-lg">
+            No maturity levels configured. Click "Add Level" to create one.
+          </div>
+        )}
+      </div>
+
+      {/* Create/Edit Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingLevel ? 'Edit' : 'Add'} Maturity Level</DialogTitle>
+            <DialogDescription>
+              {editingLevel ? 'Update the maturity level details.' : 'Create a new maturity level.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="mat-name">Name</Label>
+              <Input id="mat-name" value={formData.name}
+                onChange={e => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                placeholder="e.g., Trusted" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="mat-desc">Description</Label>
+              <Textarea id="mat-desc" value={formData.description}
+                onChange={e => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                placeholder="What this level represents..." rows={2} />
+            </div>
+            <div className="space-y-2">
+              <Label>Entity Type</Label>
+              <Select value={formData.entity_type}
+                onValueChange={v => setFormData(prev => ({ ...prev, entity_type: v }))}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {ENTITY_TYPE_OPTIONS.map(o => (
+                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Icon</Label>
+              <div className="flex flex-wrap gap-2">
+                {ICON_OPTIONS.map(ic => {
+                  const Ic = ICON_MAP[ic];
+                  return (
+                    <button key={ic}
+                      onClick={() => setFormData(prev => ({ ...prev, icon: ic }))}
+                      className={`p-2 rounded border-2 transition-colors ${formData.icon === ic ? 'border-foreground bg-muted' : 'border-transparent'}`}>
+                      <Ic className="h-4 w-4" />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Color</Label>
+              <div className="flex flex-wrap gap-2">
+                {COLOR_OPTIONS.map(c => (
+                  <button key={c}
+                    onClick={() => setFormData(prev => ({ ...prev, color: c }))}
+                    className={`px-3 py-1 rounded text-xs font-medium border-2 transition-colors ${getColorClass(c)} ${formData.color === c ? 'border-foreground' : 'border-transparent'}`}>
+                    {c}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Preview</Label>
+              <div>
+                <Badge variant="outline" className={getColorClass(formData.color)}>
+                  {(() => { const Ic = getIcon(formData.icon); return <Ic className="h-3 w-3 mr-1" />; })()}
+                  {formData.name || 'Level Name'}
+                </Badge>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+            <Button onClick={handleSave} disabled={saving || !formData.name.trim()}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : null}
+              {editingLevel ? 'Update' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete maturity level?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete "{deletingLevel?.name}"? This cannot be undone.
+              If snapshots reference this level, deletion will be blocked.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground">
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/frontend/src/components/settings/settings-layout.tsx
+++ b/src/frontend/src/components/settings/settings-layout.tsx
@@ -24,6 +24,7 @@ import {
   BoxSelect,
   Truck,
   ShieldCheck,
+  Activity,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -53,6 +54,7 @@ const settingsNavGroups: SettingsNavGroup[] = [
       { path: '/settings/teams', labelKey: 'settings:tabs.teams', defaultLabel: 'Teams', icon: UserCheck, permissionId: 'settings-teams' },
       { path: '/settings/projects', labelKey: 'settings:tabs.projects', defaultLabel: 'Projects', icon: FolderOpen, permissionId: 'settings-projects' },
       { path: '/settings/certification-levels', labelKey: 'settings:tabs.certificationLevels', defaultLabel: 'Certification Levels', icon: ShieldCheck, permissionId: 'settings-certification-levels' },
+      { path: '/settings/maturity-levels', labelKey: 'settings:tabs.maturityLevels', defaultLabel: 'Maturity Levels', icon: Activity, permissionId: 'settings-maturity-levels' },
     ],
   },
   {

--- a/src/frontend/src/types/maturity.ts
+++ b/src/frontend/src/types/maturity.ts
@@ -1,0 +1,69 @@
+export interface MaturityGate {
+  id: string;
+  maturity_level_id: string;
+  compliance_policy_id: string;
+  compliance_policy_name: string | null;
+  compliance_policy_rule: string | null;
+  required: boolean;
+  display_order: number;
+  created_at: string | null;
+}
+
+export interface MaturityLevel {
+  id: string;
+  level_order: number;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+  entity_type: string;
+  gates: MaturityGate[];
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface GateResult {
+  gate_id: string;
+  policy_id: string;
+  policy_name: string;
+  required: boolean;
+  passed: boolean;
+  message: string | null;
+}
+
+export interface LevelResult {
+  level_order: number;
+  level_name: string;
+  level_icon: string | null;
+  level_color: string | null;
+  achieved: boolean;
+  gates: GateResult[];
+}
+
+export interface MaturityReport {
+  entity_type: string;
+  entity_id: string;
+  entity_name: string | null;
+  achieved_level_order: number | null;
+  achieved_level_name: string | null;
+  total_levels: number;
+  gates_passed: number;
+  gates_total: number;
+  levels: LevelResult[];
+  evaluated_at: string;
+  evaluated_by: string | null;
+}
+
+export interface MaturitySnapshot {
+  id: string;
+  entity_type: string;
+  entity_id: string;
+  achieved_level_order: number | null;
+  achieved_level_name: string | null;
+  total_levels: number;
+  gates_passed: number;
+  gates_total: number;
+  gate_results_json: string | null;
+  evaluated_at: string;
+  evaluated_by: string | null;
+}

--- a/src/frontend/src/views/compliance-policy-details.tsx
+++ b/src/frontend/src/views/compliance-policy-details.tsx
@@ -449,10 +449,11 @@ export default function CompliancePolicyDetails() {
                     <SelectValue placeholder={t('common:placeholders.selectCategory')} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="security">{t('compliance:categories.security')}</SelectItem>
-                    <SelectItem value="data_quality">{t('compliance:categories.dataQuality')}</SelectItem>
-                    <SelectItem value="privacy">{t('compliance:categories.privacy')}</SelectItem>
-                    <SelectItem value="governance">{t('compliance:categories.governance')}</SelectItem>
+                    <SelectItem value="Security">{t('compliance:categories.security')}</SelectItem>
+                    <SelectItem value="Data Quality">{t('compliance:categories.dataQuality')}</SelectItem>
+                    <SelectItem value="Privacy">{t('compliance:categories.privacy')}</SelectItem>
+                    <SelectItem value="Governance">{t('compliance:categories.governance')}</SelectItem>
+                    <SelectItem value="Maturity">{t('compliance:categories.maturity', 'Maturity')}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/src/frontend/src/views/compliance.tsx
+++ b/src/frontend/src/views/compliance.tsx
@@ -385,7 +385,7 @@ export default function Compliance() {
           />
 
           <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-            <DialogContent>
+            <DialogContent key={selectedPolicy?.id ?? 'new'}>
               <DialogHeader>
                 <DialogTitle>
                   {selectedPolicy ? t('compliance:editRule') : t('compliance:createNewRule')}
@@ -419,6 +419,7 @@ export default function Compliance() {
                       <SelectItem value="Data Quality">{t('compliance:categories.dataQuality')}</SelectItem>
                       <SelectItem value="Privacy">{t('compliance:categories.privacy')}</SelectItem>
                       <SelectItem value="Governance">{t('compliance:categories.governance')}</SelectItem>
+                      <SelectItem value="Maturity">{t('compliance:categories.maturity', 'Maturity')}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/frontend/src/views/data-contract-details.tsx
+++ b/src/frontend/src/views/data-contract-details.tsx
@@ -23,6 +23,7 @@ import EntityMetadataPanel from '@/components/metadata/entity-metadata-panel'
 import EntityQualityPanel from '@/components/quality/entity-quality-panel'
 import { OwnershipPanel } from '@/components/common/ownership-panel'
 import { EntityTreePanel } from '@/components/common/entity-tree-panel'
+import { MaturityInline } from '@/components/common/maturity-inline'
 import { CommentSidebar } from '@/components/comments'
 import ConceptSelectDialog from '@/components/semantic/concept-select-dialog'
 import LinkedConceptChips from '@/components/semantic/linked-concept-chips'
@@ -1582,9 +1583,6 @@ export default function DataContractDetails() {
   }
 
   if (loading) {
-    // Mirrors rendered shape: header with back + version navigator + view-mode
-    // toggle on the left, action buttons on the right; body shows ODCS sections
-    // and a schema property table.
     return (
       <div className="py-6 space-y-6">
         <DetailHeaderSkeleton actionButtons={5} leftControls={2} />
@@ -1820,10 +1818,16 @@ export default function DataContractDetails() {
                 {contract.description?.purpose || 'No description provided'}
               </CardDescription>
             </div>
-            <div className="flex items-center gap-3 shrink-0">
-              <Badge variant={getStatusColor(contract.status)}>
-                {contract.status || '—'}
-              </Badge>
+            <div className="flex items-end gap-5 shrink-0">
+              <div className="flex flex-col items-center gap-1">
+                <Badge variant={getStatusColor(contract.status)}>
+                  {contract.status || '—'}
+                </Badge>
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Status</span>
+              </div>
+              {contract.id && (
+                <MaturityInline entityType="DataContract" entityId={contract.id} compact />
+              )}
             </div>
           </div>
         </CardHeader>
@@ -2840,6 +2844,7 @@ export default function DataContractDetails() {
           </CardContent>
         </Card>
       )}
+
 
       {/* Custom Properties */}
       {shouldShowSection('custom-properties') && (

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -54,6 +54,7 @@ import { AssetSelector } from '@/components/common/asset-selector';
 import { EntityTreePanel } from '@/components/common/entity-tree-panel';
 import { BusinessLineageView } from '@/components/lineage';
 import { ReadinessChecklist } from '@/components/data-products/readiness-checklist';
+import { MaturityInline } from '@/components/common/maturity-inline';
 import { LineageEditor } from '@/components/common/lineage-editor';
 import { useCopilotContext } from '@/hooks/use-copilot-context';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -1344,9 +1345,6 @@ export default function DataProductDetails() {
     shouldShowSectionForViewMode(viewMode, section);
 
   if (loading || permissionsLoading) {
-    // Match the rendered shape: header has back + version navigator + S/M/L
-    // view-mode toggle on the left, multiple action buttons on the right;
-    // body has a hero, ODPS metadata panels, and an output-ports table.
     return (
       <div className="py-6 space-y-6">
         <DetailHeaderSkeleton actionButtons={6} leftControls={2} />
@@ -1599,14 +1597,17 @@ export default function DataProductDetails() {
                   {product.description?.purpose || 'No description provided'}
                 </CardDescription>
               </div>
-              <div className="flex items-center gap-4 shrink-0">
-                <Badge variant={getStatusColor(product.status)}>
-                  {product.status || '—'}
-                </Badge>
+              <div className="flex items-end gap-5 shrink-0">
+                <div className="flex flex-col items-center gap-1">
+                  <Badge variant={getStatusColor(product.status)}>
+                    {product.status || '—'}
+                  </Badge>
+                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Status</span>
+                </div>
                 {qualitySummary && qualitySummary.items_count > 0 && (
-                  <div className="flex flex-col items-end leading-none">
+                  <div className="flex flex-col items-center gap-1">
                     <span
-                      className="text-3xl font-bold"
+                      className="text-2xl font-semibold leading-none"
                       style={{
                         color:
                           qualitySummary.overall_score_percent >= 80
@@ -1618,10 +1619,11 @@ export default function DataProductDetails() {
                     >
                       {Math.round(qualitySummary.overall_score_percent)}%
                     </span>
-                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground mt-1">
-                      Quality
-                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Quality</span>
                   </div>
+                )}
+                {productId && (
+                  <MaturityInline entityType="DataProduct" entityId={productId} compact />
                 )}
               </div>
             </div>
@@ -2019,9 +2021,6 @@ export default function DataProductDetails() {
           </CardContent>
         </Card>
       )}
-
-      {/* Production Readiness Checklist */}
-      {shouldShowSection('readiness') && productId && <ReadinessChecklist productId={productId} />}
 
       {/* Consumables (Input Ports) */}
       {shouldShowSection('consumables') && (

--- a/src/frontend/src/views/settings-maturity-levels.tsx
+++ b/src/frontend/src/views/settings-maturity-levels.tsx
@@ -1,0 +1,12 @@
+import SettingsPageWrapper from '@/components/settings/settings-page-wrapper';
+import MaturityLevelsSettings from '@/components/settings/maturity-levels-settings';
+import { useTranslation } from 'react-i18next';
+
+export default function SettingsMaturityLevelsView() {
+  const { t } = useTranslation(['settings']);
+  return (
+    <SettingsPageWrapper title={t('settings:tabs.maturityLevels', 'Maturity Levels')} permissionId="settings-maturity-levels">
+      <MaturityLevelsSettings />
+    </SettingsPageWrapper>
+  );
+}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded production readiness panel with a flexible, admin-configurable maturity model
- Maturity levels are gated by compliance DSL policies, evaluated per entity (Data Products and Data Contracts)
- Ships with 5-level seed data (Accessible → Described → Defined → Monitored → Trusted)
- Compact inline display in entity detail headers next to Status and Quality badges, with hover card for gate breakdown
- Full settings UI for admins to manage levels, gates, and linked compliance policies

## Changes

### Backend (15 files, ~1,400 lines)
- **DB models**: `maturity_levels`, `maturity_gates`, `maturity_snapshots` tables + Alembic migration `c1`
- **Entity dictionary builder**: Enriches flat dicts with computed properties (`has_owner`, `tag_count`, `business_term_count`, etc.) for DSL evaluation
- **Maturity evaluator**: Evaluates levels sequentially, persists snapshots, triggers `ON_MATURITY_CHANGE` workflow events
- **API routes**: CRUD for levels/gates, evaluate endpoint, snapshot history
- **Seed data**: 5 default levels with 10 compliance policy gates
- **Demo SQL normalization**: Categories title-cased across all industry demo files

### Frontend (12 files, ~1,200 lines)
- **MaturityInline**: Compact header badge (level name + refresh button) with HoverCard showing level-by-level gate breakdown
- **MaturityBadge**: Reusable colored badge component
- **Settings page**: Admin UI for managing maturity levels and gates with HoverCard details
- **Compliance fix**: "Maturity" category added to dropdowns, `DialogContent` key prop fixes stale Radix Select defaultValue
- **Header badges**: Consistent layout with STATUS / QUALITY / MATURITY labels

## Test plan

- [ ] Verify maturity levels settings page loads and displays 5 default levels (descending order)
- [ ] Click a maturity level to see its gates with hover details
- [ ] Navigate to a Data Product detail page — verify compact maturity badge in header
- [ ] Click re-evaluate button — verify toast notification appears
- [ ] Hover over maturity badge — verify level breakdown popover
- [ ] Edit a maturity-category compliance rule — verify "Maturity" appears in category dropdown
- [ ] Create a new maturity level with custom gates via settings UI