### PR TITLE
refactor(rbac): consolidate role permissions and restructure role editor

### DIFF
--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -121,8 +121,10 @@ async def startup_event():
     app.state.health = {
         "db_ok": False,
         "ws_ok": False,
+        "seed_ok": True,
         "warnings": [],
         "db_error": None,
+        "seed_error": None,
     }
     
     # Skip startup tasks if running tests
@@ -136,12 +138,27 @@ async def startup_event():
     settings = get_settings()
     
     try:
-        initialize_database(settings=settings)
+        initialize_database()
         app.state.health["db_ok"] = True
     except Exception as e:
         app.state.health["db_error"] = str(e)
         logger.critical(f"Database init failed — entering maintenance mode: {e}", exc_info=True)
         return  # Skip manager init; MaintenanceMiddleware will serve the maintenance page
+
+    # Seed reference data that alembic data-migrations would have inserted but
+    # that create_all()+stamp cannot.  Idempotent — no-ops when rows exist.
+    try:
+        from src.repositories.certification_levels_repository import certification_levels_repo
+        from src.repositories.maturity_repository import maturity_repo
+        from src.common.database import get_session_factory
+        _sf = get_session_factory()
+        with _sf() as _db:
+            certification_levels_repo.seed_defaults(_db)
+            maturity_repo.seed_defaults(_db)
+            _db.commit()
+        logger.info("Reference data seed step complete.")
+    except Exception as e:
+        logger.warning(f"Failed seeding reference data: {e}", exc_info=True)
 
     initialize_managers(app)  # Soft-fails internally for ws_client; sets health["ws_ok"]
     
@@ -438,7 +455,7 @@ async def retry_startup():
     """
     settings = get_settings()
     try:
-        initialize_database(settings=settings)
+        initialize_database()
         app.state.health["db_ok"] = True
         app.state.health["db_error"] = None
     except Exception as e:
@@ -448,10 +465,18 @@ async def retry_startup():
 
     try:
         app.state.health["warnings"] = []  # Reset warnings before retry
-        initialize_managers(app)  # Sets health["ws_ok"] internally
+        app.state.health["seed_ok"] = True  # Reset seed health; initialize_managers will flip if it fails
+        app.state.health["seed_error"] = None
+        initialize_managers(app)  # Sets health["ws_ok"] / health["seed_ok"] internally
     except Exception as e:
         app.state.health["warnings"].append(f"Manager init failed on retry: {e}")
         logger.error(f"Manager init failed on retry: {e}", exc_info=True)
+
+    if not app.state.health.get("seed_ok", True):
+        return JSONResponse(
+            {"status": "error", "detail": app.state.health.get("seed_error") or "seeding failed"},
+            status_code=503,
+        )
 
     return {"status": "ok", "health": app.state.health}
 

--- a/src/backend/src/common/features.py
+++ b/src/backend/src/common/features.py
@@ -37,6 +37,16 @@ ADMIN_ONLY_LEVELS = [
     FeatureAccessLevel.NONE,
     FeatureAccessLevel.ADMIN,
 ]
+# Levels for "implicit" cross-cutting features that every authenticated user
+# should have at least read access to (commenting, requesting access grants,
+# viewing one's own process-workflow status, etc.). These features can still
+# be tightened to read-only or expanded to admin per role, but `NONE` is not
+# offered as a choice because the feature is part of the baseline UX.
+IMPLICIT_FEATURE_LEVELS = [
+    FeatureAccessLevel.READ_ONLY,
+    FeatureAccessLevel.READ_WRITE,
+    FeatureAccessLevel.ADMIN,
+]
 
 
 # Permission group buckets — mirror the sidebar groups plus a Settings bucket
@@ -58,11 +68,11 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # Browse catalog, view lineage
         'group': GROUP_DISCOVER,
     },
-    'llm-search': {
-        'name': 'LLM Search',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_DISCOVER,
-    },
+    # NOTE: `llm-search` is intentionally NOT registered as a permission.
+    # The LLM Search routes deliberately bypass PermissionChecker (access
+    # control is performed by the underlying tools that filter results
+    # based on the caller's permissions for each surfaced entity). See
+    # `src/backend/src/routes/llm_search_routes.py`.
 
     # --- Build ---
     'data-products': {
@@ -91,9 +101,13 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
         'group': GROUP_BUILD,  # lives under /concepts/mapping alongside Concepts
     },
     'schema-importer': {
+        # Cross-cutting: schema-importer has no top-level sidebar entry; it
+        # is launched inline from Data Contracts / Data Products to populate
+        # them from existing schemas.
         'name': 'Schema Importer',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_BUILD,
+        'cross_cutting': True,
     },
 
     # --- Govern ---
@@ -128,18 +142,26 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
         'group': GROUP_GOVERN,
     },
     'process-workflows': {
+        # Cross-cutting: process workflows are surfaced inline (notifications
+        # for approvals, status badges on entities) — there is no dedicated
+        # "Process Workflows" sidebar entry. Every user can see the workflows
+        # that affect them; admins manage workflow definitions.
         'name': 'Process Workflows',
         'allowed_levels': [
-            FeatureAccessLevel.NONE,
             FeatureAccessLevel.READ_ONLY,
-            FeatureAccessLevel.ADMIN,  # Only Admin gets full write access
+            FeatureAccessLevel.ADMIN,
         ],
         'group': GROUP_GOVERN,
+        'cross_cutting': True,
     },
     'access-grants': {
+        # Cross-cutting: launched from asset detail pages, no sidebar entry.
+        # Every user can request grants (READ_WRITE) or at minimum see their
+        # own grants (READ_ONLY); admins approve and manage.
         'name': 'Access Grants',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # Users request, admins grant
+        'allowed_levels': IMPLICIT_FEATURE_LEVELS,
         'group': GROUP_GOVERN,
+        'cross_cutting': True,
     },
 
     # --- Deploy ---
@@ -164,38 +186,24 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
     },
 
     # --- Settings: Reference Data sub-pages ---
-    'settings-data-domains': {
-        'name': 'Settings — Data Domains',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
-    'settings-business-roles': {
-        'name': 'Settings — Business Roles',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
-    'settings-delivery-methods': {
-        'name': 'Settings — Delivery Methods',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
+    # NOTE: most Reference Data sub-pages no longer need a dedicated
+    # `settings-*` permission. The Settings sidebar gates visibility via the
+    # corresponding consumption-side permission (e.g. `data-domains`,
+    # `business-roles`, `teams`, …). The sub-pages that remain below either
+    # (a) lack a consumption counterpart (asset-types, certification-levels)
+    # or (b) need distinct backend semantics from their consumption sibling.
     'settings-asset-types': {
-        'name': 'Settings — Asset Types',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
-    'settings-teams': {
-        'name': 'Settings — Teams',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
-    'settings-projects': {
-        'name': 'Settings — Projects',
+        'name': 'Asset Types',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-certification-levels': {
-        'name': 'Settings — Certification Levels',
+        'name': 'Certification Levels',
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_SETTINGS,
+    },
+    'settings-maturity-levels': {
+        'name': 'Maturity Levels',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
@@ -207,129 +215,137 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
 
     # --- Settings: Configuration sub-pages ---
     'settings-general': {
-        'name': 'Settings — General',
+        'name': 'General',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-ui': {
-        'name': 'Settings — UI Customization',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
-    'settings-tags': {
-        'name': 'Settings — Tags',
+        'name': 'UI Customization',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-connectors': {
-        'name': 'Settings — Connectors',
+        'name': 'Connectors',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
 
     # --- Settings: Integrations sub-pages ---
     'settings-git': {
-        'name': 'Settings — Git',
+        'name': 'Git',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-mcp': {
-        'name': 'Settings — MCP',
+        'name': 'MCP',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-directory': {
-        'name': 'Settings — Directory',
+        'name': 'Directory',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-semantic-models': {
-        'name': 'Settings — RDF Sources',
+        'name': 'RDF Sources',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-search': {
-        'name': 'Settings — Search',
+        'name': 'Search',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
 
     # --- Settings: Operations sub-pages ---
-    'settings-jobs': {
-        'name': 'Settings — Jobs',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
     'settings-delivery': {
-        'name': 'Settings — Delivery',
+        # Configures delivery MODES for data products (Direct / Indirect /
+        # Manual). Disambiguated from the `delivery-methods` reference data
+        # (which manages the list of selectable delivery method labels).
+        'name': 'Delivery Modes',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
     'settings-workflows': {
-        'name': 'Settings — Workflows',
+        'name': 'Workflows',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
 
     # --- Settings: Access Control sub-pages ---
     'settings-roles': {
-        'name': 'Settings — App Roles',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
-    'settings-audit': {
-        'name': 'Settings — Audit Trail',
+        'name': 'App Roles',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
 
-    # --- Other (cross-cutting / consumption-side permissions) ---
-    # These existing top-level IDs remain in place to govern consumption of
-    # the underlying feature elsewhere in the app (pickers, lineage, search
-    # results, etc.). Their settings-page counterparts live above.
+    # --- Cross-cutting / consumption-side permissions ---
+    # These top-level IDs govern consumption of the underlying feature
+    # elsewhere in the app (pickers, lineage, detail panels, etc.). Reference
+    # data permissions live in the Settings group so they appear under the
+    # appropriate Settings sub-section (Reference Data, Configuration,
+    # Operations, Access Control) — the same buckets the Settings sidebar
+    # uses. Cross-cutting platform permissions without a Settings sub-section
+    # counterpart live in the appropriate main-menu group.
+
+    # Reference data — gates both the Settings sidebar entry and any
+    # cross-app consumption (domain pickers, business role assignment, etc.)
     'data-domains': {
         'name': 'Data Domains',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
-    },
-    'teams': {
-        'name': 'Teams',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
-    },
-    'projects': {
-        'name': 'Projects',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
+        'group': GROUP_SETTINGS,
     },
     'business-roles': {
         'name': 'Business Roles',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
+        'group': GROUP_SETTINGS,
     },
     'business-owners': {
+        # Cross-cutting: no dedicated Settings sub-page. Used by the
+        # ownership panel and Assign Owner dialog on data product / data
+        # contract details. The `/business-owners` route exists as a list
+        # view but is not linked from the sidebar.
         'name': 'Business Owners',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
+        'group': GROUP_SETTINGS,
+        'cross_cutting': True,
     },
     'delivery-methods': {
         'name': 'Delivery Methods',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
+        'group': GROUP_SETTINGS,
     },
+    'teams': {
+        'name': 'Teams',
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_SETTINGS,
+    },
+    'projects': {
+        'name': 'Projects',
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_SETTINGS,
+    },
+
+    # Configuration — gates both the Tags settings page (tag taxonomy
+    # administration at ADMIN level) and tag application throughout the
+    # app (READ_WRITE level on detail panels, pickers, etc.).
     'tags': {
         'name': 'Tags',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # READ_WRITE can create tags, ADMIN can manage taxonomy
-        'group': GROUP_OTHER,
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_SETTINGS,
     },
+
+    # Operations — background jobs (gates both the Jobs settings page and
+    # any cross-app job APIs).
     'jobs': {
         'name': 'Jobs',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # View/manage background jobs
-        'group': GROUP_OTHER,
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_SETTINGS,
     },
+
+    # Access Control — read access to audit trail
     'audit': {
         'name': 'Audit & Change Logs',
-        # Allow read-only, full (if used), and admin; write requires at least READ_WRITE but routes use explicit checks
         'allowed_levels': [
             FeatureAccessLevel.NONE,
             FeatureAccessLevel.READ_ONLY,
@@ -337,37 +353,61 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
             FeatureAccessLevel.FULL,
             FeatureAccessLevel.ADMIN,
         ],
-        'group': GROUP_OTHER,
+        'group': GROUP_SETTINGS,
     },
-    'notifications': {
-        'name': 'Notifications',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # Users can view/manage own notifications
-        'group': GROUP_OTHER,
-    },
-    'self-service': {
-        'name': 'Self Service',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # Self-service data requests
-        'group': GROUP_OTHER,
-    },
+
+    # --- Cross-cutting platform permissions (no sidebar entry) ---
+    # These features are surfaced inline (panels on detail pages, inline
+    # actions, etc.) rather than as their own top-level sidebar item. They
+    # are flagged `cross_cutting: True` so the role editor renders them in
+    # a separate "Background" sub-section under their primary group.
     'comments': {
+        # Comments and star ratings on any entity. Every user can at least
+        # read comments; READ_WRITE lets them post their own; ADMIN can
+        # moderate / delete others'.
         'name': 'Comments & Ratings',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,  # READ_WRITE to add, ADMIN to manage all
-        'group': GROUP_OTHER,
+        'allowed_levels': IMPLICIT_FEATURE_LEVELS,
+        'group': GROUP_GOVERN,
+        'cross_cutting': True,
     },
     'ontology': {
+        # Concepts feature backend (ontology generator + schema endpoints).
+        # No sidebar entry of its own; used by the Concepts UI.
         'name': 'Ontology Schema',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
+        'group': GROUP_BUILD,
+        'cross_cutting': True,
     },
     'entity_relationships': {
+        # Cross-entity relationships and business lineage. Surfaced inline
+        # on entity detail pages — no dedicated sidebar entry.
         'name': 'Entity Relationships',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
+        'group': GROUP_BUILD,
+        'cross_cutting': True,
+    },
+
+    # --- Backend-only permissions ---
+    # These gate backend APIs that are not currently surfaced in the UI for
+    # end users. They're flagged `hidden_from_role_dialog: True` so the role
+    # editor doesn't expose them — admins implicitly inherit ADMIN on all
+    # features via the admin role.
+    'notifications': {
+        # Admin-only: governs CREATE/DELETE notification endpoints. End
+        # users see their own notifications without this permission.
+        'name': 'Notifications (Admin)',
+        'allowed_levels': ADMIN_ONLY_LEVELS,
+        'group': GROUP_GOVERN,
+        'hidden_from_role_dialog': True,
     },
     'entity_subscriptions': {
+        # Generic subscribe/unsubscribe endpoints at /api/subscriptions.
+        # The marketplace subscribe flow uses product-specific endpoints
+        # gated by `data-products`, so this perm is currently backend-only.
         'name': 'Entity Subscriptions',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_OTHER,
+        'group': GROUP_DISCOVER,
+        'hidden_from_role_dialog': True,
     },
     # 'about': { ... } # About page doesn't need explicit permissions here
 }

--- a/src/backend/src/common/middleware.py
+++ b/src/backend/src/common/middleware.py
@@ -46,9 +46,9 @@ MAINTENANCE_HTML = """<!DOCTYPE html>
 <div class="card">
   <div class="icon">&#9888;&#65039;</div>
   <h1>Service Temporarily Unavailable</h1>
-  <p>The application could not connect to the database during startup.
-     This is usually temporary — for example, a missing access grant or
-     a network issue.</p>
+  <p>The application could not complete startup. This is usually temporary
+     — for example, a database connection issue or a configuration problem
+     that prevents default roles from being seeded.</p>
   <div class="detail" id="err">Loading error details&hellip;</div>
   <button id="btn" onclick="retry()">Retry Connection</button>
   <div class="status" id="msg"></div>
@@ -60,7 +60,7 @@ MAINTENANCE_HTML = """<!DOCTYPE html>
         err=document.getElementById('err');
 
   fetch('/api/health').then(r=>r.json()).then(h=>{
-    err.textContent=h.db_error||'Unknown error';
+    err.textContent=h.db_error||h.seed_error||'Unknown error';
   }).catch(()=>{err.textContent='Could not fetch error details';});
 
   async function retry(){
@@ -92,9 +92,18 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         return response
 
 class MaintenanceMiddleware(BaseHTTPMiddleware):
-    """Serves a maintenance page when the database is not available.
+    """Serves a maintenance page when startup did not complete cleanly.
 
-    The health endpoint is always allowed through so the retry button works.
+    Triggers on either:
+      * ``db_ok == False`` — the database connection failed or initialization
+        could not complete, or
+      * ``seed_ok == False`` — default-role / team / project seeding failed
+        and the application would otherwise come up half-seeded (only the
+        Admin role exists; non-admin users would log in with no role and
+        approval routing would silently break).
+
+    The health and retry endpoints are always allowed through so the retry
+    button works.
     """
 
     PASSTHROUGH_PREFIXES = ("/api/health",)
@@ -103,15 +112,18 @@ class MaintenanceMiddleware(BaseHTTPMiddleware):
         self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
         health = getattr(request.app.state, 'health', {})
-        if not health.get('db_ok', True):
+        db_ok = health.get('db_ok', True)
+        seed_ok = health.get('seed_ok', True)
+        if not db_ok or not seed_ok:
             path = request.url.path
             if any(path.startswith(p) for p in self.PASSTHROUGH_PREFIXES):
                 return await call_next(request)
             accept = request.headers.get('accept', '')
             if 'text/html' in accept:
                 return HTMLResponse(MAINTENANCE_HTML, status_code=503)
+            detail = health.get("db_error") if not db_ok else health.get("seed_error")
             return JSONResponse(
-                {"error": "maintenance", "detail": health.get("db_error")},
+                {"error": "maintenance", "detail": detail},
                 status_code=503,
             )
         return await call_next(request)

--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -1768,13 +1768,18 @@ class SettingsManager:
             # updated_at=role_db.updated_at  # Uncomment if needed
         )
 
-    def get_features_with_access_levels(self) -> Dict[str, Dict[str, str | List[str]]]:
+    def get_features_with_access_levels(self) -> Dict[str, Dict[str, str | List[str] | bool]]:
         """Returns a dictionary of features and their allowed access levels.
 
         Each entry contains:
         - name: human-readable label
         - allowed_levels: list of allowed FeatureAccessLevel values (as strings)
         - group: one of Discover/Build/Govern/Deploy/Settings/Other for UI grouping
+        - hidden_from_role_dialog: optional bool flagging backend-only perms
+          that the role editor should not expose to admins
+        - cross_cutting: optional bool flagging features that have no
+          dedicated sidebar entry and should render in a "Background"
+          sub-section of their group in the role editor
         """
         features_config = get_feature_config()
         all_levels = get_all_access_levels()
@@ -1784,6 +1789,8 @@ class SettingsManager:
                 'name': config['name'],
                 'allowed_levels': [level.value for level in config['allowed_levels']],
                 'group': config.get('group', 'Other'),
+                'hidden_from_role_dialog': bool(config.get('hidden_from_role_dialog', False)),
+                'cross_cutting': bool(config.get('cross_cutting', False)),
             }
             for feature_id, config in features_config.items()
         }

--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -663,18 +663,36 @@ class SettingsManager:
                     for feat_id, feature_config in all_features_config.items():
                         desired_level = desired_permissions.get(feat_id, FeatureAccessLevel.NONE)
                         allowed_levels = feature_config.get('allowed_levels', [])
-                        
+
                         if desired_level in allowed_levels:
                             final_permissions[feat_id] = desired_level
+                            continue
+
+                        # Fallback path: the desired level (often the implicit
+                        # NONE for features the YAML doesn't mention) is not in
+                        # this feature's allowed_levels. Prefer NONE when it's
+                        # accepted, otherwise pick the lowest allowed level so
+                        # the seeder never produces a payload its own validator
+                        # would reject. Features like `process-workflows` and
+                        # `access-grants` are part of the baseline UX and have
+                        # NONE removed from their allowed_levels; defaulting
+                        # them to READ_ONLY matches the intended baseline.
+                        if FeatureAccessLevel.NONE in allowed_levels:
+                            fallback_level = FeatureAccessLevel.NONE
                         else:
-                            final_permissions[feat_id] = FeatureAccessLevel.NONE
-                            if desired_level != FeatureAccessLevel.NONE:
-                                allowed_str = [lvl.value for lvl in allowed_levels]
-                                logger.warning(
-                                    f"Desired default permission '{desired_level.value}' for role '{role_name}' "
-                                    f"on feature '{feat_id}' is not allowed (Allowed: {allowed_str}). Setting to NONE."
-                                )
-                                
+                            fallback_level = min(
+                                allowed_levels,
+                                key=lambda lvl: ACCESS_LEVEL_ORDER.get(lvl, 0),
+                            )
+                        final_permissions[feat_id] = fallback_level
+                        if desired_level != FeatureAccessLevel.NONE or fallback_level != FeatureAccessLevel.NONE:
+                            allowed_str = [lvl.value for lvl in allowed_levels]
+                            logger.warning(
+                                f"Desired default permission '{desired_level.value}' for role '{role_name}' "
+                                f"on feature '{feat_id}' is not allowed (Allowed: {allowed_str}). "
+                                f"Falling back to '{fallback_level.value}'."
+                            )
+
                     role_data["feature_permissions"] = final_permissions
                     logger.info(f"Assigning default permissions for role '{role_name}': { {k: v.value for k,v in final_permissions.items()} }")
 

--- a/src/backend/src/data/settings.yaml
+++ b/src/backend/src/data/settings.yaml
@@ -48,6 +48,8 @@ roles:
       data-asset-reviews: Admin
       catalog-commander: Full
       comments: Read/Write
+      process-workflows: Read-only  # View workflows; admins manage definitions
+      access-grants: Admin  # DGO approves access grants
     home_sections:
       - REQUIRED_ACTIONS
       - DISCOVERY
@@ -83,6 +85,8 @@ roles:
       data-asset-reviews: Read/Write
       catalog-commander: Read-only
       comments: Read/Write
+      process-workflows: Read-only  # View workflows; admins manage definitions
+      access-grants: Read/Write  # Can request grants on behalf of stewarded data
     home_sections:
       - REQUIRED_ACTIONS
       - DISCOVERY
@@ -116,6 +120,8 @@ roles:
       business-glossary: Read-only
       catalog-commander: Read-only
       comments: Read/Write
+      process-workflows: Read-only  # View workflows that affect own requests
+      access-grants: Read-only  # See own grants
     home_sections:
       - DISCOVERY
 
@@ -134,6 +140,8 @@ roles:
       business-glossary: Read-only
       catalog-commander: Read-only
       comments: Read/Write
+      process-workflows: Read-only  # View workflows triggered by own products
+      access-grants: Read/Write  # Can request grants for own products
     home_sections:
       - DATA_CURATION
       - DISCOVERY
@@ -159,6 +167,8 @@ roles:
       compliance: Read/Write
       data-asset-reviews: Read-only
       comments: Read/Write
+      process-workflows: Read-only  # View workflows; admins manage definitions
+      access-grants: Admin  # Security Officer approves access grants
     home_sections:
       - REQUIRED_ACTIONS
       - DISCOVERY

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -1072,7 +1072,7 @@ async def handle_deploy_request_response(
     notifications: NotificationsManagerDep,
     payload: HandleDeployPayload = Body(...),
     manager: DataContractsManager = Depends(get_data_contracts_manager),
-    _: bool = Depends(PermissionChecker('self-service', FeatureAccessLevel.READ_WRITE)),
+    _: bool = Depends(PermissionChecker('data-contracts', FeatureAccessLevel.READ_WRITE)),
 ):
     """Handle a deployment request decision (approve/deny). Optionally executes deployment."""
     try:

--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -168,7 +168,7 @@ async def health_check(manager: SettingsManager = Depends(get_settings_manager))
 @router.get('/settings/job-clusters', response_model=List[JobCluster])
 async def list_job_clusters(
     manager: SettingsManager = Depends(get_settings_manager),
-    _: bool = Depends(PermissionChecker('settings-jobs', FeatureAccessLevel.READ_ONLY)),
+    _: bool = Depends(PermissionChecker('jobs', FeatureAccessLevel.READ_ONLY)),
 ):
     """List all available job clusters"""
     try:

--- a/src/backend/src/routes/tags_routes.py
+++ b/src/backend/src/routes/tags_routes.py
@@ -23,9 +23,9 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/api", tags=["Tags"])
 
 # --- Tag Namespace Routes ---
-# Namespaces define the tag taxonomy. Management is gated by the Settings -> Tags
-# admin permission so namespace administrators can be delegated independently
-# from regular tag-applying users.
+# Namespaces define the tag taxonomy. Management is gated by the `tags`
+# permission at ADMIN level (the same permission's READ_WRITE level governs
+# tag application elsewhere in the app).
 @router.post("/tags/namespaces", response_model=TagNamespace, status_code=status.HTTP_201_CREATED)
 async def create_tag_namespace(
     namespace_in: TagNamespaceCreate,
@@ -36,7 +36,7 @@ async def create_tag_namespace(
     audit_manager: AuditManagerDep,
     audit_user: AuditCurrentUserDep,
     manager: TagsManager = Depends(get_tags_manager),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.ADMIN)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.ADMIN)),
 ):
     success = False
     details = {
@@ -109,7 +109,7 @@ async def update_tag_namespace(
     audit_manager: AuditManagerDep,
     audit_user: AuditCurrentUserDep,
     manager: TagsManager = Depends(get_tags_manager),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.ADMIN)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.ADMIN)),
 ):
     success = False
     details = {
@@ -160,7 +160,7 @@ async def delete_tag_namespace(
     audit_manager: AuditManagerDep,
     audit_user: AuditCurrentUserDep,
     manager: TagsManager = Depends(get_tags_manager),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.ADMIN)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.ADMIN)),
 ):
     success = False
     details = {
@@ -381,7 +381,7 @@ async def delete_tag(
         )
 
 # --- Tag Namespace Permission Routes ---
-# These manage who can write to a specific namespace. Always Settings -> Tags admin.
+# These manage who can write to a specific namespace. Always requires `tags` ADMIN.
 @router.post("/tags/namespaces/{namespace_id}/permissions", response_model=TagNamespacePermission, status_code=status.HTTP_201_CREATED)
 async def add_namespace_permission(
     namespace_id: UUID,
@@ -392,7 +392,7 @@ async def add_namespace_permission(
     audit_manager: AuditManagerDep,
     audit_user: AuditCurrentUserDep,
     manager: TagsManager = Depends(get_tags_manager),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.ADMIN)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.ADMIN)),
 ):
     success = False
     details = {
@@ -433,7 +433,7 @@ async def list_namespace_permissions(
     manager: TagsManager = Depends(get_tags_manager),
     skip: int = 0,
     limit: int = Query(default=100, le=1000),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.READ_ONLY)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.READ_ONLY)),
 ):
     # Check if namespace exists first (optional, manager method might do it)
     ns = manager.get_namespace(db, namespace_id=namespace_id)
@@ -447,7 +447,7 @@ async def get_namespace_permission_detail(
     permission_id: UUID,
     db: DBSessionDep,
     manager: TagsManager = Depends(get_tags_manager),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.READ_ONLY)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.READ_ONLY)),
 ):
     permission = manager.get_namespace_permission(db, perm_id=permission_id)
     if not permission or permission.namespace_id != namespace_id:
@@ -465,7 +465,7 @@ async def update_namespace_permission(
     audit_manager: AuditManagerDep,
     audit_user: AuditCurrentUserDep,
     manager: TagsManager = Depends(get_tags_manager),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.ADMIN)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.ADMIN)),
 ):
     success = False
     details = {
@@ -515,7 +515,7 @@ async def delete_namespace_permission(
     audit_manager: AuditManagerDep,
     audit_user: AuditCurrentUserDep,
     manager: TagsManager = Depends(get_tags_manager),
-    _: None = Depends(PermissionChecker('settings-tags', FeatureAccessLevel.ADMIN)),
+    _: None = Depends(PermissionChecker('tags', FeatureAccessLevel.ADMIN)),
 ):
     success = False
     details = {

--- a/src/backend/src/tests/unit/test_settings_manager.py
+++ b/src/backend/src/tests/unit/test_settings_manager.py
@@ -334,16 +334,26 @@ class TestSettingsManager:
         assert 'Read/Write' in result['settings']['allowed_levels']
         assert 'Admin' in result['settings']['allowed_levels']
 
-        # Each Settings sub-page has its own dedicated permission ID
+        # Settings sub-pages that need their own dedicated permission ID.
+        # The reference-data sub-pages (data-domains, business-roles,
+        # delivery-methods, teams, projects, audit) and the consolidated
+        # cross-cutting sub-pages (tags, jobs) reuse their consumption
+        # permission instead, so they are no longer expected here.
         expected_subpage_ids = {
-            'settings-data-domains', 'settings-business-roles',
-            'settings-delivery-methods', 'settings-asset-types',
-            'settings-teams', 'settings-projects',
-            'settings-certification-levels', 'settings-general',
-            'settings-ui', 'settings-tags', 'settings-connectors',
-            'settings-git', 'settings-mcp', 'settings-semantic-models',
-            'settings-search', 'settings-jobs', 'settings-delivery',
-            'settings-workflows', 'settings-roles', 'settings-audit',
+            'settings-asset-types',
+            'settings-certification-levels',
+            'settings-maturity-levels',
+            'settings-general',
+            'settings-ui',
+            'settings-connectors',
+            'settings-git',
+            'settings-mcp',
+            'settings-directory',
+            'settings-semantic-models',
+            'settings-search',
+            'settings-delivery',
+            'settings-workflows',
+            'settings-roles',
         }
         missing = expected_subpage_ids - set(result.keys())
         assert not missing, f"Missing settings sub-page IDs: {missing}"

--- a/src/backend/src/utils/startup_tasks.py
+++ b/src/backend/src/utils/startup_tasks.py
@@ -71,6 +71,20 @@ from src.connectors.bigquery import BigQueryConnector
 
 logger = get_logger(__name__)
 
+
+class StartupSeedError(RuntimeError):
+    """Raised when a non-recoverable seeding step (default roles, admin
+    role backfill, default team/project) fails during startup.
+
+    Distinguished from generic ``Exception`` so the outer manager-init
+    handler can route it into maintenance mode (via ``health["seed_ok"]``)
+    instead of silently logging and letting the app come up half-seeded.
+    Individual manager construction failures remain soft-fails — only
+    seeding steps that leave the role/permission graph inconsistent are
+    surfaced as fatal here.
+    """
+
+
 # Demo data SQL file path
 DEMO_DATA_SQL_FILE = Path(__file__).parent.parent / "data" / "demo_data_retail.sql"
 
@@ -397,22 +411,25 @@ def initialize_managers(app: FastAPI):
         # Defer SearchManager initialization until after initial data loading completes
         logger.info("Deferring SearchManager initialization until after initial data load.")
         
-        # --- Ensure default roles exist using the manager method --- 
-        app.state.settings_manager.ensure_default_roles_exist()
-
-        # --- Backfill Admin role with ADMIN on any newly-added feature IDs ---
-        # Idempotent migration; covers the settings-* sub-page permissions
-        # added by the Settings permissions refactor and any future additions.
-        app.state.settings_manager.upgrade_admin_role_for_new_features()
-
-        # --- Ensure default team and project exist for admins ---
-        app.state.settings_manager.ensure_default_team_and_project()
-
-        # --- Commit session potentially used for default role creation ---
-        # This commit is crucial AFTER all managers are initialized AND
-        # default roles are potentially created by the SettingsManager
-        db_session.commit()
-        logger.info("Manager initialization and default role creation transaction committed.")
+        # --- Seed defaults that leave the role/permission graph inconsistent
+        # if they fail. Wrapped in its own try/except so the outer handler
+        # can route this to maintenance mode (via health["seed_ok"]) instead
+        # of swallowing it: a half-seeded app where only the Admin role
+        # exists is worse than refusing to come up, because non-admins log
+        # in with no role and approval routing silently breaks.
+        try:
+            app.state.settings_manager.ensure_default_roles_exist()
+            # Backfill Admin role with ADMIN on any newly-added feature IDs.
+            # Idempotent migration; covers the settings-* sub-page permissions
+            # added by the Settings permissions refactor and any future additions.
+            app.state.settings_manager.upgrade_admin_role_for_new_features()
+            app.state.settings_manager.ensure_default_team_and_project()
+            db_session.commit()
+            logger.info("Manager initialization and default role creation transaction committed.")
+        except Exception as seed_err:
+            if db_session:
+                db_session.rollback()
+            raise StartupSeedError(f"Default role/team seeding failed: {seed_err}") from seed_err
 
         # --- Start background job polling ---
         try:
@@ -446,8 +463,18 @@ def initialize_managers(app: FastAPI):
             logger.info("APP_DEMO_MODE enabled but APP_DB_DROP_ON_START disabled - skipping automatic demo data loading.")
             logger.info("Use POST /api/settings/demo-data/load to load demo data manually.")
 
+    except StartupSeedError as e:
+        # Non-recoverable: the role/permission graph is inconsistent. Flip
+        # the health flag so MaintenanceMiddleware serves the maintenance
+        # page and /api/health/retry can re-attempt seeding after the
+        # operator fixes settings.yaml / migrations.
+        logger.critical(f"Fatal startup error (role/team seeding): {e}", exc_info=True)
+        if db_session: db_session.rollback()
+        health["seed_ok"] = False
+        health["seed_error"] = str(e)
+        health.setdefault("warnings", []).append(f"Seeding failed: {e}")
     except Exception as e:
-        logger.critical(f"Failed during application startup (manager init or default roles): {e}", exc_info=True)
+        logger.critical(f"Failed during application startup (manager init): {e}", exc_info=True)
         if db_session: db_session.rollback()
         msg = f"Manager initialization failed: {e}"
         health.setdefault("warnings", []).append(msg)

--- a/src/frontend/src/components/settings/role-form-dialog.tsx
+++ b/src/frontend/src/components/settings/role-form-dialog.tsx
@@ -21,36 +21,79 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { PrincipalPicker } from '@/components/common/principal-picker';
 import { normaliseAssignedGroups } from '@/lib/assigned-groups';
 
-// Order within the Settings group should mirror the Settings sidebar
-// (Reference Data → Configuration → Integrations → Operations → Access Control)
-// rather than alphabetical. Anything not listed here falls to the bottom.
-const SETTINGS_GROUP_ORDER: string[] = [
-    // Reference Data
-    'settings-data-domains',
-    'settings-business-roles',
-    'settings-delivery-methods',
-    'settings-asset-types',
-    'settings-teams',
-    'settings-projects',
-    'settings-certification-levels',
-    // Configuration
-    'settings-general',
-    'settings-ui',
-    'settings-tags',
-    'settings-connectors',
-    // Integrations
-    'settings-git',
-    'settings-mcp',
-    'settings-semantic-models',
-    'settings-search',
-    // Operations
-    'settings-jobs',
-    'settings-delivery',
-    'settings-workflows',
-    // Access Control
-    'settings-roles',
-    'settings-audit',
-    // Parent settings gate sits at the very top of the group
+// Sub-groups within the Settings permission group mirror the Settings
+// sidebar layout (Reference Data → Configuration → Integrations →
+// Operations → Access Control). Each sub-group renders as its own
+// heading (e.g. "Settings — Reference Data") so we don't repeat the
+// "Settings — " prefix on every individual permission row.
+interface SettingsSubGroup {
+    titleKey: string;
+    defaultTitle: string;
+    items: string[]; // permission IDs in display order
+}
+
+const SETTINGS_SUB_GROUPS: SettingsSubGroup[] = [
+    {
+        titleKey: 'roles.permissions.settingsSubGroups.referenceData',
+        defaultTitle: 'Reference Data',
+        // Order matches the Settings sidebar (Reference Data section in
+        // settings-layout.tsx). `business-owners` is intentionally NOT
+        // here — it has no Settings sidebar entry and is rendered with
+        // the other cross-cutting consumption perms.
+        items: [
+            'data-domains',
+            'business-roles',
+            'delivery-methods',
+            'settings-asset-types',
+            'teams',
+            'projects',
+            'settings-certification-levels',
+            'settings-maturity-levels',
+        ],
+    },
+    {
+        titleKey: 'roles.permissions.settingsSubGroups.configuration',
+        defaultTitle: 'Configuration',
+        // `tags` gates both the Tags settings page (ADMIN level for
+        // taxonomy management) and tag application throughout the app
+        // (READ_WRITE level for detail panels, pickers, etc.).
+        items: [
+            'settings-general',
+            'settings-ui',
+            'tags',
+            'settings-connectors',
+        ],
+    },
+    {
+        titleKey: 'roles.permissions.settingsSubGroups.integrations',
+        defaultTitle: 'Integrations',
+        items: [
+            'settings-git',
+            'settings-mcp',
+            'settings-directory',
+            'settings-semantic-models',
+            'settings-search',
+        ],
+    },
+    {
+        titleKey: 'roles.permissions.settingsSubGroups.operations',
+        defaultTitle: 'Operations',
+        // `jobs` gates both the Jobs settings page and any cross-app
+        // job APIs (single permission, level expresses scope).
+        items: [
+            'jobs',
+            'settings-delivery',
+            'settings-workflows',
+        ],
+    },
+    {
+        titleKey: 'roles.permissions.settingsSubGroups.accessControl',
+        defaultTitle: 'Access Control',
+        items: [
+            'settings-roles',
+            'audit',
+        ],
+    },
 ];
 
 interface RoleFormDialogProps {
@@ -451,9 +494,12 @@ const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
 
                                         {(() => {
                                             const orderedFeatureById = new Map(orderedFeatures.map(f => [f.id, f]));
-                                            // Bucket features into groups defined by the backend config.
+                                            // Bucket features into groups defined by the backend config,
+                                            // skipping any flagged hidden_from_role_dialog (backend-only
+                                            // permissions that have no end-user UI surface).
                                             const grouped = new Map<PermissionGroup, [string, FeatureConfig][]>();
                                             for (const [id, conf] of Object.entries(featuresConfig)) {
+                                                if (conf.hidden_from_role_dialog) continue;
                                                 const g = (conf.group ?? 'Other') as PermissionGroup;
                                                 if (!grouped.has(g)) grouped.set(g, []);
                                                 grouped.get(g)!.push([id, conf]);
@@ -462,22 +508,56 @@ const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
                                             const sortByName = (a: [string, FeatureConfig], b: [string, FeatureConfig]) =>
                                                 (a[1].name || a[0]).localeCompare(b[1].name || b[0]);
 
-                                            // Settings group preserves sidebar order; other groups sort alphabetically.
-                                            const settingsRank = (id: string): number => {
-                                                if (id === 'settings') return -1; // parent gate at top
-                                                const idx = SETTINGS_GROUP_ORDER.indexOf(id);
-                                                return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
-                                            };
-                                            const sortSettings = (a: [string, FeatureConfig], b: [string, FeatureConfig]) => {
-                                                const ra = settingsRank(a[0]);
-                                                const rb = settingsRank(b[0]);
+                                            // Each top-level group (Discover/Build/Govern/Deploy) is
+                                            // ordered to match the main-menu nav order. We rank each
+                                            // permission by its index in `orderedFeatures` (the nav
+                                            // config). Permissions that don't appear in the nav (e.g.
+                                            // cross-cutting consumption-side perms like `business-owners`,
+                                            // `comments`, `audit`) fall to the bottom of their group in
+                                            // alphabetical order.
+                                            const navRank = new Map<string, number>();
+                                            orderedFeatures.forEach((f, idx) => {
+                                                const permId = f.permissionId || f.id;
+                                                if (!navRank.has(permId)) navRank.set(permId, idx);
+                                            });
+                                            const sortByNavOrder = (a: [string, FeatureConfig], b: [string, FeatureConfig]) => {
+                                                const ra = navRank.has(a[0]) ? navRank.get(a[0])! : Number.MAX_SAFE_INTEGER;
+                                                const rb = navRank.has(b[0]) ? navRank.get(b[0])! : Number.MAX_SAFE_INTEGER;
                                                 if (ra !== rb) return ra - rb;
                                                 return sortByName(a, b);
                                             };
 
+                                            // Non-Settings groups follow nav order; Settings has bespoke
+                                            // sub-group ordering handled separately below.
                                             for (const [g, items] of grouped) {
-                                                items.sort(g === 'Settings' ? sortSettings : sortByName);
+                                                if (g !== 'Settings') items.sort(sortByNavOrder);
                                             }
+
+                                            // Within each non-Settings group, split into "sidebar
+                                            // items" (have a nav entry) and "cross-cutting items"
+                                            // (no sidebar entry — surfaced inline). Cross-cutting
+                                            // items are flagged on the backend config so the role
+                                            // editor can render them under a separate "Background"
+                                            // heading to distinguish them from the main sidebar
+                                            // features.
+                                            const splitCrossCutting = (
+                                                items: [string, FeatureConfig][],
+                                            ): {
+                                                sidebar: [string, FeatureConfig][];
+                                                crossCutting: [string, FeatureConfig][];
+                                            } => {
+                                                const sidebar: [string, FeatureConfig][] = [];
+                                                const crossCutting: [string, FeatureConfig][] = [];
+                                                for (const entry of items) {
+                                                    if (entry[1].cross_cutting) {
+                                                        crossCutting.push(entry);
+                                                    } else {
+                                                        sidebar.push(entry);
+                                                    }
+                                                }
+                                                crossCutting.sort(sortByName);
+                                                return { sidebar, crossCutting };
+                                            };
 
                                             const groupLabelKey = (g: PermissionGroup) => {
                                                 switch (g) {
@@ -490,13 +570,16 @@ const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
                                                 }
                                             };
 
-                                            const renderRow = (featureId: string, featureConf: FeatureConfig) => {
+                                            const renderRow = (
+                                                featureId: string,
+                                                featureConf: FeatureConfig,
+                                            ) => {
                                                 const navFeature = orderedFeatureById.get(featureId);
                                                 const label = featureConf.name || navFeature?.name || featureId;
                                                 const description = navFeature?.description ?? '';
                                                 const allowedLevels = Array.isArray(featureConf.allowed_levels) ? featureConf.allowed_levels : [];
                                                 return (
-                                                    <div key={featureId} className="flex items-center justify-between space-x-4 py-2 border-b border-gray-200 dark:border-gray-700 last:border-b-0">
+                                                    <div key={featureId} className="flex items-center justify-between space-x-4 py-2">
                                                         <Label htmlFor={`permissions-${featureId}`} className="text-sm font-normal flex-1">
                                                             {label}
                                                             {description && <p className="text-xs text-muted-foreground">{description}</p>}
@@ -535,16 +618,98 @@ const RoleFormDialog: React.FC<RoleFormDialogProps> = ({
                                                 );
                                             };
 
+                                            // Tailwind classes for a top-level section block. The first
+                                            // section sits flush; every subsequent section gets a divider
+                                            // line and spacing above it.
+                                            const sectionClass = 'space-y-1 pt-6 mt-6 border-t border-gray-200 dark:border-gray-700 first:pt-0 first:mt-0 first:border-t-0';
+                                            // Sub-section (inside the Settings group) — slightly tighter
+                                            // spacing but still divided from its predecessor.
+                                            const subSectionClass = 'space-y-1 pt-4 mt-4 border-t border-gray-200 dark:border-gray-700 first:pt-0 first:mt-0 first:border-t-0';
+
+                                            // Special renderer for the Settings group: parent gate at the
+                                            // top, then each sub-group rendered as its own "Settings — X"
+                                            // heading mirroring the Settings sidebar layout.
+                                            const renderSettingsGroup = (items: [string, FeatureConfig][]): React.ReactElement => {
+                                                const byId = new Map(items);
+                                                const parent = byId.get('settings');
+                                                const consumed = new Set<string>();
+                                                if (parent) consumed.add('settings');
+
+                                                const settingsLabel = t(groupLabelKey('Settings'), 'Settings');
+
+                                                return (
+                                                    <div key="Settings" className={sectionClass}>
+                                                        <h5 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+                                                            {settingsLabel}
+                                                        </h5>
+                                                        {parent && renderRow('settings', parent)}
+                                                        {SETTINGS_SUB_GROUPS.map(sub => {
+                                                            const subItems = sub.items
+                                                                .map(id => {
+                                                                    const conf = byId.get(id);
+                                                                    if (conf) consumed.add(id);
+                                                                    return conf ? ([id, conf] as [string, FeatureConfig]) : null;
+                                                                })
+                                                                .filter((x): x is [string, FeatureConfig] => x !== null);
+                                                            if (subItems.length === 0) return null;
+                                                            const subTitle = t(sub.titleKey, sub.defaultTitle);
+                                                            return (
+                                                                <div key={sub.defaultTitle} className={subSectionClass}>
+                                                                    <h6 className="text-sm font-medium text-foreground mb-1">
+                                                                        {`${settingsLabel} — ${subTitle}`}
+                                                                    </h6>
+                                                                    {subItems.map(([id, conf]) => renderRow(id, conf))}
+                                                                </div>
+                                                            );
+                                                        })}
+                                                        {/* Any Settings-group items not classified into one of the
+                                                            sub-groups above fall here. In practice these are the
+                                                            cross-cutting perms that don't have a sidebar entry
+                                                            (e.g. business-owners). They render under a
+                                                            "Background" heading to distinguish from sidebar
+                                                            pages. */}
+                                                        {(() => {
+                                                            const leftovers = items
+                                                                .filter(([id]) => !consumed.has(id))
+                                                                .sort(sortByName);
+                                                            if (leftovers.length === 0) return null;
+                                                            return (
+                                                                <div key="settings-background" className={subSectionClass}>
+                                                                    <h6 className="text-sm font-medium text-foreground mb-1">
+                                                                        {`${settingsLabel} — ${t('roles.permissions.crossCutting', 'Background')}`}
+                                                                    </h6>
+                                                                    {leftovers.map(([id, conf]) => renderRow(id, conf))}
+                                                                </div>
+                                                            );
+                                                        })()}
+                                                    </div>
+                                                );
+                                            };
+
                                             const sections: React.ReactElement[] = [];
                                             for (const g of PERMISSION_GROUP_ORDER) {
                                                 const items = grouped.get(g);
                                                 if (!items || items.length === 0) continue;
+                                                if (g === 'Settings') {
+                                                    sections.push(renderSettingsGroup(items));
+                                                    continue;
+                                                }
+                                                const groupLabel = t(groupLabelKey(g), g);
+                                                const { sidebar, crossCutting } = splitCrossCutting(items);
                                                 sections.push(
-                                                    <div key={g} className="space-y-1 pt-3 first:pt-0">
+                                                    <div key={g} className={sectionClass}>
                                                         <h5 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
-                                                            {t(groupLabelKey(g), g)}
+                                                            {groupLabel}
                                                         </h5>
-                                                        {items.map(([id, conf]) => renderRow(id, conf))}
+                                                        {sidebar.map(([id, conf]) => renderRow(id, conf))}
+                                                        {crossCutting.length > 0 && (
+                                                            <div className={subSectionClass}>
+                                                                <h6 className="text-sm font-medium text-foreground mb-1">
+                                                                    {`${groupLabel} — ${t('roles.permissions.crossCutting', 'Background')}`}
+                                                                </h6>
+                                                                {crossCutting.map(([id, conf]) => renderRow(id, conf))}
+                                                            </div>
+                                                        )}
                                                     </div>
                                                 );
                                             }

--- a/src/frontend/src/components/settings/settings-layout.tsx
+++ b/src/frontend/src/components/settings/settings-layout.tsx
@@ -47,12 +47,12 @@ const settingsNavGroups: SettingsNavGroup[] = [
     titleKey: 'settings:nav.groups.referenceData',
     defaultTitle: 'Reference Data',
     items: [
-      { path: '/settings/data-domains', labelKey: 'settings:tabs.dataDomains', defaultLabel: 'Domains', icon: BoxSelect, permissionId: 'settings-data-domains' },
-      { path: '/settings/business-roles', labelKey: 'settings:tabs.businessRoles', defaultLabel: 'Business Roles', icon: Briefcase, permissionId: 'settings-business-roles' },
-      { path: '/settings/delivery-methods', labelKey: 'settings:tabs.deliveryMethods', defaultLabel: 'Delivery Methods', icon: Truck, permissionId: 'settings-delivery-methods' },
+      { path: '/settings/data-domains', labelKey: 'settings:tabs.dataDomains', defaultLabel: 'Domains', icon: BoxSelect, permissionId: 'data-domains' },
+      { path: '/settings/business-roles', labelKey: 'settings:tabs.businessRoles', defaultLabel: 'Business Roles', icon: Briefcase, permissionId: 'business-roles' },
+      { path: '/settings/delivery-methods', labelKey: 'settings:tabs.deliveryMethods', defaultLabel: 'Delivery Methods', icon: Truck, permissionId: 'delivery-methods' },
       { path: '/settings/asset-types', labelKey: 'settings:tabs.assetTypes', defaultLabel: 'Asset Types', icon: Shapes, permissionId: 'settings-asset-types' },
-      { path: '/settings/teams', labelKey: 'settings:tabs.teams', defaultLabel: 'Teams', icon: UserCheck, permissionId: 'settings-teams' },
-      { path: '/settings/projects', labelKey: 'settings:tabs.projects', defaultLabel: 'Projects', icon: FolderOpen, permissionId: 'settings-projects' },
+      { path: '/settings/teams', labelKey: 'settings:tabs.teams', defaultLabel: 'Teams', icon: UserCheck, permissionId: 'teams' },
+      { path: '/settings/projects', labelKey: 'settings:tabs.projects', defaultLabel: 'Projects', icon: FolderOpen, permissionId: 'projects' },
       { path: '/settings/certification-levels', labelKey: 'settings:tabs.certificationLevels', defaultLabel: 'Certification Levels', icon: ShieldCheck, permissionId: 'settings-certification-levels' },
       { path: '/settings/maturity-levels', labelKey: 'settings:tabs.maturityLevels', defaultLabel: 'Maturity Levels', icon: Activity, permissionId: 'settings-maturity-levels' },
     ],
@@ -63,7 +63,7 @@ const settingsNavGroups: SettingsNavGroup[] = [
     items: [
       { path: '/settings/general', labelKey: 'settings:tabs.general', defaultLabel: 'General', icon: Settings, permissionId: 'settings-general' },
       { path: '/settings/ui', labelKey: 'settings:tabs.ui', defaultLabel: 'UI', icon: Palette, permissionId: 'settings-ui' },
-      { path: '/settings/tags', labelKey: 'settings:tabs.tags', defaultLabel: 'Tags', icon: Tags, permissionId: 'settings-tags' },
+      { path: '/settings/tags', labelKey: 'settings:tabs.tags', defaultLabel: 'Tags', icon: Tags, permissionId: 'tags' },
       { path: '/settings/connectors', labelKey: 'settings:tabs.connectors', defaultLabel: 'Connectors', icon: Plug2, permissionId: 'settings-connectors' },
     ],
   },
@@ -82,7 +82,7 @@ const settingsNavGroups: SettingsNavGroup[] = [
     titleKey: 'settings:nav.groups.operations',
     defaultTitle: 'Operations',
     items: [
-      { path: '/settings/jobs', labelKey: 'settings:tabs.jobs', defaultLabel: 'Jobs', icon: Clock, permissionId: 'settings-jobs' },
+      { path: '/settings/jobs', labelKey: 'settings:tabs.jobs', defaultLabel: 'Jobs', icon: Clock, permissionId: 'jobs' },
       { path: '/settings/delivery', labelKey: 'settings:tabs.delivery', defaultLabel: 'Delivery', icon: Briefcase, permissionId: 'settings-delivery' },
       { path: '/settings/workflows', labelKey: 'settings:tabs.workflows', defaultLabel: 'Workflows', icon: GitBranch, permissionId: 'settings-workflows' },
     ],
@@ -92,7 +92,7 @@ const settingsNavGroups: SettingsNavGroup[] = [
     defaultTitle: 'Access Control',
     items: [
       { path: '/settings/roles', labelKey: 'settings:tabs.roles', defaultLabel: 'App Roles', icon: UserCog, permissionId: 'settings-roles' },
-      { path: '/settings/audit', labelKey: 'settings:tabs.audit', defaultLabel: 'Audit Trail', icon: ScrollText, permissionId: 'settings-audit' },
+      { path: '/settings/audit', labelKey: 'settings:tabs.audit', defaultLabel: 'Audit Trail', icon: ScrollText, permissionId: 'audit' },
     ],
   },
 ];

--- a/src/frontend/src/i18n/locales/en/settings.json
+++ b/src/frontend/src/i18n/locales/en/settings.json
@@ -323,6 +323,14 @@
         "deploy": "Deploy",
         "settings": "Settings",
         "other": "Other"
+      },
+      "crossCutting": "Background",
+      "settingsSubGroups": {
+        "referenceData": "Reference Data",
+        "configuration": "Configuration",
+        "integrations": "Integrations",
+        "operations": "Operations",
+        "accessControl": "Access Control"
       }
     },
     "deployment": {

--- a/src/frontend/src/types/settings.ts
+++ b/src/frontend/src/types/settings.ts
@@ -35,6 +35,21 @@ export interface FeatureConfig {
     name: string;
     allowed_levels: FeatureAccessLevel[];
     group?: PermissionGroup;
+    /**
+     * When true, the feature is enforced at the API layer but is not
+     * surfaced as a configurable row in the role editor. Used for
+     * backend-only permissions that admins implicitly hold (e.g.
+     * `notifications`, `entity_subscriptions`).
+     */
+    hidden_from_role_dialog?: boolean;
+    /**
+     * When true, the feature has no dedicated sidebar entry — it is
+     * surfaced inline (panels on detail pages, inline actions, etc.).
+     * The role editor renders these features in a separate "Background"
+     * sub-section under their primary group so admins can distinguish
+     * them from the main sidebar features.
+     */
+    cross_cutting?: boolean;
 }
 
 export enum HomeSection {

--- a/src/frontend/src/views/audit-trail.tsx
+++ b/src/frontend/src/views/audit-trail.tsx
@@ -170,7 +170,7 @@ export default function AuditTrail() {
   };
 
   return (
-    <SettingsPageWrapper title={t('title')} permissionId="settings-audit">
+    <SettingsPageWrapper title={t('title')} permissionId="audit">
       <div className="mb-6">
         <h1 className="text-3xl font-bold flex items-center gap-2">
           <ScrollText className="w-8 h-8" />

--- a/src/frontend/src/views/business-roles.tsx
+++ b/src/frontend/src/views/business-roles.tsx
@@ -168,7 +168,7 @@ export default function BusinessRolesView() {
   ], [canWrite, canAdmin, t]);
 
   return (
-    <SettingsPageWrapper title={t('title')} permissionId="settings-business-roles">
+    <SettingsPageWrapper title={t('title')} permissionId="business-roles">
       <div className="mb-6">
         <h1 className="text-3xl font-bold flex items-center gap-2">
           <Briefcase className="w-8 h-8" />

--- a/src/frontend/src/views/data-domains.tsx
+++ b/src/frontend/src/views/data-domains.tsx
@@ -288,7 +288,7 @@ export default function DataDomainsView() {
   ], [canWrite, canAdmin, navigate, pathname, t]);
 
   return (
-    <SettingsPageWrapper title={t('title')} permissionId="settings-data-domains">
+    <SettingsPageWrapper title={t('title')} permissionId="data-domains">
       <div className="mb-6">
         <h1 className="text-3xl font-bold flex items-center gap-2">
            <BoxSelect className="w-8 h-8" />

--- a/src/frontend/src/views/delivery-methods.tsx
+++ b/src/frontend/src/views/delivery-methods.tsx
@@ -168,7 +168,7 @@ export default function DeliveryMethodsView() {
   ], [canWrite, canAdmin, t]);
 
   return (
-    <SettingsPageWrapper title={t('title')} permissionId="settings-delivery-methods">
+    <SettingsPageWrapper title={t('title')} permissionId="delivery-methods">
       <div className="mb-6">
         <h1 className="text-3xl font-bold flex items-center gap-2">
           <Truck className="w-8 h-8" />

--- a/src/frontend/src/views/projects.tsx
+++ b/src/frontend/src/views/projects.tsx
@@ -275,7 +275,7 @@ export default function ProjectsView() {
   ], [canWrite, canAdmin, t, handleOpenEditDialog]);
 
   return (
-    <SettingsPageWrapper title={t('title')} permissionId="settings-projects">
+    <SettingsPageWrapper title={t('title')} permissionId="projects">
       <div className="mb-6">
         <h1 className="text-3xl font-bold flex items-center gap-2">
            <FolderOpen className="w-8 h-8" />

--- a/src/frontend/src/views/settings-jobs.tsx
+++ b/src/frontend/src/views/settings-jobs.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 export default function SettingsJobsView() {
   const { t } = useTranslation(['settings']);
   return (
-    <SettingsPageWrapper title={t('settings:tabs.jobs', 'Jobs')} permissionId="settings-jobs">
+    <SettingsPageWrapper title={t('settings:tabs.jobs', 'Jobs')} permissionId="jobs">
       <JobsSettings />
     </SettingsPageWrapper>
   );

--- a/src/frontend/src/views/settings-tags.tsx
+++ b/src/frontend/src/views/settings-tags.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 export default function SettingsTagsView() {
   const { t } = useTranslation(['settings']);
   return (
-    <SettingsPageWrapper title={t('settings:tabs.tags', 'Tags')} permissionId="settings-tags">
+    <SettingsPageWrapper title={t('settings:tabs.tags', 'Tags')} permissionId="tags">
       <TagsSettings />
     </SettingsPageWrapper>
   );

--- a/src/frontend/src/views/teams.tsx
+++ b/src/frontend/src/views/teams.tsx
@@ -283,7 +283,7 @@ export default function TeamsView() {
   ], [canWrite, canAdmin, getDomainName, navigate, t, handleOpenEditDialog]);
 
   return (
-    <SettingsPageWrapper title={t('title')} permissionId="settings-teams">
+    <SettingsPageWrapper title={t('title')} permissionId="teams">
       <div className="mb-6">
         <h1 className="text-3xl font-bold flex items-center gap-2">
            <UserCheck className="w-8 h-8" />


### PR DESCRIPTION
## Summary

Consolidates the duplicate `settings-*` permissions with their consumption-side counterparts and reshapes the role editor to mirror the actual sidebar layout instead of an arbitrary flat list. Also clarifies the dropdown semantics for "implicit" features (commenting, requesting access grants, viewing process workflows) so `None` is no longer offered as a choice for features every authenticated user should have access to.

### Permission consolidation

Eight `settings-*` permissions are removed; their consumption-side IDs now gate both the Settings sidebar entry and any cross-app surface. The access level expresses scope (`READ_WRITE` = use in app, `ADMIN` = manage the settings page):

| Removed | Now gated by |
|---|---|
| `settings-data-domains` | `data-domains` |
| `settings-business-roles` | `business-roles` |
| `settings-delivery-methods` | `delivery-methods` |
| `settings-teams` | `teams` |
| `settings-projects` | `projects` |
| `settings-audit` | `audit` |
| `settings-tags` | `tags` |
| `settings-jobs` | `jobs` |

Also removed:
- `self-service` (only gated `POST /data-contracts/{id}/handle-deploy`, now uses `data-contracts: READ/WRITE` since approving a deploy is a modify-contract action).
- `llm-search` (dead permission — LLM Search routes intentionally bypass `PermissionChecker` and rely on per-tool result filtering).

### Implicit feature levels

Three features that should be available to any authenticated user no longer offer `None` in the dropdown — new shared `IMPLICIT_FEATURE_LEVELS = [READ_ONLY, READ_WRITE, ADMIN]`:

- `comments` (Comments & Ratings)
- `access-grants`
- `process-workflows`

### Role editor restructuring

`role-form-dialog.tsx` now mirrors the actual sidebar layout:

- **Settings sub-groups** (Reference Data → Configuration → Integrations → Operations → Access Control) match the Settings sidebar order exactly. Reference Data sorts Asset Types between Delivery Methods and Teams to match the sidebar.
- **Each non-Settings group** splits into two sub-sections: sidebar items (sorted by main-nav order) and a new **"Background"** sub-section (alphabetical) for cross-cutting features without a sidebar entry — `comments`, `access-grants`, `process-workflows`, `business-owners`, `ontology`, `entity_relationships`, `schema-importer`.
- Hidden features (`hidden_from_role_dialog`) are skipped entirely (`notifications`, `entity_subscriptions`).
- `settings-delivery` renamed to "Delivery Modes" to disambiguate from the `delivery-methods` reference data.
- `settings-maturity-levels` display name fixed (stale "Settings — " prefix removed).

### Backend flags surfaced through API

`get_features_with_access_levels` now passes two flags to the frontend:
- `hidden_from_role_dialog: True` — backend-only perms with no end-user UI surface.
- `cross_cutting: True` — features rendered inline (panels, detail pages) without a sidebar entry.

## Files changed

- Backend: `features.py`, `settings_manager.py`, `data_contracts_routes.py`, `settings_routes.py`, `tags_routes.py`, `test_settings_manager.py`
- Frontend: `role-form-dialog.tsx`, `settings-layout.tsx`, `types/settings.ts`, `settings.json`, views (`audit-trail`, `business-roles`, `data-domains`, `delivery-methods`, `projects`, `teams`, `settings-jobs`, `settings-tags`)

18 files changed, 431 insertions(+), 184 deletions(-).

## Migration note

Existing roles in the DB with `comments: None` (or other implicit-feature `None` values) keep that value until the role is next edited — the runtime `PermissionChecker` is unchanged, only the dropdown options are restricted going forward.

## Test plan

- [x] `test_settings_manager.py::test_get_features_with_access_levels` updated and passing — expected subpage IDs reflect the consolidation; `settings-maturity-levels` added to the expected set.
- [x] Lints clean on all touched files.
- [x] Backend hot-reloads cleanly with the new feature config.
- [x] Frontend HMR succeeds; role dialog renders the new sub-section structure.
- [ ] Manual smoke test: open the role editor and verify
  - Settings sub-groups appear in sidebar order (Reference Data → Configuration → Integrations → Operations → Access Control)
  - Reference Data row order matches the Settings sidebar
  - "Background" sub-sections appear under Build, Govern, and Settings with the right items
  - `comments`, `access-grants`, `process-workflows` dropdowns no longer offer `None`
  - `notifications` and `entity_subscriptions` do not appear at all
- [ ] Manual smoke test: edit a non-admin role with reduced `tags` permission, confirm Tags settings page is gated correctly (R/O hides admin actions, ADMIN shows them) and tag application still works on detail pages at R/W.