### PR TITLE
fix(alembic): merge aa1_term_mapping, c1_maturity, g3_review_title heads

### DIFF
--- a/src/backend/alembic/versions/k1_merge_aa1_c1_g3_heads.py
+++ b/src/backend/alembic/versions/k1_merge_aa1_c1_g3_heads.py
@@ -1,0 +1,32 @@
+"""merge aa1_term_mapping, c1_maturity and g3_review_title heads
+
+Revision ID: k1_merge_aa1_c1_g3
+Revises: aa1_term_mapping, c1_maturity, g3_review_title
+Create Date: 2026-06-11
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'k1_merge_aa1_c1_g3'
+down_revision: Union[str, Sequence[str], None] = (
+    'aa1_term_mapping',
+    'c1_maturity',
+    'g3_review_title',
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary

Three migrations were merged into `main` independently and each kept `g2_ontology_gen_runs` as their `down_revision`, producing three sibling heads:

```
g2_ontology_gen_runs ──┬── aa1_term_mapping   (head)
                       ├── c1_maturity        (head)
                       └── g3_review_title    (head)
```

App startup now fails on `init_db()` with `alembic.script.revision.MultipleHeads`, and the backend drops into maintenance mode (`Application cannot start without database connection.`).

This PR adds a no-op 3-way merge revision (`k1_merge_aa1_c1_g3`) that reconciles all three heads, matching the convention of `f1_merge_aa9_e2_heads.py`. The merge itself is empty — each parent's schema changes are independent and already valid.

## Why this happened

Classic stale `down_revision` race: each of the three feature branches was cut when `g2_ontology_gen_runs` was the live head and none rebased onto the others before being merged. The `check-alembic-heads` CI gate passes for each PR individually (one new head descending from the base tip) but the combined `main` ends up with multiple heads. See `.cursor/rules/11-database-migrations.mdc` pitfall #2.

## Test plan

- [x] `alembic heads` → single head: `k1_merge_aa1_c1_g3 (head) (mergepoint)`
- [x] `alembic current` against a freshly initialised DB lands on the merge point
- [x] Local backend restarts cleanly: `Application startup complete` with no traceback
- [x] `GET /api/health` returns 200 (was 200), `GET /api/notifications` returns 200 (was 503)
- [ ] CI `check-alembic-heads` passes (label-bypassed; check 1 and 2 would pass anyway since all three parents are already on `main`)

## Notes

- Labelled `alembic-branch` per `CONTRIBUTING.md` — intentional multi-head merge.
- Naming uses `k*` as the next unused single-letter wave after `j*` (per `11-database-migrations.mdc`); existing `aa*` and the misfiled `c1_maturity` (which collided cosmetically with the legacy `c*` wave) are not renamed because their `revision` strings are referenced by descendants.