### PR TITLE
fix(ci): repair type-check and backend/frontend test failures on main

### DIFF
--- a/src/backend/src/tests/unit/test_trigger_enum_pin.py
+++ b/src/backend/src/tests/unit/test_trigger_enum_pin.py
@@ -50,6 +50,7 @@ _EXPECTED_TRIGGER_VALUES = [
     ("FOR_REQUEST_CERTIFY", "for_request_certify"),
     ("FOR_REQUEST_STATUS_CHANGE", "for_request_status_change"),
     ("ON_FIRST_ACCESS", "on_first_access"),
+    ("ON_MATURITY_CHANGE", "on_maturity_change"),
 ]
 
 

--- a/src/frontend/src/components/data-products/maturity-panel.tsx
+++ b/src/frontend/src/components/data-products/maturity-panel.tsx
@@ -114,7 +114,6 @@ export function MaturityPanel({ entityType, entityId }: MaturityPanelProps) {
         {/* Level progression */}
         {report.levels.map((level: LevelResult) => {
           const isExpanded = expandedLevel === level.level_order;
-          const allPassed = level.achieved;
           const hasWarnings = level.gates.some(g => !g.passed && !g.required);
           const hasFails = level.gates.some(g => !g.passed && g.required);
 

--- a/src/frontend/src/components/settings/maturity-levels-settings.tsx
+++ b/src/frontend/src/components/settings/maturity-levels-settings.tsx
@@ -13,9 +13,6 @@ import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
 import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from '@/components/ui/table';
-import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog';

--- a/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { systemRdfNamespaceDisplayLabel } from './system-rdf-namespace-labels';
+import { humanizeRdfFilename } from './rdf-filename';
 
 describe('systemRdfNamespaceDisplayLabel', () => {
   // Minimal stand-in for i18next's `t`: echoes the supplied defaultValue.
@@ -22,7 +23,9 @@ describe('systemRdfNamespaceDisplayLabel', () => {
     );
   });
 
-  it('returns the original key for an unknown namespace', () => {
-    expect(systemRdfNamespaceDisplayLabel('urn:something-else', t)).toBe('urn:something-else');
+  it('humanizes an unknown namespace key as a fallback', () => {
+    expect(systemRdfNamespaceDisplayLabel('urn:something-else', t)).toBe(
+      humanizeRdfFilename('urn:something-else'),
+    );
   });
 });

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -53,7 +53,6 @@ import { Link2, Unlink, GitBranch } from 'lucide-react';
 import { AssetSelector } from '@/components/common/asset-selector';
 import { EntityTreePanel } from '@/components/common/entity-tree-panel';
 import { BusinessLineageView } from '@/components/lineage';
-import { ReadinessChecklist } from '@/components/data-products/readiness-checklist';
 import { MaturityInline } from '@/components/common/maturity-inline';
 import { LineageEditor } from '@/components/common/lineage-editor';
 import { useCopilotContext } from '@/hooks/use-copilot-context';


### PR DESCRIPTION
## Summary

The **Test Coverage** workflow has been failing on `main` (and therefore on every PR branched from it). Three independent breakages, all introduced by recent merges, were the cause. This PR fixes all three.

### 1. TypeScript Type Check (TS6133 / TS6192)
- `maturity-panel.tsx`: removed unused `allPassed` local.
- `maturity-levels-settings.tsx`: removed the fully-unused `Table*` import declaration.
- `data-product-details.tsx`: removed the unused `ReadinessChecklist` import.

### 2. Backend Tests
- `test_trigger_enum_pin.py`: the new `TriggerType.ON_MATURITY_CHANGE` member (added with the maturity feature) was missing from the enum-pin table. Added `("ON_MATURITY_CHANGE", "on_maturity_change")`.

### 3. Frontend Tests
- `system-rdf-namespace-labels.test.ts`: the "unknown namespace" case still asserted the raw key, but commit `dfde85d2` (*humanize RDF source labels across UI*) intentionally changed the fallback to `humanizeRdfFilename(graphKey)`. Updated the test to assert the humanized fallback (reusing the helper so it stays decoupled from the exact string).

## Verification
Run locally against the same checks CI runs:
- `tsc --noEmit` → clean (exit 0)
- `vitest run src/lib/system-rdf-namespace-labels.test.ts` → 3 passed
- `pytest src/tests/unit/test_trigger_enum_pin.py` → 34 passed

This pull request and its description were written by Isaac.