### PR TITLE
docs(prds): add four new product requirement drafts

### DIFF
--- a/docs/prds/prd-configurable-detail-view-panels.md
+++ b/docs/prds/prd-configurable-detail-view-panels.md
@@ -1,0 +1,205 @@
+# PRD: Configurable Detail-View Panels (S/M/L + Custom Views)
+
+## Problem Statement
+
+Data Product and Data Contract detail views currently expose a three-way size toggle (S/M/L = `minimal` / `medium` / `large`) that decides which panels (sections) are visible. The mapping is **hardcoded** inside each detail view: a switch statement enumerates which section ids belong to each mode, and the active mode is persisted to `localStorage` under a single key per entity type.
+
+This is rigid in three ways:
+
+1. **No per-user choice over individual panels.** Users who want "medium plus quality" or "large minus subscribers" have no recourse — they get the curated set or nothing.
+2. **No way to save a named arrangement.** A reviewer preparing for a QBR, a steward auditing compliance, and a producer building a draft all want different panel sets, but the only knob is the size enum.
+3. **The default sets are invisible.** The mapping lives inside a TypeScript `switch`, so neither developers nor users can easily see "what's in medium?" without reading code.
+
+The role-based initial default (`computeDefaultViewMode`: owner-team → large, write/admin → medium, else minimal) is a reasonable first-load behavior but stops being useful the moment a user wants anything else.
+
+## Solution
+
+Replace the hardcoded S/M/L mapping with a **canonical section registry** per entity type plus a **per-user view configuration** stored in `localStorage`. The three built-in views (`minimal` / `medium` / `large`) remain as defaults, but every user can:
+
+- **Override** any built-in view in place (toggle individual panels), with a one-click Reset.
+- **Create** named custom views ("QBR focus", "Compliance audit") with their own panel selection.
+- **Switch** between views via the existing S/M/L icon buttons when no custom views exist, or a unified "Select view" dropdown once they create their first custom view.
+
+The registry is a plain TypeScript module per entity type — anyone reading the codebase can see at a glance which panels exist and which are in each built-in view. The role-based first-load default is preserved (it picks a built-in slot, which may itself be overridden).
+
+Views are stored as **diffs**, not snapshots:
+
+- Built-in overrides diff against that built-in's section set, so new panels shipped in the code automatically appear inside overridden built-ins.
+- User-created views diff against the **full** canonical section list, so new panels appear there too by default (user can opt out by hiding).
+
+Storage is browser-local for v1; multi-device sync is explicitly deferred.
+
+## User Stories
+
+### Discovery and defaults
+
+1. As a first-time user on a Data Product detail page, I want the view to start in the size that matches my role (owner-team → large, write/admin → medium, else minimal), so that I see a useful set of panels without configuring anything.
+2. As a returning user, I want my last-selected view restored on reload, so that my preference is sticky across sessions.
+3. As any user, I want to see the names of the built-in views (Small / Medium / Large, localised), so that I understand what the S/M/L buttons mean without hovering.
+
+### Toggling panels on the current view
+
+4. As a Data Producer on a "medium" view, I want to add the Quality panel to my current view via a checkbox in a popover, so that I can monitor quality without jumping to a different size.
+5. As a Data Consumer on a "minimal" view, I want to remove the Description panel from my view, so that I can declutter further.
+6. As any user, I want my panel toggles applied immediately (no Save button for the current view), so that I get instant feedback.
+7. As any user, I want a "Reset to default" action on overridden built-in views, so that I can return to the shipped Medium/Small/Large composition with one click.
+
+### Creating, naming, and managing custom views
+
+8. As a Solution Architect preparing for a QBR, I want to save my current panel arrangement as a named view "QBR focus", so that I can switch to it instantly during the meeting.
+9. As a user with a custom view, I want to rename it, so that I can clarify its purpose later.
+10. As a user with multiple custom views, I want to delete one I no longer need, so that my dropdown stays clean.
+11. As a user, I want to be told if I try to save an empty view (zero panels), so that I don't end up with a useless arrangement.
+12. As a user, I want to be free to create two views with the same display name, so that I'm not blocked by spurious uniqueness validation (each view has its own id internally).
+13. As a user, I want a soft cap of 20 custom views with a warning, so that I'm nudged to tidy up without being hard-blocked.
+14. As a user, I want the built-in views (Small/Medium/Large) to remain in my dropdown even when I've created custom views, so that I always have a way back to the canonical defaults.
+15. As a user, I should not be able to delete or rename the built-in views, so that the system always has a stable reset path.
+
+### Switching between views
+
+16. As a user with zero custom views, I want to keep the familiar S/M/L icon buttons, so that the UI does not become heavier than it is today.
+17. As a user with one or more custom views, I want the S/M/L buttons to collapse into a single "Select view" dropdown listing all built-ins + custom views + a "Customize…" entry, so that all my options are in one place.
+18. As a user on an overridden built-in view, I want to see a small dot indicator on the trigger and "(customized)" suffix in the dropdown for that entry, so that I know I'm not on the pristine default.
+
+### Behavior across code changes
+
+19. As a user who has overridden the Medium built-in, I want any new panel shipped in a future release to appear inside my overridden Medium by default, so that I do not silently fall behind the product's evolution.
+20. As a user with a saved custom view, I want any new panel shipped in a future release to appear in my view by default (with the option to hide it), so that I am made aware of new capabilities.
+
+### Permissions
+
+21. As a read-only user, I should not see panels in the customize popover that I would not be allowed to render anyway (e.g. Subscribers, Access Grants), so that the UI does not advertise capabilities I cannot use.
+22. As an admin who later loses elevated permissions on an entity, panels in my saved view that I can no longer render are silently hidden in render output (not removed from my stored configuration), so that my view comes back intact if my permissions are restored.
+
+### Migration
+
+23. As an existing user who previously selected "large" before this change shipped, my prior size selection should be migrated to the new storage shape on first load, so that I am not reset to the role-based default.
+
+### Scope-related expectations
+
+24. As a user, I expect the same mechanism to land on Asset detail and Domain detail views in the future, but I do not require it in this initial release.
+
+## Implementation Decisions
+
+### Architecture
+
+- A new **section registry** per entity type is the single source of truth for: (a) the canonical ordered list of section ids with i18n keys, (b) optional permission predicates per section, and (c) the three built-in view definitions (`minimal`, `medium`, `large`) expressed as section-id sets. This **replaces** the existing inline `shouldShowSectionForViewMode` switch in each detail view.
+- A new **view config store** module is a pure functional layer over `localStorage`. It owns the storage shape, the diff-apply logic, legacy-key migration, and the view-resolution function that produces the final visible section list for a given (config, viewId, permissions) tuple. No React inside.
+- A **`useViewConfig(entityType)` React hook** wraps the store with state. It exposes read state (`activeView`, `customViews`, `builtinOverrides`) and a small set of mutators (`setActiveViewId`, `overrideBuiltin`, `createCustomView`, `updateCustomView`, `renameCustomView`, `deleteCustomView`, `resetBuiltin`). It is intentionally thin — all logic lives in the store module.
+- A **`ViewSelector` component** consumes the hook and decides whether to render the S/M/L icon-button trio or the unified dropdown, based on whether any custom views exist. It also renders the customized-state indicator (dot + suffix) and the Reset-to-default action on overridden built-ins.
+- A **`ViewCustomizePopover`** component shows a checkbox list of sections (filtered by permission predicate) and toggles call directly into `useViewConfig`.
+- A **`ManageViewsDialog`** modal handles the heavier flows: Save-as-new, rename, delete, reset.
+
+### Storage shape
+
+Per entity type, one `localStorage` key (`viewconfig:dataProduct`, `viewconfig:dataContract`):
+
+```
+{
+  activeViewId: 'minimal' | 'medium' | 'large' | <uuid>,
+  overrides: {
+    <builtinId>: { hidden: [<sectionId>...], added: [<sectionId>...] }
+  },
+  custom: [
+    { id: <uuid>, name: <string>, hidden: [<sectionId>...], added: [<sectionId>...] }
+  ]
+}
+```
+
+`hidden`/`added` are always relative to the entry's base:
+
+- For a built-in override, the base is that built-in's section set.
+- For a custom view, the base is the **full canonical section list** from the registry. (So a freshly-created custom view starts as "all visible".)
+
+This symmetry guarantees that new code-side sections automatically appear in both overridden built-ins and user-created views unless the user has explicitly hidden them.
+
+### Legacy migration
+
+On hook initialization, if `viewconfig:<entityType>` is absent but the legacy `<entityType>-view-mode` key exists with a value in `{minimal, medium, large}`, the legacy value is migrated into `activeViewId` and the legacy key is deleted. Mirror logic for Data Contract.
+
+### First-load default
+
+When `activeViewId` is absent after migration, the role-based selector (owner-team → `large`, write/admin → `medium`, else `minimal`) picks the initial slot. The slot is set explicitly into `activeViewId` and persisted, so subsequent loads bypass the selector.
+
+### Permission gating
+
+Each section in the registry may define `canShow(permissions)`. The customize popover filters out sections returning false; the detail-view renderer continues to gate independently (defense in depth). User configuration is **never** mutated based on permission changes — hidden-by-permission sections re-appear if permission is restored.
+
+### Toolbar transition rule
+
+- `customViews.length === 0` → render the existing S/M/L icon-button trio.
+- `customViews.length >= 1` → render a single "Select view" dropdown that lists, in order: the three built-ins (with customized indicator where applicable), then the user's custom views, then a separator and a `Customize…` entry that opens the popover for the currently-active view, then a `Manage views…` entry that opens the dialog.
+
+### Edge cases
+
+- Empty view (0 sections) on save: rejected with inline validation in the dialog.
+- Duplicate names: allowed (uuid is the identity).
+- Built-in display names: i18n-managed, not user-renameable.
+- Soft cap: 20 custom views per entity type, with a warning at save time; no hard limit.
+
+### Entity-type scope
+
+- Product and Contract detail views are wired in this change.
+- Asset detail (`asset-detail.tsx`) and Domain detail are out of scope for v1 but the registry/store/hook are designed to accept additional entity types without changes to their interfaces — a new `*-sections.ts` module and a new `entityType` argument value are all that's needed later.
+
+### What the detail views lose
+
+Both `data-product-details.tsx` and `data-contract-details.tsx` shed their local `ViewMode` type, `parseStoredViewMode`, `computeDefaultViewMode`, `shouldShowSectionForViewMode`, the size-toggle JSX, and the size-related state. They replace these with `const { isSectionVisible } = useViewConfig('dataProduct' | 'dataContract')` and `<ViewSelector entityType={...} />` in the toolbar. The existing per-section JSX gating (`shouldShowSection('foo')`) becomes `isSectionVisible('foo')`.
+
+## Testing Decisions
+
+### What makes a good test for this work
+
+Tests target **external behavior**, not implementation details. Specifically:
+
+- **Inputs**: configuration object + section registry + permissions.
+- **Outputs**: resolved section list, mutated configuration, migration result.
+
+Tests must NOT assert on:
+
+- The internal shape of intermediate objects beyond the documented storage schema.
+- Specific React state transitions in the hook (test the store, not the hook plumbing).
+- DOM structure of the UI components.
+
+### Modules to be tested
+
+Per the agreed scope, unit tests cover the two deep modules:
+
+1. **Section registry modules** (`product-sections`, `contract-sections`):
+   - Built-in view section sets are deterministic and contain only valid registry-known section ids.
+   - `canShow(permissions)` predicates return the expected boolean for representative permission inputs (read-only, write, admin, owner-team-member).
+   - The exported canonical order is stable across calls.
+
+2. **View config store**:
+   - **Load/save round-trips**: writing a config, reading it back, produces an identical object (modulo serialization).
+   - **Legacy migration**: each of `minimal`/`medium`/`large`/missing/garbage legacy values produces the right post-migration state; legacy key is removed on success.
+   - **Diff apply**: applying `{ hidden, added }` against a base set produces the expected resolved section list; ids in `hidden` that don't exist in base are ignored; ids in `added` that already exist in base are ignored; duplicates collapse.
+   - **Resolution end-to-end**: given a config + registry + permissions, `resolveVisibleSections(viewId, …)` returns the expected ordered, permission-filtered section list for: a pristine built-in, an overridden built-in, a custom view, an active id that doesn't exist (fall back to the role-based default), a custom view referencing a section that no longer exists in the registry (silently dropped).
+   - **Mutators**: `overrideBuiltin`, `resetBuiltin`, `createCustomView`, `updateCustomView`, `renameCustomView`, `deleteCustomView` produce the expected next-state config; empty-view creation is rejected at the store boundary, not only in the UI.
+   - **New-section propagation**: when the registry gains a section after a config was saved, an overridden built-in and a custom view both surface the new section in their resolved output (unless the user explicitly hid it).
+
+### Modules explicitly NOT unit-tested in this work
+
+- `useViewConfig` hook: it is a thin React-state wrapper. The store's tests cover the logic; manual testing covers re-render behavior.
+- `ViewSelector`, `ViewCustomizePopover`, `ManageViewsDialog`: covered by manual / Playwright testing in subsequent verification, not unit-tested in this PRD.
+
+### Prior art in the codebase
+
+Existing pure-function unit tests for `parseStoredViewMode`, `computeDefaultViewMode`, and `shouldShowSectionForViewMode` in `src/frontend/src/views/data-product-details.test.tsx` are the canonical pattern. Those tests will be **moved** to test the new registry / store modules; the originals are deleted along with the now-unused helpers in the detail view.
+
+## Out of Scope
+
+- **Server-side sync** of view configuration across browsers, devices, or users. Storage is browser-local for v1.
+- **Per-entity-instance overrides** ("this view, but only for *this* particular product"). Configuration is per entity *type*, not per entity *instance*.
+- **Sharing or exporting** custom views to other users.
+- **Asset-detail and Domain-detail wiring**. The mechanism is generic; only Product and Contract are wired in v1.
+- **Per-view section reordering**. Sections always render in the canonical order from the registry. Reordering is a substantially larger refactor of the detail-view JSX and can be reconsidered after usage data is collected.
+- **Admin-configured organization defaults**. The role-based first-load default remains hardcoded.
+- **Bulk view-config import/export** (JSON download/upload of views).
+
+## Further Notes
+
+- The exact section-id sets for the three built-in views will be copied verbatim from the current `shouldShowSectionForViewMode` implementations in `data-product-details.tsx` and `data-contract-details.tsx`. If any of those sets should change as part of this work (e.g., promote `quality` from large-only to medium), that should be called out and adjusted in the registry — but it is not a goal of this change.
+- Section labels (i18n keys) need to be added to the existing translation files alongside the registry.
+- The polymorphic panel matrix in `.cursor/rules/10-entity-panel-matrix.mdc` should be cross-referenced when defining the canonical section list for each entity type, and updated if new panel ids are introduced.
+- Future extension: once Asset and Domain detail views adopt the same mechanism, the panel matrix could be consumed directly by the registry to keep eligibility rules in one place.

--- a/docs/prds/prd-external-marketplace-providers.md
+++ b/docs/prds/prd-external-marketplace-providers.md
@@ -1,0 +1,285 @@
+# PRD: External Marketplace Providers
+
+## Problem Statement
+
+Ontos already lets a workspace publish data products and data contracts internally — the existing Marketplace view lists items whose `publication_scope` makes them visible to all users in this deployment. What it does not do is reach **outside** the workspace.
+
+Today, when a data steward wants to ground their catalog in industry vocabulary, they have to:
+
+- Hunt across the web for the right TTL file (FIBO, Schema.org, GS1, HL7 FHIR, OBO Foundry, ...).
+- Save it locally, upload it through `Settings → Semantic Models`, and pray they grabbed the right module.
+- Repeat the same dance for every industry, every team, every refresh cycle.
+- Maintain a brittle, hand-curated `industry_ontologies.yaml` to remember the URLs we already discovered.
+
+When a steward wants to ground their catalog in **realistic industry data models** (typed tables, foreign-key graphs, metric views, ER diagrams), there is no out-of-the-box source at all. Excellent reference work exists — friends working on the `vibe-business-data-models` project ship 80 production-shaped models across 40 industries (23,918 tables, 924,919 attributes, 10,488 metric views) — but Ontos has no way to surface it. The model.json files sit in a GitHub repo; no Ontos user will ever stumble across them.
+
+Commercial data vendors face the same dead end from the other direction. S&P Global publishes an "ontology read" marketplace at metadata.marketplace.spglobal.com offering their product catalog as semantic metadata, with actual data behind it. There is no mechanism for them to plug Ontos into their catalog so a customer's stewards see S&P products inline when they search Ontos.
+
+Without a marketplace layer that **third parties** can plug into, Ontos is a closed system:
+
+- Customers cannot discover external ontologies and data products from inside Ontos.
+- Free providers (Vibe Business) cannot offer their catalog to Ontos users as a built-in default.
+- Commercial vendors (S&P, Snowflake Marketplace partners, industry consortia) cannot integrate without bespoke per-vendor code in Ontos itself.
+- Workspace admins have no way to curate which external providers their users see, restrict commercial providers to a subset of teams/domains, or audit what came from where.
+
+The promise of an ontology-driven, data-product-first catalog cannot be fulfilled if every customer has to re-discover the same industry models, the same FIBO modules, the same FHIR taxonomies from scratch.
+
+## Solution
+
+Introduce **External Marketplace Providers** — a pluggable, admin-configurable registry of third-party catalogs that expose ontologies, data products, and data contracts as importable, searchable listings inside Ontos. Each provider publishes a **DCAT-AP catalog** as a single Turtle URL (with small Ontos-specific extensions for offering mode, audience hints, and delivery method). Ontos polls those catalogs on a schedule, caches them in the existing RDF triple store, and surfaces the listings inline in unified search plus a dedicated marketplace browse view. A user can import any listing (or a subset of a bundle's children) into their workspace as a **linked copy** — a real Ontos data product / data contract / semantic model with full provenance back to the source listing, including a `sync_state` that flips to "update available" when the upstream version moves. For listings that carry actual data, the existing Access Grant flow is wired through to the provider's contact point so a request for a Delta-Sharing-backed S&P dataset goes through the same audit and approval rails as any internal data product.
+
+The first shipped provider is **Vibe Business**: a small generator script we maintain crawls the `amralieg/vibe-business-data-models` repo, emits a DCAT-AP `catalog.ttl`, and hosts it; Ontos seeds a built-in provider row pointing at that URL on first startup, with a bundled offline snapshot as a fallback when the network is unreachable. Customers who do nothing get Vibe Business for free; customers who add S&P, Snowflake Marketplace, or their internal data exchange add a single Settings row.
+
+Provider configuration lives under `Settings → Marketplace Providers`. Each provider row captures publisher metadata (name, logo, website), offering mode (free / commercial / mixed), the DCAT catalog URL, auth credentials (none / API key / bearer / basic), enable/disable toggle, refresh cadence, and a two-tier visibility model — provider-level audience tokens (Entra group, team, role, data domain) plus rule-based per-listing filters (e.g. "match `dcat:theme=Healthcare` → visible only to data_domain Healthcare"). Disabling a provider hides its listings from search and the marketplace view but does not break previously imported items, because imports are linked copies, not live proxies.
+
+Listings appear as a new search type alongside data products and contracts. The listing detail drawer shows DCAT metadata, license, publisher contact, and the distributions on offer; an Import Wizard renders bundles as an expandable tree (children carry `parent_listing_iri`) and lets the user check which sub-items to materialize and into which project / team. Importers prefer attached ODPS / ODCS distributions when present (`application/vnd.odps+json`, `application/vnd.odcs+json`) and fall back to DCAT-derived stubs otherwise. After import, a new "Marketplace Origin" polymorphic panel attaches to each materialized entity, showing the provider, source IRI, imported version, current upstream version, and re-sync / detach actions.
+
+For data-bearing listings (S&P's case), `delivery_method=delta_sharing` triggers Ontos's existing `ON_REQUEST_ACCESS` workflow trigger to fan out a webhook / email to the provider's `dcat:contactPoint` when the user clicks Request Access on the imported product. The provider grants the Delta Share recipient out-of-band and posts back to a callback endpoint, which materializes a normal Ontos access grant carrying the share name and schema. Admins can manually fulfill a pending request when no webhook is available. Only Delta Sharing is supported in v1 — every other delivery method falls through to a generic "external link" affordance.
+
+## User Stories
+
+### Provider configuration (admin)
+
+1. As an Ontos admin, I want a `Settings → Marketplace Providers` page under the Integrations group, so that I can manage external providers without leaving Settings.
+2. As an Ontos admin, I want to see all configured providers in a single list with their enabled state, offering mode, last refresh status, and listing count, so that I can spot misconfigured or stale providers at a glance.
+3. As an Ontos admin, I want to add a new provider by entering a name, display name, description, publisher name, publisher website, publisher logo URL, offering mode (free / commercial / mixed), and the DCAT catalog TTL URL, so that I can plug in any DCAT-conformant catalog.
+4. As an Ontos admin, I want to choose an auth mode (none / api_key / bearer / basic) and supply the matching credentials, so that I can wire up commercial providers behind API keys.
+5. As an Ontos admin, I want provider credentials stored encrypted at rest, so that an attacker with database read access cannot exfiltrate vendor API keys.
+6. As an Ontos admin, I want to toggle each provider enabled / disabled, so that I can pause a provider without losing its config or any items already imported from it.
+7. As an Ontos admin, I want to set provider-level audience tokens (data domains, Entra groups, teams, roles) using the same grammar I already use for comment audiences, so that I can restrict commercial providers to the teams that have a contract with that vendor.
+8. As an Ontos admin, I want to add rule-based per-listing visibility filters (e.g. "any listing whose `dcat:theme` is Healthcare is only visible to data domain Healthcare"), so that I can fine-tune visibility without editing each individual listing.
+9. As an Ontos admin, I want a configurable refresh cadence (per provider, default 24 h), so that I can pull more aggressively for fast-moving catalogs and less aggressively for stable ones.
+10. As an Ontos admin, I want a "Refresh now" button on each provider row, so that I can force-pull a catalog after a vendor pushes an update.
+11. As an Ontos admin, I want the last refresh timestamp, status (success / failed / never), and the last error message visible on the row, so that I can diagnose pull failures.
+12. As an Ontos admin without the `settings-marketplace-providers` permission, I do not want to see the Settings entry, so that I am not shown features I cannot use.
+13. As an Ontos admin, I want every provider mutation (create / update / delete / enable / disable / refresh) audit-logged, so that I have a forensic trail of marketplace configuration changes.
+14. As an Ontos admin, I want the default Vibe Business provider seeded on first startup as `is_builtin=true`, so that brand-new deployments have a working marketplace out of the box.
+15. As an Ontos admin, I want the built-in flag to prevent accidental deletion of the default Vibe Business row (with a clearly-labelled "Disable instead" affordance), so that I do not have to re-seed it after a misclick.
+
+### Catalog fetch and cache
+
+16. As an Ontos operator, I want a Databricks workflow to periodically refresh every enabled provider on its configured cadence, so that catalogs stay current without manual intervention.
+17. As an Ontos operator, I want each refreshed catalog cached in the existing `rdf_triples` store under a deterministic named graph (`urn:provider:<id>:catalog`), so that SPARQL queries across all catalogs work without a parallel store.
+18. As an Ontos operator, I want the cached listings persisted in a flat `marketplace_listings` table (one row per `dcat:Dataset` / `dcat:DataService`), so that search indexing does not have to repeatedly walk the RDF graph.
+19. As an Ontos operator, I want a refresh failure (network error, malformed TTL, expired credentials) to leave the previous cache intact and surface a clear error in the provider row, so that a flaky vendor never blanks out my marketplace.
+20. As an Ontos operator, I want refresh runs to bulk-replace a provider's listings transactionally per provider, so that a partial refresh never leaves the catalog half-updated.
+21. As an Ontos operator, I want refresh fetches to send the provider's auth header (per the configured auth mode), so that authenticated catalogs are pullable.
+22. As an Ontos operator, I want a fallback path that loads an offline snapshot of the Vibe Business catalog from a bundled TTL when the hosted URL is unreachable, so that a brand-new deployment without internet still has a working default marketplace.
+23. As an Ontos operator, I want bundle child listings linked to their parent via `ontosmkt:parentListing`, so that the import wizard can render the bundle tree without re-parsing the catalog.
+
+### Discovery and browsing
+
+24. As a data steward, I want a "Marketplace" entry in the main navigation, so that I can browse external offerings from one place.
+25. As a data steward, I want the Marketplace view to combine **published in your workspace** (current behaviour) and **external providers** in a single browse experience with provider-grouping, so that I do not have to context-switch between internal and external catalogues.
+26. As a data steward, I want filter chips on the Marketplace view for provider, listing type (ontology / data product / data contract / bundle), offering mode, and theme, so that I can narrow the catalogue to my current curation task.
+27. As a data steward, I want listings of type `marketplace-listing` to appear inline in the global header search and `/search/index`, so that I discover external items in the same flow I use for everything else.
+28. As a data steward, I want each marketplace-listing search result tagged with a provider badge and a free / commercial / mixed offering indicator, so that I instantly know what I am looking at.
+29. As a data steward, I want clicking a listing to open a detail drawer with the listing's DCAT metadata (title, description, themes, keywords, version, license label and link, publisher contact, distributions on offer), so that I have enough context to decide whether to import.
+30. As a data steward browsing a bundle, I want the detail drawer to show an expandable tree of child listings (with their own types and titles), so that I can scan what is inside before importing.
+31. As a data steward, I want listings hidden when a provider is disabled or when I am not in the provider's audience, so that I never see items I cannot use.
+32. As a data steward, I want listings visibility filters that depend on `dcat:theme` to evaluate against my team memberships and data domains, so that an admin's rule-based filter "Healthcare theme → Healthcare domain" actually works.
+33. As a data steward without the `marketplace` permission, I do not want to see the Marketplace entry or marketplace-listing results in search, so that I am not shown a feature I cannot use.
+
+### Importing a listing
+
+34. As a data steward, I want an "Import" button in the listing detail drawer, so that I can pull a listing into my workspace from where I am reading it.
+35. As a data steward, I want the Import Wizard to render the listing — or for a bundle, the listing and its children — as a checkbox tree, so that I can select exactly which sub-items to materialize.
+36. As a data steward, I want the ontology child of a bundle to be checked by default and the data product / data contract children unchecked, so that the lightest-weight default is one click.
+37. As a data steward, I want to choose the target project (and / or team) for the imported entities in the wizard, so that imported products land in the right organizational context.
+38. As a data steward, I want the wizard to warn me when a child item already exists in my workspace (by external_listing_iri), so that I do not silently create a duplicate.
+39. As a data steward, I want the importer to prefer attached ODPS / ODCS JSON distributions when the listing provides them and fall back to DCAT-derived stub fields when it does not, so that I get the highest fidelity available without manual editing.
+40. As a data steward, I want imported entities to carry `external_provider_id`, `external_listing_iri`, `external_version`, `imported_at`, `imported_by`, and `sync_state`, so that I can answer "where did this come from?" forever.
+41. As a data steward, I want every import recorded in a `marketplace_import_records` row, so that there is a single page to query historical provenance.
+42. As a data steward, I want an ontology import to land in the existing semantic models store and immediately become available in the concept picker, so that I can start linking concepts to entities right away.
+43. As a data steward, I want a data product / data contract import to land in the existing data-products / data-contracts tables (respecting my chosen target project), so that the imported items behave identically to natively-authored ones.
+44. As a data steward, I want audience hints published by the provider on a listing (`ontosmkt:audience` tokens) to carry through to the imported entity, so that the provider's intended scoping is preserved.
+45. As a data steward, I want a clear progress indicator during multi-child imports and a final summary (N entities imported, list of links), so that I know whether the operation succeeded.
+46. As a data steward, I want imports to be permission-checked against the **target entity type**, so that I cannot use the marketplace import to bypass per-project data-product write permissions.
+
+### Provenance and sync state
+
+47. As a data steward, I want a "Marketplace Origin" panel on every detail page for an imported entity, showing provider name + logo, source listing IRI (link out to provider), imported version, current upstream version, and `sync_state`, so that I always know whether the entity is in sync with the upstream.
+48. As a data steward, I want the background refresh job to compute a fresh upstream version for every imported entity and flip its `sync_state` to `update_available` when the version moves, so that I get notified about new vendor releases without manual checking.
+49. As a data steward, I want a "Re-sync" button in the Marketplace Origin panel that fetches the latest version and overwrites the local entity (with confirmation dialog), so that I can adopt upstream updates in one click.
+50. As a data steward, I want a "Detach from upstream" button that clears the provenance fields and sets `sync_state=drifted_locally`, so that I can take ownership of an entity that I have customised beyond what re-sync should overwrite.
+51. As a data steward who has manually edited an imported entity, I want `sync_state` to transition to `drifted_locally` automatically (or at least on next refresh check) so that "Re-sync" surfaces a destructive-change warning before overwriting my edits.
+52. As a data steward, I want the Marketplace Origin panel to be polymorphic so that the same panel implementation works for data products, data contracts, and semantic models, so that the UX is consistent.
+
+### Request Access for data-bearing listings (Delta Sharing v1)
+
+53. As a data consumer, I want imported data products that carry a Delta Sharing delivery method to expose a "Request Access" button that opens the existing access-grant request dialog, so that the access flow is identical to any internal data product.
+54. As a data consumer, I want my access request to be persisted as a pending `access_grant_request` row in Ontos, so that the request is auditable and visible in my pending-requests view.
+55. As a data consumer, I want submission of the access request to fire the existing `ON_REQUEST_ACCESS` workflow trigger with the provider id and source listing IRI in `entity_data`, so that any configured approval / notification workflow runs unchanged.
+56. As a data consumer, I want the workflow to send a webhook (or email fallback) to the provider's `dcat:contactPoint`, including my email, the requested duration, the reason, and a callback URL, so that the provider knows who is asking and how to respond.
+57. As a provider, I want a documented callback endpoint (`/api/marketplace/access-callback`) that I can POST to with the recipient name, share name, and schema name (plus optional expiry), so that I can hand a Delta Share grant back to Ontos without phone calls.
+58. As a provider's callback, I want my POST authenticated against a per-provider shared secret, so that random callers cannot fabricate grants.
+59. As Ontos, I want the callback to persist a normal `access_grant` row with the Delta Sharing payload, mark the original request as approved, and notify the requester, so that the rest of the access-grant UX works unchanged.
+60. As an Ontos admin handling a provider that has no webhook capability, I want an "Admin fulfill" action on the pending request where I can paste the recipient / share / schema by hand, so that I am not blocked on the provider supporting callbacks.
+61. As a data consumer, I want the approved grant to show me the Delta Sharing recipient name, share name, and schema name in a copy-able form, so that I can wire up my consumer side immediately.
+62. As an Ontos operator, I do not want any delivery method other than Delta Sharing to be auto-fulfilled in v1; instead, I want the listing to expose a generic "External link" button pointing at the provider's `ontosmkt:requestAccessURL`, so that v1 scope is contained but non-Delta-Sharing flows still work degraded.
+
+### Default Vibe Business provider
+
+63. As a fresh-install Ontos user, I want Vibe Business to appear pre-configured under Marketplace Providers as `enabled=true` with a non-empty catalog, so that I see real listings on first login without any setup.
+64. As an Ontos admin, I want the Vibe Business catalog.ttl to be hosted at a stable URL that we (the Ontos team) maintain, so that we control the schema and update cadence.
+65. As an Ontos admin, I want a small generator tool (separate repo) that crawls the `amralieg/vibe-business-data-models` GitHub repo and emits a DCAT-AP catalog.ttl, so that updates to that source repo propagate to the hosted catalog through a deterministic build.
+66. As an Ontos admin, I want a bundled offline catalog.ttl snapshot to load when the hosted URL is unreachable on first startup, so that air-gapped or initial-bootstrap deployments still get the default marketplace.
+67. As a data steward exploring Vibe Business, I want each industry (Retail, Healthcare, ...) exposed as one Bundle listing whose children are the ontology, the data contracts, the data products, and the metric views, so that I can pick exactly what I want without importing everything.
+68. As a data steward, I want imported Vibe Business items to be visibly attributed to Vibe Business in the Marketplace Origin panel, so that downstream consumers know the lineage of these models.
+
+### Permissions
+
+69. As an Ontos admin, I want a `settings-marketplace-providers` feature permission that gates the entire Settings page (CRUD on providers), so that only authorised admins manage external providers.
+70. As an Ontos admin, I want a `marketplace-listings` (or extended `marketplace`) feature permission that gates listing browse and import for end users, so that I can roll out the marketplace to a subset of teams during pilot.
+71. As an Ontos admin, I want the import action to also require the user's existing permissions on the **target entity type** (e.g. `data-products` write on the chosen project), so that the marketplace cannot be used as a privilege-escalation back door.
+72. As an Ontos admin, I want the callback endpoint authenticated only by the per-provider shared secret (not requiring user session), so that a server-to-server webhook works without UI-level auth.
+
+### Operations and observability
+
+73. As an Ontos operator, I want every catalog refresh (per provider) to log start, end, listing count delta, and failure reason if any, so that I can monitor catalog freshness with our existing log pipeline.
+74. As an Ontos operator, I want the refresh job to emit metrics suitable for our existing dashboard pattern (count per status, average duration per provider), so that I can SLO catalog freshness.
+75. As an Ontos operator, I want a provider in repeated failed state for more than N consecutive refreshes to surface a warning banner in `Settings → Marketplace Providers`, so that operators notice silent breakages.
+
+### Edge cases
+
+76. As an Ontos admin, I want deleting a provider to leave previously imported entities intact (since they are linked copies, not proxies), but to clear their `external_provider_id` (or mark provider as deleted) so that "update available" checks no longer fire, so that nothing breaks but provenance is degraded gracefully.
+77. As an Ontos operator, I want catalog parsing tolerant of unknown DCAT properties (forward-compat) and intolerant of structural violations (missing required `dcat:Catalog`, malformed TTL), so that conformant catalogs always load and broken ones fail loudly.
+78. As an Ontos operator, I want a hard cap on number of listings per provider (configurable, default 50,000), so that a misbehaving provider cannot exhaust the listings table.
+79. As an Ontos operator, I want a hard cap on TTL fetch size (configurable, default 100 MB), so that a misbehaving provider cannot OOM the refresh worker.
+80. As a data steward importing a listing whose ontology IRI collides with an already-imported ontology IRI from a different provider, I want the second import blocked with a clear conflict message, so that I am never silently shadowing one provider's terms with another's.
+
+## Implementation Decisions
+
+### Architecture
+
+- **Wire protocol with providers**: DCAT-AP / DCAT-3 Turtle catalog at a single root URL per provider. A small Ontos-specific extension vocabulary (namespace `https://ontos.dev/ns/marketplace#`, prefix `ontosmkt:`) adds:
+  - `ontosmkt:listingType` ∈ `{Ontology, DataProduct, DataContract, Bundle}`
+  - `ontosmkt:offeringMode` ∈ `{free, commercial, mixed}`
+  - `ontosmkt:audience` (string token grammar reusing the comments-audience grammar)
+  - `ontosmkt:requestAccessURL`
+  - `ontosmkt:deliveryMethod` ∈ `{delta_sharing}` (v1; future: `s3_volume_share`, `uc_table_share`, `rest_endpoint`, `external_link`)
+  - `ontosmkt:parentListing` (links bundle child to parent)
+- ODPS / ODCS payloads ride as `dcat:Distribution` with media types `application/vnd.odps+json` and `application/vnd.odcs+json` (or `+yaml`).
+- The Ontos extension TTL is bundled and loaded into the graph on startup like the other shipped taxonomies.
+
+### Data model
+
+Three new tables:
+
+- **`marketplace_providers`** — registry of external providers. Columns include: id, name (unique), display_name, description, publisher metadata (name, url, logo url), offering_mode enum, catalog_url, auth_mode enum, auth_config JSON (encrypted), enabled, audience_tokens JSON, listing_audience_rules JSON, refresh_interval_seconds, last_refreshed_at, last_refresh_status, last_refresh_error, is_builtin, webhook_secret, plus standard audit columns.
+- **`marketplace_listings`** — cache of per-listing metadata, rebuilt per provider per refresh. Columns include: id, provider_id (FK), listing_iri, title, description, listing_type, parent_listing_iri, themes JSON, keywords JSON, offering_mode, license_url, license_label, contact_point JSON, audience_tokens JSON, distributions JSON, delivery_methods JSON, request_access_url, raw_metadata JSON, version, indexed_at. UNIQUE on (provider_id, listing_iri).
+- **`marketplace_import_records`** — provenance log. Columns include: id, provider_id, listing_iri, listing_version, imported_entity_type enum (semantic_model | data_product | data_contract), imported_entity_id, sync_state enum (up_to_date | update_available | drifted_locally), imported_at, imported_by.
+
+Additive columns on existing entity tables (`data_products`, `data_contracts`, `semantic_models`):
+- `external_provider_id` (nullable FK), `external_listing_iri`, `external_version`, `sync_state`.
+
+Catalog RDF caching reuses `rdf_triples` with a deterministic `context_name` per provider: `urn:provider:<id>:catalog`. SPARQL across all caches is therefore free.
+
+### Modules
+
+Deep modules with simple, testable interfaces:
+
+- **`MarketplaceManager`** — singleton on `app.state`. Public surface: `refresh_provider(id)`, `refresh_all_due()`, `list_providers()`, `list_listings(filters)`, `get_listing(iri)`, `import_listing(iri, child_selection, target_project)`, `register_webhook_callback(provider_id, payload)`. Implements `SearchableAsset.get_search_index_items()` for the unified search registry. Encapsulates audience-evaluation against the user's principal context.
+- **`DcatCatalogParser`** — stateless. Public surface: `parse(ttl_text, base_iri) -> ParsedCatalog`. Converts a TTL blob into a `ParsedCatalog` data class containing `provider_metadata`, `listings: list[ParsedListing]`, `extension_warnings`. Pure function over the rdflib graph; easy to unit-test against fixture TTL files.
+- **`Importers`** — one per `listing_type` (`ontology_importer`, `data_product_importer`, `data_contract_importer`). Each accepts a `ParsedListing` + `ImportContext` (provider, target project, target team, importer email) and returns the new entity ID plus an import record. Importers prefer attached ODPS / ODCS distributions and fall back to DCAT-derived stub fields. Each importer is independently testable with a fixture listing and a fake repository.
+- **`AudienceEvaluator`** — stateless. Public surface: `evaluate(audience_tokens, principal_context) -> bool`. Reuses the same grammar as comments and is exercised by tests against a matrix of token / principal combinations.
+- **`MarketplaceWebhookDispatcher`** — handles the outbound side of the Access Request flow. Public surface: `dispatch_access_request(provider, request, callback_url)`. Listens to the `ON_REQUEST_ACCESS` workflow trigger filtered to `entity_type=data_product` with provenance to an external provider.
+- **`MarketplaceCallbackHandler`** — handles the inbound POST from a provider. Public surface: `handle(provider_id, signed_payload) -> AccessGrant`. Authenticates the per-provider shared secret, materialises the access grant, notifies the requester.
+
+These modules are intentionally extracted so they can be unit-tested without spinning up the FastAPI app or the Postgres harness.
+
+### Permissions
+
+- `settings-marketplace-providers` (admin) — Settings group: Integrations.
+- `marketplace-listings` (consumer browse + import) — possibly fold under existing `marketplace` permission to avoid permission sprawl.
+- Per-import permission check against the target entity type (e.g. `data-products` write on the target project).
+- Webhook callback endpoint authenticated by a per-provider shared secret (not user session).
+
+### Visibility evaluation
+
+Two-tier:
+
+- **Provider-level**: `audience_tokens` JSON on `marketplace_providers`. Evaluated once per request against the caller's principal context. If the provider is invisible, none of its listings are returned regardless of other filters.
+- **Listing-level**: `listing_audience_rules` JSON on `marketplace_providers` is a list of rules `{match: {dcat_theme|listing_type|keyword|...: value}, audience: [tokens]}`. Each cached listing is tested against each rule; the most restrictive matching audience applies. Per-listing direct audience hints from the provider (`ontosmkt:audience`) are merged in. If no rule matches and the provider has no audience filter, the listing is visible to everyone with the `marketplace` permission.
+
+### API contracts
+
+`/api/marketplace/providers` — CRUD + `POST /{id}/refresh`.
+`/api/marketplace/listings` — `GET` (paginated, filterable by provider, type, theme, offering mode, free-text), `GET /{iri:path}`.
+`/api/marketplace/listings/{iri:path}/import` — `POST` with body declaring `child_selection: [listing_iri]`, `target_project_id`, `target_team_id`.
+`/api/marketplace/imports` — `GET` provenance.
+`/api/marketplace/access-callback` — `POST` from provider with HMAC-signed payload.
+
+Listings appear in `/api/search` as type `marketplace-listing` via the SearchableAsset implementation.
+
+### Background refresh
+
+- Reuse the existing `workflow_installations` + `SettingsManager` job pattern. Register a `marketplace_catalog_refresh` job at startup; it iterates enabled providers, picks those whose `last_refreshed_at + refresh_interval_seconds < now()`, and calls `MarketplaceManager.refresh_provider(id)`.
+- Refresh failures persist `last_refresh_status='failed'` and `last_refresh_error=<message>` without clearing the cache.
+
+### Polymorphic panel matrix
+
+Add a new "Marketplace Origin" panel to the polymorphic entity panel matrix. Supported entity types: data product, data contract, semantic model. Hidden when the entity has no `external_provider_id`.
+
+### Provider seeding
+
+- A small companion generator tool (separate small repo under our ownership) crawls the `amralieg/vibe-business-data-models` repo and emits a DCAT-AP `catalog.ttl`.
+- The generated catalog is hosted at a stable URL we own.
+- Ontos startup tasks idempotently insert a `marketplace_providers` row with `is_builtin=true`, `name="vibe-business"`, pointing at that URL.
+- A bundled offline snapshot of the catalog.ttl is shipped inside the backend resources and used as a fallback on first startup when the URL is unreachable.
+
+### Phasing
+
+The feature is delivered as six vertical slices, each independently shippable:
+
+- **P1 – Providers Registry.** Tables, models, repository, manager skeleton, Settings UI CRUD, audience tokens, auth_config. No DCAT fetch yet.
+- **P2 – Catalog Fetch + Cache.** `DcatCatalogParser`, refresh workflow + manual refresh, RDF + listing-table cache, last-refresh status surfaced.
+- **P3 – Search + Browse.** SearchableAsset integration, marketplace-view extension, listing detail drawer.
+- **P4 – Import Wizard.** Tree selector, ontology / data product / data contract importers, provenance columns, Marketplace Origin panel, re-sync / detach.
+- **P5 – Access Flow.** `MarketplaceWebhookDispatcher`, `MarketplaceCallbackHandler`, admin manual-fulfill dialog; Delta-Sharing-only.
+- **P6 – Vibe Business Default.** Generator script, hosted catalog, seed in startup tasks, offline TTL fallback.
+
+## Testing Decisions
+
+A test is good when it asserts the **external behaviour** of a module — what callers observe — and is silent about internal organisation, caching strategy, query shape, or which library is used to parse a Turtle file. Tests that fail when an internal helper is renamed but no observable behaviour changes are anti-tests.
+
+### Unit-tested modules (in priority order)
+
+- **`DcatCatalogParser`** — fixture-driven. Input: a directory of canonical TTL fixtures covering free / commercial / bundle / missing-extension / malformed catalogs. Output: a `ParsedCatalog` dataclass. Tests assert: required fields present, optional fields default sensibly, bundle children correctly nested via `ontosmkt:parentListing`, attached ODPS / ODCS distributions detected, audience hints extracted, malformed inputs raise the documented error class. Prior art: the existing OWL parser tests around `clean_truncated_turtle()`.
+- **`Importers`** (one test class per importer). Inputs: a `ParsedListing` fixture + an `ImportContext`. Assertions: the right entity type is created in the (fake) repository, provenance fields are populated, audience hints carry through, ODPS / ODCS preferred when present and DCAT fallback used when not. Prior art: existing importer tests for ODCS upload in data contracts.
+- **`AudienceEvaluator`** — pure function table tests. Input: token-list + principal context fixture. Assertions: matches Entra group, team, role, domain tokens correctly; empty audience means visible; logical OR semantics across tokens. Prior art: existing comment-audience tests.
+- **`MarketplaceManager.refresh_provider`** — using a fake DCAT fetcher and a fake repository. Assertions: successful refresh replaces the listings transactionally; failures persist the error without clearing the cache; the listings table delta is correct (insert / update / delete); RDF cache context is updated.
+- **`MarketplaceCallbackHandler`** — using a fake repository and signing helper. Assertions: a valid signed payload materialises an access grant and marks the request approved; an invalid signature is rejected; an unknown listing IRI is rejected; an idempotent retry is a no-op.
+
+### Integration-tested flows
+
+- **Provider CRUD + audit log.** Settings UI CRUD operations write audit log rows; permission gating returns 403 for unauthorised callers.
+- **Catalog refresh end-to-end against a local HTTP fixture server.** Wire-level test that a real refresh job hits a fixture HTTP server serving a TTL file, populates `marketplace_listings`, and surfaces in `/api/marketplace/listings`.
+- **Search index sees marketplace listings.** Add a listing, refresh, hit `/api/search?search_term=...`, assert a `marketplace-listing` result is returned with the correct provider badge data.
+- **Import wizard happy path.** POST `/api/marketplace/listings/{iri}/import` with a bundle selection; assert the target entities exist with correct provenance; assert the Marketplace Origin panel data is returned by the entity detail endpoint.
+- **Access flow happy path.** POST a request, assert workflow trigger fired, simulate a callback POST, assert grant materialised.
+
+### Out of testing scope
+
+- We do not test that rdflib parses Turtle correctly — that is the library's job.
+- We do not test cross-provider conflict resolution beyond the documented IRI collision rule.
+- We do not load-test the refresh workflow under thousands of providers; capacity is bounded by the per-provider limits.
+
+## Out of Scope
+
+- A bi-directional **Ontos Access API** spec for providers to implement (poll-based access negotiation). v1 uses webhook + email + manual fulfillment only. The spec is a v2 follow-up.
+- Delivery methods other than Delta Sharing in v1. S3 volume share, UC table share, REST endpoints, email-delivered files all fall through to a generic external-link affordance.
+- `oauth_client_credentials` auth mode. Token-refresh worker adds operational surface; deferred to v2.
+- Provider rating / reputation / verified badge.
+- Cross-provider dependency resolution (listing X depends on ontology Y from another provider).
+- Paid-subscription / billing integration with commercial providers.
+- A per-individual-listing audience editor UI. v1 supports admin-defined rule-based per-listing visibility only; provider-published `ontosmkt:audience` hints are honoured.
+- A workspace-internal marketplace publication flow targeting Ontos itself (we already have `publication_scope`). External providers do not push **into** Ontos.
+
+## Further Notes
+
+- Adopting DCAT-AP is a strategic bet: it aligns Ontos with the EU Data Spaces / Gaia-X direction and avoids us re-inventing a marketplace JSON schema. It also makes Ontos a natural sink for any DCAT-AP catalog that already exists (national open-data portals, sector consortia).
+- The Vibe Business generator tool is intentionally a separate, small repo. We do not want Ontos itself to ship a GitHub crawler; we want it to ship a DCAT consumer. The architecture stays clean.
+- The Marketplace Origin panel is a precedent worth re-using: any future "this entity was imported / generated from elsewhere" feature (e.g. the LLM Ontology Generator's outputs) can reuse the same provenance shape.
+- The `ON_REQUEST_ACCESS` workflow trigger reuse means commercial providers can plug into any approval workflow a customer has already configured (CAB review, Slack approval, ticket creation, etc.) without further provider-side work.
+- We expect early-stage commercial providers (Vibe Business in alpha; small data-product startups) to be the dominant ecosystem before large vendors like S&P. The protocol must be cheap to author manually, which is why DCAT-AP TTL was chosen over a heavy JSON spec.

--- a/docs/prds/prd-multi-domain-assignment.md
+++ b/docs/prds/prd-multi-domain-assignment.md
@@ -1,0 +1,185 @@
+# PRD: Multi-Domain Assignment for Teams, Data Contracts, Data Products, and Assets
+
+## Concept Model
+
+The relevant primitives:
+
+- **Data Domain** — a hierarchical governance grouping (`data_domains` table; self-referential `parent_id`). Domains describe what the data is about (e.g., Sales, Finance, HR, Customer Master) and are used for browsing, discovery, ownership scoping, and tag propagation to Unity Catalog.
+- **Domain-aware entities** — Teams, Data Contracts, Data Products, and Assets each carry a single, optional reference to one Data Domain today.
+- **Primary domain** — the one domain a downstream system that only accepts a single value (ODCS export, Unity Catalog `data_domain` tag) should treat as authoritative.
+- **Additional domains** — further domains the entity also belongs to. These participate fully in browsing, discovery, filtering, and search but are exposed to single-value integrations through extension fields.
+
+These are distinct from the marketplace `publication_scope = "domain"` setting (which controls visibility, not assignment) and from the ODCS/ODPS YAML `domain` string (which is a single name field, exported from the primary).
+
+## Problem Statement
+
+Real assets, products, contracts, and teams routinely span more than one business domain, but Ontos forces every domain-aware entity into exactly one domain. This produces three concrete pains:
+
+1. **Shared entities are misfiled or duplicated.** A `customers` table belongs to both Sales and Marketing; a "Customer 360" data product is consumed by Support, Sales, and Marketing. Today users either pick the "least wrong" domain (silently hiding the entity from the others) or duplicate the entity, which then drifts.
+2. **Org structure cannot be modeled honestly.** A platform team that supports Finance and HR has to be filed under one or split into two teams. Cross-domain contracts (e.g., a master data contract used by several domains) cannot represent that fact in metadata.
+3. **Discovery silently fails.** Users browsing the Sales domain do not see assets that are filed under Marketing but actually used in Sales workflows. Cross-domain reuse — one of the main reasons to run a data marketplace — becomes invisible.
+
+The single-domain limit is also inconsistent across the four entity types: teams, contracts, and assets store `domain_id` (FK / soft-FK to `data_domains.id`); data products store a free-form `domain` string column that sometimes contains an ID and sometimes a name. Cleaning this up is a prerequisite for any cross-domain feature.
+
+## Solution
+
+Replace each entity's single domain reference with a polymorphic many-to-many relationship that designates exactly one primary domain alongside zero or more additional domains. Internally this is one junction table — `entity_domain_associations` — modeled on `entity_tag_associations`, with a `is_primary` boolean and a uniqueness constraint that enforces at most one primary per (entity_type, entity_id).
+
+Single-value integrations (ODCS/ODPS export, Unity Catalog tag sync) consume the primary as their canonical value and emit additional domains through extension fields — `customProperties` for ODCS, multi-tag for UC. Filtering, search, browsing, and the marketplace are upgraded to "any of" semantics: an entity matches a domain filter when any of its assigned domains match (optionally including descendants, as marketplace already does today). Existing single-domain assignments migrate cleanly: every existing value becomes a primary record in the junction table.
+
+The frontend introduces a single shared `DomainMultiSelector` component (popover + searchable badge list with a primary indicator) that replaces every existing single-domain `<Select>` and the legacy free-text input on the data product form.
+
+## User Stories
+
+### Multi-domain assignment
+
+1. As a Data Steward, I want to assign a Data Product to multiple Data Domains, so that consumers in any of those domains can find it.
+2. As a Data Steward, I want to assign a Data Contract to multiple Data Domains, so that contracts shared across business areas (e.g., master data) reflect their true scope.
+3. As a Data Producer, I want to assign an Asset to multiple Data Domains, so that a shared table (e.g., `customers`) appears in every domain that uses it.
+4. As an Admin, I want to assign a Team to multiple Data Domains, so that platform or cross-functional teams are visible to every domain they support.
+5. As a Data Steward, I want to designate exactly one of an entity's domains as primary, so that downstream systems that need a single value have a deterministic answer.
+6. As a Data Steward, I want the UI to clearly mark which domain is primary and let me change it without removing/re-adding domains, so that the primary choice is reversible and obvious.
+7. As a Data Steward, I want to add or remove an additional domain without affecting the primary, so that I can iterate on domain breadth without re-confirming the canonical owner.
+8. As a Data Steward, I want to remove all domains and leave an entity unassigned, so that draft or unclassified entities do not have to fake an affiliation.
+
+### Discovery, search, and filtering
+
+9. As a Data Consumer browsing a Data Domain detail page, I want to see all assets, contracts, products, and teams that include this domain (primary or additional), so that I see the full inventory of what the domain governs.
+10. As a Data Consumer in the marketplace, I want to filter by one or more domains and have results show entities matching any of them, so that I can explore the union of multiple domains in one query.
+11. As a Data Steward, I want the existing "include child domains" marketplace behavior to keep working with multi-domain entities, so that selecting a parent domain still surfaces entities assigned to its descendants.
+12. As a Data Steward, I want list views (Teams, Contracts, Products, Assets) to display every assigned domain as a badge, with the primary visually distinguished, so that I can scan domain affiliation without opening a detail page.
+13. As a Data Steward, I want to filter list views by domain and see entities where the domain is primary OR additional, so that the filter behaves like a tag filter.
+14. As a Data Consumer searching the catalog, I want full-text and semantic search to match an entity by any of its domain names, so that domain-keyed searches return cross-domain entities.
+
+### Forms and editing
+
+15. As a Data Steward editing a Team, I want to pick multiple domains from a searchable popover and mark one as primary, so that team scope reflects reality.
+16. As a Data Producer creating a Data Contract, I want the wizard to let me select multiple domains with one marked primary, so that the contract is correctly classified at creation time.
+17. As a Data Producer creating a Data Product, I want a single, consistent domain selector that stores domain IDs (not free-text names), so that domain values are unambiguous and round-trip with import/export.
+18. As a Data Producer viewing an Asset detail, I want to edit its domain assignments inline (not just see a read-only ID), so that I can correct or extend asset classification without leaving the page.
+19. As a Data Steward, I want bulk imports of Assets to accept a `domain_ids` column (semicolon-separated, with the first treated as primary), so that I can onboard cross-domain inventories at scale.
+20. As a Data Steward, I want bulk exports of Assets to emit `domain_ids` (primary first), so that round-tripping the export preserves all assignments.
+
+### ODCS/ODPS exports
+
+21. As a Data Producer exporting a Data Contract to ODCS, I want the standard `domain` field to receive the primary domain name, so that downstream tools that read ODCS see a valid single value.
+22. As a Data Producer exporting a Data Contract to ODCS, I want any additional domains to be emitted under `customProperties` (e.g., `additionalDomains: [...]`), so that no information is lost in the export.
+23. As a Data Producer exporting a Data Product to ODPS, I want the same primary-plus-additional convention applied to the ODPS export, so that the two formats behave consistently.
+24. As a Data Producer importing an ODCS contract that uses the additional-domains custom property, I want those domains to be re-attached on import, so that round-tripping preserves multi-domain assignment.
+
+### Unity Catalog tag sync
+
+25. As a Data Steward, I want the UC tag sync to write the `data_domain` tag value as the primary domain, so that the existing convention is preserved for catalogs and consumers that read a single value.
+26. As a Data Steward, I want additional domains to be written as separate UC tags (e.g., `data_domain_additional` per assignment), so that downstream UC tooling can still see the full set without breaking single-value consumers.
+
+### Domain lifecycle
+
+27. As an Admin deleting a Data Domain, I want the system to block the deletion if any entity has it as their primary domain, so that I do not silently leave entities without a canonical owner.
+28. As an Admin deleting a Data Domain that is only ever an additional domain, I want the deletion to proceed and the corresponding association rows to be removed, so that domain cleanup does not require manual unassignment of every reference.
+29. As an Admin, I want a domain detail page section that lists every entity (across types) assigned to the domain, distinguishing primary from additional, so that I can review impact before deletion.
+
+### Migration and backward compatibility
+
+30. As a System Operator, I want every existing single-domain assignment to be backfilled as a primary association during migration, so that no entity loses its current domain.
+31. As a System Operator, I want the migration to resolve the data product `domain` column whether it currently stores a domain ID or a domain name, so that legacy rows are not lost.
+32. As an Admin, I want the migration to log any unresolvable domain values (e.g., a stale name with no matching domain) so that I can manually reconcile them after upgrade.
+
+### RBAC and visibility
+
+33. As a User assigned to a team that spans multiple domains, I want my project visibility to consider all domains my teams belong to, so that cross-domain projects do not become invisible after the migration.
+
+## Implementation Decisions
+
+### Data model
+
+- A new polymorphic junction table holds every domain assignment for every entity type, with a boolean primary flag and audit columns. The schema enforces at most one primary per (entity_type, entity_id) and uniqueness on (domain_id, entity_type, entity_id).
+- The four scalar columns disappear: `teams.domain_id`, `data_contracts.domain_id`, `assets.domain_id`, `data_products.domain`. They are replaced entirely by the junction table.
+- The migration backfills every non-null value as a primary association. For data products, the migration first attempts to interpret the legacy `domain` string as an ID, then falls back to a domain name lookup; unresolved values are logged and dropped.
+- `data_domains` keeps its hierarchy. Multi-domain assignment is orthogonal to the parent/child tree — assigning a parent does not implicitly assign children.
+
+### Backend modules
+
+- **EntityDomainAssociationRepository** is the deep module. It provides: `set_domains_for_entity(entity_type, entity_id, domain_ids, primary_domain_id, assigned_by)` with replace-all semantics, idempotent upsert, batch reads (`get_domains_for_entities` for list endpoints to avoid N+1), and inverse lookups (`find_entity_ids_by_domain`, `find_entity_ids_by_domains`). Its interface mirrors `tags_repository.set_tags_for_entity`. It encapsulates the at-most-one-primary invariant and the deletion-blocking check.
+- The four entity repositories (teams, contracts, products, assets) lose their domain column references and route domain reads/writes through the junction repository. Existing methods like `get_teams_by_domain`, `get_standalone_teams`, `get_by_domain`, `get_distinct_domains` are rewritten as junction-table queries with "any-of" semantics.
+- The four entity managers gain a uniform `domain_ids: list[str]` plus `primary_domain_id: str | None` payload contract; managers validate the primary is in the set, resolve names→IDs where legacy code did so, and call the junction repository.
+- A new **DomainExportAdapter** wraps the export-side concerns (ODCS `domain` field + `customProperties.additionalDomains`, ODPS equivalent, UC primary tag + additional tags). Both ODCS and UC code paths consume this adapter rather than reading the junction directly, keeping the export format conventions in one testable place.
+
+### API contract
+
+- Request/response payloads for the four entity types switch from `domain_id` (or `domain`) to `domain_ids: list[str]` and `primary_domain_id: str | null`. The primary is included in `domain_ids`. List endpoints accept `?domain_id=` (single, treated as any-of) and `?domain_ids=` (CSV, any-of) as filters.
+- Existing teams routes that scope by domain (`/api/teams/domains/{domain_id}/teams`, `/api/teams/standalone`) keep their paths but adopt any-of semantics. "Standalone" means: zero domain assignments.
+- The contract create payload no longer accepts the legacy `domain` (name) field; clients must pass `domain_ids` with resolved IDs.
+- Domain delete endpoint surfaces a 409 with a structured body listing the entities for which it is primary, so the UI can offer reassignment guidance.
+
+### Export and integration semantics
+
+- **ODCS export**: standard `domain` string receives the primary domain's name; additional domains are emitted as a list under `customProperties` (key: `additionalDomains`, value: array of domain names). ODCS import recognizes the same custom property and reattaches the additional domains.
+- **ODPS export**: same convention. Primary in the ODPS `domain` field; additional domains under `customProperties.additionalDomains`.
+- **Unity Catalog tag sync**: primary written as the `data_domain` tag (current convention preserved). Each additional domain written as a separate tag with key `data_domain_additional`. The sync writes the primary tag first, then iterates the additionals.
+- **Asset bulk CSV**: column renamed to `domain_ids`, semicolon-separated; the first ID in the list is the primary on import; on export the primary is emitted first, additional IDs follow.
+- **Marketplace and term-mapping filters**: existing `RunTargetFilter.domain_ids: list[str]` already supports multi-value on the read side; adapters switch from filtering on the dropped scalar columns to joining through the junction table.
+
+### Frontend modules
+
+- **DomainMultiSelector** (new) is the deep frontend module: searchable popover, badge list with a primary indicator (e.g., a star icon or accent), add/remove and "set as primary" actions, controlled value `{ domain_ids, primary_domain_id }`. Modeled on the existing `TagSelector`. Used by every entity form.
+- The data product create dialog and the legacy data product form both use the new selector. The legacy free-text `info.domain` input is removed.
+- Asset detail gains a domain editor section using the same component.
+- List views render badge groups in their domain columns. The `useDomains` hook gains a `getDomainNames(ids: string[])` helper.
+- Marketplace and discovery filters become multi-select and pass `domain_ids` to the backend; the existing "include child domains" toggle behavior is preserved.
+
+### RBAC and visibility
+
+- The `projects_repository.get_projects_by_domain_relationship` join now derives the user's team-domain set from the junction table (union across all the user's teams' domains, primary and additional) and uses `IN` instead of equality. Project visibility expands consistently with multi-domain teams; no project-side schema change is needed for this PRD.
+
+### Domain deletion
+
+- Deletion is blocked when at least one entity has the domain as its primary. The 409 response includes the count and a small sample of affected entities per type so the UI can guide the user.
+- When a domain is only ever an additional domain, deletion proceeds and association rows are removed.
+- The existing `cascade="all, delete-orphan"` for `data_domains.children` is unchanged.
+
+### Out-of-band cleanups bundled with this PRD
+
+- `src/backend/src/file_models/data_products.py` references `entity.domain_id` against a model whose column is `domain` — broken today; replaced by reading from the junction table.
+- Defensive code that matches data products by both ID and name (marketplace views) is removed once products store domain IDs only.
+
+## Testing Decisions
+
+Tests focus on external behavior — domain assignment outcomes, filter results, export shapes — not on implementation details like specific SQL or column names.
+
+### Deep-module unit tests
+
+- **EntityDomainAssociationRepository**: replace-all semantics (adding, removing, reordering domains), at-most-one-primary invariant (rejects two primaries, allows zero only when the set is empty), idempotent upserts, batch reads return correct primary marking, inverse lookups return the right entity IDs for any-of and primary-only queries, deletion-blocking returns the right blocker list. Prior art: `src/backend/src/tests/unit/test_data_domains_repository.py`.
+- **DomainExportAdapter**: given a stub primary + additionals, produces the correct ODCS dict (primary in `domain`, additionals under `customProperties.additionalDomains`); UC tag sync emits the primary tag first and then one tag per additional; round-trip from ODCS dict back to (primary, additionals) is lossless. Prior art: `src/backend/src/tests/integration/test_odcs_export_validation.py`.
+
+### Integration tests (per entity)
+
+- For each of teams, contracts, products, assets: create with `domain_ids` + `primary_domain_id`, update to add/remove/swap primary, list with `?domain_ids=A,B` filter and assert any-of, list with `?domain_id=A` and assert any-of, GET detail returns the full set. Prior art: `test_data_contracts_db.py`, `test_teams_routes.py`, `test_data_product_routes.py`.
+
+### Migration tests
+
+- Seed each table with mixed legacy values, including: a contract with `domain_id`, a team with null `domain_id`, an asset with `domain_id`, a product whose `domain` is an ID, a product whose `domain` is a name, and a product whose `domain` is unresolvable. After the upgrade, assert: the right rows exist in `entity_domain_associations`, every backfilled row is `is_primary = true`, and unresolvable values are absent (and were logged).
+
+### Frontend tests
+
+- **DomainMultiSelector** unit tests: rendering with empty / single / multiple domains, add/remove flows, primary indicator, "set as primary" action, search filter, controlled value updates. Prior art: `src/frontend/src/components/ui/tag-selector.test.tsx` (if present) and `src/frontend/src/hooks/use-domains.test.ts`.
+- Wizard/dialog updates: existing tests for `data-contract-wizard-dialog.test.tsx` and `data-product-create-dialog.test.tsx` updated to assert the new payload shape (`domain_ids`, `primary_domain_id`).
+
+### What we deliberately do not test
+
+- We do not snapshot SQL strings, column lists, or JSON shapes beyond the contract surface. Tests should keep passing if internal queries are rewritten as long as the API behavior and exports stay correct.
+
+## Out of Scope
+
+- **Per-domain RBAC and permissions.** Feature-level permissions (e.g., `data-domains`, `settings-data-domains`) are unchanged. Future work could add row-level domain-scoped permissions but is not part of this PRD.
+- **Hierarchy-aware automatic assignment.** Assigning an entity to a parent domain does not implicitly assign it to descendants. Marketplace's "include child domains" filter remains a discovery-time feature.
+- **Multiple primaries** or per-domain ordering beyond `assigned_at`. The model is one primary per entity, period.
+- **Soft-deletion of domains** or any kind of "archive" status. Domain deletion is hard delete (blocked when in use as primary).
+- **Renaming the entire `domain` concept** (for example to "subject area" or "business glossary domain"). Naming is unchanged.
+- **Backfill heuristics for assets without a current `domain_id`** (e.g., infer from contract or product). Backfill is purely the literal column value.
+
+## Further Notes
+
+- The four scalar columns are dropped in the same migration that introduces the junction table. There is no transitional period where both shapes are accepted; clients update with the release.
+- The data product `domain` column has long been a soft-typed string with mixed ID/name semantics. This PRD removes the ambiguity at the storage layer and at the API layer at the same time. UI code that previously matched products by both ID and name is simplified.
+- The existing process workflow scoping (`scope_config: {type: "domain", ids: [...]}`) and term-mapping `RunTargetFilter.domain_ids` already use list-of-IDs shapes and require no contract changes; only the underlying joins move to the junction table.
+- The plan file generated earlier (multi-domain_assignment_2f7410be.plan.md) reflects the prior "fully replace, no primary" decision and needs to be revised to add the `is_primary` column, the export adapter, and the deletion-block behavior described here.

--- a/docs/prds/prd-ontology-term-mapping.md
+++ b/docs/prds/prd-ontology-term-mapping.md
@@ -1,0 +1,238 @@
+# PRD: Ontology Term Mapping (Bulk Suggest & Apply)
+
+## Problem Statement
+
+Ontos already lets stewards attach customer-ontology concepts to individual entities, one at a time. On any Data Product, Data Contract (schema or property), or Asset detail page, a "Linked Terms" panel offers a single-pick concept selector that writes one row to the polymorphic semantic-link store. This is fine for occasional curation, but it does not scale to the realistic onboarding workflow:
+
+- A steward who has just uploaded — or generated — a customer ontology covering hundreds of concepts has no way to bulk-assign those concepts across thousands of catalog assets, contract properties, and products.
+- There is no AI-assisted "here are 240 columns that look like Customer Name" workflow. Every assignment is manually discovered and manually clicked.
+- There is no review queue: if a suggestion engine existed, there would be nowhere for a steward to triage suggestions over multiple sessions.
+- Rejected assignments are not remembered. A future suggester would re-propose the same wrong matches every time.
+- There is no audit trail of *batches* of assignments, only per-link change-log entries — making it hard to answer "what did Tuesday's mapping run change?" or to roll back a single bad run.
+- Onyx, a sibling project, has a working term-assignment feature with a heuristic suggester, persistent mapping, audit, diff, and rollback. We have an explicit brief to port that capability into Ontos, adapted to Ontos's data model and conventions.
+
+Without this capability, customer ontologies in Ontos remain decorative. They live in the system but are not effectively *applied* to the catalog. The promise of ontology-driven governance (impact analysis across business terms, semantic search, automated compliance) cannot be fulfilled until the assignment layer is bulk-tractable.
+
+## Solution
+
+Introduce a new top-level "Term Mapping" feature under the **Govern** group: a workbench where a steward selects targets (Assets, Contract schemas / properties, Data Products) and one or more customer ontologies, runs a suggester, reviews the proposed concept assignments in a persistent queue, accepts or rejects them in bulk (with the option to override the suggested concept IRI per row), and applies the accepted set as one atomic run. Applied assignments land in the existing semantic-links store and immediately appear in the existing "Linked Terms" panels on the affected entity detail pages — no parallel storage, no new shape to read elsewhere.
+
+The suggester is heuristic-first: deterministic name-similarity, type-compatibility, and primary-key / foreign-key hints, with a human-readable "why" rationale on every suggestion. For mid-confidence candidates, an optional LLM-as-judge re-rank uses the existing Databricks Foundation Model client to disambiguate. Embedding-based semantic ranking is documented as a v2 enhancement.
+
+Per-run traceability comes from two new entities: a persistent **suggestion queue** (status `pending` / `accepted` / `rejected` / `applied` / `superseded`) and an **apply run record** that captures the run's configuration, statistics, and the list of links it created. The run record powers a single-click "Undo this run" affordance. Per-link audit continues to flow through the existing entity-change-log infrastructure. The source repo's snapshot-per-version model is intentionally not ported — Ontos's per-row link store is already the source of truth, and duplicating it would create two diverging stores.
+
+Customer ontologies are the sole concept source. Rows in the existing `semantic_models` table (uploaded via Settings or produced by the Ontology Generator) feed the suggester by default. The three shipped internal taxonomies — `ontos-ontology` (Ontos's structural Asset types), `databricks_ontology`, `odcs-ontology` — are excluded by default. The Ontos structural ontology is permanently blocked at the API level; the other two can be explicitly opted into per run for the rare case where shipped platform vocabulary is legitimately assignable.
+
+Two adjacent enhancements are documented in this PRD but built as separate follow-ups: an **Ontology Publishing approval workflow** that adds a steward review gate between draft (uploaded / generated) and published (loaded into the graph and selectable in the term-mapping suggester), and a **Generator → Term Mapping handoff** that contextually launches a mapping run pre-filtered to the catalog the ontology was derived from.
+
+## User Stories
+
+### Discovery and entry points
+
+1. As a steward, I want a new "Term Mapping" entry under the Govern group of the main navigation, so that I can find the bulk-assignment workbench without hunting through entity detail pages.
+2. As a user without the term-mapping permission, I want the navigation entry hidden, so that I am not shown features I cannot use.
+3. As a steward on any Data Contract / Data Product / Asset detail page, I want a small "N pending suggestions" badge near the existing Linked Terms panel that deep-links into the workbench filtered to this entity, so that I can jump from "what's pending here?" to the review queue.
+4. As a steward who has just generated or uploaded a customer ontology, I want a one-click affordance to launch a mapping run pre-scoped to that ontology and the source catalog, so that I do not have to re-enter context I just used (deferred to follow-up PRD; entry point reserved).
+
+### Starting a suggester run
+
+5. As a steward, I want to start a new run by selecting targets across one or more entity types (Assets / Contract schemas / Contract properties / Data Products), so that I can scope a run to whatever curation pass I am doing.
+6. As a steward, I want to scope target selection by Domain, Catalog, Schema, Tag, or a specific Contract / Product, so that I can target precisely the slice I am curating.
+7. As a steward, I want to pick one or more customer ontologies (rows from `semantic_models` with `enabled=true`) as the concept source, so that the suggester only proposes terms from the vocabularies I have approved.
+8. As a steward, I want all enabled customer ontologies pre-selected by default, so that the most common case is one click.
+9. As a steward, I do not want to see Ontos's internal structural ontology (`ontos-ontology`) in the picker, so that I cannot accidentally try to assign Asset-typing classes (Table, Column) as if they were domain concepts.
+10. As a steward, I want a collapsed "Include shipped taxonomies" disclosure with `databricks_ontology` and `odcs-ontology` available as opt-in checkboxes, so that I can include platform vocabulary in the rare cases where it is appropriate.
+11. As a steward, I want to toggle the LLM-as-judge re-rank on or off per run, so that I can control LLM cost.
+12. As a steward, I want a one-line description / comment field on the run, so that I can capture the curation context for audit ("Q3 retail onboarding — orders schema").
+13. As a steward, I want the run to start immediately and execute in the background, so that I can leave the page and check back later.
+14. As a steward, I want to see a live status badge on the run (`suggesting → suggested → applying → applied / undone`) so that I know when results are ready.
+
+### Reviewing suggestions
+
+15. As a steward, I want suggestions grouped by source entity (e.g. all suggestions for one contract property listed together), so that I can curate one entity at a time.
+16. As a steward, I want to filter the queue by status (`pending` / `accepted` / `rejected`), confidence range, source entity type, source domain, and ontology, so that I can drive through a large queue in passes.
+17. As a steward, I want each suggestion to show a human-readable "why" rationale (e.g. "column name 'cust_email' matches 'Customer Email' by 0.91 trigram similarity; types compatible: STRING ↔ xsd:string"), so that I can judge plausibility quickly.
+18. As a steward, I want each suggestion to show the source taxonomy (which customer ontology proposed it), so that I can prefer concepts from the ontology I trust most.
+19. As a steward, I want bulk Accept and Reject buttons over a row selection, so that I can clear a large queue efficiently.
+20. As a steward, I want to override the suggested concept IRI on a single row before accepting (pick a different concept via the existing concept picker), so that I can correct a near-miss instead of rejecting it.
+21. As a steward, I want auto-apply candidates (suggestions above the high-confidence threshold) pre-marked as accepted but still requiring my final Apply click, so that the easy work is done by default but I am never surprised.
+22. As a steward, I want a clear visual signal when a suggestion conflicts with an existing semantic link on the same entity (different IRI for the same source), so that I can decide whether to supersede or skip.
+23. As a steward, I want the suggester to skip source entities that are already linked to the proposed concept, so that I never see a re-suggestion of work I have already done.
+24. As a steward, I want attribute-level suggestions whose parent entity is unmapped (and not in the same accepted batch) to be flagged with a clear "parent entity unmapped" warning, so that I do not silently land an orphan link.
+
+### Applying a run
+
+25. As a steward, I want a pre-apply summary dialog that shows: count of accepted suggestions per target type, count of rejected, count of warnings, estimated number of new semantic links, and any conflict resolutions, so that I have a final preview before mutating the catalog.
+26. As a steward, I want apply to be atomic per run (either all accepted suggestions become links, or none and an error is surfaced), so that a partial failure does not leave my catalog in a half-applied state.
+27. As a steward, I want to see the apply-run record listed in a "Recent runs" view with start time, finished time, run config, comment, statistics, and the user who ran it, so that I have a single page to inspect history.
+28. As a steward, I want each applied link to immediately show up in the existing Linked Terms panel on the affected entity detail page, so that the rest of Ontos sees my work without delay.
+29. As a steward, I want the LLM-as-judge call count, token usage, and rough cost surfaced on the run record, so that I can monitor spend.
+
+### Undoing an applied run
+
+30. As a steward, I want a single-click "Undo this run" action on an applied run, so that I can revert a mass mistake without scripting against the database.
+31. As a steward, I want undo to remove only the links the run created and to leave any pre-existing links untouched, so that an undo never destroys other work.
+32. As a steward, I want suggestions in the undone run to revert to `accepted` status (so I can re-apply selectively), unless the same source/target has been re-linked manually since, in which case the suggestion is marked `superseded`.
+33. As a steward, I want the entity change-log to record each link removal under the same change-log infrastructure that the per-entity Linked Terms panel writes to, so that the per-entity audit story is unified.
+34. As a governance admin, I want to gate the Undo action behind admin permission, so that arbitrary stewards cannot reverse approved bulk runs.
+
+### Auditing and permissions
+
+35. As an auditor, I want every run-create, apply, undo, and individual accept/reject decision recorded in the user-action audit log under a `term-mapping` feature key, so that compliance reviews are traceable.
+36. As an auditor, I want per-link create / delete entries in the entity change log to look identical regardless of whether the link came from a manual Linked Terms panel click or from a term-mapping run, so that per-entity history is consistent.
+37. As an admin, I want a new feature ID (e.g. `term-mapping`) registered with the standard Read-Only / Read-Write / Admin levels, so that role-based access can be configured per organisation.
+38. As an admin, I want the run-create + run-apply actions gated to Read-Write, the Undo action gated to Admin, and the per-entity badge + run history list gated to Read-Only, so that low-trust users can monitor without mutating.
+
+### LLM consent and cost
+
+39. As a steward enabling LLM-as-judge for the first time, I want a one-time consent dialog explaining that selected concept names and source-column metadata will be sent to the configured Databricks Foundation Model endpoint, so that I make an informed choice in line with existing LLM consent patterns in Ontos.
+40. As a steward, I want the LLM-as-judge toggle on the run-config dialog to remember my last choice per user, so that I am not re-prompted every run.
+41. As a steward, I want to see, on the run config dialog, an estimate of how many LLM calls will happen given the current target selection, so that I can pre-size the cost.
+
+### Customer ontologies as the concept source
+
+42. As a steward, I want the suggester to consider only concepts from customer ontologies (`semantic_models` table), so that the platform's internal Asset-typing schema cannot be assigned to my data.
+43. As a steward, I want an attempt to include the internal `ontos-ontology` context (via an API client) rejected with a clear error, so that no out-of-band caller can bypass this rule.
+44. As an admin, I want to opt-in `databricks_ontology` per run, so that genuinely platform-level vocabulary (Cluster, Job) can be assigned where appropriate.
+45. As an admin, I want disabled customer ontologies (`enabled=false` in `semantic_models`) hidden from the picker, so that retired vocabularies do not pollute suggestions.
+
+### Demo experience
+
+46. As an evaluator running the retail demo preset, I want at least one customer ontology pre-seeded in `semantic_models` with `enabled=true`, so that the workbench has candidate concepts on first load.
+47. As an evaluator, I want a pre-seeded completed apply run with a handful of suggestions across an Asset, a Contract, and a Product, so that the Recent Runs view and the per-entity badges are non-empty.
+
+### Search and discoverability
+
+48. As any user, I want apply runs to appear in global search (so I can find "Q3 retail onboarding"), so that auditors can locate runs by free text.
+49. As any user, I do not want individual suggestions to appear in global search, so that the index stays useful.
+
+### Adjacent: Generator → Term Mapping handoff (follow-up PRD)
+
+50. As a steward who has just generated a customer ontology with the Ontology Generator, I want a "Run Term Mapping" button on the generator result view that opens the run-config dialog pre-filled with the new ontology and the catalog the ontology was derived from, so that I can go from generation to assignment in one motion.
+51. As an admin, I want an opt-in setting where ontology publication automatically triggers a heuristic-only suggester run (no auto-apply), so that newly published vocabularies arrive with a ready-for-review queue.
+
+### Adjacent: Ontology publishing approval workflow (follow-up PRD)
+
+52. As an ontology author, I want my newly generated or uploaded customer ontology to start in a `draft` state visible only to me, so that I can iterate before others see it.
+53. As an ontology author, I want a "Request Publishing" action mirroring the existing Request dialogs for contracts and products, so that I use a familiar promotion pattern.
+54. As an ontology author, I want submitting the request to fire a process-workflow trigger that notifies the governance role, so that the right reviewers are alerted automatically.
+55. As a steward in the governance role, I want a notification with a deep link to the candidate ontology's preview, so that I can review and approve or reject in one navigation.
+56. As a steward, I want approval to flip the ontology to `published`, load it into the in-memory RDF graph, and notify the author, so that the change is immediately reflected for everyone (including the term-mapping suggester).
+57. As a steward, I want rejection to flip the ontology back to a working state with my comments captured and the author notified, so that the author has clear next steps.
+58. As any user with semantic-model write access, I want draft ontologies hidden from the term-mapping run-config dialog, so that unreviewed vocabularies cannot accidentally be applied.
+59. As an admin, I want the publish workflow to be a default workflow shipped in the standard workflows YAML and modifiable in Settings, so that organisations can adapt the approval path to their governance structure.
+
+## Implementation Decisions
+
+### Scope and adjacencies
+
+- **In scope for v1**: bulk term assignment over Assets (including Columns), Data Contract schemas and properties, Data Products. Heuristic suggester + optional LLM-as-judge re-rank on mid-confidence candidates. Persistent suggestion queue. Apply + Undo at the run granularity. New top-level workbench view under Govern.
+- **Out of scope for v1** but documented for follow-up PRDs: relationship / foreign-key suggestions, schema-drift watcher, auto-derive mapping from ontology, embedding-based semantic suggester, Ontology Publishing approval workflow, Generator → Term Mapping handoff.
+
+### Storage model
+
+- Term assignments continue to live in the existing polymorphic semantic-link store. No parallel "mapping" table; no snapshot duplication. The source repo's snapshot-per-version model is rejected in favour of Ontos's per-row store plus per-link change-log.
+- Two new tables: a **suggestion queue** (one row per suggestion with status, confidence, reason, engine metadata, decision metadata, applied-link reference, optional steward IRI override) and an **apply-run record** (run configuration, ontology contexts, target filter, stats, the ordered list of links the run created, and the user who ran it).
+- The suggestion queue and apply-run record are persisted; suggestions never disappear silently. Rejected suggestions stay for negative-feedback consumption by future suggester runs.
+- No batch versioning. Per-link audit comes from the existing entity change-log infrastructure. Run-level audit comes from the existing user-action audit log under a new `term-mapping` feature key.
+
+### Ontology selection rules
+
+- Customer ontologies (`semantic_models` rows mirrored into the RDF graph under `urn:semantic-model:*` contexts) are the default concept source. All enabled rows pre-selected.
+- The internal `urn:taxonomy:ontos-ontology` context is permanently blocked. The manager validates every run's context list and rejects requests that include it.
+- The remaining two shipped contexts (`urn:taxonomy:databricks_ontology`, `urn:taxonomy:odcs-ontology`) are excluded by default and surfaced under an "Include shipped" disclosure as opt-in.
+- Concept lookup uses the existing semantic-models concept search APIs, never the internal ontology-schema manager (which serves Asset typing).
+
+### Suggester engine architecture
+
+- **Heuristic engine** (ported from the Onyx source): deterministic name similarity (snake/camel-case normalisation with irregular-plural handling, trigram + SequenceMatcher), type compatibility, primary-key / foreign-key column hints. Scoring formula and reason strings preserved verbatim from the source so behaviour is reproducible. Three source bugs fixed during the port: the broken "skip already-mapped sources" path, the silent placeholder URI on orphan attributes, and the dual-write-with-swallowed-error pattern (the latter is moot because Ontos has no YAML side-channel).
+- **LLM-as-judge engine** (new): fires only for heuristic confidences in the mid-range and only when enabled on the run. Uses the existing Databricks Foundation Model client. Output is a confidence ∈ [0, 1] plus a short rationale. The judge's confidence multiplies the heuristic confidence; the product is rounded to preserve the high-confidence auto-mark threshold semantics from the source.
+- Engines are isolated behind a Suggester interface. Adding a new engine (e.g. embedding-based in v2) is additive.
+- **Adapters** translate each Ontos target type (Asset / Column, Contract schema / property, Data Product) into a uniform feature shape (`name`, `type_label`, `parent_name`, `is_pk`, `is_fk`, optional sample values) that engines consume. The boundary between Ontos types and engine inputs lives in the adapters.
+
+### Apply orchestrator
+
+- Accepted suggestions are sorted entity-assignment first, attribute-assignment second, so an attribute's domain validation against the freshly-applied entity always passes.
+- Each accepted suggestion writes through the existing semantic-links manager so its cache invalidation and RDF-graph mirror side-effects fire automatically.
+- The orchestrator runs in a single DB transaction per run. The set of newly-created link IDs is appended to the run record for undo.
+- Suggestions carrying a `NEW:` IRI prefix (proposing concept minting) are rejected in v1 with a clear reason. Concept minting is an ontology-evolution concern reserved for v2.
+
+### Undo
+
+- Removes only the links recorded on the run; pre-existing links are untouched.
+- Suggestions revert to `accepted` (re-apply possible) unless a manual link for the same source/IRI now exists, in which case `superseded`.
+- Each link removal flows through the same per-entity change-log path as a manual Linked Terms removal.
+- Gated to admin permission.
+
+### API surface
+
+- A new route group covers run create / list / detail / apply / undo, suggestion list with filters, bulk decision update, and a per-entity "pending suggestions" lookup that powers the badge.
+- Every route is gated by a new `term-mapping` feature ID with standard Read-Only / Read-Write / Admin levels. Admin gates the Undo action.
+
+### Frontend architecture
+
+- A new top-level view hosts the workbench (runs list + filter), with a per-run detail view showing the grouped suggestion queue. The run-config dialog covers target selection, ontology context selection (with the shipped opt-in disclosure), and the LLM toggle. An apply-summary dialog gates the destructive Apply.
+- A reusable "pending suggestions" badge component is dropped into existing entity detail pages alongside the existing Linked Terms panel. The badge does not duplicate the existing Linked Terms read path; it links into the workbench.
+- The bulk Accept / Reject UX reuses the established DQX-suggestions dialog interaction model. Concept overrides reuse the existing concept picker. LLM consent reuses the existing one-time consent dialog.
+
+### Workflow and notifications
+
+- Term-mapping runs do not require an approval gate to execute (a steward already has Read-Write to use the feature). Notifications are emitted on run completion to the run's creator only.
+- The adjacent **Ontology Publishing** PRD introduces a real approval gate using the existing trigger / workflow / notification stack — same primitives as the data-product and data-contract publish-approval workflows.
+
+### Demo data
+
+- Each demo preset (retail at minimum, ideally HLS / FSI / MFG / Auto) ships one enabled customer ontology row in `semantic_models` plus one completed apply-run with a handful of suggestions covering an Asset, a Contract, and a Product, so the workbench is non-empty on first load.
+
+### Adjacent #1 — Ontology Generator → Term Mapping handoff (separate PRD)
+
+- New "Run Term Mapping" button on the Ontology Generator result view and on every published `semantic_models` detail page.
+- The button opens the term-mapping run-config dialog with ontology context and target filter pre-filled from the ontology's derivation metadata.
+- Optional opt-in automation: on the publishing transition (status → `published`), fire a heuristic-only suggester run whose results land in the queue for human review. Disabled by default.
+
+### Adjacent #2 — Ontology publishing approval workflow (separate PRD)
+
+- Introduces an explicit lifecycle on `semantic_models`: `draft → pending_approval → published / rejected → retired`. `enabled` becomes a derived back-compat field.
+- "Request Publishing" route + dialog mirror the existing Request Action dialogs for contracts and products.
+- A new entity type (`semantic_model`) is added to the process-workflow entity-type enum. The existing `ON_REQUEST_PUBLISH` trigger is extended to dispatch for the new entity type. A new default workflow `ontology-publish-approval` ships in the workflows YAML and is modifiable in Settings.
+- Approval sets status to `published`, rebuilds the in-memory graph from enabled models, and notifies the author. Rejection captures the reviewer's reason and notifies the author.
+- Draft and pending models are hidden from the term-mapping run-config dialog. Only `published` customer ontologies feed the suggester. This is the gating mechanism that makes term-mapping safe at scale.
+
+## Testing Decisions
+
+A good test in this codebase exercises external behaviour through the manager / route surface, asserts on observable outcomes (DB rows, returned API payloads, audit-log entries), and never reaches into engine internals. Pure-function helpers (scoring, naming normalisation, irregular plurals) are tested directly because their public surface *is* the function.
+
+### Modules tested
+
+- **Heuristic engine** — pure-function tests covering: known scoring formula edge cases at the auto-accept threshold (rounding behaviour); snake / camel / irregular-plural normalisation; primary-key and foreign-key hint detection; the "skip already-mapped sources" path (regression test for source bug 1) verifying that a column with an existing link to concept X is never re-suggested for X; the "orphan attribute" guard (regression test for source bug 2) verifying that an attribute suggestion for a sub-entity whose parent is unmapped is flagged, not silently linked to a placeholder.
+- **Adapters** — one focused test per target type (Asset / Contract / Product) using a small fixture, verifying that the produced feature shape matches what the heuristic engine expects, that composite IDs for sub-entities follow the existing semantic-helpers convention, and that disabled / draft ontologies are excluded.
+- **Apply orchestrator** — integration tests against a real session verifying: ordering (entity assignments applied before attribute assignments); atomicity (transaction rollback on a mid-run failure); idempotency on re-apply of an already-applied accepted suggestion (no duplicate link rows); rejection of `NEW:` URI suggestions; correct population of the run's `applied_link_ids` for downstream undo.
+- **Undo** — integration tests verifying: only the run's links are removed; pre-existing links untouched; suggestions move to `accepted` or `superseded` correctly; entity change-log records the removals; admin permission required.
+- **Routes** — minimal happy-path + permission-gate tests per endpoint. Verify the `ontology` context guard rejects requests that include the internal context. Verify the per-entity pending-suggestions badge endpoint returns the right count for a known fixture.
+- **LLM-as-judge engine** — uses a stub LLM client. Tests verify: invocation only on mid-confidence range; correct multiplication and rounding of confidences; capture of token / call counters in the run stats; graceful handling of LLM errors (degrade to heuristic-only, do not fail the run).
+
+### Prior art for the tests
+
+- `tests/unit/test_workflow_triggers_*.py` is the model for trigger / workflow wiring tests (used when the publishing-approval PRD is built).
+- `tests/integration/test_user_header_override.py` shows the persona-switching pattern for testing role-gated routes.
+- The existing data-contracts manager tests exercise the persistent-suggestion pattern (DQX) the term-mapping queue mirrors; review for fixture style.
+- Pure-function naming and similarity tests should follow the style of the existing change-analyzer tests, which use small parameterised fixtures.
+
+## Out of Scope
+
+- **Relationship and foreign-key suggestions.** Where Asset–Asset relationship suggestions land (the cross-asset relationship store validated against the ontology) versus where Contract property-level FK suggestions land (the existing contract-property relationship rows) is a real design decision that needs its own PRD.
+- **Schema drift watcher.** Detecting that a previously-linked column or property has been renamed or dropped, and re-queueing the affected links as suggestions, is a v2 feature that plugs into the existing workflows infrastructure.
+- **Embedding-based semantic suggester.** Requires wiring a Databricks Foundation Model embedding endpoint and is the largest single addition; document but defer.
+- **Auto-derive mapping from ontology.** The source repo's "derive entire mapping by name-matching the ontology back to its source tables" path assumes the ontology was LLM-derived from the same tables. Useful but orthogonal.
+- **Ontology evolution (the `NEW:` URI prefix).** Minting new concept URIs from suggestions either requires write access to the underlying ontology (TTL editing) or coupling to the Ontology Generator. Reserved for v2.
+- **Point-in-time versioning of the entire mapping.** Ontos's per-row store plus per-link change-log is the chosen audit model. If stewards report needing true batch rollback beyond the per-run undo, revisit then.
+- **Generator → Term Mapping handoff.** Documented as Adjacent #1; built as a follow-up PRD.
+- **Ontology publishing approval workflow.** Documented as Adjacent #2; built as a follow-up PRD. Until that lands, the suggester reads every enabled `semantic_models` row, so organisations relying on the current uploader-only access model should treat ontology upload itself as the trust boundary in v1.
+
+## Further Notes
+
+- The plan companion to this PRD lives at `.cursor/plans/adopt_onyx_term-mapping_into_ontos_ea5044ed.plan.md` and includes the concrete file layout, the architecture and sequence diagrams, the Alembic migration shape, the route shapes, the engine module layout, and the verification smoke list. It is the source of truth for the implementer; this PRD is the source of truth for the *what* and *why*.
+- The source repo brief (treated as ground truth for the port) is at `/Users/lars.george/Documents/dev/onyx_ontology/docs/EXTRACT_ONTOLOGY_MAPPING_TO_ONTOS.md`. Three known source bugs (broken existing-mapping skip, orphan-attribute placeholder URI, non-atomic dual-write) are explicitly fixed during the port and have regression tests called out in the Testing Decisions section.
+- The Linked Terms read path (the existing per-entity concept-chips panel) is unchanged. After applies, new links appear there automatically. This is intentional — there should be one canonical place to see "what concepts are linked to this entity" regardless of how the link was created.
+- The two adjacent PRDs (publishing approval; generator handoff) make this feature dramatically more useful. Implementers building v1 should leave clean extension points for them (in particular: the run-config dialog should expect `ontology_contexts` and `target_filter` as pre-fillable from query parameters, and the suggester should treat `semantic_models.enabled` as the gate today and accept replacing it with `status == 'published'` later without code churn).
+- This feature is the assignment substrate that lets ontology-driven impact analysis, semantic search, and automated compliance work end-to-end. Without it those downstream capabilities have no data to operate on. Prioritising v1 unblocks an entire downstream theme.


### PR DESCRIPTION
## Summary

Adds four new PRDs to `docs/prds/` to capture upcoming feature work as versioned documents:

- **Configurable detail-view panels (S/M/L + custom views)** — replace the hardcoded panel/size mapping in Data Product and Data Contract detail views with per-user, named arrangements.
- **External marketplace providers** — extend the marketplace beyond the workspace to reach external industry ontologies (FIBO, Schema.org, GS1, HL7 FHIR, OBO Foundry, ...) and reference business data models.
- **Multi-domain assignment** — let Teams, Data Contracts, Data Products, and Assets belong to multiple Data Domains, with a designated primary for single-value integrations (ODCS export, Unity Catalog `data_domain` tag).
- **Ontology term mapping (bulk suggest & apply)** — port Onyx-style bulk term assignment with a heuristic suggester, review queue, audit, and rollback into Ontos.

Docs only. No runtime, schema, or API changes.

## Test plan

- [ ] Render each new PRD on GitHub and confirm formatting (headings, tables, links) is intact.
- [ ] Skim each PRD for cross-references and broken intra-doc links.