### PR TITLE
fix(semantic-models): hide internal graphs from RDF Sources

### DIFF
--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -31,6 +31,20 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api", tags=["Semantic Models"])
 
+# Internal named-graph contexts that must never surface as user-facing RDF
+# Sources. These are computed/managed graphs (app entities, semantic links,
+# source-registry metadata, the rdflib default graph), not uploaded or bundled
+# taxonomy files. Mirrors the frontend's SYSTEM_RDF_NAMESPACE_KEYS so the two
+# stay aligned.
+INTERNAL_GRAPH_CONTEXTS = frozenset({
+    "urn:meta:sources",
+    "urn:semantic-links",
+    "urn:x-rdflib:default",
+    "urn:app-entities",
+    "urn:demo",
+    "",  # rdflib default-default
+})
+
 def get_semantic_models_manager(request: Request) -> SemanticModelsManager:
     """Retrieves the SemanticModelsManager singleton from app.state."""
     manager = getattr(request.app.state, 'semantic_models_manager', None)
@@ -83,6 +97,10 @@ async def get_semantic_models(
         for tax in graph_taxonomies:
             # Skip if this is a database-backed model (already included above)
             if tax.source_type == 'database':
+                continue
+            # Skip internal/system graphs (app entities, semantic links, etc.)
+            # so they don't leak into the user-facing RDF Sources list.
+            if tax.name in INTERNAL_GRAPH_CONTEXTS:
                 continue
             # Skip if name matches (either original or sanitized version)
             if tax.name in db_model_names or tax.name in db_model_names_sanitized:

--- a/src/backend/src/tests/unit/test_semantic_models_internal_contexts.py
+++ b/src/backend/src/tests/unit/test_semantic_models_internal_contexts.py
@@ -1,0 +1,54 @@
+"""Internal/system graphs must not leak into the RDF Sources list.
+
+The `/api/semantic-models` route combines DB-backed models with computed
+graph taxonomies. Internal named graphs (app entities, demo data, semantic
+links, source-registry metadata, the rdflib default graph) are managed/computed
+and have no uploadable file behind them, so surfacing them produces broken rows
+whose Preview action 404s. This guards the route-level filter that strips them.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from src.models.ontology import SemanticModel as SemanticModelOntology
+from src.routes.semantic_models_routes import (
+    INTERNAL_GRAPH_CONTEXTS,
+    get_semantic_models,
+)
+
+
+def _call_endpoint(manager: MagicMock) -> dict:
+    """Invoke the async route handler directly, bypassing FastAPI auth/DI."""
+    return asyncio.run(get_semantic_models(manager=manager, _=True))
+
+
+def test_internal_graphs_are_excluded_from_list() -> None:
+    manager = MagicMock()
+    # No DB-backed models in this scenario.
+    manager.list.return_value = []
+    # Computed taxonomies include internal graphs plus one real file taxonomy.
+    manager.get_taxonomies.return_value = [
+        SemanticModelOntology(name="urn:app-entities", source_type="external"),
+        SemanticModelOntology(name="urn:demo", source_type="external"),
+        SemanticModelOntology(name="urn:semantic-links", source_type="external"),
+        SemanticModelOntology(name="urn:meta:sources", source_type="external"),
+        SemanticModelOntology(name="foo", source_type="file", format="ttl"),
+    ]
+    manager.bundled_taxonomy_file_size_bytes.return_value = 123
+
+    payload = _call_endpoint(manager)
+
+    names = {m["name"] for m in payload["semantic_models"]}
+    assert names == {"foo"}
+    assert not (names & INTERNAL_GRAPH_CONTEXTS)
+
+
+def test_internal_graph_contexts_cover_known_namespaces() -> None:
+    for key in (
+        "urn:meta:sources",
+        "urn:semantic-links",
+        "urn:x-rdflib:default",
+        "urn:app-entities",
+        "urn:demo",
+    ):
+        assert key in INTERNAL_GRAPH_CONTEXTS

--- a/src/frontend/src/components/settings/semantic-models-settings.tsx
+++ b/src/frontend/src/components/settings/semantic-models-settings.tsx
@@ -35,10 +35,8 @@ import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { systemRdfNamespaceDisplayLabel } from '@/lib/system-rdf-namespace-labels';
+import { systemRdfNamespaceDisplayLabel, SYSTEM_RDF_NAMESPACE_KEY_SET } from '@/lib/system-rdf-namespace-labels';
 import type { TFunction } from 'i18next';
-
-const SYSTEM_CONTEXTS = ['urn:meta:sources', 'urn:semantic-links'];
 
 interface TitleCandidateRow {
   iri: string;
@@ -100,7 +98,7 @@ export default function SemanticModelsSettings() {
   const [titleSaving, setTitleSaving] = useState(false);
 
   const filteredItems = useMemo(() => 
-    items.filter(m => !SYSTEM_CONTEXTS.includes(m.name)),
+    items.filter(m => !SYSTEM_RDF_NAMESPACE_KEY_SET.has(m.name)),
     [items]
   );
 

--- a/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { systemRdfNamespaceDisplayLabel } from './system-rdf-namespace-labels';
+import {
+  systemRdfNamespaceDisplayLabel,
+  SYSTEM_RDF_NAMESPACE_KEY_SET,
+} from './system-rdf-namespace-labels';
 import { humanizeRdfFilename } from './rdf-filename';
 
 describe('systemRdfNamespaceDisplayLabel', () => {
@@ -27,5 +30,23 @@ describe('systemRdfNamespaceDisplayLabel', () => {
     expect(systemRdfNamespaceDisplayLabel('urn:something-else', t)).toBe(
       humanizeRdfFilename('urn:something-else'),
     );
+  });
+});
+
+describe('SYSTEM_RDF_NAMESPACE_KEY_SET', () => {
+  it('contains all known internal namespaces used to filter RDF Sources', () => {
+    for (const key of [
+      'urn:meta:sources',
+      'urn:semantic-links',
+      'urn:x-rdflib:default',
+      'urn:app-entities',
+      'urn:demo',
+    ]) {
+      expect(SYSTEM_RDF_NAMESPACE_KEY_SET.has(key)).toBe(true);
+    }
+  });
+
+  it('does not include user-facing taxonomy contexts', () => {
+    expect(SYSTEM_RDF_NAMESPACE_KEY_SET.has('urn:taxonomy:foo')).toBe(false);
   });
 });

--- a/src/frontend/src/lib/system-rdf-namespace-labels.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.ts
@@ -6,7 +6,7 @@ import { humanizeRdfFilename } from '@/lib/rdf-filename';
  * Known internal graph names / API pseudo-row `name` values (not user taxonomies).
  * Keys use the semantic-models namespace as default when calling `t`.
  */
-const SYSTEM_RDF_NAMESPACE_KEYS: Record<string, { i18nKey: string; defaultLabel: string }> = {
+export const SYSTEM_RDF_NAMESPACE_KEYS: Record<string, { i18nKey: string; defaultLabel: string }> = {
   'urn:meta:sources': {
     i18nKey: 'rdfSources.systemNamespaces.metaSources',
     defaultLabel: 'Source registry metadata',
@@ -29,6 +29,13 @@ const SYSTEM_RDF_NAMESPACE_KEYS: Record<string, { i18nKey: string; defaultLabel:
     defaultLabel: 'Demo business concepts',
   },
 };
+
+/**
+ * Set of internal graph keys, used to filter system contexts out of user-facing
+ * lists (e.g. the RDF Sources table). Derived from the canonical key map so the
+ * filter automatically covers any new internal namespace added above.
+ */
+export const SYSTEM_RDF_NAMESPACE_KEY_SET = new Set(Object.keys(SYSTEM_RDF_NAMESPACE_KEYS));
 
 /**
  * Human-readable label for internal RDF graph keys, or the original key if unknown.


### PR DESCRIPTION
## Summary

- Internal/computed named graphs (`urn:app-entities`, `urn:demo`, `urn:semantic-links`, `urn:meta:sources`, the rdflib default graph) were leaking into the **RDF Sources** list once the in-memory graph contained triples — e.g. after uploading the first ontology while a Data Contract existed. The `urn:app-entities` context got enumerated by `_compute_taxonomies()`, materialized into a pseudo-row (`id=file-urn:app-entities`), and its Preview action 404'd with "Failed to load content."
- Filter internal contexts at the `/api/semantic-models` boundary via a new `INTERNAL_GRAPH_CONTEXTS` frozenset.
- Derive the frontend table filter from the canonical `SYSTEM_RDF_NAMESPACE_KEYS` map (new exported `SYSTEM_RDF_NAMESPACE_KEY_SET`) so backend and frontend stay in sync, replacing the incomplete local `SYSTEM_CONTEXTS` (covered only 2 of 5 namespaces).
- Caching and Knowledge Graph stats are intentionally left untouched; the fix is applied at the API/read boundary only.

## Changes

- `src/backend/src/routes/semantic_models_routes.py`: add `INTERNAL_GRAPH_CONTEXTS` and skip those names in `get_semantic_models()`.
- `src/frontend/src/lib/system-rdf-namespace-labels.ts`: export the key map and a derived `SYSTEM_RDF_NAMESPACE_KEY_SET`.
- `src/frontend/src/components/settings/semantic-models-settings.tsx`: filter the table with the imported set.
- Tests: frontend `system-rdf-namespace-labels.test.ts` asserts the canonical key set; new backend `test_semantic_models_internal_contexts.py` asserts the route strips internal namespaces.

## Test plan

- [x] Backend: `test_semantic_models_internal_contexts.py` (2 passed)
- [x] Frontend: `system-rdf-namespace-labels.test.ts` (5 passed)
- [ ] Manual: start app empty, define a Data Contract, upload first ontology in RDF Sources, confirm no "App Entities" row appears.