### PR TITLE
test(fixtures): add ODCS/ODPS test data matrix with Ontos extensions

### DIFF
--- a/src/backend/src/tests/data/README.md
+++ b/src/backend/src/tests/data/README.md
@@ -1,0 +1,82 @@
+# Test data fixtures: ODCS contracts & ODPS data products
+
+This directory holds YAML fixtures used by the backend unit and integration
+tests to exercise import/export, parsing, and validation of Bitol standard
+documents plus this app's own extensions to those standards.
+
+## Folder layout
+
+```
+tests/data/
+├── odcs/   # Open Data Contract Standard (Bitol ODCS) contracts
+└── odps/   # Open Data Product Standard (Bitol ODPS) data products
+```
+
+### `odcs/` — Data Contracts
+
+| File | Purpose |
+|---|---|
+| `full-example.odcs.yaml` | Canonical reference loaded by `test_odcs_roundtrip.py` and `test_odcs_export_validation.py`. **Keep to a single schema object, team-as-array, and rule-based quality** — those tests assert `len(exported["schema"]) == 1` and look for a `countCheck` rule. |
+| `full-example.odcs_v3_0_2.yaml` | Bitol full example, ODCS v3.0.2 shape (team array, `rule`-based quality). |
+| `full-example.odcs_v3_1_0.yaml` | Bitol full example, ODCS v3.1.0 shape (team object, `metric`-based quality, `relationships`, stable `id`s, two schema objects). |
+| `full-example.odcs_v3_1_0-ontos-extensions.yaml` | v3.1.0 full example **plus all Ontos extensions** (namespaced tag FQNs, semantic assignments at every level, `ontos.businessOwners`, stable ids). |
+| `team-as-object.odcs_v3_1_0.yaml` | Focused fixture for the v3.1.0 Team-as-object shape (team-level tags / customProperties / authoritativeDefinitions). |
+| `minimal.odcs_v3_1_0.yaml` | Only the required fields — negative/edge surface for "optional sections absent". |
+| `relationships-composite-keys.odcs_v3_1_0.yaml` | Schema-level composite FKs and property-level relationships. |
+| `quality-rules-matrix.odcs_v3_1_0.yaml` | Every quality `type`, comparator, and dimension, at schema and property level. |
+| `all-data-types.odcs.yaml` | Logical-type options matrix (string/number/date/array/object constraints). |
+| `semantic-test.odcs.yaml` | Semantic-assignment-only contract. |
+| `postgresql-adventureworks-contract.odcs_v3_0_2.yaml` / `_v3_1_0.yaml` | Large real-world AdventureWorks contract for both ODCS versions. |
+
+### `odps/` — Data Products
+
+| File | Purpose |
+|---|---|
+| `full-example.odps_v1_0_0.yaml` | Comprehensive ODPS v1.0.0 product: input/output/management ports, server connection details, SBOM, input contracts, support, team. |
+| `full-example.odps_v1_0_0-ontos-extensions.yaml` | Full example **plus Ontos extensions** (`consumer_principals`, `max_level_inheritance`, `ontos.businessOwners`, namespaced tag FQNs, semantic assignments on product and ports). |
+| `minimal.odps_v1_0_0.yaml` | Only the required fields (`apiVersion`, `kind`, `id`, `status`). |
+| `ports-matrix.odps_v1_0_0.yaml` | Every input/output/management port variant (Kafka topic, Databricks share, S3 file, BigQuery, contract-less, tagged). |
+| `multi-product-batch.odps_v1_0_0.yaml` | Top-level list of products (mix of valid + invalid) for the batch upload path. |
+
+## Ontos extension encoding conventions
+
+The app extends ODCS/ODPS with concepts the native specs do not model. To keep
+fixtures **spec-valid**, extensions are encoded using existing in-spec carriers:
+
+1. **Semantic assignments** — encoded as `authoritativeDefinitions` entries
+   whose `type` is the semantic-assignment IRI
+   `http://databricks.com/ontology/uc/semanticAssignment`. The `url` points at
+   the ontology class (`rdfs:Class`) or property (`rdf:Property`). Valid at the
+   contract, schema, property, role, team, product, and port levels. These are
+   ingested by `process_all_semantic_links_from_odcs`. Non-semantic
+   authoritative-definition `type`s (e.g. `businessDefinition`) must be
+   preserved as-is.
+
+2. **Unified tags with namespaces** — encoded as FQN strings inside the native
+   `tags:` arrays. A bare name (`transactions`) maps to the `default`
+   namespace; a slash-qualified name (`finance/payments`) maps to namespace
+   `finance`, tag `payments`. The FQN is parsed via `AssignedTagCreate.tag_fqn`.
+
+3. **Polymorphic business owners** — encoded under `customProperties` using the
+   reserved key `ontos.businessOwners`, whose value is a list of records shaped
+   like `BusinessOwnerCreate`:
+   `{ objectType: data_contract|data_product|asset|data_domain|business_term|tag|dataset, userEmail, roleName }`.
+   This mirrors the demo MDM contracts' use of `mdm*` custom properties, so the
+   document stays schema-valid.
+
+Other Ontos-only fields surfaced at the top level of ODPS products
+(`consumer_principals`, `max_level_inheritance`) are parsed directly by the
+`DataProduct` Pydantic model.
+
+## Schema references
+
+Live JSON Schemas used for validation are in `src/backend/src/schemas/`:
+
+- `odcs-json-schema-v3.0.2.json`, `odcs-json-schema-v3.0.2-strict.json`,
+  `odcs-json-schema-v3.1.0.json` — ODCS contract schemas.
+- `odps-json-schema-v1.0.0.json` — ODPS product schema.
+
+Bitol upstream sources:
+
+- ODCS: <https://github.com/bitol-io/open-data-contract-standard>
+- ODPS: <https://github.com/bitol-io/open-data-product-standard>

--- a/src/backend/src/tests/data/odcs/full-example.odcs.yaml
+++ b/src/backend/src/tests/data/odcs/full-example.odcs.yaml
@@ -1,0 +1,248 @@
+# Canonical reference ODCS contract used by the upload/export round-trip and
+# export-validation integration tests (test_odcs_roundtrip.py,
+# test_odcs_export_validation.py). Despite living next to the version-suffixed
+# fixtures, this file is the version-agnostic reference those tests load by name.
+#
+# IMPORTANT: keep this contract to a SINGLE schema object, team-as-array, and
+# rule-based quality. test_odcs_roundtrip.py asserts len(exported["schema"]) == 1
+# and looks for a "countCheck" rule, so adding a second schema object or
+# switching to metric-based quality will break those tests.
+
+# What's this data contract about?
+domain: seller # Domain
+dataProduct: my quantum # Data product name
+version: 1.1.0 # Version (follows semantic versioning)
+status: active
+id: 53581432-6c55-4ba2-a65f-72344a91553a
+
+# Lots of information
+description:
+  purpose: Views built on top of the seller tables.
+  limitations: Data based on seller perspective, no buyer information
+  usage: Predict sales over time
+  authoritativeDefinitions:
+    - type: privacy-statement
+      url: https://example.com/gdpr.pdf
+tenant: ClimateQuantumInc
+
+kind: DataContract
+apiVersion: v3.1.0 # Standard version (follows semantic versioning)
+
+# Infrastructure & servers
+servers:
+  - server: my-postgres
+    type: postgres
+    host: localhost
+    port: 5432
+    database: pypl-edw
+    schema: pp_access_views
+
+# Dataset, schema and quality
+schema:
+  - name: tbl
+    physicalName: tbl_1
+    physicalType: table
+    businessName: Core Payment Metrics
+    description: Provides core payment metrics
+    authoritativeDefinitions:
+      - url: https://catalog.data.gov/dataset/air-quality
+        type: businessDefinition
+      - url: https://youtu.be/jbY1BKFj9ec
+        type: videoTutorial
+    tags: [ 'finance', 'payments']
+    dataGranularityDescription: Aggregation on columns txn_ref_dt, pmt_txn_id
+    properties:
+      - name: transaction_reference_date
+        physicalName: txn_ref_dt
+        primaryKey: false
+        primaryKeyPosition: -1
+        businessName: transaction reference date
+        logicalType: date
+        physicalType: date
+        required: false
+        description: Reference date for transaction
+        partitioned: true
+        partitionKeyPosition: 1
+        criticalDataElement: false
+        tags: [ ]
+        classification: public
+        transformSourceObjects:
+          - table_name_1
+          - table_name_2
+          - table_name_3
+        transformLogic: sel t1.txn_dt as txn_ref_dt from table_name_1 as t1, table_name_2 as t2, table_name_3 as t3 where t1.txn_dt=date-3
+        transformDescription: defines the logic in business terms; logic for dummies
+        examples:
+          - "2022-10-03"
+          - "2020-01-28"
+        customProperties:
+          - property: anonymizationStrategy
+            value: none
+      - name: rcvr_id
+        primaryKey: true
+        primaryKeyPosition: 1
+        businessName: receiver id
+        logicalType: string
+        physicalType: varchar(18)
+        required: false
+        description: A description for column rcvr_id.
+        partitioned: false
+        partitionKeyPosition: -1
+        criticalDataElement: false
+        tags: [ 'uid' ]
+        classification: restricted
+      - name: rcvr_cntry_code
+        primaryKey: false
+        primaryKeyPosition: -1
+        businessName: receiver country code
+        logicalType: string
+        physicalType: varchar(2)
+        required: false
+        description: Country code
+        partitioned: false
+        partitionKeyPosition: -1
+        criticalDataElement: false
+        tags: [ ]
+        classification: public
+        authoritativeDefinitions:
+          - url: https://collibra.com/asset/742b358f-71a5-4ab1-bda4-dcdba9418c25
+            type: businessDefinition
+          - url: https://github.com/myorg/myrepo
+            type: transformationImplementation
+          - url: jdbc:postgresql://localhost:5432/adventureworks/tbl_1/rcvr_cntry_code
+            type: implementation
+        encryptedName: rcvr_cntry_code_encrypted
+        quality:
+          - rule: nullCheck
+            description: column should not contain null values
+            dimension: completeness # dropdown 7 values
+            type: library
+            severity: error
+            businessImpact: operational
+            schedule: 0 20 * * *
+            scheduler: cron
+            customProperties:
+              - property: FIELD_NAME
+                value:
+              - property: COMPARE_TO
+                value:
+              - property: COMPARISON_TYPE
+                value: Greater than
+    quality:
+      - rule: countCheck
+        type: library
+        description: Ensure row count is within expected volume range
+        dimension: completeness
+        method: reconciliation
+        severity: error
+        businessImpact: operational
+        schedule: 0 20 * * *
+        scheduler: cron
+    customProperties:
+      - property: business-key
+        value:
+          - txn_ref_dt
+          - rcvr_id
+
+
+# Pricing
+price:
+  priceAmount: 9.95
+  priceCurrency: USD
+  priceUnit: megabyte
+
+
+# Team
+team:
+  - username: ceastwood
+    role: Data Scientist
+    dateIn: "2022-08-02"
+    dateOut: "2022-10-01"
+    replacedByUsername: mhopper
+  - username: mhopper
+    role: Data Scientist
+    dateIn: "2022-10-01"
+  - username: daustin
+    role: Owner
+    description: Keeper of the grail
+    dateIn: "2022-10-01"
+
+
+# Roles
+roles:
+  - role: microstrategy_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'mandolorian'
+  - role: bq_queryman_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: na
+  - role: risk_data_access_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'dathvador'
+  - role: bq_unica_user_opr
+    access: write
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'mickey'
+
+# SLA
+slaDefaultElement: tab1.txn_ref_dt
+slaProperties:
+  - property: latency # Property, see list of values in DP QoS
+    value: 4
+    unit: d # d, day, days for days; y, yr, years for years
+    element: tab1.txn_ref_dt # This would not be needed as it is the same table.column as the default one
+  - property: generalAvailability
+    value: "2022-05-12T09:30:10-08:00"
+  - property: endOfSupport
+    value: "2032-05-12T09:30:10-08:00"
+  - property: endOfLife
+    value: "2042-05-12T09:30:10-08:00"
+  - property: retention
+    value: 3
+    unit: y
+    element: tab1.txn_ref_dt
+  - property: frequency
+    value: 1
+    valueExt: 1
+    unit: d
+    element: tab1.txn_ref_dt
+  - property: timeOfAvailability
+    value: 09:00-08:00
+    element: tab1.txn_ref_dt
+    driver: regulatory # Describes the importance of the SLA: [regulatory|analytics|operational|...]
+  - property: timeOfAvailability
+    value: 08:00-08:00
+    element: tab1.txn_ref_dt
+    driver: analytics
+
+
+# Support
+support:
+  - channel: '#product-help' # Simple Slack communication channel
+    tool: slack
+    url: https://aidaug.slack.com/archives/C05UZRSBKLY
+  - channel: datacontract-ann # Simple distribution list
+    tool: email
+    url: mailto:datacontract-ann@bitol.io
+  - channel: Feedback  # Product Feedback
+    description: General Product Feedback (Public)
+    url: https://product-feedback.com
+
+# Tags
+tags:
+  - transactions
+
+
+# Custom properties
+customProperties:
+  - property: refRulesetName
+    value: gcsc.ruleset.name
+  - property: somePropertyName
+    value: property.value
+  - property: dataprocClusterName # Used for specific applications like Elevate
+    value: [ cluster name ]
+
+contractCreatedTs: "2022-11-15T02:59:43+00:00"

--- a/src/backend/src/tests/data/odcs/full-example.odcs_v3_1_0-ontos-extensions.yaml
+++ b/src/backend/src/tests/data/odcs/full-example.odcs_v3_1_0-ontos-extensions.yaml
@@ -1,0 +1,315 @@
+# ============================================================================
+# ODCS v3.1.0 full example + ONTOS EXTENSIONS
+# ============================================================================
+# Superset of full-example.odcs_v3_1_0.yaml that additionally exercises every
+# Ontos-specific extension that rides inside a spec-valid ODCS document:
+#
+#   1. Unified tags with namespaces  -> FQN strings in `tags:` arrays
+#      (e.g. "finance/payments"). Bare names (no "/") map to the default
+#      namespace; "ns/name" maps to namespace "ns".
+#   2. Semantic assignments          -> authoritativeDefinitions entries with
+#      type "http://databricks.com/ontology/uc/semanticAssignment" at the
+#      contract, schema, and property levels. Both class (rdfs:Class) and
+#      property (rdf:Property) IRIs are represented.
+#   3. Polymorphic business owners   -> customProperties[].property
+#      "ontos.businessOwners" whose value is a list of
+#      {objectType, userEmail, roleName} records (BusinessOwnerCreate shape).
+#
+# Stable `id` is set on roles, support, slaProperties, customProperties, and
+# servers so the stable_id plumbing in the _create_* helpers is covered.
+# ============================================================================
+
+domain: seller
+dataProduct: my quantum
+version: 1.1.0
+status: active
+id: ontos-ext-53581432-6c55-4ba2-a65f-72344a91553a
+
+authoritativeDefinitions:
+  # Ontos extension: contract-level semantic assignment to an ontology class.
+  - type: "http://databricks.com/ontology/uc/semanticAssignment"
+    url: "https://ontology.example.com/PaymentDataContract"
+  # Plain ODCS authoritative definition (non-semantic) must be preserved.
+  - type: canonical
+    url: https://github.com/bitol-io/open-data-contract-standard/blob/main/docs/examples/all/full-example.odcs.yaml
+    description: Canonical URL to the latest version of the contract.
+
+description:
+  purpose: Views built on top of the seller tables.
+  limitations: Data based on seller perspective, no buyer information
+  usage: Predict sales over time
+  authoritativeDefinitions:
+    - type: privacy-statement
+      url: https://example.com/gdpr.pdf
+tenant: ClimateQuantumInc
+
+kind: DataContract
+apiVersion: v3.1.0
+
+# Infrastructure & servers (stable id on the server)
+servers:
+  - id: srv-001
+    server: my-postgres
+    type: postgres
+    host: localhost
+    port: 5432
+    database: pypl-edw
+    schema: pp_access_views
+
+# Dataset, schema, and quality
+schema:
+  - id: tbl_obj
+    name: tbl
+    physicalName: tbl_1
+    physicalType: table
+    businessName: Core Payment Metrics
+    description: Provides core payment metrics
+    authoritativeDefinitions:
+      - url: https://catalog.data.gov/dataset/air-quality
+        type: businessDefinition
+      # Ontos extension: schema-level semantic assignment to an ontology class.
+      - url: "https://ontology.example.com/PaymentTransaction"
+        type: "http://databricks.com/ontology/uc/semanticAssignment"
+    # Unified tags: bare name + two namespaced FQNs.
+    tags: [ 'finance/payments', 'governance/critical', 'transactions' ]
+    dataGranularityDescription: Aggregation on columns txn_ref_dt, pmt_txn_id
+    relationships:
+      - type: foreignKey
+        from:
+          - tbl.rcvr_id
+          - tbl.rcvr_cntry_code
+        to:
+          - receivers.id
+          - receivers.country_code
+        customProperties:
+          - property: description
+            value: "Composite key linking to receivers table"
+          - property: cardinality
+            value: "many-to-one"
+    properties:
+      - id: txn_ref_dt_prop
+        name: transaction_reference_date
+        physicalName: txn_ref_dt
+        primaryKey: false
+        primaryKeyPosition: -1
+        businessName: transaction reference date
+        logicalType: date
+        physicalType: date
+        required: false
+        description: Reference date for transaction
+        partitioned: true
+        partitionKeyPosition: 1
+        criticalDataElement: false
+        tags: [ 'temporal/reference-date' ]
+        classification: public
+        authoritativeDefinitions:
+          # Ontos extension: property-level semantic assignment to an
+          # ontology property (rdf:Property IRI).
+          - url: "https://ontology.example.com/property/transactionDate"
+            type: "http://databricks.com/ontology/uc/semanticAssignment"
+        transformSourceObjects:
+          - table_name_1
+          - table_name_2
+          - table_name_3
+        transformLogic: sel t1.txn_dt as txn_ref_dt from table_name_1 as t1, table_name_2 as t2, table_name_3 as t3 where t1.txn_dt=date-3
+        transformDescription: defines the logic in business terms; logic for dummies
+        examples:
+          - "2022-10-03"
+          - "2020-01-28"
+        customProperties:
+          - property: anonymizationStrategy
+            value: none
+      - id: rcvr_id_prop
+        name: rcvr_id
+        primaryKey: true
+        primaryKeyPosition: 1
+        businessName: receiver id
+        logicalType: string
+        physicalType: varchar(18)
+        required: false
+        description: A description for column rcvr_id.
+        partitioned: false
+        partitionKeyPosition: -1
+        criticalDataElement: false
+        tags: [ 'identity/uid' ]
+        classification: restricted
+        authoritativeDefinitions:
+          - url: "https://ontology.example.com/property/receiverIdentifier"
+            type: "http://databricks.com/ontology/uc/semanticAssignment"
+        relationships:
+          - to: receivers.id
+            type: foreignKey
+            customProperties:
+              - property: description
+                value: "Links to receiver master data"
+      - id: rcvr_cntry_code_prop
+        name: rcvr_cntry_code
+        primaryKey: false
+        primaryKeyPosition: -1
+        businessName: receiver country code
+        logicalType: string
+        physicalType: varchar(2)
+        required: false
+        description: Country code
+        partitioned: false
+        partitionKeyPosition: -1
+        criticalDataElement: false
+        tags: [ 'pii/country-code' ]
+        classification: public
+        encryptedName: rcvr_cntry_code_encrypted
+        quality:
+          - metric: nullValues
+            mustBe: 0
+            description: column should not contain null values
+            dimension: completeness
+            type: library
+            severity: error
+            businessImpact: operational
+            schedule: 0 20 * * *
+            scheduler: cron
+    quality:
+      - metric: rowCount
+        mustBeGreaterThan: 1000000
+        type: library
+        description: Ensure row count is within expected volume range
+        dimension: completeness
+        method: reconciliation
+        severity: error
+        businessImpact: operational
+        schedule: 0 20 * * *
+        scheduler: cron
+    customProperties:
+      - property: business-key
+        value:
+          - txn_ref_dt
+          - rcvr_id
+
+  # Receivers master table (second schema object).
+  - id: receivers_obj
+    name: receivers
+    physicalName: receivers_master
+    physicalType: table
+    businessName: Receivers Master Data
+    description: Master data for all receivers
+    tags: [ 'master-data', 'governance/critical' ]
+    authoritativeDefinitions:
+      - url: "https://ontology.example.com/Receiver"
+        type: "http://databricks.com/ontology/uc/semanticAssignment"
+    properties:
+      - id: receiver_id_prop
+        name: id
+        primaryKey: true
+        primaryKeyPosition: 1
+        businessName: receiver identifier
+        logicalType: string
+        physicalType: varchar(18)
+        required: true
+        description: Unique identifier for receiver
+        unique: true
+        classification: restricted
+      - id: country_code_prop
+        name: country_code
+        primaryKey: true
+        primaryKeyPosition: 2
+        businessName: receiver country
+        logicalType: string
+        physicalType: varchar(2)
+        required: true
+        description: Country code of the receiver
+        classification: public
+
+# Pricing
+price:
+  priceAmount: 9.95
+  priceCurrency: USD
+  priceUnit: megabyte
+
+# Team (ODCS v3.1.0 Team-as-object with team-level metadata)
+team:
+  id: team-quantum
+  name: my-team
+  description: The team owning the data contract
+  tags: [ 'org/seller-analytics' ]
+  customProperties:
+    - property: costCenter
+      value: CC-4815
+  authoritativeDefinitions:
+    - url: "https://ontology.example.com/Team/SellerAnalytics"
+      type: "http://databricks.com/ontology/uc/semanticAssignment"
+  members:
+    - username: ceastwood
+      role: Data Scientist
+      dateIn: "2022-08-02"
+      dateOut: "2022-10-01"
+      replacedByUsername: mhopper
+    - username: mhopper
+      role: Data Scientist
+      dateIn: "2022-10-01"
+    - username: daustin
+      role: Owner
+      description: Keeper of the grail
+      dateIn: "2022-10-01"
+
+# Roles (stable ids)
+roles:
+  - id: role-001
+    role: microstrategy_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'mandolorian'
+  - id: role-002
+    role: bq_queryman_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: na
+
+# SLA
+slaDefaultElement: tab1.txn_ref_dt
+slaProperties:
+  - id: sla-001
+    property: latency
+    value: 4
+    unit: d
+    element: tab1.txn_ref_dt
+  - id: sla-002
+    property: generalAvailability
+    value: "2022-05-12T09:30:10-08:00"
+
+# Support (stable ids)
+support:
+  - id: sup-001
+    channel: '#product-help'
+    tool: slack
+  - id: sup-002
+    channel: datacontract-ann
+    tool: email
+    url: mailto:datacontract-ann@bitol.io
+
+# Tags: contract-level mix of bare + namespaced FQNs.
+tags:
+  - transactions
+  - domain/seller
+  - governance/critical
+
+# Custom properties, including the Ontos polymorphic-owners extension.
+customProperties:
+  - id: cp-001
+    property: refRulesetName
+    value: gcsc.ruleset.name
+  # Ontos extension: polymorphic business owners. Each record matches the
+  # BusinessOwnerCreate shape (object_type / user_email / role_name). The
+  # objectType values intentionally span multiple polymorphic entity types.
+  - id: cp-owners
+    property: ontos.businessOwners
+    value:
+      - objectType: data_contract
+        userEmail: daustin@example.com
+        roleName: Data Owner
+      - objectType: data_contract
+        userEmail: ceastwood@example.com
+        roleName: Data Steward
+      - objectType: asset
+        userEmail: data-platform@example.com
+        roleName: Technical Owner
+
+contractCreatedTs: "2022-11-15T02:59:43+00:00"

--- a/src/backend/src/tests/data/odcs/minimal.odcs_v3_1_0.yaml
+++ b/src/backend/src/tests/data/odcs/minimal.odcs_v3_1_0.yaml
@@ -1,0 +1,18 @@
+# ============================================================================
+# ODCS v3.1.0 - Minimal contract
+# ============================================================================
+# Contains ONLY the fields the app treats as required for a usable contract:
+# the ODCS-required id/kind/apiVersion/version/status plus name (required for
+# app usability per ODCSContract). No schema, team, servers, quality, tags,
+# pricing, SLA, support, or custom properties.
+#
+# Use this to assert that optional sections are gracefully absent on
+# import/export and that the minimal create path works end to end.
+# ============================================================================
+
+id: minimal-0001
+kind: DataContract
+apiVersion: v3.1.0
+version: 1.0.0
+status: draft
+name: Minimal Contract

--- a/src/backend/src/tests/data/odcs/quality-rules-matrix.odcs_v3_1_0.yaml
+++ b/src/backend/src/tests/data/odcs/quality-rules-matrix.odcs_v3_1_0.yaml
@@ -1,0 +1,158 @@
+# ============================================================================
+# ODCS v3.1.0 - Quality rules matrix
+# ============================================================================
+# Dedicated fixture exercising the full breadth of the ODCS quality model so
+# quality parsing/export can be asserted in one place. It covers:
+#
+#   * Every quality `type`: text, library, sql, custom.
+#   * Every comparator: mustBe, mustNotBe, mustBeGreaterThan,
+#     mustBeGreaterOrEqualTo, mustBeLessThan, mustBeLessOrEqualTo,
+#     mustBeBetween, mustNotBeBetween.
+#   * Every ODCS dimension: accuracy, completeness, conformity, consistency,
+#     coverage, timeliness, uniqueness.
+#   * Both business impact values (operational, regulatory) and all severities
+#     (info, warning, error).
+#   * Quality at BOTH the schema-object level and the property level.
+# ============================================================================
+
+id: quality-matrix-0001
+kind: DataContract
+apiVersion: v3.1.0
+version: 1.0.0
+status: active
+name: Quality Rules Matrix Contract
+domain: quality
+
+description:
+  purpose: Exercise every ODCS quality type, comparator, and dimension.
+
+schema:
+  - id: txns_obj
+    name: transactions
+    physicalName: transactions
+    physicalType: table
+    description: Table carrying schema-level and property-level quality rules.
+
+    # --- Schema-level quality rules ---
+    quality:
+      # type: text (free-form human-readable expectation)
+      - type: text
+        description: Row counts should look sensible to a human reviewer.
+        dimension: completeness
+        severity: info
+        businessImpact: operational
+
+      # type: library + mustBeGreaterThan
+      - type: library
+        rule: rowCount
+        mustBeGreaterThan: 1000000
+        dimension: completeness
+        method: reconciliation
+        severity: error
+        businessImpact: operational
+        schedule: 0 20 * * *
+        scheduler: cron
+
+      # type: library + mustBeGreaterOrEqualTo
+      - type: library
+        rule: rowCount
+        mustBeGreaterOrEqualTo: 1000000
+        dimension: coverage
+        severity: warning
+        businessImpact: operational
+
+      # type: library + mustBeBetween (range comparator)
+      - type: library
+        rule: freshnessHours
+        mustBeBetween: [0, 24]
+        unit: hours
+        dimension: timeliness
+        severity: warning
+        businessImpact: operational
+
+      # type: sql + mustBe (custom query returning a single value)
+      - type: sql
+        query: SELECT COUNT(*) FROM transactions WHERE amount < 0
+        mustBe: 0
+        dimension: accuracy
+        severity: error
+        businessImpact: regulatory
+
+      # type: custom (external engine)
+      - type: custom
+        engine: greatExpectations
+        implementation: |
+          expectation_suite: transactions_suite
+          expectations:
+            - expect_table_row_count_to_be_between:
+                min_value: 1
+        dimension: consistency
+        severity: warning
+        businessImpact: operational
+
+    properties:
+      - id: txns_id
+        name: transaction_id
+        logicalType: string
+        physicalType: varchar(36)
+        primaryKey: true
+        primaryKeyPosition: 1
+        required: true
+        # --- Property-level quality rules ---
+        quality:
+          # uniqueness + mustBe
+          - type: library
+            rule: duplicateCount
+            mustBe: 0
+            dimension: uniqueness
+            severity: error
+            businessImpact: regulatory
+          # completeness + mustNotBe
+          - type: library
+            rule: nullCount
+            mustNotBe: 1
+            dimension: completeness
+            severity: error
+            businessImpact: operational
+
+      - id: txns_amount
+        name: amount
+        logicalType: number
+        physicalType: decimal(10,2)
+        required: true
+        quality:
+          # accuracy + mustBeLessThan
+          - type: library
+            rule: maxValue
+            mustBeLessThan: 1000000
+            dimension: accuracy
+            severity: warning
+            businessImpact: operational
+          # accuracy + mustBeLessOrEqualTo
+          - type: library
+            rule: maxValue
+            mustBeLessOrEqualTo: 999999
+            dimension: accuracy
+            severity: info
+            businessImpact: operational
+          # mustNotBeBetween (exclusion range)
+          - type: library
+            rule: value
+            mustNotBeBetween: [-1, 0]
+            dimension: conformity
+            severity: warning
+            businessImpact: operational
+
+      - id: txns_currency
+        name: currency_code
+        logicalType: string
+        physicalType: varchar(3)
+        required: true
+        quality:
+          # conformity + sql query
+          - type: sql
+            query: SELECT COUNT(*) FROM transactions WHERE LENGTH(currency_code) <> 3
+            mustBe: 0
+            dimension: conformity
+            severity: error
+            businessImpact: regulatory

--- a/src/backend/src/tests/data/odcs/relationships-composite-keys.odcs_v3_1_0.yaml
+++ b/src/backend/src/tests/data/odcs/relationships-composite-keys.odcs_v3_1_0.yaml
@@ -1,0 +1,141 @@
+# ============================================================================
+# ODCS v3.1.0 - Relationships / composite foreign keys focus fixture
+# ============================================================================
+# Slim contract dedicated to the ODCS v3.1.0 `relationships` model so tests can
+# assert relationship parsing without full-document noise. Covers:
+#
+#   * Schema-level composite foreign key (multi-column from/to arrays).
+#   * Property-level single-column relationship with EXPLICIT `to`
+#     (implicit `from`).
+#   * Property-level relationship with customProperties metadata.
+#   * A relationship that omits an explicit `type` (should default to
+#     "foreignKey" per SchemaRelationship).
+#
+# Three tables: orders (fact) -> customers (dim) and orders -> products (dim),
+# with a composite FK from order_lines to orders.
+# ============================================================================
+
+id: relationships-0001
+kind: DataContract
+apiVersion: v3.1.0
+version: 1.0.0
+status: active
+name: Relationships Composite Keys Contract
+domain: commerce
+
+description:
+  purpose: Exercise schema-level and property-level ODCS relationships.
+
+schema:
+  - id: orders_obj
+    name: orders
+    physicalName: orders
+    physicalType: table
+    description: Order header fact table.
+    properties:
+      - id: orders_order_id
+        name: order_id
+        logicalType: string
+        physicalType: varchar(36)
+        primaryKey: true
+        primaryKeyPosition: 1
+        required: true
+      - id: orders_customer_id
+        name: customer_id
+        logicalType: string
+        physicalType: varchar(36)
+        required: true
+        description: FK to customers.
+        # Property-level relationship, explicit `to`, implicit `from`.
+        relationships:
+          - to: customers.customer_id
+            type: foreignKey
+            customProperties:
+              - property: description
+                value: "Each order belongs to exactly one customer"
+              - property: cardinality
+                value: "many-to-one"
+      - id: orders_product_id
+        name: product_id
+        logicalType: string
+        physicalType: varchar(36)
+        required: true
+        description: FK to products.
+        # Relationship with NO explicit type -> should default to foreignKey.
+        relationships:
+          - to: products.product_id
+
+  - id: order_lines_obj
+    name: order_lines
+    physicalName: order_lines
+    physicalType: table
+    description: Order line items keyed by a composite (order_id, line_no).
+    # Schema-level COMPOSITE foreign key (multi-column from/to).
+    relationships:
+      - type: foreignKey
+        from:
+          - order_lines.order_id
+          - order_lines.line_no
+        to:
+          - orders.order_id
+          - orders.line_no
+        customProperties:
+          - property: description
+            value: "Composite key linking order lines back to order header"
+          - property: cardinality
+            value: "many-to-one"
+    properties:
+      - id: order_lines_order_id
+        name: order_id
+        logicalType: string
+        physicalType: varchar(36)
+        primaryKey: true
+        primaryKeyPosition: 1
+        required: true
+      - id: order_lines_line_no
+        name: line_no
+        logicalType: integer
+        physicalType: int
+        primaryKey: true
+        primaryKeyPosition: 2
+        required: true
+      - id: order_lines_qty
+        name: quantity
+        logicalType: integer
+        physicalType: int
+        required: true
+
+  - id: customers_obj
+    name: customers
+    physicalName: customers
+    physicalType: table
+    description: Customer dimension (composite natural key for demonstration).
+    properties:
+      - id: customers_customer_id
+        name: customer_id
+        logicalType: string
+        physicalType: varchar(36)
+        primaryKey: true
+        primaryKeyPosition: 1
+        required: true
+        unique: true
+      - id: customers_region_code
+        name: region_code
+        logicalType: string
+        physicalType: varchar(4)
+        required: true
+
+  - id: products_obj
+    name: products
+    physicalName: products
+    physicalType: table
+    description: Product dimension.
+    properties:
+      - id: products_product_id
+        name: product_id
+        logicalType: string
+        physicalType: varchar(36)
+        primaryKey: true
+        primaryKeyPosition: 1
+        required: true
+        unique: true

--- a/src/backend/src/tests/data/odcs/team-as-object.odcs_v3_1_0.yaml
+++ b/src/backend/src/tests/data/odcs/team-as-object.odcs_v3_1_0.yaml
@@ -1,0 +1,76 @@
+# ============================================================================
+# ODCS v3.1.0 - Team-as-object focus fixture
+# ============================================================================
+# Minimal contract whose sole purpose is to exercise the ODCS v3.1.0
+# Team-as-object shape and the _create_team_metadata path
+# (DataContractTeamMetadataDb): team-level id, name, description, tags,
+# customProperties, and authoritativeDefinitions (both a semantic assignment
+# and a plain businessDefinition). Members carry the v3.1.0 dateIn/dateOut/
+# replacedByUsername lifecycle fields.
+# ============================================================================
+
+id: team-object-0001
+kind: DataContract
+apiVersion: v3.1.0
+version: 1.0.0
+status: active
+name: Team As Object Contract
+domain: platform
+tenant: AcmeCorp
+
+description:
+  purpose: Validate ODCS v3.1.0 Team-as-object parsing and team metadata persistence.
+
+schema:
+  - name: events
+    physicalName: events_tbl
+    physicalType: table
+    description: Minimal schema so the contract is not empty.
+    properties:
+      - name: event_id
+        logicalType: string
+        physicalType: varchar(36)
+        primaryKey: true
+        primaryKeyPosition: 1
+        required: true
+
+# ODCS v3.1.0 Team object (NOT the deprecated array form).
+team:
+  id: team-platform-core
+  name: Platform Core Team
+  description: Owns and maintains the shared platform event streams.
+  tags:
+    - org/platform
+    - team/core
+  customProperties:
+    - property: costCenter
+      value: CC-1001
+    - property: onCallRotation
+      value: platform-core-oncall
+  authoritativeDefinitions:
+    # Semantic assignment at the team level.
+    - url: "https://ontology.example.com/Team/PlatformCore"
+      type: "http://databricks.com/ontology/uc/semanticAssignment"
+    # Plain (non-semantic) authoritative definition must be preserved.
+    - url: "https://wiki.example.com/teams/platform-core"
+      type: businessDefinition
+  members:
+    - username: alice@example.com
+      name: Alice Anders
+      role: Owner
+      description: Team lead and primary owner.
+      dateIn: "2021-01-15"
+    - username: bob@example.com
+      name: Bob Becker
+      role: Data Engineer
+      dateIn: "2020-06-01"
+      dateOut: "2023-03-31"
+      replacedByUsername: carol@example.com
+    - username: carol@example.com
+      name: Carol Chen
+      role: Data Engineer
+      dateIn: "2023-04-01"
+
+tags:
+  - platform
+  - team/core

--- a/src/backend/src/tests/data/odps/full-example.odps_v1_0_0-ontos-extensions.yaml
+++ b/src/backend/src/tests/data/odps/full-example.odps_v1_0_0-ontos-extensions.yaml
@@ -1,0 +1,133 @@
+# ============================================================================
+# ODPS v1.0.0 full example + ONTOS EXTENSIONS
+# ============================================================================
+# Superset of full-example.odps_v1_0_0.yaml that adds Ontos-specific fields:
+#
+#   1. consumer_principals  -> typed principals (group / service_principal /
+#      role / scope). See ConsumerPrincipal in data_products.py.
+#   2. max_level_inheritance -> metadata inheritance depth from contracts.
+#   3. Polymorphic business owners -> customProperties[].property
+#      "ontos.businessOwners" with {objectType, userEmail, roleName} records.
+#   4. Unified tags with namespaces -> FQN strings ("ns/name") mixed with
+#      bare names.
+#   5. Semantic assignments -> authoritativeDefinitions with type
+#      "http://databricks.com/ontology/uc/semanticAssignment" on the product
+#      itself and on individual ports.
+# ============================================================================
+
+apiVersion: v1.0.0
+kind: DataProduct
+id: ontos-ext-dp-0001
+name: Seller Analytics Data Product (Ontos)
+version: 1.0.0
+status: active
+domain: seller
+tenant: ClimateQuantumInc
+
+# Ontos extension: metadata inheritance depth.
+max_level_inheritance: 5
+
+# Ontos extension: typed consumer principals (polymorphic identity methods).
+consumer_principals:
+  - type: group
+    value: seller-analytics-consumers
+  - type: service_principal
+    value: 12345678-90ab-cdef-1234-567890abcdef
+  - type: role
+    value: analytics_reader
+  - type: scope
+    value: read:seller-analytics
+
+description:
+  purpose: Curated seller analytics with Ontos governance metadata.
+  usage: Subscribe via output ports; ownership and semantics are app-managed.
+
+authoritativeDefinitions:
+  # Ontos extension: product-level semantic assignment.
+  - type: "http://databricks.com/ontology/uc/semanticAssignment"
+    url: "https://ontology.example.com/SellerAnalyticsProduct"
+  - type: businessDefinition
+    url: https://wiki.example.com/products/seller-analytics
+
+customProperties:
+  - property: costCenter
+    value: CC-4815
+  # Ontos extension: polymorphic business owners (BusinessOwnerCreate shape).
+  - property: ontos.businessOwners
+    value:
+      - objectType: data_product
+        userEmail: daustin@example.com
+        roleName: Data Owner
+      - objectType: data_product
+        userEmail: mhopper@example.com
+        roleName: Data Steward
+      - objectType: asset
+        userEmail: data-platform@example.com
+        roleName: Technical Owner
+
+# Unified tags: mix of bare names and namespaced FQNs.
+tags:
+  - seller
+  - domain/seller
+  - governance/certified
+
+inputPorts:
+  - name: raw-orders
+    version: 1.0.0
+    contractId: raw-orders-contract-001
+    assetType: table
+    assetIdentifier: main.raw.orders
+
+outputPorts:
+  - id: op-sales-table
+    name: sales-aggregates
+    version: 1.0.0
+    description: Daily sales aggregates published as a Delta table.
+    type: Table
+    contractId: sales-aggregates-contract-001
+    assetType: table
+    assetIdentifier: main.seller_analytics.sales_aggregates
+    status: active
+    containsPii: false
+    autoApprove: true
+    server:
+      database: main
+      schema: seller_analytics
+      table: sales_aggregates
+    tags:
+      - gold
+      - governance/certified
+    authoritativeDefinitions:
+      # Ontos extension: port-level semantic assignment.
+      - type: "http://databricks.com/ontology/uc/semanticAssignment"
+        url: "https://ontology.example.com/SalesAggregate"
+
+managementPorts:
+  - name: observability-endpoint
+    content: observability
+    type: rest
+    url: https://api.example.com/products/seller-analytics/health
+
+support:
+  - channel: '#seller-analytics-help'
+    url: https://example.slack.com/archives/C0SELLER
+    tool: slack
+    scope: interactive
+
+team:
+  name: Seller Analytics Team
+  description: Owns the seller analytics product end to end.
+  authoritativeDefinitions:
+    - type: "http://databricks.com/ontology/uc/semanticAssignment"
+      url: "https://ontology.example.com/Team/SellerAnalytics"
+  members:
+    - username: daustin@example.com
+      name: Dirk Austin
+      role: owner
+      dateIn: "2022-10-01"
+    - username: mhopper@example.com
+      name: Mary Hopper
+      role: data steward
+      dateIn: "2022-10-01"
+
+productCreatedTs: "2022-11-15T02:59:43Z"

--- a/src/backend/src/tests/data/odps/full-example.odps_v1_0_0.yaml
+++ b/src/backend/src/tests/data/odps/full-example.odps_v1_0_0.yaml
@@ -1,0 +1,184 @@
+# ============================================================================
+# ODPS v1.0.0 (Open Data Product Standard) - Full example
+# ============================================================================
+# Comprehensive Bitol ODPS v1.0.0 data product exercising every field the app
+# parses (see src/backend/src/models/data_products.py). Beyond the strict ODPS
+# spec, output ports also carry the app's Databricks extensions
+# (assetType, assetIdentifier, server, containsPii, autoApprove,
+# deliveryMethodId) so the OutputPort model is fully covered.
+# ============================================================================
+
+apiVersion: v1.0.0
+kind: DataProduct
+id: full-example-dp-0001
+name: Seller Analytics Data Product
+version: 1.0.0
+status: active
+domain: seller
+tenant: ClimateQuantumInc
+
+description:
+  purpose: Curated seller analytics for downstream reporting and ML.
+  limitations: Aggregated from seller perspective only; no buyer-side data.
+  usage: Subscribe to the output ports for sales forecasting and dashboards.
+  authoritativeDefinitions:
+    - type: businessDefinition
+      url: https://wiki.example.com/products/seller-analytics
+  customProperties:
+    - property: reviewCadence
+      value: quarterly
+
+authoritativeDefinitions:
+  - type: businessDefinition
+    url: https://wiki.example.com/products/seller-analytics
+  - type: tutorial
+    url: https://youtu.be/seller-analytics-intro
+
+customProperties:
+  - property: costCenter
+    value: CC-4815
+  - property: dataClassification
+    value: internal
+
+tags:
+  - seller
+  - analytics
+  - finance
+
+# --- Input ports (each REQUIRES a contractId per ODPS) ---
+inputPorts:
+  - name: raw-orders
+    version: 1.0.0
+    contractId: raw-orders-contract-001
+    tags:
+      - source
+    assetType: table
+    assetIdentifier: main.raw.orders
+    customProperties:
+      - property: ingestionTool
+        value: autoloader
+    authoritativeDefinitions:
+      - type: implementation
+        url: https://github.com/example/raw-orders-pipeline
+  - name: raw-customers
+    version: 1.0.0
+    contractId: raw-customers-contract-001
+    assetType: table
+    assetIdentifier: main.raw.customers
+
+# --- Output ports (promises; carry Databricks connection extensions) ---
+outputPorts:
+  - id: op-sales-table
+    name: sales-aggregates
+    version: 1.0.0
+    description: Daily sales aggregates published as a Delta table.
+    type: Table
+    contractId: sales-aggregates-contract-001
+    assetType: table
+    assetIdentifier: main.seller_analytics.sales_aggregates
+    status: active
+    containsPii: false
+    autoApprove: true
+    server:
+      database: main
+      schema: seller_analytics
+      table: sales_aggregates
+    sbom:
+      - type: external
+        url: https://sbom.example.com/seller-analytics/sales-aggregates
+    inputContracts:
+      - id: raw-orders-contract-001
+        version: 1.0.0
+      - id: raw-customers-contract-001
+        version: 1.0.0
+    tags:
+      - gold
+    customProperties:
+      - property: refreshSchedule
+        value: 0 6 * * *
+    authoritativeDefinitions:
+      - type: businessDefinition
+        url: https://wiki.example.com/ports/sales-aggregates
+  - id: op-sales-share
+    name: sales-share
+    version: 1.0.0
+    description: Delta Sharing output of the same aggregates for external partners.
+    type: Table
+    contractId: sales-aggregates-contract-001
+    assetType: table
+    assetIdentifier: share.seller_analytics.sales_aggregates
+    status: active
+    containsPii: false
+    autoApprove: false
+    server:
+      share: seller_analytics_share
+      database: main
+      schema: seller_analytics
+
+# --- Management ports (all four ODPS content types) ---
+managementPorts:
+  - name: discovery-endpoint
+    content: discoverability
+    type: rest
+    url: https://api.example.com/products/seller-analytics/discovery
+    description: Discovery and catalog metadata.
+  - name: observability-endpoint
+    content: observability
+    type: rest
+    url: https://api.example.com/products/seller-analytics/health
+    description: Health, freshness, and quality metrics.
+  - name: control-endpoint
+    content: control
+    type: rest
+    url: https://api.example.com/products/seller-analytics/control
+    description: Lifecycle and access control operations.
+  - name: dictionary-topic
+    content: dictionary
+    type: topic
+    channel: seller-analytics-dictionary
+    description: Schema/dictionary change events.
+
+# --- Support channels ---
+support:
+  - channel: '#seller-analytics-help'
+    url: https://example.slack.com/archives/C0SELLER
+    tool: slack
+    scope: interactive
+  - channel: seller-analytics-announce
+    url: mailto:seller-analytics-announce@example.com
+    tool: email
+    scope: announcements
+  - channel: seller-analytics-issues
+    url: https://jira.example.com/projects/SELLER
+    tool: ticket
+    scope: issues
+
+# --- Team (ODPS Team object) ---
+team:
+  name: Seller Analytics Team
+  description: Owns the seller analytics product end to end.
+  tags:
+    - org/seller-analytics
+  customProperties:
+    - property: timezone
+      value: Europe/Berlin
+  authoritativeDefinitions:
+    - type: businessDefinition
+      url: https://wiki.example.com/teams/seller-analytics
+  members:
+    - username: daustin@example.com
+      name: Dirk Austin
+      role: owner
+      dateIn: "2022-10-01"
+    - username: mhopper@example.com
+      name: Mary Hopper
+      role: data steward
+      dateIn: "2022-10-01"
+    - username: ceastwood@example.com
+      name: Clint Eastwood
+      role: data engineer
+      dateIn: "2022-08-02"
+      dateOut: "2022-10-01"
+      replacedByUsername: mhopper@example.com
+
+productCreatedTs: "2022-11-15T02:59:43Z"

--- a/src/backend/src/tests/data/odps/minimal.odps_v1_0_0.yaml
+++ b/src/backend/src/tests/data/odps/minimal.odps_v1_0_0.yaml
@@ -1,0 +1,15 @@
+# ============================================================================
+# ODPS v1.0.0 - Minimal data product
+# ============================================================================
+# Contains ONLY the ODPS-required fields: apiVersion, kind, id, status.
+# No name, version, ports, team, support, tags, or custom properties.
+#
+# Use this to assert the minimal create path and graceful absence of all
+# optional sections. Note: a product with no input/output ports is valid per
+# the ODPS schema's required set, even though it is not useful in practice.
+# ============================================================================
+
+apiVersion: v1.0.0
+kind: DataProduct
+id: minimal-dp-0001
+status: draft

--- a/src/backend/src/tests/data/odps/multi-product-batch.odps_v1_0_0.yaml
+++ b/src/backend/src/tests/data/odps/multi-product-batch.odps_v1_0_0.yaml
@@ -1,0 +1,73 @@
+# ============================================================================
+# ODPS v1.0.0 - Multi-product batch
+# ============================================================================
+# Top-level YAML LIST of data products, used to drive the batch upload path
+# (DataProductsManager.upload_products_batch). The batch is intentionally a
+# mix of valid and invalid entries so per-item error collection can be
+# asserted:
+#
+#   [0] valid     - complete minimal product.
+#   [1] valid     - product with ports + team.
+#   [2] INVALID   - missing the required `id` field (create should fail and be
+#                   collected into the errors list, not abort the whole batch).
+#   [3] INVALID   - duplicate id (same id as [0]); exercises duplicate handling.
+#
+# Expectation: items [0] and [1] are created; items [2] and [3] are reported
+# in the errors list.
+# ============================================================================
+
+- apiVersion: v1.0.0
+  kind: DataProduct
+  id: batch-product-001
+  name: Batch Product One
+  version: 1.0.0
+  status: active
+  domain: sales
+  description:
+    purpose: First valid product in the batch.
+  tags:
+    - sales
+
+- apiVersion: v1.0.0
+  kind: DataProduct
+  id: batch-product-002
+  name: Batch Product Two
+  version: 1.0.0
+  status: draft
+  domain: marketing
+  description:
+    purpose: Second valid product, with ports and a team.
+  inputPorts:
+    - name: raw-leads
+      version: 1.0.0
+      contractId: raw-leads-contract-001
+  outputPorts:
+    - name: scored-leads
+      version: 1.0.0
+      type: Table
+      contractId: scored-leads-contract-001
+      assetType: table
+      assetIdentifier: main.marketing.scored_leads
+  team:
+    name: Marketing Analytics
+    members:
+      - username: lead-owner@example.com
+        role: owner
+        dateIn: "2023-01-01"
+
+# INVALID: missing required `id` field.
+- apiVersion: v1.0.0
+  kind: DataProduct
+  name: Batch Product Missing Id
+  version: 1.0.0
+  status: active
+  domain: ops
+
+# INVALID: duplicate id (collides with batch-product-001).
+- apiVersion: v1.0.0
+  kind: DataProduct
+  id: batch-product-001
+  name: Batch Product Duplicate Id
+  version: 2.0.0
+  status: active
+  domain: sales

--- a/src/backend/src/tests/data/odps/ports-matrix.odps_v1_0_0.yaml
+++ b/src/backend/src/tests/data/odps/ports-matrix.odps_v1_0_0.yaml
@@ -1,0 +1,122 @@
+# ============================================================================
+# ODPS v1.0.0 - Ports matrix
+# ============================================================================
+# Dedicated fixture exercising every input/output/management port variant so
+# port parsing can be asserted in one place. Covers:
+#
+#   Input ports:
+#     * Standard input port with a contract.
+#     * Input port with customProperties + authoritativeDefinitions.
+#   Output ports:
+#     * Table output port + Databricks share server (Delta Sharing).
+#     * Topic output port + Kafka server (host/topic/format).
+#     * S3/file output port + object-store server (location/format/delimiter).
+#     * BigQuery output port + server (project/dataset).
+#     * Contract-less output port (no contractId).
+#     * Output port carrying inheritance-suppressing tags.
+#   Management ports:
+#     * rest type and topic type.
+# ============================================================================
+
+apiVersion: v1.0.0
+kind: DataProduct
+id: ports-matrix-dp-0001
+name: Ports Matrix Data Product
+version: 1.0.0
+status: active
+domain: platform
+
+description:
+  purpose: Exercise the full matrix of ODPS port shapes and server types.
+
+inputPorts:
+  - name: input-with-contract
+    version: 1.0.0
+    contractId: input-contract-001
+  - name: input-with-metadata
+    version: 1.0.0
+    contractId: input-contract-002
+    tags:
+      - source
+    customProperties:
+      - property: ingestionTool
+        value: fivetran
+    authoritativeDefinitions:
+      - type: implementation
+        url: https://github.com/example/input-pipeline
+
+outputPorts:
+  # Databricks Delta Sharing table.
+  - id: op-share
+    name: share-table
+    version: 1.0.0
+    type: Table
+    contractId: share-contract-001
+    assetType: table
+    assetIdentifier: share.analytics.metrics
+    server:
+      share: analytics_share
+      database: main
+      schema: analytics
+
+  # Kafka topic.
+  - id: op-topic
+    name: events-topic
+    version: 1.0.0
+    type: Topic
+    contractId: events-contract-001
+    assetType: stream
+    assetIdentifier: events.metrics
+    server:
+      host: kafka.example.com:9092
+      topic: analytics.metrics
+      format: avro
+
+  # S3 / object-store file output.
+  - id: op-s3
+    name: parquet-export
+    version: 1.0.0
+    type: File
+    contractId: export-contract-001
+    server:
+      location: s3://example-bucket/analytics/metrics/
+      format: parquet
+      delimiter: newline
+
+  # BigQuery output.
+  - id: op-bq
+    name: bigquery-export
+    version: 1.0.0
+    type: Table
+    contractId: bq-contract-001
+    server:
+      project: example-gcp-project
+      dataset: analytics
+
+  # Contract-less output port (contractId omitted).
+  - id: op-no-contract
+    name: adhoc-extract
+    version: 1.0.0
+    type: Table
+    assetType: view
+    assetIdentifier: main.analytics.adhoc_extract
+
+  # Output port carrying inheritance-suppressing tags.
+  - id: op-tagged
+    name: tagged-output
+    version: 1.0.0
+    type: Table
+    contractId: tagged-contract-001
+    tags:
+      - no-inherit
+      - governance/restricted
+
+managementPorts:
+  - name: rest-observability
+    content: observability
+    type: rest
+    url: https://api.example.com/ports-matrix/health
+  - name: topic-control
+    content: control
+    type: topic
+    channel: ports-matrix-control


### PR DESCRIPTION
## Summary

- Expands `src/backend/src/tests/data` with a broader matrix of ODCS contract and ODPS data product YAML fixtures so tests can exercise Ontos-specific extensions (polymorphic owners, namespaced unified tags, semantic assignments, v3.1.0 Team-as-object, ports, consumer principals) on top of the baseline Bitol specs.
- Adds the canonical `odcs/full-example.odcs.yaml` that the existing `test_odcs_roundtrip.py` and `test_odcs_export_validation.py` integration tests reference by name (it was previously missing, so the roundtrip test's `assert reference_path.exists()` would fail).
- Introduces a new `odps/` fixtures folder (none existed before).

### ODCS fixtures (`src/backend/src/tests/data/odcs/`)
- `full-example.odcs.yaml` — canonical reference (single schema object, team-as-array, rule-based quality to satisfy existing test assertions).
- `full-example.odcs_v3_1_0-ontos-extensions.yaml` — v3.1.0 superset with namespaced tag FQNs, semantic-assignment `authoritativeDefinitions` at every level, `ontos.businessOwners` custom property, and stable ids.
- `team-as-object.odcs_v3_1_0.yaml` — v3.1.0 Team-as-object shape.
- `minimal.odcs_v3_1_0.yaml` — required fields only.
- `relationships-composite-keys.odcs_v3_1_0.yaml` — schema- and property-level FK relationships.
- `quality-rules-matrix.odcs_v3_1_0.yaml` — every quality type, comparator, and dimension.

### ODPS fixtures (`src/backend/src/tests/data/odps/`)
- `full-example.odps_v1_0_0.yaml` — all input/output/management ports, server details, SBOM, input contracts, support, team.
- `full-example.odps_v1_0_0-ontos-extensions.yaml` — `consumer_principals`, `max_level_inheritance`, `ontos.businessOwners`, namespaced tags, semantic assignments.
- `minimal.odps_v1_0_0.yaml` — required fields only.
- `ports-matrix.odps_v1_0_0.yaml` — Kafka topic, Databricks share, S3 file, BigQuery, contract-less, tagged ports.
- `multi-product-batch.odps_v1_0_0.yaml` — top-level list (valid + invalid) for the batch upload path.

### Docs
- `tests/data/README.md` documents the folder layout and the three Ontos encoding conventions (semantic assignments via `authoritativeDefinitions`, namespaced tag FQNs, `ontos.businessOwners`), plus pointers to the JSON schemas.

This change is fixtures-only: no test or ingestion code was modified.

## Test plan
- [x] All 17 ODCS/ODPS YAML fixtures parse via `yaml.safe_load_all` (multi-product batch loads as a list).
- [ ] `test_odcs_roundtrip.py` and `test_odcs_export_validation.py` now find `full-example.odcs.yaml` and pass.
- [ ] New fixtures wired into tests in follow-up work as needed.