### PR TITLE
fix(glossary): allow choosing collection in Create Concept dialog

### DIFF
--- a/src/frontend/src/components/knowledge/concept-editor-dialog.tsx
+++ b/src/frontend/src/components/knowledge/concept-editor-dialog.tsx
@@ -110,6 +110,7 @@ export const ConceptEditorDialog: React.FC<ConceptEditorDialogProps> = ({
 
   const isNew = !concept;
   const canEdit = !readOnly && (!concept?.status || concept.status === 'draft');
+  const editableCollections = collections.filter((c) => c.is_editable);
 
   useEffect(() => {
     if (concept) {
@@ -250,7 +251,7 @@ export const ConceptEditorDialog: React.FC<ConceptEditorDialogProps> = ({
           <form onSubmit={handleSubmit}>
             <div className="grid gap-4 py-4 px-1">
               {/* Collection (for new concepts) */}
-              {isNew && collections.length > 0 && (
+              {isNew && editableCollections.length > 0 && (
                 <div className="grid gap-2">
                   <Label htmlFor="collection">{t('Collection')}</Label>
                   <Select
@@ -258,19 +259,17 @@ export const ConceptEditorDialog: React.FC<ConceptEditorDialogProps> = ({
                     onValueChange={(value) =>
                       setFormData((prev) => ({ ...prev, collection_iri: value }))
                     }
-                    disabled={!!collection}
+                    disabled={editableCollections.length <= 1}
                   >
                     <SelectTrigger>
                       <SelectValue placeholder={t('Select collection...')} />
                     </SelectTrigger>
                     <SelectContent>
-                      {collections
-                        .filter((c) => c.is_editable)
-                        .map((c) => (
-                          <SelectItem key={c.iri} value={c.iri}>
-                            {c.label}
-                          </SelectItem>
-                        ))}
+                      {editableCollections.map((c) => (
+                        <SelectItem key={c.iri} value={c.iri}>
+                          {c.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/frontend/src/tests/cuj-4-glossary.spec.ts
+++ b/src/frontend/src/tests/cuj-4-glossary.spec.ts
@@ -83,8 +83,9 @@ test.describe('CUJ-4 — Business Terms Browser', () => {
       const dialog = page.getByRole('dialog')
       await expect(dialog).toBeVisible()
 
-      // The collection select is auto-filled and disabled when a default
-      // collection is provided — no need to interact with it.
+      // The collection select defaults to the first editable collection. It is
+      // interactive when multiple editable collections exist, but this test
+      // relies on the default, so we don't switch it.
       await dialog.getByLabel(/^label$/i).fill(conceptLabel)
 
       await dialog.getByRole('button', { name: /^create$/i }).click()

--- a/src/frontend/src/views/business-terms.tsx
+++ b/src/frontend/src/views/business-terms.tsx
@@ -332,7 +332,9 @@ export default function BusinessTermsView() {
   const editableCollections = collections.filter((c) => c.is_editable);
   const totalConcepts = stats?.total_concepts ?? Object.values(groupedConcepts).flat().length;
   const totalProperties = stats?.total_properties ?? Object.values(groupedProperties).flat().length;
-  const selectedCollection = editableCollections[0] || null;
+  // Seed the editor with a default collection; the dialog lets the user pick
+  // another when more than one editable collection exists.
+  const defaultCollection = editableCollections[0];
 
   return (
     <div className="flex flex-col py-6">
@@ -443,7 +445,7 @@ export default function BusinessTermsView() {
         open={conceptEditorOpen}
         onOpenChange={setConceptEditorOpen}
         concept={null}
-        collection={selectedCollection || editableCollections[0]}
+        collection={defaultCollection}
         collections={editableCollections}
         onSave={handleSaveConcept}
       />


### PR DESCRIPTION
## Summary
- The collection picker in the Create Concept dialog was disabled whenever a default `collection` prop was passed. Since the business terms view always passes the first editable collection as a default, users could never switch to another collection when creating a concept.
- Disable the picker only when there is at most one editable collection; otherwise treat the prop purely as a default seed value and let the user pick.
- Cleaned up the misleading `selectedCollection` fallback in `business-terms.tsx` (renamed to `defaultCollection`) and updated the now-incorrect comment in the CUJ-4 glossary e2e spec.

## Changes
- `src/frontend/src/components/knowledge/concept-editor-dialog.tsx`: hoist `editableCollections`, change `disabled={!!collection}` to `disabled={editableCollections.length <= 1}`.
- `src/frontend/src/views/business-terms.tsx`: replace `selectedCollection` fallback chain with a clearly-named `defaultCollection`.
- `src/frontend/src/tests/cuj-4-glossary.spec.ts`: update stale comment describing the old disabled behavior.

## Test plan
- [x] `yarn type-check` passes
- [x] `business-terms.test.tsx` passes
- [ ] Manual: with two editable collections, confirm the Collection dropdown defaults to one but can be switched, and the concept lands in the chosen collection
- [ ] Manual: with a single editable collection, confirm the dropdown is disabled
- [ ] Run `cuj-4-glossary.spec.ts` against the live stack