### PR TITLE
fix(contracts): make a creator's own draft discoverable (ONT-CUJ-006)

### DIFF
--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -2237,12 +2237,28 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             elif not isinstance(description, dict):
                 description = {}
             
+            # A contract created without an owning team would otherwise have no
+            # owner at all, which makes it invisible to its own creator under the
+            # PRD #442 role-aware visibility filter (the family is "elevated" only
+            # for the draft_owner or owner_team members). Stamp the creator as the
+            # personal-draft owner so they can find the contract they just created.
+            # When an owner team is supplied the draft is team-visible from the
+            # start, so we leave draft_owner_id unset (tier-2 visibility). The
+            # draft_owner_id is cleared again on the draft->proposed transition.
+            status_value = data_dict.get('status', 'draft')
+            draft_owner_id = (
+                current_user
+                if (status_value or '').lower() == 'draft' and not owner_team_id
+                else None
+            )
+
             # Create main contract record
             db_obj = DataContractDb(
                 name=data_dict.get('name'),
                 version=data_dict.get('version', '1.0.0'),
-                status=data_dict.get('status', 'draft'),
+                status=status_value,
                 owner_team_id=owner_team_id,
+                draft_owner_id=draft_owner_id,
                 project_id=project_id,  # Add project_id
                 kind=data_dict.get('kind', 'DataContract'),
                 api_version=data_dict.get('apiVersion', 'v3.1.0'),
@@ -4857,8 +4873,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if from_status != 'draft':
             raise ValueError(f"Cannot request review from status {contract.status}. Must be DRAFT.")
         
-        # Transition to PROPOSED
+        # Transition to PROPOSED. Clear the personal-draft owner so the contract
+        # is promoted from tier-1 (creator-only) to organisation visibility; a
+        # contract under steward review must be discoverable by stewards and
+        # other team members, not just its author (PRD #442).
         contract.status = 'proposed'
+        contract.draft_owner_id = None
         db.add(contract)
         db.flush()
         self._update_search_index(contract, db)
@@ -5917,6 +5937,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         project_id=None,
         is_admin=False,
         latest_only=True,
+        status=None,
         *,
         caller_email: Optional[str] = None,
         caller_team_ids: Optional[Set[str]] = None,
@@ -5976,6 +5997,16 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 or (not is_admin_only_status(c) and is_visible_consumer(c))
             ]
 
+        # Optional status filter (e.g. ?status=draft). Applied after the
+        # visibility filter so callers can only ever narrow to statuses they
+        # are already allowed to see — a consumer asking for ?status=draft
+        # still gets nothing because drafts were dropped above.
+        if status:
+            wanted = status.strip().lower()
+            contracts = [
+                c for c in contracts if (c.status or '').lower() == wanted
+            ]
+
         # Family counts are taken from the post-visibility-filter set so
         # the badge reflects what the caller can actually navigate to.
         counts = compute_family_counts(contracts)
@@ -5999,6 +6030,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         db,
         domain_id: Optional[str] = None,
         project_id: Optional[str] = None,
+        status: Optional[str] = None,
         is_admin: bool = False,
         latest_only: bool = True,
         include_history: bool = False,
@@ -6021,6 +6053,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             project_id,
             is_admin,
             latest_only,
+            status=status,
             caller_email=caller_email,
             caller_team_ids=caller_team_ids,
         )

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -90,6 +90,7 @@ async def get_contracts(
     db: DBSessionDep,
     domain_id: Optional[str] = None,
     project_id: Optional[str] = None,
+    status: Optional[str] = None,
     include_history: bool = False,
     current_user: CurrentUserDep = None,
     manager: DataContractsManager = Depends(get_data_contracts_manager),
@@ -101,6 +102,11 @@ async def get_contracts(
     one row per ``version_family_id`` — the newest visible version of each
     family, plus a ``versionCount`` field. When True, every visible version
     is returned (used by the "Show all versions" toggle in the UI).
+
+    ``status`` optionally narrows the result to a single lifecycle status
+    (e.g. ``draft``, ``proposed``, ``active``). The filter is applied *after*
+    the role-aware visibility filter, so it can only narrow the set a caller
+    is already permitted to see.
     """
     try:
         # Check if user is admin
@@ -139,6 +145,7 @@ async def get_contracts(
             db,
             domain_id=domain_id,
             project_id=project_id,
+            status=status,
             is_admin=is_admin,
             include_history=include_history,
             caller_email=caller_email,

--- a/src/backend/src/tests/unit/test_version_family.py
+++ b/src/backend/src/tests/unit/test_version_family.py
@@ -402,6 +402,84 @@ class TestContractsListCollapse:
         # versionCount is intentionally omitted on the expanded view.
         assert all(s.versionCount is None for s in summaries)
 
+    def test_status_filter_narrows_to_single_status(
+        self, db_session: Session, family_with_loose_row
+    ):
+        # ``?status=draft`` must actually filter (previously the route had no
+        # such param so it was silently ignored — CUJ-006). Family A's draft
+        # rep (v3) is the only draft; the active rows must be excluded.
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=True, status="draft"
+        )
+        ids = {s.id for s in summaries}
+        assert ids == {family_with_loose_row["v3"]}
+
+    def test_status_filter_is_case_insensitive(
+        self, db_session: Session, family_with_loose_row
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=True, status="ACTIVE", include_history=True
+        )
+        # Three active rows across the two families; the draft (v3) is excluded.
+        assert {s.id for s in summaries} == {
+            family_with_loose_row["v1"],
+            family_with_loose_row["v2"],
+            family_with_loose_row["loose"],
+        }
+
+
+class TestPersonalDraftVisibility:
+    """A draft stamped with ``draft_owner_id`` is visible to its owner but not
+    to other non-admin callers — the elevation path that lets a contract's
+    creator find the draft they just created (CUJ-006)."""
+
+    @pytest.fixture
+    def two_personal_drafts(self, db_session: Session):
+        from datetime import datetime, timezone
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        alice = str(uuid.uuid4())
+        bob = str(uuid.uuid4())
+        db_session.add(DataContractDb(
+            id=alice, name="Alice Draft", version="1.0.0", status="draft",
+            version_family_id=alice, draft_owner_id="alice@example.com",
+            created_at=base, updated_at=base,
+        ))
+        db_session.add(DataContractDb(
+            id=bob, name="Bob Draft", version="1.0.0", status="draft",
+            version_family_id=bob, draft_owner_id="bob@example.com",
+            created_at=base, updated_at=base,
+        ))
+        db_session.commit()
+        return {"alice": alice, "bob": bob}
+
+    def _manager(self, db_session):
+        from pathlib import Path
+        from src.controller.data_contracts_manager import DataContractsManager
+        return DataContractsManager(data_dir=Path("/tmp"))
+
+    def test_owner_sees_own_draft_others_do_not(
+        self, db_session: Session, two_personal_drafts
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=False, caller_email="alice@example.com"
+        )
+        ids = {s.id for s in summaries}
+        assert two_personal_drafts["alice"] in ids
+        assert two_personal_drafts["bob"] not in ids
+
+    def test_non_owner_consumer_sees_no_drafts(
+        self, db_session: Session, two_personal_drafts
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=False, caller_email="carol@example.com"
+        )
+        # Carol owns neither personal draft and drafts aren't consumer-visible.
+        assert summaries == []
+
 
 class TestProductsListCollapse:
     """``list_products`` collapses by version_family_id and attaches counts."""


### PR DESCRIPTION
## Summary

A data contract created via `POST /api/data-contracts` was saved with **no owner** — `create_contract_with_relations` never set `draft_owner_id`, and only set `owner_team_id` when an `owner` was supplied. Under the PRD #442 role-aware visibility filter, a version family is "elevated" (in-flight statuses visible) only for its `draft_owner` or `owner_team` members. So an owner-less draft was invisible to its own creator: after **Create Contract** the dialog closed and the new contract never appeared in the Data Contracts list.

Two coupled gaps:

1. **No owner on create** -> creator can't see their own draft.
2. **`GET /api/data-contracts` has no `status` query parameter**, so `?status=draft` was silently dropped by FastAPI (the documented "filter by draft" did nothing).

## Changes

- Stamp the creator as `draft_owner_id` when a draft is created without an owning team (mirrors the existing personal-draft clone path at `data_contracts_manager.py:4285`). When an owner team *is* supplied the draft stays team-visible (tier-2), so `draft_owner_id` is left unset.
- Clear `draft_owner_id` on the `draft -> proposed` transition in `request_steward_review`, promoting the contract from creator-only to organisation visibility so it's discoverable once under review.
- Add a real `status` filter to `GET /api/data-contracts`, threaded through `list_contracts_from_db` -> `_query_contracts`. It is applied **after** the visibility filter, so a caller can only ever narrow to statuses they were already permitted to see (a consumer asking `?status=draft` still gets nothing).
- Unit tests covering the `status` filter (incl. case-insensitivity) and personal-draft owner visibility (owner sees their draft; non-owners do not).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression test **ONT-CUJ-006** (Ontos CUJ regression suite — Golden Path): "After New Contract -> Create, the created contract does not appear in the Data Contracts list; the list endpoint excludes drafts and `?status=draft` is ignored."

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_version_family.py` — all pass, including 4 new tests (`test_status_filter_narrows_to_single_status`, `test_status_filter_is_case_insensitive`, `test_owner_sees_own_draft_others_do_not`, `test_non_owner_consumer_sees_no_drafts`).
- Ran the contracts unit + visibility suites (`test_version_family`, `test_version_visibility`, `test_workflow_triggers_status`): 49 passed. No new failures introduced (the pre-existing route-integration failures are an unrelated "Audit service not configured" fixture gap on `main`).

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Golden Path tab).