### PR TITLE
fix(contracts): persist column-level data quality rules (ONT-CUJ-008)

### DIFF
--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -1652,6 +1652,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         all_properties = []
         all_obj_relationships = []
         all_prop_relationships = []
+        all_quality_checks = []
         # Collect semantic link work to process after bulk insert
         schema_semantic_work = []
         prop_semantic_work = []
@@ -1739,6 +1740,18 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 )
                 all_properties.append(prop)
 
+                # Collect property-level (column) quality rules. These arrive
+                # nested under the column as `properties[].quality`; previously
+                # nothing read them here, so column-level rules silently
+                # vanished on save (the only persisted quality was object-level
+                # via the separate `qualityRules` field).
+                for rule_data in (prop_dict.get('quality') or []):
+                    all_quality_checks.append(
+                        self._build_quality_check_db(
+                            rule_data, object_id=schema_obj_id, property_id=prop_id
+                        )
+                    )
+
                 # Collect property-level relationships (ODCS v3.1.0)
                 for rel_data in (prop_dict.get('relationships') or []):
                     if isinstance(rel_data, dict):
@@ -1778,6 +1791,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             db.add_all(all_obj_relationships)
         if all_prop_relationships:
             db.add_all(all_prop_relationships)
+        if all_quality_checks:
+            db.add_all(all_quality_checks)
         db.flush()
 
         # Process semantic links after bulk insert
@@ -1803,10 +1818,51 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     created_by=current_user
                 )
 
+    @staticmethod
+    def _build_quality_check_db(rule_data, object_id: str, property_id: Optional[str] = None) -> 'DataQualityCheckDb':
+        """Map an incoming quality-rule dict/model to a DataQualityCheckDb row.
+
+        Shared by object-level (``property_id is None``) and property-level
+        (``property_id`` set) persistence so both honour the same ODCS field
+        mapping and camelCase/snake_case aliases. The default ``level`` follows
+        whether the check targets a column or the whole object.
+        """
+        rule_dict = rule_data.model_dump() if hasattr(rule_data, 'model_dump') else rule_data
+        default_level = 'property' if property_id else 'object'
+        return DataQualityCheckDb(
+            object_id=object_id,
+            property_id=property_id,
+            stable_id=rule_dict.get('id'),
+            level=rule_dict.get('level', default_level),
+            name=rule_dict.get('name'),
+            description=rule_dict.get('description'),
+            dimension=rule_dict.get('dimension'),
+            business_impact=rule_dict.get('businessImpact') or rule_dict.get('business_impact'),
+            method=rule_dict.get('method'),
+            schedule=rule_dict.get('schedule'),
+            scheduler=rule_dict.get('scheduler'),
+            severity=rule_dict.get('severity'),
+            type=rule_dict.get('type', 'library'),
+            unit=rule_dict.get('unit'),
+            tags=rule_dict.get('tags'),
+            rule=rule_dict.get('rule'),
+            query=rule_dict.get('query'),
+            engine=rule_dict.get('engine'),
+            implementation=rule_dict.get('implementation'),
+            must_be=rule_dict.get('mustBe') or rule_dict.get('must_be'),
+            must_not_be=rule_dict.get('mustNotBe') or rule_dict.get('must_not_be'),
+            must_be_gt=rule_dict.get('mustBeGt') or rule_dict.get('must_be_gt'),
+            must_be_ge=rule_dict.get('mustBeGe') or rule_dict.get('must_be_ge'),
+            must_be_lt=rule_dict.get('mustBeLt') or rule_dict.get('must_be_lt'),
+            must_be_le=rule_dict.get('mustBeLe') or rule_dict.get('must_be_le'),
+            must_be_between_min=rule_dict.get('mustBeBetweenMin') or rule_dict.get('must_be_between_min'),
+            must_be_between_max=rule_dict.get('mustBeBetweenMax') or rule_dict.get('must_be_between_max'),
+        )
+
     def _create_quality_checks(self, db, contract_id: str, quality_rules: List):
         """
-        Create quality checks for a contract.
-        
+        Create object-level quality checks for a contract.
+
         Args:
             db: Database session
             contract_id: Contract UUID
@@ -1817,43 +1873,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if not schema_obj:
             logger.warning(f"No schema objects found for contract {contract_id}, skipping quality checks")
             return
-        
+
         for rule_data in quality_rules:
-            # Support both Pydantic models and dicts
-            if hasattr(rule_data, 'model_dump'):
-                rule_dict = rule_data.model_dump()
-            else:
-                rule_dict = rule_data
-            
-            quality_check = DataQualityCheckDb(
-                object_id=schema_obj.id,
-                stable_id=rule_dict.get('id'),
-                level=rule_dict.get('level', 'object'),
-                name=rule_dict.get('name'),
-                description=rule_dict.get('description'),
-                dimension=rule_dict.get('dimension'),
-                business_impact=rule_dict.get('businessImpact') or rule_dict.get('business_impact'),
-                method=rule_dict.get('method'),
-                schedule=rule_dict.get('schedule'),
-                scheduler=rule_dict.get('scheduler'),
-                severity=rule_dict.get('severity'),
-                type=rule_dict.get('type', 'library'),
-                unit=rule_dict.get('unit'),
-                tags=rule_dict.get('tags'),
-                rule=rule_dict.get('rule'),
-                query=rule_dict.get('query'),
-                engine=rule_dict.get('engine'),
-                implementation=rule_dict.get('implementation'),
-                must_be=rule_dict.get('mustBe') or rule_dict.get('must_be'),
-                must_not_be=rule_dict.get('mustNotBe') or rule_dict.get('must_not_be'),
-                must_be_gt=rule_dict.get('mustBeGt') or rule_dict.get('must_be_gt'),
-                must_be_ge=rule_dict.get('mustBeGe') or rule_dict.get('must_be_ge'),
-                must_be_lt=rule_dict.get('mustBeLt') or rule_dict.get('must_be_lt'),
-                must_be_le=rule_dict.get('mustBeLe') or rule_dict.get('must_be_le'),
-                must_be_between_min=rule_dict.get('mustBeBetweenMin') or rule_dict.get('must_be_between_min'),
-                must_be_between_max=rule_dict.get('mustBeBetweenMax') or rule_dict.get('must_be_between_max')
-            )
-            db.add(quality_check)
+            db.add(self._build_quality_check_db(rule_data, object_id=schema_obj.id))
     
     def _process_semantic_links(self, db, contract_id: str, contract_data, current_user: Optional[str] = None):
         """
@@ -2477,13 +2499,17 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 ).all()
                 
                 if schema_objects:
-                    # Remove ALL existing quality checks for all schema objects in this contract
+                    # Replace only OBJECT-level checks (property_id IS NULL).
+                    # Property-level (column) checks are owned by the schema
+                    # recreation path above; deleting them here would drop the
+                    # column rules that were just persisted from the same save.
                     for schema_obj in schema_objects:
                         db.query(DataQualityCheckDb).filter(
-                            DataQualityCheckDb.object_id == schema_obj.id
+                            DataQualityCheckDb.object_id == schema_obj.id,
+                            DataQualityCheckDb.property_id.is_(None),
                         ).delete()
-                    
-                    # Add new quality rules
+
+                    # Add new object-level quality rules
                     if data_dict['qualityRules']:
                         self._create_quality_checks(db, contract_id, data_dict['qualityRules'])
             

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -77,6 +77,12 @@ class ColumnProperty(BaseModel):
     # ODCS v3.1.0 relationships (property-level FKs)
     relationships: Optional[List[SchemaRelationship]] = None
 
+    # ODCS quality checks nested under the column. Declared explicitly (rather
+    # than relying on extra="allow") so the rules survive model_dump and are
+    # persisted by the manager — column-level rules were previously dropped on
+    # save because nothing read this field.
+    quality: Optional[List['QualityRule']] = Field(default_factory=list)
+
     class Config:
         # Accept both JSON keys: "logicalType" (field name) and "logical_type" (alias)
         populate_by_name = True

--- a/src/backend/src/tests/unit/test_contract_quality_persistence.py
+++ b/src/backend/src/tests/unit/test_contract_quality_persistence.py
@@ -1,0 +1,114 @@
+"""Unit tests for column-level (property) quality-rule persistence.
+
+Regression coverage for ONT-CUJ-008: quality rules authored on a schema
+column were accepted by the UI but silently dropped on save because
+``_create_schema_objects`` never read ``properties[].quality``. These tests
+exercise the manager's schema-object builder directly against the in-memory
+DB so they stay fast and dependency-free.
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.data_contracts_manager import DataContractsManager
+from src.db_models.data_contracts import (
+    DataContractDb,
+    DataQualityCheckDb,
+    SchemaObjectDb,
+    SchemaPropertyDb,
+)
+
+
+def _manager():
+    return DataContractsManager(data_dir=Path("/tmp"))
+
+
+@pytest.fixture
+def contract(db_session: Session):
+    cid = str(uuid.uuid4())
+    db_session.add(DataContractDb(id=cid, name="C", version="1.0.0", status="draft"))
+    db_session.commit()
+    return cid
+
+
+def _schema_with_column_rule():
+    return [
+        {
+            "name": "orders",
+            "properties": [
+                {
+                    "name": "amount",
+                    "logicalType": "number",
+                    "quality": [
+                        {
+                            "name": "non_negative",
+                            "type": "library",
+                            "rule": "rangeCheck",
+                            "dimension": "accuracy",
+                            "severity": "error",
+                            "description": "amount must be >= 0",
+                            "mustBeGe": "0",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+
+class TestColumnQualityPersistence:
+    def test_property_quality_rule_is_persisted(self, db_session: Session, contract):
+        manager = _manager()
+        manager._create_schema_objects(db_session, contract, _schema_with_column_rule())
+        db_session.commit()
+
+        prop = db_session.query(SchemaPropertyDb).filter_by(name="amount").one()
+        checks = (
+            db_session.query(DataQualityCheckDb)
+            .filter(DataQualityCheckDb.property_id == prop.id)
+            .all()
+        )
+        assert len(checks) == 1
+        check = checks[0]
+        # Bound to the column, not just the table.
+        assert check.property_id == prop.id
+        assert check.object_id is not None
+        assert check.level == "property"
+        # ODCS fields round-trip through the shared builder.
+        assert check.name == "non_negative"
+        assert check.rule == "rangeCheck"
+        assert check.dimension == "accuracy"
+        assert check.severity == "error"
+        assert check.must_be_ge == "0"
+
+    def test_column_without_quality_creates_no_checks(self, db_session: Session, contract):
+        manager = _manager()
+        manager._create_schema_objects(
+            db_session,
+            contract,
+            [{"name": "t", "properties": [{"name": "c", "logicalType": "string"}]}],
+        )
+        db_session.commit()
+        assert db_session.query(DataQualityCheckDb).count() == 0
+
+    def test_object_and_property_checks_coexist(self, db_session: Session, contract):
+        """Object-level (qualityRules) and property-level checks are distinct
+        rows distinguishable by property_id."""
+        manager = _manager()
+        manager._create_schema_objects(db_session, contract, _schema_with_column_rule())
+        db_session.flush()
+        # Object-level rule attaches to the first schema object (property_id NULL).
+        manager._create_quality_checks(
+            db_session, contract, [{"name": "row_count", "type": "sql", "query": "SELECT 1"}]
+        )
+        db_session.commit()
+
+        all_checks = db_session.query(DataQualityCheckDb).all()
+        assert len(all_checks) == 2
+        property_level = [c for c in all_checks if c.property_id is not None]
+        object_level = [c for c in all_checks if c.property_id is None]
+        assert len(property_level) == 1
+        assert len(object_level) == 1
+        assert object_level[0].name == "row_count"


### PR DESCRIPTION
## Summary

Quality rules authored on a schema **column** (the schema editor's per-column "Quality" tab → Add Check → name / dimension / severity / type / rule) were accepted in the dialog but **silently dropped on save**. After saving, `GET /api/data-contracts/{id}` returned `schema.quality=[]` and the column had no `quality` field, so ODCS export omitted the rules entirely.

**Root cause:** column rules arrive nested under `properties[].quality`, but `_create_schema_objects` (used by both the create and update paths) only persisted the property row itself — it never read the property's `quality` list. The only quality persistence path was the separate object-level `qualityRules` field. The `ColumnProperty` API model also didn't declare `quality`, relying on `extra="allow"` to carry it through.

## Changes

- Declare `quality: List[QualityRule]` explicitly on the `ColumnProperty` API model so the rules are first-class and survive `model_dump`.
- Extract the rule → `DataQualityCheckDb` field mapping into a shared `_build_quality_check_db(rule, object_id, property_id=None)` helper so object-level and property-level checks use identical ODCS/camelCase mapping.
- Persist `properties[].quality` in `_create_schema_objects`, bound to both `object_id` and `property_id` (so it round-trips through the existing property-level export at `data_contracts_manager.py:1063`).
- On update, scope the object-level `qualityRules` replacement to `property_id IS NULL`, so replacing object-level rules no longer deletes the column rules that the schema recreation just persisted in the same save.
- Unit tests for column-rule persistence, the no-rule case, and object/property coexistence.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression test **ONT-CUJ-008** (Ontos CUJ regression suite — Golden Path): "Column-level data-quality rules authored via the schema editor appear in the in-dialog list but are NOT persisted on Save Changes."

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_contract_quality_persistence.py` — 3 new tests pass.
- `hatch -e dev run pytest src/backend/src/tests/unit/test_data_contracts_api_models.py` — all pass (the new `ColumnProperty.quality` field is non-breaking).
- No new failures across the contracts DB-integration suite (the single `test_contract_timestamps` failure is a pre-existing flake on `main`, unrelated to this change).

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Golden Path tab).