### PR TITLE
fix(contracts): surface proposed contracts to stewards; drop dead review stub (ONT-CUJ-012)

### DIFF
--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -4847,8 +4847,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         from datetime import datetime
         from src.common.workflow_triggers import get_trigger_registry
         from src.models.process_workflows import EntityType
-        from src.models.data_asset_reviews import AssetType, ReviewedAssetStatus
-        
+
         contract = data_contract_repo.get(db, id=contract_id)
         if not contract:
             raise ValueError("Contract not found")
@@ -4865,27 +4864,22 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         
         now = datetime.utcnow()
         request_id = str(uuid4())
-        
-        # Create asset review record
-        try:
-            from src.controller.data_asset_reviews_manager import DataAssetReviewManager
-            from src.models.data_asset_reviews import ReviewedAsset as ReviewedAssetApi
-            from src.common.databricks_utils import get_workspace_client
-            
-            ws_client = get_workspace_client()
-            review_manager = DataAssetReviewManager(db=db, ws_client=ws_client, notifications_manager=notifications_manager)
-            
-            review_asset = ReviewedAssetApi(
-                id=str(uuid4()),
-                asset_fqn=f"contract:{contract_id}",
-                asset_type=AssetType.DATA_CONTRACT,
-                status=ReviewedAssetStatus.PENDING,
-                updated_at=now
-            )
-            logger.info(f"Created asset review record for contract {contract_id}")
-        except Exception as e:
-            logger.warning(f"Failed to create asset review record: {e}", exc_info=True)
-        
+
+        # NOTE: a proposed contract surfaces to stewards through two real paths,
+        # so we deliberately do NOT create a data-asset review record here:
+        #   1. GET /api/approvals/queue lists every contract in proposed/
+        #      under_review status (see ApprovalsManager.get_approvals_queue),
+        #      and the steward acts on it via the contract approve/reject
+        #      endpoints.
+        #   2. The ON_REQUEST_REVIEW trigger below runs any configured review
+        #      workflow (notifications, approval routing).
+        # The /data-asset-reviews surface is for Unity Catalog assets (tables,
+        # views, functions) and needs an explicit reviewer; routing a contract
+        # there would require a steward-assignment policy that doesn't exist
+        # yet. A previous stub here constructed an in-memory ReviewedAsset and
+        # logged "Created asset review record" without ever persisting it —
+        # misleading dead code that is removed.
+
         # Fire the ON_REQUEST_REVIEW trigger
         trigger_registry = get_trigger_registry(db)
         executions = trigger_registry.on_request_review(

--- a/src/backend/src/tests/unit/test_contract_steward_review.py
+++ b/src/backend/src/tests/unit/test_contract_steward_review.py
@@ -1,0 +1,72 @@
+"""Unit tests for requesting a steward review on a data contract.
+
+Regression coverage for ONT-CUJ-008/ONT-CUJ-012-adjacent behaviour: after a
+producer requests review, the contract must transition to ``proposed`` and be
+discoverable by stewards via the approvals queue. A previous stub in
+``request_steward_review`` constructed an in-memory ReviewedAsset and logged a
+(false) "Created asset review record" without persisting anything; this test
+pins the real surfacing path (the approvals queue) and that the call itself
+does not raise.
+"""
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.approvals_manager import ApprovalsManager
+from src.controller.data_contracts_manager import DataContractsManager
+from src.db_models.data_contracts import DataContractDb
+
+
+def _manager():
+    return DataContractsManager(data_dir=Path("/tmp"))
+
+
+@pytest.fixture
+def draft_contract(db_session: Session):
+    cid = str(uuid.uuid4())
+    db_session.add(DataContractDb(id=cid, name="Reviewable", version="1.0.0", status="draft"))
+    db_session.commit()
+    return cid
+
+
+class TestRequestStewardReview:
+    def test_transitions_to_proposed_and_surfaces_in_approvals_queue(
+        self, db_session: Session, draft_contract
+    ):
+        manager = _manager()
+        result = manager.request_steward_review(
+            db=db_session,
+            notifications_manager=MagicMock(),
+            contract_id=draft_contract,
+            requester_email="producer@example.com",
+            message="please review",
+            current_user="producer@example.com",
+        )
+        db_session.commit()
+
+        assert result["status"] == "proposed"
+
+        contract = db_session.query(DataContractDb).filter_by(id=draft_contract).one()
+        assert contract.status == "proposed"
+
+        # The steward-facing surface: proposed contracts appear in the queue.
+        queue = ApprovalsManager().get_approvals_queue(db_session)
+        queued_ids = {c["id"] for c in queue["contracts"]}
+        assert draft_contract in queued_ids
+
+    def test_rejects_review_from_non_draft_status(self, db_session: Session):
+        manager = _manager()
+        cid = str(uuid.uuid4())
+        db_session.add(DataContractDb(id=cid, name="Active", version="1.0.0", status="active"))
+        db_session.commit()
+
+        with pytest.raises(ValueError):
+            manager.request_steward_review(
+                db=db_session,
+                notifications_manager=MagicMock(),
+                contract_id=cid,
+                requester_email="producer@example.com",
+            )


### PR DESCRIPTION
## Summary

When a producer requested a steward review, `request_steward_review` constructed an in-memory `ReviewedAsset`, logged **"Created asset review record,"** and then **never persisted it**. The result: a proposed contract was undiscoverable to stewards except by direct URL, while the logs falsely implied a review record had been created.

Proposed contracts actually reach stewards through two paths that already exist in the codebase:

1. **`GET /api/approvals/queue`** — `ApprovalsManager.get_approvals_queue` lists every contract in `proposed`/`under_review` status; the steward approves/rejects via the contract approve/reject endpoints.
2. **The `ON_REQUEST_REVIEW` workflow trigger** — runs any configured review workflow (notifications, approval routing).

The `/data-asset-reviews` surface is built for Unity Catalog assets (tables, views, functions) and `create_review_request` requires an explicit single `reviewer_email`. Routing a contract there would require a steward-assignment policy that doesn't exist in the codebase yet, so this PR intentionally does **not** invent one.

## Changes

- Remove the unsaved `ReviewedAsset` stub and its false "Created asset review record" log (and the now-unused `AssetType`/`ReviewedAssetStatus` import).
- Document the two real surfacing paths inline so the omission is intentional and clear.
- Tests: requesting review transitions `draft -> proposed` and the contract then appears in the approvals queue; requesting review from a non-draft status raises.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup / removal of misleading dead code

Addresses regression test **ONT-CUJ-012** (Ontos CUJ regression suite — Golden Path). Contract-list discoverability of proposed contracts is additionally improved by the companion draft-owner-visibility fix (#527), which clears `draft_owner_id` on the `draft -> proposed` transition and adds a `?status=` filter.

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_contract_steward_review.py src/backend/src/tests/unit/test_approvals_manager.py` — 7 passed (2 new).

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Golden Path tab). Note: full `/data-asset-reviews` integration for contracts is deliberately out of scope pending a maintainer decision on steward/reviewer assignment.