### PR TITLE
fix(contracts): allow approving a contract directly from proposed (ONT-CUJ-013)

### DIFF
--- a/src/backend/src/models/lifecycle.py
+++ b/src/backend/src/models/lifecycle.py
@@ -48,7 +48,10 @@ DATA_PRODUCT_TRANSITIONS: dict[str, list[str]] = {
 
 DATA_CONTRACT_TRANSITIONS: dict[str, list[str]] = {
     "draft": ["proposed", "deprecated"],
-    "proposed": ["draft", "under_review", "deprecated"],
+    # A steward can approve directly from "proposed" (the approve endpoint is
+    # documented as PROPOSED/UNDER_REVIEW -> APPROVED). "under_review" stays an
+    # optional intermediate step rather than a mandatory one.
+    "proposed": ["draft", "under_review", "approved", "deprecated"],
     "under_review": ["draft", "approved", "deprecated"],
     "approved": ["active", "draft", "deprecated"],
     "active": ["deprecated"],

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -218,7 +218,12 @@ async def approve_contract(
         return {'status': updated.status}
     except HTTPException:
         raise
-    except Exception as e:
+    except ValueError as e:
+        # Invalid lifecycle transition (or missing contract) is a client error,
+        # not a server fault — surface it as 409 instead of an opaque 500.
+        logger.warning("Approve contract rejected for contract_id=%s: %s", contract_id, e)
+        raise HTTPException(status_code=409, detail=str(e))
+    except Exception:
         logger.exception("Approve contract failed for contract_id=%s", contract_id)
         raise HTTPException(status_code=500, detail="Failed to approve contract")
 
@@ -264,7 +269,10 @@ async def reject_contract(
         return {'status': updated.status}
     except HTTPException:
         raise
-    except Exception as e:
+    except ValueError as e:
+        logger.warning("Reject contract rejected for contract_id=%s: %s", contract_id, e)
+        raise HTTPException(status_code=409, detail=str(e))
+    except Exception:
         logger.exception("Reject contract failed for contract_id=%s", contract_id)
         raise HTTPException(status_code=500, detail="Failed to reject contract")
 

--- a/src/backend/src/tests/unit/test_workflow_triggers_status.py
+++ b/src/backend/src/tests/unit/test_workflow_triggers_status.py
@@ -235,6 +235,69 @@ class TestDataContractsManagerGating:
                 )
 
 
+class TestContractApproveFromProposed:
+    """ONT-CUJ-013: a steward must be able to approve a proposed contract.
+
+    Previously DATA_CONTRACT_TRANSITIONS omitted "approved" from "proposed",
+    so the approve endpoint's transition_status(proposed -> approved) raised
+    ValueError, which the route turned into an opaque 500.
+    """
+
+    def test_lifecycle_map_allows_proposed_to_approved(self):
+        from src.models.lifecycle import DATA_CONTRACT_TRANSITIONS
+        assert 'approved' in DATA_CONTRACT_TRANSITIONS['proposed']
+
+    def test_transition_proposed_to_approved_succeeds(self, db_session):
+        from src.controller.data_contracts_manager import DataContractsManager
+        from src.db_models.data_contracts import DataContractDb
+        import uuid
+        from pathlib import Path
+
+        contract = DataContractDb(
+            id=str(uuid.uuid4()),
+            name="Approvable Contract",
+            version="1.0.0",
+            status="proposed",
+        )
+        db_session.add(contract)
+        db_session.commit()
+
+        mgr = DataContractsManager(data_dir=Path("/tmp"))
+        updated = mgr.transition_status(
+            db=db_session,
+            contract_id=contract.id,
+            new_status='approved',
+            current_user='steward@example.com',
+        )
+        assert updated.status == 'approved'
+
+    def test_invalid_transition_still_raises_valueerror(self, db_session):
+        # A genuinely invalid jump (active -> approved) must still be rejected,
+        # so the route can map it to a 409 rather than silently allowing it.
+        from src.controller.data_contracts_manager import DataContractsManager
+        from src.db_models.data_contracts import DataContractDb
+        import uuid
+        from pathlib import Path
+
+        contract = DataContractDb(
+            id=str(uuid.uuid4()),
+            name="Active Contract",
+            version="1.0.0",
+            status="active",
+        )
+        db_session.add(contract)
+        db_session.commit()
+
+        mgr = DataContractsManager(data_dir=Path("/tmp"))
+        with pytest.raises(ValueError, match="Invalid status transition"):
+            mgr.transition_status(
+                db=db_session,
+                contract_id=contract.id,
+                new_status='approved',
+                current_user='steward@example.com',
+            )
+
+
 # =========================================================================
 # YAML validation — User Story 15
 # =========================================================================


### PR DESCRIPTION
## Summary

`POST /api/data-contracts/{id}/approve` returned **HTTP 500** (`"Failed to approve contract"`) for a `proposed` contract, leaving it stuck in `proposed` with no error toast in the UI.

**Root cause:** the approve endpoint is documented as `PROPOSED/UNDER_REVIEW -> APPROVED` and explicitly pre-checks that the source status is one of those — but `DATA_CONTRACT_TRANSITIONS["proposed"]` only listed `["draft", "under_review", "deprecated"]`. `"approved"` was missing, so `transition_status(proposed -> approved)` raised `ValueError("Invalid status transition")`, which the route swallowed with a bare `except Exception` and re-raised as an opaque 500.

## Changes

- Add `"approved"` to the allowed transitions from `"proposed"` in `DATA_CONTRACT_TRANSITIONS`, so a steward can approve directly. `under_review` remains an optional intermediate step rather than a mandatory one — consistent with the route's documented behavior.
- In the `approve` and `reject` routes, catch `ValueError` and return **409** with the message instead of an opaque 500, so any genuinely invalid transition is a clean client error.
- Tests: the lifecycle map allows `proposed -> approved`; `transition_status` succeeds for `proposed -> approved`; a genuinely invalid jump (`active -> approved`) still raises.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression test **ONT-CUJ-013** (Ontos CUJ regression suite — Golden Path): "Steward 'Approve' on the proposed contract fails with HTTP 500; contract remains 'proposed'."

Note on separation-of-duties: the regression note also observed that a self-approval (approver == author) should ideally return a clean 403. The codebase has no SoD check today, so the 500 was purely the transition-map bug fixed here; an explicit author≠approver guard is left as a separate enhancement pending a maintainer decision.

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_workflow_triggers_status.py` — 15 passed (3 new).

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Golden Path tab).