### PR TITLE
fix(data-products): make products editable by creator and feature admins (ONT-CUJ-015)

### DIFF
--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -164,6 +164,21 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             product_data.setdefault('kind', 'DataProduct')
             product_data.setdefault('status', DataProductStatus.DRAFT.value)
 
+            # Stamp the creator as the single-user owner when no other owner is
+            # supplied. Without this, a freshly created product has no
+            # project_id, owner_team_id, or draft_owner_id, so the update
+            # authorization cascade fails for *everyone* except a workspace
+            # admin — the creator can't even add deliverables to their own
+            # product (ONT-CUJ-015). Mirrors the personal-draft clone path.
+            if (
+                user
+                and not product_data.get('draft_owner_id')
+                and not product_data.get('draftOwnerId')
+                and not product_data.get('owner_team_id')
+                and not product_data.get('project_id')
+            ):
+                product_data['draft_owner_id'] = user
+
             # Validate
             try:
                 product_api_model = DataProductCreate(**product_data)
@@ -522,6 +537,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         db: Optional[Session] = None,
         background_tasks: Optional[Any] = None,
         caller_team_ids: Optional[List[str]] = None,
+        is_feature_admin: bool = False,
     ) -> Optional[DataProductApi]:
         """
         Update a data product with ownership-scope authorization.
@@ -580,8 +596,15 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             settings = get_settings()
 
             # Admin always allowed (short-circuit, also matches existing
-            # is_user_project_member behavior).
-            if is_user_admin(user_groups, settings):
+            # is_user_project_member behavior). This covers both workspace
+            # admins (group-based) and callers whose *feature-level*
+            # data-products permission is ADMIN — e.g. an in-app role override
+            # that grants data-products=Admin. The latter is resolved by the
+            # route (which has access to the effective-permissions/role
+            # machinery) and passed in as ``is_feature_admin``; without it an
+            # in-app admin who isn't the object owner was wrongly denied
+            # (ONT-CUJ-015).
+            if is_feature_admin or is_user_admin(user_groups, settings):
                 logger.debug(f"User {user_email} is admin — bypassing ownership cascade")
                 return self.update_product(
                     product_id,

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -2148,6 +2148,33 @@ async def update_data_product(
                 f"continuing without team-ownership branch"
             )
 
+        # Resolve the caller's *feature-level* data-products permission so a
+        # data-products Admin (including via an in-app role override) can edit
+        # any product, not just ones they own. Mirrors the resolution used by
+        # the DP-assets route. Best-effort: on failure we fall back to the
+        # ownership cascade (project / team / draft-owner) only.
+        is_feature_admin = False
+        try:
+            auth_manager = getattr(request.app.state, "authorization_manager", None)
+            settings_manager = getattr(request.app.state, "settings_manager", None)
+            if auth_manager and current_user:
+                applied_role_id = (
+                    settings_manager.get_applied_role_override_for_user(current_user.email)
+                    if settings_manager else None
+                )
+                if applied_role_id and settings_manager:
+                    eff = settings_manager.get_feature_permissions_for_role_id(applied_role_id)
+                else:
+                    eff = auth_manager.get_user_effective_permissions(user_groups, None)
+                is_feature_admin = auth_manager.has_permission(
+                    eff, DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.ADMIN
+                )
+        except Exception:
+            logger.exception(
+                "Failed to resolve data-products admin level for product update; "
+                "falling back to ownership cascade"
+            )
+
         updated_product_response = manager.update_product_with_auth(
             product_id=product_id,
             product_data_dict=product_dict,
@@ -2156,6 +2183,7 @@ async def update_data_product(
             db=db,
             background_tasks=background_tasks,
             caller_team_ids=caller_team_ids,
+            is_feature_admin=is_feature_admin,
         )
 
         if not updated_product_response:

--- a/src/backend/src/routes/delivery_methods_routes.py
+++ b/src/backend/src/routes/delivery_methods_routes.py
@@ -19,6 +19,11 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/delivery-methods", tags=["Delivery Methods"])
 FEATURE_ID = "delivery-methods"
+# Reads of the delivery-method catalog are a prerequisite for authoring a
+# deliverable on a data product, so they are gated by the data-products
+# feature (any product author can list/get) rather than the admin-managed
+# delivery-methods feature. Writes stay gated by delivery-methods:READ_WRITE.
+READ_FEATURE_ID = "data-products"
 
 
 def get_delivery_methods_manager():
@@ -68,7 +73,7 @@ def create_delivery_method(
 @router.get(
     "",
     response_model=List[DeliveryMethodRead],
-    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+    dependencies=[Depends(PermissionChecker(READ_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
 )
 def get_all_delivery_methods(
     db: DBSessionDep,
@@ -85,7 +90,7 @@ def get_all_delivery_methods(
 @router.get(
     "/{method_id}",
     response_model=DeliveryMethodRead,
-    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+    dependencies=[Depends(PermissionChecker(READ_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
 )
 def get_delivery_method(
     method_id: UUID,

--- a/src/backend/src/tests/unit/test_data_products_ownership_scope.py
+++ b/src/backend/src/tests/unit/test_data_products_ownership_scope.py
@@ -340,6 +340,55 @@ class TestUpdateProductWithAuthCascade:
         )
         assert result == "UPDATED_OK"
 
+    # ---- feature-admin path (ONT-CUJ-015) ----
+
+    def test_feature_admin_can_edit_orphan(self, manager, db_session):
+        """A data-products feature admin (is_feature_admin=True) edits an
+        owner-less product even when not a workspace admin."""
+        product = _make_product(db_session, name="orphan")
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="role-admin@example.com",
+            user_groups=[],  # not a workspace admin
+            db=db_session,
+            caller_team_ids=[],
+            is_feature_admin=True,
+        )
+        assert result == "UPDATED_OK"
+
+    def test_feature_admin_can_edit_others_product(self, manager, db_session):
+        product = _make_product(
+            db_session, name="theirs", status="draft", draft_owner_id="bob@example.com"
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="role-admin@example.com",
+            user_groups=[],
+            db=db_session,
+            caller_team_ids=[],
+            is_feature_admin=True,
+        )
+        assert result == "UPDATED_OK"
+
+    def test_non_feature_admin_orphan_still_denied(self, manager, db_session):
+        """The default (is_feature_admin=False) preserves fail-closed behavior."""
+        product = _make_product(db_session, name="orphan")
+
+        with pytest.raises(PermissionError):
+            manager.update_product_with_auth(
+                product_id=product.id,
+                product_data_dict={"name": "renamed"},
+                user_email="alice@example.com",
+                user_groups=[],
+                db=db_session,
+                caller_team_ids=[],
+                is_feature_admin=False,
+            )
+
     # ---- project membership branch ----
 
     def test_non_admin_with_project_membership_can_edit(
@@ -501,3 +550,46 @@ class TestUpdateProductWithAuthCascade:
             db=db_session,
         )
         assert result is None
+
+
+class TestCreateProductOwnership:
+    """ONT-CUJ-015: a newly created product must be owned by its creator so
+    the creator can edit it (e.g. add deliverables). Otherwise it is an
+    owner-less orphan that fails the update authorization cascade."""
+
+    @pytest.fixture
+    def manager(self, db_session):
+        mgr = DataProductsManager(
+            db=db_session,
+            ws_client=MagicMock(),
+            notifications_manager=MagicMock(),
+            tags_manager=MagicMock(),
+        )
+        # Focus on ownership stamping — neutralize delivery/search side effects.
+        mgr._queue_delivery = MagicMock()
+        mgr._update_search_index = MagicMock()
+        return mgr
+
+    def _minimal_product(self):
+        return {
+            "info": {"title": "My Product", "owner": "team@example.com"},
+            "name": "My Product",
+            "version": "1.0.0",
+        }
+
+    def test_creator_becomes_draft_owner_when_no_other_owner(
+        self, manager, db_session
+    ):
+        created = manager.create_product(
+            self._minimal_product(), db=db_session, user="alice@example.com"
+        )
+        assert created.draft_owner_id == "alice@example.com"
+
+    def test_explicit_owner_team_is_not_overwritten(self, manager, db_session):
+        data = self._minimal_product()
+        data["owner_team_id"] = "team-A"
+        created = manager.create_product(
+            data, db=db_session, user="alice@example.com"
+        )
+        # Team-owned product stays team-visible; not stamped as a personal draft.
+        assert created.draft_owner_id is None


### PR DESCRIPTION
## Summary

Adding a deliverable to a data product failed with `PUT /api/data-products/{id}` → **403** for both the Producer who created it *and* for an Admin. Three coupled root causes:

1. **`create_product` never assigned an owner.** A new product had no `project_id`, `owner_team_id`, or `draft_owner_id`, so the update authorization cascade failed for everyone except a workspace admin. The creator couldn't edit their own product — and it could never be given an owner, since assigning one also requires `PUT`.
2. **The update ownership cascade only short-circuited on workspace admin** (group-based `is_user_admin`), ignoring the caller's **feature-level** `data-products` permission. An in-app role override granting `data-products=Admin` was therefore denied when the caller wasn't the object owner (the "Admin retry still 403" finding).
3. **`GET /api/delivery-methods` required the `delivery-methods` feature**, which a Producer lacks — so the Add Deliverable delivery-method dropdown was empty (403).

## Changes

- `create_product` stamps the creator as `draft_owner_id` when no project, team, or draft owner is supplied (mirrors the personal-draft clone path). Team-owned products are left team-visible.
- `update_product_with_auth` accepts `is_feature_admin` and short-circuits on it in addition to workspace admin. The update route resolves the caller's effective `data-products` permission — honoring in-app role overrides via the same `applied_role_override → effective-permissions → ADMIN` resolution the DP-assets route uses — and passes it in.
- Gate the delivery-methods **read** endpoints (`GET ""`, `GET /{id}`) on `data-products:READ_ONLY` — reading the catalog is a prerequisite for authoring deliverables (same precedent as the DP linked-assets route, Issue #347). **Write** endpoints stay on `delivery-methods:READ_WRITE` (admin-managed catalog).
- Tests: creator becomes draft owner on create; an explicit owner team is not overwritten; a feature-admin can edit an orphan and others' products; non-feature-admins remain fail-closed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression test **ONT-CUJ-015** (Ontos CUJ regression suite — Golden Path): "Add Deliverable submit -> 403 (deliverable not saved); delivery-methods 403 for Producer; product update gated by object-level ownership that ignores the Admin feature permission, and new products saved with no owner -> uneditable by anyone."

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_data_products_ownership_scope.py` — 28 passed (5 new).
- Broader product manager/route suites show no new failures vs. `main` (pre-existing failures are an unrelated "Audit service not configured" fixture gap).

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Golden Path tab). This is the data-products analogue of the contract draft-ownership fix (#527).