### PR TITLE
fix(data-products): require a deliverable before requesting certification (ONT-CUJ-019, ONT-NEG-008)

### DIFF
--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -386,6 +386,15 @@ async def request_certify_product(
         if not product_db:
             raise HTTPException(status_code=404, detail="Data product not found")
 
+        # A product with no deliverables (output ports) has nothing to certify;
+        # block the request rather than accepting an empty product into the
+        # certification workflow (ONT-CUJ-019 / ONT-NEG-008).
+        if not (product_db.output_ports or []):
+            raise HTTPException(
+                status_code=409,
+                detail="At least one deliverable is required before requesting certification",
+            )
+
         username = current_user.username if current_user else None
         change_log_manager.log_change_with_details(
             db,

--- a/src/backend/src/tests/integration/test_data_product_routes.py
+++ b/src/backend/src/tests/integration/test_data_product_routes.py
@@ -322,6 +322,44 @@ class TestDataProductRoutes:
         # Verify audit log
         verify_audit_log("data-products", "SUBMIT_CERTIFICATION", success=True)
 
+    def test_request_certify_without_deliverable_fails(
+        self, client, sample_product_data
+    ):
+        """ONT-CUJ-019 / ONT-NEG-008: requesting certification on a product
+        with zero deliverables (output ports) must be blocked (409)."""
+        sample_product_data["status"] = "draft"
+        create_response = client.post("/api/data-products", json=sample_product_data)
+        product_id = create_response.json()["id"]
+
+        response = client.post(
+            f"/api/data-products/{product_id}/request-certify",
+            json={"certification_level": "gold"},
+        )
+
+        assert response.status_code == 409
+        assert "deliverable" in response.json()["detail"].lower()
+
+    def test_request_certify_with_deliverable_succeeds(
+        self, client, sample_product_data
+    ):
+        """A product with at least one deliverable is accepted for
+        certification (202)."""
+        sample_product_data["status"] = "draft"
+        sample_product_data["outputPorts"] = [{
+            "name": "test-output",
+            "version": "1.0.0",
+            "contractId": "test-contract",
+        }]
+        create_response = client.post("/api/data-products", json=sample_product_data)
+        product_id = create_response.json()["id"]
+
+        response = client.post(
+            f"/api/data-products/{product_id}/request-certify",
+            json={"certification_level": "gold"},
+        )
+
+        assert response.status_code == 202
+
     def test_publish_product_success(self, client, sample_product_data):
         """Test POST /api/data-products/{id}/publish."""
         # Arrange


### PR DESCRIPTION
## Summary

`POST /api/data-products/{id}/request-certify` returned **202 Accepted** for a product with **zero deliverables** (no output ports), letting an empty product into the certification workflow. The documented "at least one deliverable required" guard was never enforced.

## Changes

- Block `request-certify` with **409** when the product has no output ports, with the message "At least one deliverable is required before requesting certification".
- Tests: requesting certification without a deliverable returns 409; with a deliverable returns 202.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression tests **ONT-CUJ-019** and **ONT-NEG-008** (Ontos CUJ regression suite — Golden Path / Negative Paths): "request-certify accepted on a product with zero deliverables; the documented 'at least one deliverable required' guard is not enforced."

## Note on the state model

The regression note for CUJ-019 also observed that `request-certify` does not transition the product `Draft -> Proposed`. This is by design: `request-certify` uses a **request-based** model — it records a certification request and fires the `on_request_certify` workflow, leaving status management to the approver via `handle-certify`. The separate `/submit-certification` endpoint is the one that performs the `draft -> proposed` transition. This PR only adds the missing deliverable precondition; it does not change the request-vs-transition model (that would be a larger product decision).

## Testing

- New tests added to `test_data_product_routes.py` following the existing `test_publish_product_without_contracts_fails` guard-test pattern. (These route tests require the integration test harness's audit fixture, which runs in CI.)

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Golden Path + Negative Paths tabs).