### PR TITLE
fix(contracts): reject duplicate contract name within the same domain (ONT-NEG-002)

### DIFF
--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -2211,7 +2211,29 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 domain_id = self._resolve_domain(db, domain_id=data_dict.get('domainId'))
             elif data_dict.get('domain'):
                 domain_id = self._resolve_domain(db, domain_name=data_dict.get('domain'))
-            
+
+            # Reject a duplicate contract name within the same domain. This path
+            # always creates a *new* version family (new versions go through
+            # create_version), so any existing contract sharing the name+domain
+            # is a genuine duplicate, not another version of the same family
+            # (ONT-NEG-002). Name match is case-insensitive.
+            from sqlalchemy import func as _sa_func
+            from src.common.errors import ConflictError
+            new_name = data_dict.get('name', '').strip()
+            dup_query = db.query(DataContractDb).filter(
+                _sa_func.lower(DataContractDb.name) == new_name.lower()
+            )
+            dup_query = (
+                dup_query.filter(DataContractDb.domain_id == domain_id)
+                if domain_id is not None
+                else dup_query.filter(DataContractDb.domain_id.is_(None))
+            )
+            if dup_query.first() is not None:
+                where = "domain" if domain_id is not None else "global scope"
+                raise ConflictError(
+                    f"A data contract named '{new_name}' already exists in this {where}"
+                )
+
             # Resolve owner team if provided
             owner_team_id = data_dict.get('owner_team_id')
             if not owner_team_id and data_dict.get('owner'):

--- a/src/backend/src/tests/unit/test_contract_duplicate_name.py
+++ b/src/backend/src/tests/unit/test_contract_duplicate_name.py
@@ -1,0 +1,68 @@
+"""Unit tests for duplicate data-contract name rejection (ONT-NEG-002).
+
+Creating a contract whose name duplicates an existing contract in the same
+domain previously succeeded silently. It must now raise a ConflictError
+(surfaced as HTTP 409 by the route).
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.common.errors import ConflictError
+from src.controller.data_contracts_manager import DataContractsManager
+from src.db_models.data_contracts import DataContractDb
+
+
+def _manager():
+    mgr = DataContractsManager(data_dir=Path("/tmp"))
+    # The duplicate check runs before any writes; neutralize the post-create
+    # side effects so the happy-path create stays dependency-free.
+    mgr._queue_delivery = lambda *a, **k: None
+    mgr._update_search_index = lambda *a, **k: None
+    return mgr
+
+
+@pytest.fixture
+def existing_contract(db_session: Session):
+    cid = str(uuid.uuid4())
+    db_session.add(
+        DataContractDb(id=cid, name="Customer Data", version="1.0.0", status="active")
+    )
+    db_session.commit()
+    return cid
+
+
+class TestDuplicateContractName:
+    def test_duplicate_name_same_domain_raises_conflict(
+        self, db_session: Session, existing_contract
+    ):
+        manager = _manager()
+        with pytest.raises(ConflictError):
+            manager.create_contract_with_relations(
+                db=db_session,
+                contract_data={"name": "Customer Data", "version": "1.0.0"},
+                current_user="alice@example.com",
+            )
+
+    def test_duplicate_name_is_case_insensitive(
+        self, db_session: Session, existing_contract
+    ):
+        manager = _manager()
+        with pytest.raises(ConflictError):
+            manager.create_contract_with_relations(
+                db=db_session,
+                contract_data={"name": "customer DATA", "version": "1.0.0"},
+                current_user="alice@example.com",
+            )
+
+    def test_distinct_name_is_allowed(self, db_session: Session, existing_contract):
+        manager = _manager()
+        created = manager.create_contract_with_relations(
+            db=db_session,
+            contract_data={"name": "Orders Data", "version": "1.0.0"},
+            current_user="alice@example.com",
+        )
+        assert created.id is not None
+        assert created.name == "Orders Data"


### PR DESCRIPTION
## Summary

Creating a data contract whose name duplicated an existing contract in the same domain **succeeded silently** — `POST /api/data-contracts` returned 200 with a duplicate persisted, no 409 and no inline validation error.

`create_contract_with_relations` always creates a **new version family** (new versions of an existing contract go through `create_version`), so any existing contract sharing the same `name` + `domain` is a genuine duplicate, not another version of the same family.

## Changes

- Add a case-insensitive `name` + `domain_id` duplicate check in `create_contract_with_relations`, raising `ConflictError` (HTTP 409) — consistent with the existing duplicate-id behavior for data products and the `ConflictError` pattern used by the projects and delivery-methods managers. The check runs before any writes.
- A contract with the same name in a **different** domain is still allowed; versioning (same name within a family) is unaffected since it uses a different code path.
- Unit tests: duplicate name in the same domain raises `ConflictError` (including case-insensitive match); a distinct name still creates successfully.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression test **ONT-NEG-002** (Ontos CUJ regression suite — Negative Paths): "Creating a contract named 'Customer Data Contract' (duplicate of an existing active contract of the same name/domain) succeeded; expected 409/inline error and no duplicate."

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_contract_duplicate_name.py` — 3 passed.
- Contract create / version-family suites show no new failures (the single `test_contract_timestamps` failure is a pre-existing flake on `main`).

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Negative Paths tab).