### PR TITLE
fix(contracts): require a schema before proposing a contract for review (ONT-NEG-005)

### DIFF
--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -4919,7 +4919,19 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         from_status = (contract.status or '').lower()
         if from_status != 'draft':
             raise ValueError(f"Cannot request review from status {contract.status}. Must be DRAFT.")
-        
+
+        # A contract must describe at least one schema object before it can be
+        # proposed for review — there is nothing for a steward to review on an
+        # empty draft. Block the transition and leave the contract in draft
+        # (ONT-NEG-005).
+        schema_object_count = (
+            db.query(SchemaObjectDb)
+            .filter(SchemaObjectDb.contract_id == contract_id)
+            .count()
+        )
+        if schema_object_count == 0:
+            raise ValueError("A schema is required before a contract can be proposed for review.")
+
         # Transition to PROPOSED. Clear the personal-draft owner so the contract
         # is promoted from tier-1 (creator-only) to organisation visibility; a
         # contract under steward review must be discoverable by stewards and

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -417,8 +417,11 @@ async def request_steward_review(
         
     except ValueError as e:
         logger.error("Request review validation error for contract_id=%s: %s", contract_id, e)
-        error_status = 404 if "not found" in str(e).lower() else 409
-        raise HTTPException(status_code=error_status, detail="Invalid review request")
+        if "not found" in str(e).lower():
+            raise HTTPException(status_code=404, detail="Contract not found")
+        # Surface the validation reason (e.g. "schema required before review")
+        # so the UI can explain why the request was blocked.
+        raise HTTPException(status_code=409, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:

--- a/src/backend/src/tests/unit/test_contract_review_schema_guard.py
+++ b/src/backend/src/tests/unit/test_contract_review_schema_guard.py
@@ -1,0 +1,60 @@
+"""Unit tests for the 'schema required before review' guard (ONT-NEG-005).
+
+An empty draft contract (no schema objects) could previously be proposed for
+review (request-review returned 200, status -> proposed). It must now be
+blocked and left in draft.
+"""
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.data_contracts_manager import DataContractsManager
+from src.db_models.data_contracts import DataContractDb, SchemaObjectDb
+
+
+def _manager():
+    return DataContractsManager(data_dir=Path("/tmp"))
+
+
+def _draft(db_session: Session) -> str:
+    cid = str(uuid.uuid4())
+    db_session.add(DataContractDb(id=cid, name="C", version="1.0.0", status="draft"))
+    db_session.commit()
+    return cid
+
+
+class TestRequireSchemaBeforeReview:
+    def test_empty_draft_cannot_be_proposed(self, db_session: Session):
+        manager = _manager()
+        cid = _draft(db_session)
+
+        with pytest.raises(ValueError, match="schema is required"):
+            manager.request_steward_review(
+                db=db_session,
+                notifications_manager=MagicMock(),
+                contract_id=cid,
+                requester_email="producer@example.com",
+            )
+
+        # State must remain draft — the failed guard must not transition it.
+        contract = db_session.query(DataContractDb).filter_by(id=cid).one()
+        assert contract.status == "draft"
+
+    def test_draft_with_schema_can_be_proposed(self, db_session: Session):
+        manager = _manager()
+        cid = _draft(db_session)
+        db_session.add(
+            SchemaObjectDb(id=str(uuid.uuid4()), contract_id=cid, name="orders")
+        )
+        db_session.commit()
+
+        result = manager.request_steward_review(
+            db=db_session,
+            notifications_manager=MagicMock(),
+            contract_id=cid,
+            requester_email="producer@example.com",
+        )
+        assert result["status"] == "proposed"

--- a/src/backend/src/tests/unit/test_contract_steward_review.py
+++ b/src/backend/src/tests/unit/test_contract_steward_review.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from src.controller.approvals_manager import ApprovalsManager
 from src.controller.data_contracts_manager import DataContractsManager
-from src.db_models.data_contracts import DataContractDb
+from src.db_models.data_contracts import DataContractDb, SchemaObjectDb
 
 
 def _manager():
@@ -28,6 +28,10 @@ def _manager():
 def draft_contract(db_session: Session):
     cid = str(uuid.uuid4())
     db_session.add(DataContractDb(id=cid, name="Reviewable", version="1.0.0", status="draft"))
+    # A contract must describe at least one schema object before it can be
+    # proposed for review (ONT-NEG-005); seed one so the happy-path transition
+    # reflects a reviewable draft.
+    db_session.add(SchemaObjectDb(contract_id=cid, name="orders", logical_type="object"))
     db_session.commit()
     return cid
 


### PR DESCRIPTION
## Summary

An empty draft contract (no schema objects) could be proposed for review: `POST /api/data-contracts/{id}/request-review` returned 200 with `status -> proposed`. There is nothing for a steward to review on an empty draft, and the documented "schema required before proposal" guard was never enforced.

## Changes

- `request_steward_review` raises `ValueError` when the contract has zero schema objects, leaving the contract in `draft`.
- The request-review route now surfaces the validation message on the 409 response (previously masked as a generic "Invalid review request") so the UI can explain *why* the request was blocked. A "not found" error still maps to 404.
- Unit tests: an empty draft cannot be proposed (and stays `draft`); a draft with a schema object can.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression test **ONT-NEG-005** (Ontos CUJ regression suite — Negative Paths): "A Draft contract with no schema objects can be proposed for review; the documented 'schema required before proposal' guard is not enforced."

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_contract_review_schema_guard.py` — 2 passed.

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Negative Paths tab).