### PR TITLE
fix(data-products): gate direct reads of unpublished products (ONT-NEG-011)

### DIFF
--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -64,6 +64,81 @@ def get_data_products_manager(
     return manager
 
 
+def _caller_can_read_product(request, db, current_user, manager, product) -> bool:
+    """Whether ``current_user`` may read ``product`` directly.
+
+    Published products (active/deprecated) are readable by any caller with
+    data-products READ_ONLY — that's the catalog/marketplace contract.
+    Unpublished products (draft/proposed/under_review/approved/...) are only
+    readable by data-products admins (incl. via an in-app role override) and
+    by owners (draft_owner / owning team / project member). This stops a
+    consumer from reading an unpublished product by its id (ONT-NEG-011).
+    Fails closed on error.
+    """
+    try:
+        from types import SimpleNamespace
+        from src.common.version_visibility import is_visible_consumer
+
+        # Normalize status (may be an enum on the API model) for the
+        # consumer-visibility check (active/deprecated are readable by all).
+        raw_status = getattr(product, "status", None)
+        status_str = raw_status.value if hasattr(raw_status, "value") else str(raw_status or "")
+        if is_visible_consumer(SimpleNamespace(status=status_str)):
+            return True
+
+        product_id = str(getattr(product, "id", "") or "")
+        auth_manager = getattr(request.app.state, "authorization_manager", None)
+        settings_manager = getattr(request.app.state, "settings_manager", None)
+        caller_email = current_user.email if current_user else None
+        user_groups = current_user.groups if current_user else []
+
+        if auth_manager and current_user:
+            applied_role_id = (
+                settings_manager.get_applied_role_override_for_user(caller_email)
+                if settings_manager else None
+            )
+            if applied_role_id and settings_manager:
+                eff = settings_manager.get_feature_permissions_for_role_id(applied_role_id)
+            else:
+                eff = auth_manager.get_user_effective_permissions(user_groups or [], None)
+            if auth_manager.has_permission(eff, DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.ADMIN):
+                return True
+
+        # Non-admin: resolve ownership scope and check the accessible set.
+        from src.controller.teams_manager import teams_manager
+        from src.controller.projects_manager import projects_manager
+
+        caller_team_ids: list = []
+        caller_project_ids: list = []
+        try:
+            user_teams = teams_manager.get_teams_for_user(db, caller_email, user_groups)
+            caller_team_ids = [t.id for t in user_teams if getattr(t, "id", None)]
+            user_projects = projects_manager.get_user_projects(db, caller_email, user_groups)
+            caller_project_ids = [
+                p.id for p in user_projects.projects if getattr(p, "id", None)
+            ]
+        except Exception:
+            logger.exception(
+                "Failed to resolve ownership scope for %s in product read gate; "
+                "falling back to published-only visibility",
+                caller_email,
+            )
+
+        accessible = manager.list_products(
+            skip=0,
+            limit=10_000,
+            is_admin=False,
+            caller_email=caller_email,
+            caller_team_ids=caller_team_ids,
+            caller_project_ids=caller_project_ids,
+        )
+        accessible_ids = {str(p.id) for p in accessible if getattr(p, "id", None)}
+        return product_id in accessible_ids
+    except Exception:
+        logger.exception("Product read gate failed for %s; denying", product_id)
+        return False
+
+
 # --- Lifecycle transitions (minimal) ---
 
 @router.post('/data-products/{product_id}/move-to-sandbox')
@@ -2297,6 +2372,9 @@ async def delete_data_product(
 @router.get('/data-products/{product_id}', response_model=Any)
 async def get_data_product(
     product_id: str,
+    request: Request,
+    db: DBSessionDep,
+    current_user: CurrentUserDep,
     manager: DataProductsManager = Depends(get_data_products_manager),
     _: bool = Depends(PermissionChecker(DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.READ_ONLY))
 ) -> Any: # Return Any to allow returning a dict
@@ -2304,6 +2382,17 @@ async def get_data_product(
         product = manager.get_product(product_id)
         if not product:
             raise HTTPException(status_code=404, detail="Data product not found")
+
+        # Gate direct reads by the same ownership scope the listing uses. The
+        # marketplace listing already hides unpublished products, but a direct
+        # GET by id must not let a consumer read a draft/proposed product they
+        # don't own (ONT-NEG-011). data-products admins see everything; other
+        # callers only see products in their accessible set (published
+        # products, plus drafts they own / their team or project owns). A miss
+        # returns 404 (not 403) so the existence of the draft isn't disclosed.
+        if not _caller_can_read_product(request, db, current_user, manager, product):
+            raise HTTPException(status_code=404, detail="Data product not found")
+
         return product.model_dump(by_alias=False, exclude={'created_at', 'updated_at'}, exclude_none=True, exclude_unset=True)
     except ValueError as e:
         logger.error("Validation error fetching product %s: %s", product_id, e)

--- a/src/backend/src/tests/unit/test_data_product_read_gate.py
+++ b/src/backend/src/tests/unit/test_data_product_read_gate.py
@@ -1,0 +1,66 @@
+"""Unit tests for the direct-read gate on data products (ONT-NEG-011).
+
+A consumer could read an unpublished (draft) product by id via
+GET /api/data-products/{id}. The gate must allow published products to
+everyone but restrict unpublished ones to admins and owners.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.routes.data_product_routes import _caller_can_read_product
+
+
+def _request(*, is_admin: bool):
+    auth_manager = MagicMock()
+    auth_manager.get_user_effective_permissions.return_value = {}
+    auth_manager.has_permission.return_value = is_admin
+    request = MagicMock()
+    request.app.state.authorization_manager = auth_manager
+    request.app.state.settings_manager = None
+    return request
+
+
+def _user(email="consumer@example.com"):
+    return SimpleNamespace(email=email, groups=[])
+
+
+class TestProductReadGate:
+    def test_published_product_readable_by_anyone(self):
+        manager = MagicMock()
+        # Even if the accessible set is empty, a published product is readable.
+        manager.list_products.return_value = []
+        product = SimpleNamespace(id="p1", status="active")
+
+        assert _caller_can_read_product(
+            _request(is_admin=False), MagicMock(), _user(), manager, product
+        ) is True
+        # Published short-circuit: we never needed to scope the listing.
+        manager.list_products.assert_not_called()
+
+    def test_draft_denied_for_non_owner_non_admin(self):
+        manager = MagicMock()
+        manager.list_products.return_value = []  # caller owns nothing
+        product = SimpleNamespace(id="p1", status="draft")
+
+        assert _caller_can_read_product(
+            _request(is_admin=False), MagicMock(), _user(), manager, product
+        ) is False
+
+    def test_draft_allowed_for_feature_admin(self):
+        manager = MagicMock()
+        product = SimpleNamespace(id="p1", status="draft")
+
+        assert _caller_can_read_product(
+            _request(is_admin=True), MagicMock(), _user(), manager, product
+        ) is True
+
+    def test_draft_allowed_for_owner_in_accessible_set(self):
+        manager = MagicMock()
+        manager.list_products.return_value = [SimpleNamespace(id="p1")]  # caller owns it
+        product = SimpleNamespace(id="p1", status="draft")
+
+        assert _caller_can_read_product(
+            _request(is_admin=False), MagicMock(), _user(), manager, product
+        ) is True


### PR DESCRIPTION
## Summary

`GET /api/data-products/{id}` returned the full product to any caller with `data-products:READ_ONLY`, with **no status or ownership check**. A Data Consumer could read a **draft** (uncertified) product directly by id — `GET /api/data-products/{draftId}` → 200 with the full draft — even though the marketplace listing correctly hides drafts.

## Changes

A read gate on the get-by-id route (`_caller_can_read_product`):

- **Published** products (`active`/`deprecated`) remain readable by anyone with `READ_ONLY` — the catalog/marketplace contract.
- **Unpublished** products (`draft`/`proposed`/`under_review`/`approved`/...) are readable only by data-products **admins** (including via an in-app role override) and **owners** (`draft_owner` / owning team / project member) — reusing the same ownership scope the listing uses (`list_products` + role-override resolution), consistent with the DP-assets route.
- A denied read returns **404** (not 403) so the draft's existence isn't disclosed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes regression test **ONT-NEG-011** (Ontos CUJ regression suite — Negative Paths): "A Consumer can directly read a DRAFT (uncertified) product via the API; expected 404/not-available. (The marketplace listing already hides drafts, but direct API access was not gated.)"

## Testing

- `hatch -e dev run pytest src/backend/src/tests/unit/test_data_product_read_gate.py` — 4 passed. The gate is tested directly (published readable by all; draft denied for a non-owner consumer; draft allowed for a feature admin and for an owner in the accessible set).

## Related Issues

Surfaced during manual CUJ regression testing of the Ontos app (Negative Paths tab).