### PR TITLE
ci: run required checks on merge_group for merge queue

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  # Required by the merge queue: GitHub builds each batch on a temporary
+  # gh-readonly-queue/<base>/... branch and fires a merge_group event. The
+  # required status checks must run on that event or queued PRs hang forever
+  # waiting on checks that never report.
+  merge_group:
 
 permissions:
   id-token: write
@@ -354,8 +359,12 @@ jobs:
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "Auto-regenerated \`requirements.txt\` lockfiles to match \`requirements.in\`."
 
-      - name: Fail if drift on fork PR or push to protected branch
-        if: steps.drift.outputs.drifted == 'true' && (github.event_name == 'push' || steps.fork.outputs.is_fork == 'true')
+      - name: Fail if drift on fork PR, push to protected branch, or merge queue
+        # merge_group is included so a queued batch with stale lockfiles fails
+        # the queue instead of silently merging: the auto-commit fixup above is
+        # PR-only (it can't push to the read-only queue branch), so the queue
+        # must hard-fail on drift rather than skip the check.
+        if: steps.drift.outputs.drifted == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || steps.fork.outputs.is_fork == 'true')
         run: |
           echo "ERROR: requirements.txt lockfiles are out of sync with .in files."
           echo "Run ./scripts/lock-requirements.sh locally and commit the updated .txt files."


### PR DESCRIPTION
## What

Adds a `merge_group:` trigger to the **Test Coverage** workflow so it runs on the temporary `gh-readonly-queue/<base>/...` branch GitHub builds for each queued batch.

This is the prerequisite CI change for enabling a GitHub **merge queue** on `main` and `develop`. The five required status checks must report on the `merge_group` event or queued PRs hang forever waiting on checks that never run:

- Backend Tests
- Frontend Tests
- TypeScript Type Check
- Requirements Lockfile Check
- Frontend Build Check

## Changes

- `on.merge_group` added (no branch filter, so it covers both `main` and `develop` queues).
- The lockfile **drift gate** now also hard-fails under `merge_group`. The auto-commit fixup is PR-only (it can't push to the read-only queue branch), so the queue must fail on drift rather than silently skip the check.

## Not touched (intentionally)

- `check-alembic-heads` and `pr-title-lint` are **not** required checks and are inherently PR-scoped (they read `pull_request.*` context), so they stay PR-only and do not gate the queue.

## Rollout order

1. Merge this PR so `main`/`develop` emit the `merge_group` checks.
2. **Then** activate the merge queue via a ruleset on each branch (separate, settings-only change). Activating before this lands would stall the queue.

This pull request and its description were written by Isaac.