### PR TITLE
fix(estate-manager): estate detail route 404

### DIFF
--- a/src/frontend/src/views/estate-manager.test.tsx
+++ b/src/frontend/src/views/estate-manager.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Tests for the pure helpers exported from `estate-manager.tsx`.
+ *
+ * The component file pulls in many heavy modules (API, breadcrumb store,
+ * graph view, i18n), so we deliberately keep these tests at the helper level
+ * and avoid importing/rendering the full view.
+ *
+ * `buildEstateDetailPath` is the contract that has to stay in lock-step with
+ * the route registered in `app.tsx` (`/estates/:estateId`). Regression guard
+ * for ONT-FEAT-008: "View Details" used to navigate to `/estate-manager/${id}`,
+ * an unregistered URL that rendered the 404 page.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildEstateDetailPath } from './estate-manager';
+
+describe('buildEstateDetailPath', () => {
+  it('targets the registered /estates/:estateId route', () => {
+    expect(buildEstateDetailPath('1')).toBe('/estates/1');
+  });
+
+  it('does NOT derive the path from the /estate-manager list location', () => {
+    // The old bug produced `/estate-manager/1`, which has no matching route
+    // and rendered "404 - Page Not Found".
+    expect(buildEstateDetailPath('1')).not.toBe('/estate-manager/1');
+    expect(buildEstateDetailPath('1').startsWith('/estate-manager/')).toBe(false);
+  });
+
+  it('handles arbitrary estate ids (uuid-style)', () => {
+    const id = 'a1b2c3d4-0000-1111-2222-333344445555';
+    expect(buildEstateDetailPath(id)).toBe(`/estates/${id}`);
+  });
+});

--- a/src/frontend/src/views/estate-manager.tsx
+++ b/src/frontend/src/views/estate-manager.tsx
@@ -24,7 +24,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { ViewModeToggle } from '@/components/common/view-mode-toggle';
 import { DataTable } from '@/components/ui/data-table';
@@ -73,12 +73,23 @@ interface Estate {
 }
 // --- End TypeScript Interfaces ---
 
+/**
+ * Builds the route path for an estate's detail view.
+ *
+ * This MUST stay in lock-step with the route registered in `app.tsx`
+ * (`/estates/:estateId`). A previous implementation derived the path from the
+ * current location (`/estate-manager/${id}`), which produced an unregistered
+ * URL and rendered the 404 page when "View Details" was clicked.
+ */
+export function buildEstateDetailPath(estateId: string): string {
+  return `/estates/${estateId}`;
+}
+
 export default function EstateManager() {
   const { t } = useTranslation(['estates', 'common']);
   const { toast } = useToast();
   const { get, post, put, delete: deleteEstateApi } = useApi();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
   const setStaticSegments = useBreadcrumbStore((state) => state.setStaticSegments);
   const setDynamicTitle = useBreadcrumbStore((state) => state.setDynamicTitle);
   const [estates, setEstates] = useState<Estate[]>([]);
@@ -253,7 +264,7 @@ export default function EstateManager() {
   };
   
   const handleNodeClick = (estateId: string) => {
-    navigate(`${pathname}/${estateId}`);
+    navigate(buildEstateDetailPath(estateId));
   };
 
   const columns: ColumnDef<Estate>[] = [


### PR DESCRIPTION
## CUJ
ONT-FEAT-008 (live CUJ regression on ontos-dev)

## Observed failure
In Estate Manager, clicking **View Details** (row click, row action menu, or graph node) navigated to `/estate-manager/1` and rendered **"404 - Page Not Found"**.

## Root cause
`handleNodeClick` in `src/frontend/src/views/estate-manager.tsx` built the destination from the current location:

```ts
const { pathname } = useLocation();
navigate(`${pathname}/${estateId}`); // -> /estate-manager/1
```

But the estate detail route registered in `src/frontend/src/app.tsx` is `/estates/:estateId`, not `/estate-manager/:estateId`. The constructed URL had no matching route, so the router fell through to the 404 page. The detail view (`estate-details.tsx`) itself was correct — it reads `:estateId` from `/estates/:estateId` and its back button already targets `/estate-manager`.

## Fix
- Navigate to the registered route `/estates/${estateId}` via a small exported pure helper `buildEstateDetailPath`, keeping the link in lock-step with the route in `app.tsx`.
- Removed the now-unused `useLocation`/`pathname` (would otherwise trip `noUnusedLocals`).

## Tests
- Added `src/frontend/src/views/estate-manager.test.tsx` — a focused unit test asserting `buildEstateDetailPath` produces `/estates/:id` and never the old `/estate-manager/:id`. Passes (3/3) via `yarn test:run`.
- `yarn type-check` (tsc --noEmit) passes with zero errors.
- Zero new failures introduced vs clean main.

## Out of scope (needs-design)
The regression note also flagged the absence of a bulk "add tag to N tables" operation. That is a genuine missing feature (multi-select UI + batch tagging endpoint/permission-gating), not a localizable routing bug, so it is intentionally not bundled into this PR.