### PR TITLE
fix(connectors): surface Snowflake connector credential fields

### DIFF
--- a/src/frontend/src/components/settings/connection-form-dialog.test.ts
+++ b/src/frontend/src/components/settings/connection-form-dialog.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for connection-form-dialog config-field helpers.
+ *
+ * These cover the config-building logic that determines which credential /
+ * config fields are persisted per connector type. The full dialog itself
+ * relies on Radix UI components that hang in jsdom, so the testable logic is
+ * extracted into pure functions (see role-form-dialog.test.tsx for context).
+ *
+ * Regression: ONT-FEAT-029 — selecting "Snowflake" in Add Connection showed no
+ * credential/config fields because the Snowflake connector type was missing
+ * from the form's config-field map. These tests lock in that Snowflake exposes
+ * its credential/config fields just like BigQuery.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  CONNECTOR_CONFIG_FIELDS,
+  buildConnectionConfig,
+} from './connection-form-dialog';
+
+describe('CONNECTOR_CONFIG_FIELDS', () => {
+  it('exposes BigQuery config fields', () => {
+    expect(CONNECTOR_CONFIG_FIELDS.bigquery).toEqual([
+      'project_id',
+      'location',
+      'uc_connection_name',
+      'credentials_secret_scope',
+      'credentials_secret_key',
+      'credentials_path',
+    ]);
+  });
+
+  it('exposes Snowflake credential/config fields (ONT-FEAT-029)', () => {
+    // The defect was that this entry did not exist, so the form rendered no
+    // credential fields for Snowflake.
+    expect(CONNECTOR_CONFIG_FIELDS.snowflake).toBeDefined();
+    expect(CONNECTOR_CONFIG_FIELDS.snowflake).toEqual([
+      'account',
+      'user',
+      'warehouse',
+      'database',
+      'default_schema',
+      'role',
+    ]);
+  });
+});
+
+describe('buildConnectionConfig', () => {
+  it('includes only non-empty Snowflake fields', () => {
+    const config = buildConnectionConfig('snowflake', {
+      name: 'Prod SF',
+      connector_type: 'snowflake',
+      account: 'myorg-myaccount',
+      user: 'ONTOS_SVC',
+      warehouse: 'COMPUTE_WH',
+      database: '',
+      default_schema: 'PUBLIC',
+      role: '',
+      // BigQuery fields present in the shared form state must be ignored.
+      project_id: 'should-not-leak',
+    });
+
+    expect(config).toEqual({
+      account: 'myorg-myaccount',
+      user: 'ONTOS_SVC',
+      warehouse: 'COMPUTE_WH',
+      default_schema: 'PUBLIC',
+    });
+    expect(config).not.toHaveProperty('project_id');
+    expect(config).not.toHaveProperty('database');
+    expect(config).not.toHaveProperty('role');
+  });
+
+  it('includes only non-empty BigQuery fields', () => {
+    const config = buildConnectionConfig('bigquery', {
+      connector_type: 'bigquery',
+      project_id: 'my-gcp-project',
+      location: 'US',
+      uc_connection_name: '',
+      // Snowflake fields present in shared form state must be ignored.
+      account: 'should-not-leak',
+    });
+
+    expect(config).toEqual({
+      project_id: 'my-gcp-project',
+      location: 'US',
+    });
+    expect(config).not.toHaveProperty('account');
+  });
+
+  it('returns an empty config for connector types without field hints', () => {
+    expect(buildConnectionConfig('databricks', { account: 'x' })).toEqual({});
+    expect(buildConnectionConfig('unknown', { foo: 'bar' })).toEqual({});
+  });
+});

--- a/src/frontend/src/components/settings/connection-form-dialog.tsx
+++ b/src/frontend/src/components/settings/connection-form-dialog.tsx
@@ -49,6 +49,13 @@ const formSchema = z.object({
   credentials_secret_scope: z.string().optional(),
   credentials_secret_key: z.string().optional(),
   credentials_path: z.string().optional(),
+  // Snowflake config fields
+  account: z.string().optional(),
+  user: z.string().optional(),
+  warehouse: z.string().optional(),
+  database: z.string().optional(),
+  default_schema: z.string().optional(),
+  role: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -57,6 +64,36 @@ const BQ_CONFIG_FIELDS = [
   'project_id', 'location', 'uc_connection_name',
   'credentials_secret_scope', 'credentials_secret_key', 'credentials_path',
 ] as const;
+
+const SNOWFLAKE_CONFIG_FIELDS = [
+  'account', 'user', 'warehouse', 'database', 'default_schema', 'role',
+] as const;
+
+// Maps a connector type to the set of config field names the form persists.
+// Kept as a pure lookup so it can be unit-tested without rendering the dialog.
+export const CONNECTOR_CONFIG_FIELDS: Record<string, readonly string[]> = {
+  bigquery: BQ_CONFIG_FIELDS,
+  snowflake: SNOWFLAKE_CONFIG_FIELDS,
+};
+
+/**
+ * Build the `config` object that gets persisted for a connection, given the
+ * selected connector type and the raw form values. Only non-empty fields that
+ * belong to the connector type are included.
+ */
+export function buildConnectionConfig(
+  connectorType: string,
+  values: Record<string, any>,
+): Record<string, any> {
+  const config: Record<string, any> = {};
+  const fields = CONNECTOR_CONFIG_FIELDS[connectorType];
+  if (fields) {
+    for (const f of fields) {
+      if (values[f]) config[f] = values[f];
+    }
+  }
+  return config;
+}
 
 const SYSTEM_CREATED_BY = 'system';
 
@@ -134,17 +171,18 @@ export function ConnectionFormDialog({
         credentials_secret_scope: cfg.credentials_secret_scope || '',
         credentials_secret_key: cfg.credentials_secret_key || '',
         credentials_path: cfg.credentials_path || '',
+        account: cfg.account || '',
+        user: cfg.user || '',
+        warehouse: cfg.warehouse || '',
+        database: cfg.database || '',
+        default_schema: cfg.default_schema || '',
+        role: cfg.role || '',
       });
     }
   }, [isOpen, initialConnection]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const buildPayload = (values: FormValues) => {
-    const config: Record<string, any> = {};
-    if (values.connector_type === 'bigquery') {
-      for (const f of BQ_CONFIG_FIELDS) {
-        if (values[f]) config[f] = values[f];
-      }
-    }
+    const config = buildConnectionConfig(values.connector_type, values);
     return {
       name: values.name,
       connector_type: values.connector_type,
@@ -469,6 +507,103 @@ export function ConnectionFormDialog({
                     </FormItem>
                   )}
                 />
+              </>
+            )}
+
+            {/* Snowflake-specific config */}
+            {selectedType === 'snowflake' && (
+              <>
+                <Separator />
+                <p className="text-sm font-medium">
+                  {t('settings:connectors.snowflake.configTitle', 'Snowflake Configuration')}
+                </p>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="account"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('settings:connectors.snowflake.account', 'Account Identifier')}</FormLabel>
+                        <FormControl>
+                          <Input placeholder="myorg-myaccount" {...field} value={field.value || ''} />
+                        </FormControl>
+                        <FormDescription>
+                          {t('settings:connectors.snowflake.accountHelp', 'e.g. myorg-myaccount or xy12345.us-east-1')}
+                        </FormDescription>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="user"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('settings:connectors.snowflake.user', 'User')}</FormLabel>
+                        <FormControl>
+                          <Input placeholder="ONTOS_SVC" {...field} value={field.value || ''} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="warehouse"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('settings:connectors.snowflake.warehouse', 'Warehouse')}</FormLabel>
+                        <FormControl>
+                          <Input placeholder="COMPUTE_WH" {...field} value={field.value || ''} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="role"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('settings:connectors.snowflake.role', 'Role')}</FormLabel>
+                        <FormControl>
+                          <Input placeholder="SYSADMIN" {...field} value={field.value || ''} />
+                        </FormControl>
+                        <FormDescription>
+                          {t('settings:connectors.snowflake.roleHelp', 'Optional. Role to assume for queries.')}
+                        </FormDescription>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="database"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('settings:connectors.snowflake.database', 'Default Database')}</FormLabel>
+                        <FormControl>
+                          <Input placeholder="ANALYTICS" {...field} value={field.value || ''} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="default_schema"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('settings:connectors.snowflake.defaultSchema', 'Default Schema')}</FormLabel>
+                        <FormControl>
+                          <Input placeholder="PUBLIC" {...field} value={field.value || ''} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
               </>
             )}
 

--- a/src/frontend/src/i18n/locales/en/settings.json
+++ b/src/frontend/src/i18n/locales/en/settings.json
@@ -543,6 +543,17 @@
       "credentialsPath": "Credentials File Path",
       "credentialsPathHelp": "Dev fallback: local path to a service account key JSON file."
     },
+    "snowflake": {
+      "configTitle": "Snowflake Configuration",
+      "account": "Account Identifier",
+      "accountHelp": "e.g. myorg-myaccount or xy12345.us-east-1",
+      "user": "User",
+      "warehouse": "Warehouse",
+      "role": "Role",
+      "roleHelp": "Optional. Role to assume for queries.",
+      "database": "Default Database",
+      "defaultSchema": "Default Schema"
+    },
     "databricks": {
       "systemNote": "This connection is auto-configured from environment variables and cannot be modified."
     },


### PR DESCRIPTION
## CUJ: ONT-FEAT-029

### Observed failure
In Settings -> Connectors -> Add Connection, selecting **Snowflake** shows NO credential/config fields and NO **Test Connection** button — only the generic Name / Description / Enabled / Default inputs. By contrast, selecting **BigQuery** renders a full configuration block (project, location, UC connection, secret scope/key, credentials path).

### Root cause
The connection form (`src/frontend/src/components/settings/connection-form-dialog.tsx`) is **not** data-driven from the connector metadata. It hardcodes a config block that is gated on `selectedType === 'bigquery'`, and `buildPayload` only collected `config` for `bigquery`. There was no Snowflake branch, so Snowflake fell through to the generic-only form.

This is purely a frontend gap, not a missing backend integration: the backend already advertises Snowflake config field hints (`account`, `user`, `warehouse`, `database`, `default_schema`, `role`) from `SnowflakeConnectorConfig` via `GET /api/connections/types` (`ConnectionsManager.list_connector_types`). The form simply ignored those hints.

(Note: the backend `SnowflakeConnector` is still a stub — `is_available = False` — so the underlying asset-discovery/Test integration remains pending. That is a separate, pre-existing backend limitation and out of scope for this UI defect. The **Test Connection** button itself is shown for any saved connection while editing; the original report's "no Test Connection button" was because the unsupported Snowflake form could not be meaningfully filled in/saved with config.)

### Fix
- Added a **Snowflake Configuration** block to the dialog mirroring the existing BigQuery pattern, exposing: Account Identifier, User, Warehouse, Role, Default Database, Default Schema.
- Extended the Zod form schema and the `form.reset` defaults to round-trip the Snowflake config fields when editing.
- Extracted the per-connector config-field mapping into a pure, exported helper — `CONNECTOR_CONFIG_FIELDS` + `buildConnectionConfig(connectorType, values)` — replacing the inline BigQuery-only loop in `buildPayload`. This keeps the logic data-driven and unit-testable, and prevents fields from one connector type leaking into another's persisted `config`.
- Added the `connectors.snowflake.*` i18n strings to `en/settings.json`.

### How tested
- New focused unit test `src/frontend/src/components/settings/connection-form-dialog.test.ts` (5 cases) covering `CONNECTOR_CONFIG_FIELDS` and `buildConnectionConfig` for Snowflake + BigQuery, including cross-connector field isolation and empty-field stripping. All pass via `vitest run`.
- `tsc --noEmit` type-check: clean.
- Full `src/components/settings/` vitest suite: passing (existing `role-form-dialog` test remains skipped, unchanged).
- JSON validity of `en/settings.json` confirmed.

The full dialog is not rendered in jsdom because its Radix UI Select hangs there (same documented limitation as `role-form-dialog.test.tsx`); the testable logic was therefore extracted into pure helpers.