### PR TITLE
fix(catalog-commander): allow applying a tag to a selected table

### DIFF
--- a/src/frontend/src/components/metadata/entity-tags-panel.test.tsx
+++ b/src/frontend/src/components/metadata/entity-tags-panel.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { FeatureAccessLevel } from '@/types/feature-access-levels'
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+
+vi.mock('@/hooks/use-api', () => ({
+  useApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    loading: false,
+  }),
+}))
+
+const toastSpy = vi.fn()
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastSpy }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+let mockLevel: FeatureAccessLevel = FeatureAccessLevel.READ_WRITE
+vi.mock('@/stores/permissions-store', () => ({
+  usePermissions: () => ({
+    hasPermission: (_feature: string, required: FeatureAccessLevel) => {
+      const order: Record<string, number> = {
+        [FeatureAccessLevel.NONE]: 0,
+        [FeatureAccessLevel.READ_ONLY]: 1,
+        [FeatureAccessLevel.READ_WRITE]: 3,
+        [FeatureAccessLevel.ADMIN]: 4,
+      }
+      return (order[mockLevel] ?? 0) >= (order[required] ?? 0)
+    },
+  }),
+}))
+
+// TagSelector pulls in Radix popover/command which hangs in jsdom; stub it with
+// a simple control that drives the onChange contract this panel relies on.
+vi.mock('@/components/ui/tag-selector', () => ({
+  default: ({ onChange }: { onChange: (tags: string[]) => void }) => (
+    <button onClick={() => onChange(['governance.pii'])}>add-tag</button>
+  ),
+}))
+
+// TagChip fetches global settings on mount; stub the store so jsdom does not
+// attempt a real network request for the relative /api/settings URL.
+vi.mock('@/stores/app-settings-store', () => ({
+  useAppSettingsStore: () => ({ tagDisplayFormat: 'long', fetchSettings: vi.fn() }),
+}))
+
+import EntityTagsPanel from './entity-tags-panel'
+
+const sampleTags = [
+  {
+    tag_id: 'tag-1',
+    tag_name: 'pii',
+    namespace_id: 'ns-1',
+    namespace_name: 'governance',
+    status: 'active',
+    fully_qualified_name: 'governance.pii',
+    assigned_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+function renderPanel() {
+  return render(
+    <BrowserRouter>
+      <TooltipProvider>
+        <EntityTagsPanel entityId="samples.nyctaxi.trips" entityType="catalog-object" />
+      </TooltipProvider>
+    </BrowserRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockGet.mockReset()
+  mockPost.mockReset()
+  toastSpy.mockReset()
+  mockLevel = FeatureAccessLevel.READ_WRITE
+})
+
+describe('EntityTagsPanel', () => {
+  it('loads assigned tags from the entity-tags endpoint', async () => {
+    mockGet.mockResolvedValue({ data: sampleTags })
+    renderPanel()
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        '/api/entities/catalog-object/samples.nyctaxi.trips/tags',
+      )
+    })
+    expect(await screen.findByText('governance.pii')).toBeInTheDocument()
+  })
+
+  it('applies a tag via the tags:set endpoint as {tag_fqn} payload', async () => {
+    mockGet.mockResolvedValue({ data: [] })
+    mockPost.mockResolvedValue({ data: sampleTags })
+    renderPanel()
+
+    // Enter edit mode
+    await userEvent.click(await screen.findByRole('button', { name: 'tags.edit' }))
+    // Select a tag via the stubbed TagSelector
+    await userEvent.click(screen.getByText('add-tag'))
+    // Save
+    await userEvent.click(screen.getByText('tags.save'))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/entities/catalog-object/samples.nyctaxi.trips/tags:set',
+        [{ tag_fqn: 'governance.pii' }],
+      )
+    })
+  })
+
+  it('hides the edit control without tags write permission', async () => {
+    mockLevel = FeatureAccessLevel.READ_ONLY
+    mockGet.mockResolvedValue({ data: [] })
+    renderPanel()
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: 'tags.edit' })).not.toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/components/metadata/entity-tags-panel.tsx
+++ b/src/frontend/src/components/metadata/entity-tags-panel.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tags, Pencil, Loader2, RefreshCcw } from 'lucide-react';
+import TagSelector from '@/components/ui/tag-selector';
+import TagChip, { AssignedTag } from '@/components/ui/tag-chip';
+import { useApi } from '@/hooks/use-api';
+import { usePermissions } from '@/stores/permissions-store';
+import { FeatureAccessLevel } from '@/types/feature-access-levels';
+import { useToast } from '@/hooks/use-toast';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  /** Stable identifier of the entity the tags are assigned to (e.g. a table's full path). */
+  entityId: string;
+  /** Polymorphic entity type understood by the tags backend (e.g. 'catalog-object'). */
+  entityType: string;
+}
+
+/**
+ * Surfaces the generic entity-tag assignment API
+ * (GET/POST /api/entities/{entityType}/{entityId}/tags) so that a user can view
+ * and apply tags to any polymorphic entity, including Unity Catalog objects in
+ * the Catalog Commander Info panel.
+ */
+const EntityTagsPanel: React.FC<Props> = ({ entityId, entityType }) => {
+  const { get, post, loading: saving } = useApi();
+  const { toast } = useToast();
+  const { t } = useTranslation('metadata');
+  const { hasPermission } = usePermissions();
+  const canEditTags = hasPermission('tags', FeatureAccessLevel.READ_WRITE);
+
+  const [assignedTags, setAssignedTags] = React.useState<AssignedTag[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [editing, setEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState<(string | AssignedTag)[]>([]);
+
+  const fetchTags = React.useCallback(async () => {
+    if (!entityId) return;
+    try {
+      setLoading(true);
+      const resp = await get<AssignedTag[]>(`/api/entities/${entityType}/${encodeURIComponent(entityId)}/tags`);
+      setAssignedTags(Array.isArray(resp.data) ? resp.data : []);
+    } catch (e: any) {
+      // A missing assignment is not an error; only surface real failures.
+      setAssignedTags([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [entityId, entityType, get]);
+
+  React.useEffect(() => { fetchTags(); }, [fetchTags]);
+
+  const startEditing = () => {
+    setDraft(assignedTags.map(tag => tag.fully_qualified_name));
+    setEditing(true);
+  };
+
+  const handleSave = async () => {
+    try {
+      // The backend accepts a list of FQN strings or {tag_fqn} objects.
+      const payload = draft.map(tag => (typeof tag === 'string' ? { tag_fqn: tag } : { tag_fqn: tag.fully_qualified_name }));
+      const resp = await post<AssignedTag[]>(`/api/entities/${entityType}/${encodeURIComponent(entityId)}/tags:set`, payload);
+      if (resp.error) throw new Error(resp.error);
+      setAssignedTags(Array.isArray(resp.data) ? resp.data : []);
+      setEditing(false);
+      toast({ title: t('tags.messages.saveSuccess') || 'Tags updated' });
+    } catch (e: any) {
+      toast({ title: t('tags.messages.saveFailed') || 'Failed to update tags', description: e.message, variant: 'destructive' });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-medium flex items-center gap-2">
+          <Tags className="h-5 w-5 text-primary" />
+          {t('tags.title') || 'Tags'}
+          <TooltipProvider>
+            <div className="flex items-center gap-1 border rounded-md bg-muted/40 px-1 py-0.5 ml-1">
+              {canEditTags && !editing && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon" aria-label={t('tags.edit') || 'Edit tags'} onClick={startEditing}>
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('tags.edit') || 'Edit tags'}</TooltipContent>
+                </Tooltip>
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" aria-label={t('tags.refresh') || 'Refresh'} onClick={fetchTags} disabled={editing}>
+                    <RefreshCcw className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t('tags.refresh') || 'Refresh'}</TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
+        </CardTitle>
+        <CardDescription>{t('tags.description') || 'Apply governance tags to this object.'}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {editing ? (
+          <div className="space-y-3">
+            <TagSelector
+              value={draft}
+              onChange={setDraft}
+              placeholder={t('tags.placeholder') || 'Search and select tags...'}
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleSave} disabled={saving}>
+                {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+                {t('tags.save') || 'Save'}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => setEditing(false)} disabled={saving}>
+                {t('tags.cancel') || 'Cancel'}
+              </Button>
+            </div>
+          </div>
+        ) : loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> {t('common:actions.loading')}
+          </div>
+        ) : assignedTags.length === 0 ? (
+          <div className="text-sm text-muted-foreground">{t('tags.noTags') || 'No tags applied.'}</div>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {assignedTags.map(tag => (
+              <TagChip key={tag.tag_id} tag={tag} size="sm" displayFormat="long" />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default EntityTagsPanel;

--- a/src/frontend/src/i18n/locales/de/metadata.json
+++ b/src/frontend/src/i18n/locales/de/metadata.json
@@ -119,5 +119,19 @@
     "loadFailed": "Metadaten-Laden fehlgeschlagen",
     "attachSuccess": "Geteiltes Asset erfolgreich angehängt",
     "attachFailed": "Anhängen des geteilten Assets fehlgeschlagen"
+  },
+  "tags": {
+    "title": "Tags",
+    "description": "Apply governance tags to this object.",
+    "edit": "Edit tags",
+    "refresh": "Refresh",
+    "placeholder": "Search and select tags...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "noTags": "No tags applied.",
+    "messages": {
+      "saveSuccess": "Tags updated",
+      "saveFailed": "Failed to update tags"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/en/metadata.json
+++ b/src/frontend/src/i18n/locales/en/metadata.json
@@ -119,5 +119,19 @@
     "loadFailed": "Metadata load failed",
     "attachSuccess": "Shared asset attached successfully",
     "attachFailed": "Failed to attach shared asset"
+  },
+  "tags": {
+    "title": "Tags",
+    "description": "Apply governance tags to this object.",
+    "edit": "Edit tags",
+    "refresh": "Refresh",
+    "placeholder": "Search and select tags...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "noTags": "No tags applied.",
+    "messages": {
+      "saveSuccess": "Tags updated",
+      "saveFailed": "Failed to update tags"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/es/metadata.json
+++ b/src/frontend/src/i18n/locales/es/metadata.json
@@ -119,5 +119,19 @@
     "loadFailed": "Error al cargar metadatos",
     "attachSuccess": "Asset compartido adjuntado correctamente",
     "attachFailed": "Error al adjuntar asset compartido"
+  },
+  "tags": {
+    "title": "Tags",
+    "description": "Apply governance tags to this object.",
+    "edit": "Edit tags",
+    "refresh": "Refresh",
+    "placeholder": "Search and select tags...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "noTags": "No tags applied.",
+    "messages": {
+      "saveSuccess": "Tags updated",
+      "saveFailed": "Failed to update tags"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/fr/metadata.json
+++ b/src/frontend/src/i18n/locales/fr/metadata.json
@@ -119,5 +119,19 @@
     "loadFailed": "Échec du chargement des métadonnées",
     "attachSuccess": "Asset partagé joint avec succès",
     "attachFailed": "Échec de l'attachement de l'asset partagé"
+  },
+  "tags": {
+    "title": "Tags",
+    "description": "Apply governance tags to this object.",
+    "edit": "Edit tags",
+    "refresh": "Refresh",
+    "placeholder": "Search and select tags...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "noTags": "No tags applied.",
+    "messages": {
+      "saveSuccess": "Tags updated",
+      "saveFailed": "Failed to update tags"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/it/metadata.json
+++ b/src/frontend/src/i18n/locales/it/metadata.json
@@ -119,5 +119,19 @@
     "loadFailed": "Caricamento metadati fallito",
     "attachSuccess": "Asset condiviso allegato con successo",
     "attachFailed": "Allegamento asset condiviso fallito"
+  },
+  "tags": {
+    "title": "Tags",
+    "description": "Apply governance tags to this object.",
+    "edit": "Edit tags",
+    "refresh": "Refresh",
+    "placeholder": "Search and select tags...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "noTags": "No tags applied.",
+    "messages": {
+      "saveSuccess": "Tags updated",
+      "saveFailed": "Failed to update tags"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/ja/metadata.json
+++ b/src/frontend/src/i18n/locales/ja/metadata.json
@@ -119,5 +119,19 @@
     "loadFailed": "メタデータの読み込みに失敗しました",
     "attachSuccess": "共有アセットが正常に添付されました",
     "attachFailed": "共有アセットの添付に失敗しました"
+  },
+  "tags": {
+    "title": "Tags",
+    "description": "Apply governance tags to this object.",
+    "edit": "Edit tags",
+    "refresh": "Refresh",
+    "placeholder": "Search and select tags...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "noTags": "No tags applied.",
+    "messages": {
+      "saveSuccess": "Tags updated",
+      "saveFailed": "Failed to update tags"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/nl/metadata.json
+++ b/src/frontend/src/i18n/locales/nl/metadata.json
@@ -119,6 +119,19 @@
     "loadFailed": "Metadata laden mislukt",
     "attachSuccess": "Gedeelde asset succesvol bijgevoegd",
     "attachFailed": "Kon gedeelde asset niet bijvoegen"
+  },
+  "tags": {
+    "title": "Tags",
+    "description": "Apply governance tags to this object.",
+    "edit": "Edit tags",
+    "refresh": "Refresh",
+    "placeholder": "Search and select tags...",
+    "save": "Save",
+    "cancel": "Cancel",
+    "noTags": "No tags applied.",
+    "messages": {
+      "saveSuccess": "Tags updated",
+      "saveFailed": "Failed to update tags"
+    }
   }
 }
-

--- a/src/frontend/src/views/catalog-commander.tsx
+++ b/src/frontend/src/views/catalog-commander.tsx
@@ -42,6 +42,7 @@ import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { CommentTimeline } from '@/components/comments/comment-timeline';
 import { cn } from '@/lib/utils';
 import EntityMetadataPanel from '@/components/metadata/entity-metadata-panel';
+import EntityTagsPanel from '@/components/metadata/entity-tags-panel';
 import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useToast } from '@/hooks/use-toast';
@@ -1164,6 +1165,14 @@ const CatalogCommander: React.FC = () => {
                           })()}
                         </CardContent>
                       </Card>
+
+                      {/* Tags - apply governance tags to the selected object */}
+                      {getSelectedNodeDetails()?.id && (
+                        <EntityTagsPanel
+                          entityId={getSelectedNodeDetails()?.id || ''}
+                          entityType="catalog-object"
+                        />
+                      )}
 
                       {/* Entity Metadata Panel - Notes, Links, Documents */}
                       {getSelectedNodeDetails() && (


### PR DESCRIPTION
## CUJ
ONT-FEAT-007 — Catalog Commander: apply a tag to a selected table.

## Observed failure
In Catalog Commander, selecting a table (e.g. `samples.nyctaxi.trips`) gives a toolbar (View Data / Move / Delete / Rename / Ask Ontos / Info / Operations / Comments) and an Info panel showing only notes/links/documents. There was **no way to apply a tag** to the selected table.

## Root cause
The Info panel renders `EntityMetadataPanel`, which only covers notes, links, and documents. No control surfaced the tagging API. The backend already exposes a generic, free-form entity-tag assignment API:

- `GET  /api/entities/{entity_type}/{entity_id}/tags`
- `POST /api/entities/{entity_type}/{entity_id}/tags:set`
- `POST /api/entities/{entity_type}/{entity_id}/tags:add`
- `DELETE /api/entities/{entity_type}/{entity_id}/tags:remove`

`TagsManager.set_tags_for_entity` / `add_tag_to_entity` pass `entity_type` straight through to the repository with no whitelist, and `AssignedTagCreate` accepts a list of FQN strings or `{tag_fqn}` objects — exactly what the existing `TagSelector` produces. The Comments panel already uses `entity_type="catalog-object"` for these same items. So this was a **frontend surfacing gap**, not a missing feature — fully localizable, no backend change required.

## Fix
- New `EntityTagsPanel` (`src/frontend/src/components/metadata/entity-tags-panel.tsx`): loads assigned tags via the entity-tags GET endpoint, displays them with the existing `TagChip`, and lets the user edit/apply via the existing `TagSelector`, saving with `tags:set` (`[{ tag_fqn }]` payload). Editing is gated on the `tags` `READ_WRITE` permission, mirroring `TagSelector`'s own gating; without write access the panel is read-only.
- Wired the panel into the Catalog Commander Info panel for the selected object, using `entity_type="catalog-object"` (consistent with the Comments panel).
- Added `tags.*` i18n keys to `metadata.json` for all 7 locales (English copy as baseline for non-English).
- Icon buttons get `aria-label`s for accessibility/testability.

## Testing
- New unit test `entity-tags-panel.test.tsx` (vitest) — 3 cases, all pass:
  1. loads assigned tags from `GET /api/entities/catalog-object/{id}/tags`
  2. applies a tag via `POST .../tags:set` with `[{ tag_fqn }]` payload
  3. hides the edit control without `tags` write permission
- `tsc --noEmit` passes cleanly (exit 0, no errors).
- No backend change; the generic entity-tag endpoints already support arbitrary entity types.
