### PR TITLE
fix(i18n): align access-grants locale keys with en source

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  # Required by the merge queue: GitHub builds each batch on a temporary
+  # gh-readonly-queue/<base>/... branch and fires a merge_group event. The
+  # required status checks must run on that event or queued PRs hang forever
+  # waiting on checks that never report.
+  merge_group:
 
 permissions:
   id-token: write
@@ -354,8 +359,12 @@ jobs:
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "Auto-regenerated \`requirements.txt\` lockfiles to match \`requirements.in\`."
 
-      - name: Fail if drift on fork PR or push to protected branch
-        if: steps.drift.outputs.drifted == 'true' && (github.event_name == 'push' || steps.fork.outputs.is_fork == 'true')
+      - name: Fail if drift on fork PR, push to protected branch, or merge queue
+        # merge_group is included so a queued batch with stale lockfiles fails
+        # the queue instead of silently merging: the auto-commit fixup above is
+        # PR-only (it can't push to the read-only queue branch), so the queue
+        # must hard-fail on drift rather than skip the check.
+        if: steps.drift.outputs.drifted == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || steps.fork.outputs.is_fork == 'true')
         run: |
           echo "ERROR: requirements.txt lockfiles are out of sync with .in files."
           echo "Run ./scripts/lock-requirements.sh locally and commit the updated .txt files."

--- a/src/backend/src/controller/compliance_manager.py
+++ b/src/backend/src/controller/compliance_manager.py
@@ -13,7 +13,7 @@ from src.repositories.compliance_repository import (
     compliance_run_repo,
     compliance_result_repo,
 )
-from ..models.compliance import CompliancePolicy, ComplianceRun, ComplianceResult
+from ..models.compliance import CompliancePolicy, CompliancePolicyCreate, ComplianceRun, ComplianceResult
 from src.common.compliance_dsl import evaluate_rule_on_object as eval_dsl, parse_rule, Evaluator
 from src.common.compliance_actions import ActionExecutor, ActionContext, get_action_registry
 from src.common.compliance_entities import (
@@ -168,13 +168,13 @@ class ComplianceManager:
         return db.get(CompliancePolicyDb, policy_id)
 
     def create_policy(
-        self, 
-        db: Session, 
-        policy: CompliancePolicy,
+        self,
+        db: Session,
+        policy: CompliancePolicyCreate,
         current_user: Optional[str] = None,
     ) -> CompliancePolicyDb:
         db_obj = CompliancePolicyDb(
-            id=str(policy.id),  # Convert UUID to string for SQLite
+            id=str(uuid.uuid4()),  # Server-generated UUID
             name=policy.name,
             description=policy.description,
             failure_message=policy.failure_message,

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -2233,7 +2233,29 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 domain_id = self._resolve_domain(db, domain_id=data_dict.get('domainId'))
             elif data_dict.get('domain'):
                 domain_id = self._resolve_domain(db, domain_name=data_dict.get('domain'))
-            
+
+            # Reject a duplicate contract name within the same domain. This path
+            # always creates a *new* version family (new versions go through
+            # create_version), so any existing contract sharing the name+domain
+            # is a genuine duplicate, not another version of the same family
+            # (ONT-NEG-002). Name match is case-insensitive.
+            from sqlalchemy import func as _sa_func
+            from src.common.errors import ConflictError
+            new_name = data_dict.get('name', '').strip()
+            dup_query = db.query(DataContractDb).filter(
+                _sa_func.lower(DataContractDb.name) == new_name.lower()
+            )
+            dup_query = (
+                dup_query.filter(DataContractDb.domain_id == domain_id)
+                if domain_id is not None
+                else dup_query.filter(DataContractDb.domain_id.is_(None))
+            )
+            if dup_query.first() is not None:
+                where = "domain" if domain_id is not None else "global scope"
+                raise ConflictError(
+                    f"A data contract named '{new_name}' already exists in this {where}"
+                )
+
             # Resolve owner team if provided
             owner_team_id = data_dict.get('owner_team_id')
             if not owner_team_id and data_dict.get('owner'):

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -2237,12 +2237,28 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             elif not isinstance(description, dict):
                 description = {}
             
+            # A contract created without an owning team would otherwise have no
+            # owner at all, which makes it invisible to its own creator under the
+            # PRD #442 role-aware visibility filter (the family is "elevated" only
+            # for the draft_owner or owner_team members). Stamp the creator as the
+            # personal-draft owner so they can find the contract they just created.
+            # When an owner team is supplied the draft is team-visible from the
+            # start, so we leave draft_owner_id unset (tier-2 visibility). The
+            # draft_owner_id is cleared again on the draft->proposed transition.
+            status_value = data_dict.get('status', 'draft')
+            draft_owner_id = (
+                current_user
+                if (status_value or '').lower() == 'draft' and not owner_team_id
+                else None
+            )
+
             # Create main contract record
             db_obj = DataContractDb(
                 name=data_dict.get('name'),
                 version=data_dict.get('version', '1.0.0'),
-                status=data_dict.get('status', 'draft'),
+                status=status_value,
                 owner_team_id=owner_team_id,
+                draft_owner_id=draft_owner_id,
                 project_id=project_id,  # Add project_id
                 kind=data_dict.get('kind', 'DataContract'),
                 api_version=data_dict.get('apiVersion', 'v3.1.0'),
@@ -4857,8 +4873,12 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if from_status != 'draft':
             raise ValueError(f"Cannot request review from status {contract.status}. Must be DRAFT.")
         
-        # Transition to PROPOSED
+        # Transition to PROPOSED. Clear the personal-draft owner so the contract
+        # is promoted from tier-1 (creator-only) to organisation visibility; a
+        # contract under steward review must be discoverable by stewards and
+        # other team members, not just its author (PRD #442).
         contract.status = 'proposed'
+        contract.draft_owner_id = None
         db.add(contract)
         db.flush()
         self._update_search_index(contract, db)
@@ -5917,6 +5937,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         project_id=None,
         is_admin=False,
         latest_only=True,
+        status=None,
         *,
         caller_email: Optional[str] = None,
         caller_team_ids: Optional[Set[str]] = None,
@@ -5976,6 +5997,16 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 or (not is_admin_only_status(c) and is_visible_consumer(c))
             ]
 
+        # Optional status filter (e.g. ?status=draft). Applied after the
+        # visibility filter so callers can only ever narrow to statuses they
+        # are already allowed to see — a consumer asking for ?status=draft
+        # still gets nothing because drafts were dropped above.
+        if status:
+            wanted = status.strip().lower()
+            contracts = [
+                c for c in contracts if (c.status or '').lower() == wanted
+            ]
+
         # Family counts are taken from the post-visibility-filter set so
         # the badge reflects what the caller can actually navigate to.
         counts = compute_family_counts(contracts)
@@ -5999,6 +6030,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         db,
         domain_id: Optional[str] = None,
         project_id: Optional[str] = None,
+        status: Optional[str] = None,
         is_admin: bool = False,
         latest_only: bool = True,
         include_history: bool = False,
@@ -6021,6 +6053,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             project_id,
             is_admin,
             latest_only,
+            status=status,
             caller_email=caller_email,
             caller_team_ids=caller_team_ids,
         )

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -4889,8 +4889,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         from datetime import datetime
         from src.common.workflow_triggers import get_trigger_registry
         from src.models.process_workflows import EntityType
-        from src.models.data_asset_reviews import AssetType, ReviewedAssetStatus
-        
+
         contract = data_contract_repo.get(db, id=contract_id)
         if not contract:
             raise ValueError("Contract not found")
@@ -4911,27 +4910,22 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         
         now = datetime.utcnow()
         request_id = str(uuid4())
-        
-        # Create asset review record
-        try:
-            from src.controller.data_asset_reviews_manager import DataAssetReviewManager
-            from src.models.data_asset_reviews import ReviewedAsset as ReviewedAssetApi
-            from src.common.databricks_utils import get_workspace_client
-            
-            ws_client = get_workspace_client()
-            review_manager = DataAssetReviewManager(db=db, ws_client=ws_client, notifications_manager=notifications_manager)
-            
-            review_asset = ReviewedAssetApi(
-                id=str(uuid4()),
-                asset_fqn=f"contract:{contract_id}",
-                asset_type=AssetType.DATA_CONTRACT,
-                status=ReviewedAssetStatus.PENDING,
-                updated_at=now
-            )
-            logger.info(f"Created asset review record for contract {contract_id}")
-        except Exception as e:
-            logger.warning(f"Failed to create asset review record: {e}", exc_info=True)
-        
+
+        # NOTE: a proposed contract surfaces to stewards through two real paths,
+        # so we deliberately do NOT create a data-asset review record here:
+        #   1. GET /api/approvals/queue lists every contract in proposed/
+        #      under_review status (see ApprovalsManager.get_approvals_queue),
+        #      and the steward acts on it via the contract approve/reject
+        #      endpoints.
+        #   2. The ON_REQUEST_REVIEW trigger below runs any configured review
+        #      workflow (notifications, approval routing).
+        # The /data-asset-reviews surface is for Unity Catalog assets (tables,
+        # views, functions) and needs an explicit reviewer; routing a contract
+        # there would require a steward-assignment policy that doesn't exist
+        # yet. A previous stub here constructed an in-memory ReviewedAsset and
+        # logged "Created asset review record" without ever persisting it —
+        # misleading dead code that is removed.
+
         # Fire the ON_REQUEST_REVIEW trigger
         trigger_registry = get_trigger_registry(db)
         executions = trigger_registry.on_request_review(

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -1652,6 +1652,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         all_properties = []
         all_obj_relationships = []
         all_prop_relationships = []
+        all_quality_checks = []
         # Collect semantic link work to process after bulk insert
         schema_semantic_work = []
         prop_semantic_work = []
@@ -1739,6 +1740,18 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 )
                 all_properties.append(prop)
 
+                # Collect property-level (column) quality rules. These arrive
+                # nested under the column as `properties[].quality`; previously
+                # nothing read them here, so column-level rules silently
+                # vanished on save (the only persisted quality was object-level
+                # via the separate `qualityRules` field).
+                for rule_data in (prop_dict.get('quality') or []):
+                    all_quality_checks.append(
+                        self._build_quality_check_db(
+                            rule_data, object_id=schema_obj_id, property_id=prop_id
+                        )
+                    )
+
                 # Collect property-level relationships (ODCS v3.1.0)
                 for rel_data in (prop_dict.get('relationships') or []):
                     if isinstance(rel_data, dict):
@@ -1778,6 +1791,8 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             db.add_all(all_obj_relationships)
         if all_prop_relationships:
             db.add_all(all_prop_relationships)
+        if all_quality_checks:
+            db.add_all(all_quality_checks)
         db.flush()
 
         # Process semantic links after bulk insert
@@ -1803,10 +1818,51 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                     created_by=current_user
                 )
 
+    @staticmethod
+    def _build_quality_check_db(rule_data, object_id: str, property_id: Optional[str] = None) -> 'DataQualityCheckDb':
+        """Map an incoming quality-rule dict/model to a DataQualityCheckDb row.
+
+        Shared by object-level (``property_id is None``) and property-level
+        (``property_id`` set) persistence so both honour the same ODCS field
+        mapping and camelCase/snake_case aliases. The default ``level`` follows
+        whether the check targets a column or the whole object.
+        """
+        rule_dict = rule_data.model_dump() if hasattr(rule_data, 'model_dump') else rule_data
+        default_level = 'property' if property_id else 'object'
+        return DataQualityCheckDb(
+            object_id=object_id,
+            property_id=property_id,
+            stable_id=rule_dict.get('id'),
+            level=rule_dict.get('level', default_level),
+            name=rule_dict.get('name'),
+            description=rule_dict.get('description'),
+            dimension=rule_dict.get('dimension'),
+            business_impact=rule_dict.get('businessImpact') or rule_dict.get('business_impact'),
+            method=rule_dict.get('method'),
+            schedule=rule_dict.get('schedule'),
+            scheduler=rule_dict.get('scheduler'),
+            severity=rule_dict.get('severity'),
+            type=rule_dict.get('type', 'library'),
+            unit=rule_dict.get('unit'),
+            tags=rule_dict.get('tags'),
+            rule=rule_dict.get('rule'),
+            query=rule_dict.get('query'),
+            engine=rule_dict.get('engine'),
+            implementation=rule_dict.get('implementation'),
+            must_be=rule_dict.get('mustBe') or rule_dict.get('must_be'),
+            must_not_be=rule_dict.get('mustNotBe') or rule_dict.get('must_not_be'),
+            must_be_gt=rule_dict.get('mustBeGt') or rule_dict.get('must_be_gt'),
+            must_be_ge=rule_dict.get('mustBeGe') or rule_dict.get('must_be_ge'),
+            must_be_lt=rule_dict.get('mustBeLt') or rule_dict.get('must_be_lt'),
+            must_be_le=rule_dict.get('mustBeLe') or rule_dict.get('must_be_le'),
+            must_be_between_min=rule_dict.get('mustBeBetweenMin') or rule_dict.get('must_be_between_min'),
+            must_be_between_max=rule_dict.get('mustBeBetweenMax') or rule_dict.get('must_be_between_max'),
+        )
+
     def _create_quality_checks(self, db, contract_id: str, quality_rules: List):
         """
-        Create quality checks for a contract.
-        
+        Create object-level quality checks for a contract.
+
         Args:
             db: Database session
             contract_id: Contract UUID
@@ -1817,43 +1873,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if not schema_obj:
             logger.warning(f"No schema objects found for contract {contract_id}, skipping quality checks")
             return
-        
+
         for rule_data in quality_rules:
-            # Support both Pydantic models and dicts
-            if hasattr(rule_data, 'model_dump'):
-                rule_dict = rule_data.model_dump()
-            else:
-                rule_dict = rule_data
-            
-            quality_check = DataQualityCheckDb(
-                object_id=schema_obj.id,
-                stable_id=rule_dict.get('id'),
-                level=rule_dict.get('level', 'object'),
-                name=rule_dict.get('name'),
-                description=rule_dict.get('description'),
-                dimension=rule_dict.get('dimension'),
-                business_impact=rule_dict.get('businessImpact') or rule_dict.get('business_impact'),
-                method=rule_dict.get('method'),
-                schedule=rule_dict.get('schedule'),
-                scheduler=rule_dict.get('scheduler'),
-                severity=rule_dict.get('severity'),
-                type=rule_dict.get('type', 'library'),
-                unit=rule_dict.get('unit'),
-                tags=rule_dict.get('tags'),
-                rule=rule_dict.get('rule'),
-                query=rule_dict.get('query'),
-                engine=rule_dict.get('engine'),
-                implementation=rule_dict.get('implementation'),
-                must_be=rule_dict.get('mustBe') or rule_dict.get('must_be'),
-                must_not_be=rule_dict.get('mustNotBe') or rule_dict.get('must_not_be'),
-                must_be_gt=rule_dict.get('mustBeGt') or rule_dict.get('must_be_gt'),
-                must_be_ge=rule_dict.get('mustBeGe') or rule_dict.get('must_be_ge'),
-                must_be_lt=rule_dict.get('mustBeLt') or rule_dict.get('must_be_lt'),
-                must_be_le=rule_dict.get('mustBeLe') or rule_dict.get('must_be_le'),
-                must_be_between_min=rule_dict.get('mustBeBetweenMin') or rule_dict.get('must_be_between_min'),
-                must_be_between_max=rule_dict.get('mustBeBetweenMax') or rule_dict.get('must_be_between_max')
-            )
-            db.add(quality_check)
+            db.add(self._build_quality_check_db(rule_data, object_id=schema_obj.id))
     
     def _process_semantic_links(self, db, contract_id: str, contract_data, current_user: Optional[str] = None):
         """
@@ -2493,13 +2515,17 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 ).all()
                 
                 if schema_objects:
-                    # Remove ALL existing quality checks for all schema objects in this contract
+                    # Replace only OBJECT-level checks (property_id IS NULL).
+                    # Property-level (column) checks are owned by the schema
+                    # recreation path above; deleting them here would drop the
+                    # column rules that were just persisted from the same save.
                     for schema_obj in schema_objects:
                         db.query(DataQualityCheckDb).filter(
-                            DataQualityCheckDb.object_id == schema_obj.id
+                            DataQualityCheckDb.object_id == schema_obj.id,
+                            DataQualityCheckDb.property_id.is_(None),
                         ).delete()
-                    
-                    # Add new quality rules
+
+                    # Add new object-level quality rules
                     if data_dict['qualityRules']:
                         self._create_quality_checks(db, contract_id, data_dict['qualityRules'])
             

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -164,6 +164,21 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             product_data.setdefault('kind', 'DataProduct')
             product_data.setdefault('status', DataProductStatus.DRAFT.value)
 
+            # Stamp the creator as the single-user owner when no other owner is
+            # supplied. Without this, a freshly created product has no
+            # project_id, owner_team_id, or draft_owner_id, so the update
+            # authorization cascade fails for *everyone* except a workspace
+            # admin — the creator can't even add deliverables to their own
+            # product (ONT-CUJ-015). Mirrors the personal-draft clone path.
+            if (
+                user
+                and not product_data.get('draft_owner_id')
+                and not product_data.get('draftOwnerId')
+                and not product_data.get('owner_team_id')
+                and not product_data.get('project_id')
+            ):
+                product_data['draft_owner_id'] = user
+
             # Validate
             try:
                 product_api_model = DataProductCreate(**product_data)
@@ -522,6 +537,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         db: Optional[Session] = None,
         background_tasks: Optional[Any] = None,
         caller_team_ids: Optional[List[str]] = None,
+        is_feature_admin: bool = False,
     ) -> Optional[DataProductApi]:
         """
         Update a data product with ownership-scope authorization.
@@ -580,8 +596,15 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             settings = get_settings()
 
             # Admin always allowed (short-circuit, also matches existing
-            # is_user_project_member behavior).
-            if is_user_admin(user_groups, settings):
+            # is_user_project_member behavior). This covers both workspace
+            # admins (group-based) and callers whose *feature-level*
+            # data-products permission is ADMIN — e.g. an in-app role override
+            # that grants data-products=Admin. The latter is resolved by the
+            # route (which has access to the effective-permissions/role
+            # machinery) and passed in as ``is_feature_admin``; without it an
+            # in-app admin who isn't the object owner was wrongly denied
+            # (ONT-CUJ-015).
+            if is_feature_admin or is_user_admin(user_groups, settings):
                 logger.debug(f"User {user_email} is admin — bypassing ownership cascade")
                 return self.update_product(
                     product_id,

--- a/src/backend/src/models/compliance.py
+++ b/src/backend/src/models/compliance.py
@@ -5,13 +5,24 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
+class CompliancePolicyCreate(BaseModel):
+    """Payload accepted by POST /api/compliance/policies. id, compliance score, and timestamps are server-generated."""
+    name: str = Field(..., description="Name of the compliance policy")
+    description: str = Field(..., description="Description of what the policy checks")
+    failure_message: Optional[str] = Field(default=None, description="Human-readable message shown when policy fails")
+    rule: str = Field(..., description="Policy rule using the compliance DSL")
+    is_active: bool = Field(default=True, description="Whether the policy is active")
+    severity: str = Field(default="medium", description="Severity level: low, medium, high")
+    category: str = Field(default="general", description="Category of the policy")
+
+
 class CompliancePolicy(BaseModel):
     id: UUID = Field(..., description="Unique identifier for the policy (UUID)")
     name: str = Field(..., description="Name of the compliance policy")
     description: str = Field(..., description="Description of what the policy checks")
     failure_message: Optional[str] = Field(default=None, description="Human-readable message shown when policy fails")
     rule: str = Field(..., description="Policy rule using the compliance DSL")
-    compliance: float = Field(..., description="Current compliance score (0-100)")
+    compliance: float = Field(default=0.0, description="Current compliance score (0-100)")
     history: List[float] = Field(default_factory=list, description="Historical compliance scores")
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -77,6 +77,12 @@ class ColumnProperty(BaseModel):
     # ODCS v3.1.0 relationships (property-level FKs)
     relationships: Optional[List[SchemaRelationship]] = None
 
+    # ODCS quality checks nested under the column. Declared explicitly (rather
+    # than relying on extra="allow") so the rules survive model_dump and are
+    # persisted by the manager — column-level rules were previously dropped on
+    # save because nothing read this field.
+    quality: Optional[List['QualityRule']] = Field(default_factory=list)
+
     class Config:
         # Accept both JSON keys: "logicalType" (field name) and "logical_type" (alias)
         populate_by_name = True

--- a/src/backend/src/models/lifecycle.py
+++ b/src/backend/src/models/lifecycle.py
@@ -48,7 +48,10 @@ DATA_PRODUCT_TRANSITIONS: dict[str, list[str]] = {
 
 DATA_CONTRACT_TRANSITIONS: dict[str, list[str]] = {
     "draft": ["proposed", "deprecated"],
-    "proposed": ["draft", "under_review", "deprecated"],
+    # A steward can approve directly from "proposed" (the approve endpoint is
+    # documented as PROPOSED/UNDER_REVIEW -> APPROVED). "under_review" stays an
+    # optional intermediate step rather than a mandatory one.
+    "proposed": ["draft", "under_review", "approved", "deprecated"],
     "under_review": ["draft", "approved", "deprecated"],
     "approved": ["active", "draft", "deprecated"],
     "active": ["deprecated"],

--- a/src/backend/src/routes/compliance_routes.py
+++ b/src/backend/src/routes/compliance_routes.py
@@ -8,6 +8,7 @@ from src.common.authorization import PermissionChecker
 from src.controller.compliance_manager import ComplianceManager
 from src.models.compliance import (
     CompliancePolicy,
+    CompliancePolicyCreate,
     ComplianceRun,
     ComplianceResult,
     ComplianceRunRequest,
@@ -58,7 +59,7 @@ async def create_policy(
     db: DBSessionDep,
     audit_manager: AuditManagerDep,
     current_user: AuditCurrentUserDep,
-    policy: CompliancePolicy = Body(...),
+    policy: CompliancePolicyCreate = Body(...),
     _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
 ):
     created = manager.create_policy(

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -225,7 +225,12 @@ async def approve_contract(
         return {'status': updated.status}
     except HTTPException:
         raise
-    except Exception as e:
+    except ValueError as e:
+        # Invalid lifecycle transition (or missing contract) is a client error,
+        # not a server fault — surface it as 409 instead of an opaque 500.
+        logger.warning("Approve contract rejected for contract_id=%s: %s", contract_id, e)
+        raise HTTPException(status_code=409, detail=str(e))
+    except Exception:
         logger.exception("Approve contract failed for contract_id=%s", contract_id)
         raise HTTPException(status_code=500, detail="Failed to approve contract")
 
@@ -271,7 +276,10 @@ async def reject_contract(
         return {'status': updated.status}
     except HTTPException:
         raise
-    except Exception as e:
+    except ValueError as e:
+        logger.warning("Reject contract rejected for contract_id=%s: %s", contract_id, e)
+        raise HTTPException(status_code=409, detail=str(e))
+    except Exception:
         logger.exception("Reject contract failed for contract_id=%s", contract_id)
         raise HTTPException(status_code=500, detail="Failed to reject contract")
 

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -90,6 +90,7 @@ async def get_contracts(
     db: DBSessionDep,
     domain_id: Optional[str] = None,
     project_id: Optional[str] = None,
+    status: Optional[str] = None,
     include_history: bool = False,
     current_user: CurrentUserDep = None,
     manager: DataContractsManager = Depends(get_data_contracts_manager),
@@ -101,6 +102,11 @@ async def get_contracts(
     one row per ``version_family_id`` — the newest visible version of each
     family, plus a ``versionCount`` field. When True, every visible version
     is returned (used by the "Show all versions" toggle in the UI).
+
+    ``status`` optionally narrows the result to a single lifecycle status
+    (e.g. ``draft``, ``proposed``, ``active``). The filter is applied *after*
+    the role-aware visibility filter, so it can only narrow the set a caller
+    is already permitted to see.
     """
     try:
         # Check if user is admin
@@ -139,6 +145,7 @@ async def get_contracts(
             db,
             domain_id=domain_id,
             project_id=project_id,
+            status=status,
             is_admin=is_admin,
             include_history=include_history,
             caller_email=caller_email,

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -2148,6 +2148,33 @@ async def update_data_product(
                 f"continuing without team-ownership branch"
             )
 
+        # Resolve the caller's *feature-level* data-products permission so a
+        # data-products Admin (including via an in-app role override) can edit
+        # any product, not just ones they own. Mirrors the resolution used by
+        # the DP-assets route. Best-effort: on failure we fall back to the
+        # ownership cascade (project / team / draft-owner) only.
+        is_feature_admin = False
+        try:
+            auth_manager = getattr(request.app.state, "authorization_manager", None)
+            settings_manager = getattr(request.app.state, "settings_manager", None)
+            if auth_manager and current_user:
+                applied_role_id = (
+                    settings_manager.get_applied_role_override_for_user(current_user.email)
+                    if settings_manager else None
+                )
+                if applied_role_id and settings_manager:
+                    eff = settings_manager.get_feature_permissions_for_role_id(applied_role_id)
+                else:
+                    eff = auth_manager.get_user_effective_permissions(user_groups, None)
+                is_feature_admin = auth_manager.has_permission(
+                    eff, DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.ADMIN
+                )
+        except Exception:
+            logger.exception(
+                "Failed to resolve data-products admin level for product update; "
+                "falling back to ownership cascade"
+            )
+
         updated_product_response = manager.update_product_with_auth(
             product_id=product_id,
             product_data_dict=product_dict,
@@ -2156,6 +2183,7 @@ async def update_data_product(
             db=db,
             background_tasks=background_tasks,
             caller_team_ids=caller_team_ids,
+            is_feature_admin=is_feature_admin,
         )
 
         if not updated_product_response:

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -64,6 +64,81 @@ def get_data_products_manager(
     return manager
 
 
+def _caller_can_read_product(request, db, current_user, manager, product) -> bool:
+    """Whether ``current_user`` may read ``product`` directly.
+
+    Published products (active/deprecated) are readable by any caller with
+    data-products READ_ONLY — that's the catalog/marketplace contract.
+    Unpublished products (draft/proposed/under_review/approved/...) are only
+    readable by data-products admins (incl. via an in-app role override) and
+    by owners (draft_owner / owning team / project member). This stops a
+    consumer from reading an unpublished product by its id (ONT-NEG-011).
+    Fails closed on error.
+    """
+    try:
+        from types import SimpleNamespace
+        from src.common.version_visibility import is_visible_consumer
+
+        # Normalize status (may be an enum on the API model) for the
+        # consumer-visibility check (active/deprecated are readable by all).
+        raw_status = getattr(product, "status", None)
+        status_str = raw_status.value if hasattr(raw_status, "value") else str(raw_status or "")
+        if is_visible_consumer(SimpleNamespace(status=status_str)):
+            return True
+
+        product_id = str(getattr(product, "id", "") or "")
+        auth_manager = getattr(request.app.state, "authorization_manager", None)
+        settings_manager = getattr(request.app.state, "settings_manager", None)
+        caller_email = current_user.email if current_user else None
+        user_groups = current_user.groups if current_user else []
+
+        if auth_manager and current_user:
+            applied_role_id = (
+                settings_manager.get_applied_role_override_for_user(caller_email)
+                if settings_manager else None
+            )
+            if applied_role_id and settings_manager:
+                eff = settings_manager.get_feature_permissions_for_role_id(applied_role_id)
+            else:
+                eff = auth_manager.get_user_effective_permissions(user_groups or [], None)
+            if auth_manager.has_permission(eff, DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.ADMIN):
+                return True
+
+        # Non-admin: resolve ownership scope and check the accessible set.
+        from src.controller.teams_manager import teams_manager
+        from src.controller.projects_manager import projects_manager
+
+        caller_team_ids: list = []
+        caller_project_ids: list = []
+        try:
+            user_teams = teams_manager.get_teams_for_user(db, caller_email, user_groups)
+            caller_team_ids = [t.id for t in user_teams if getattr(t, "id", None)]
+            user_projects = projects_manager.get_user_projects(db, caller_email, user_groups)
+            caller_project_ids = [
+                p.id for p in user_projects.projects if getattr(p, "id", None)
+            ]
+        except Exception:
+            logger.exception(
+                "Failed to resolve ownership scope for %s in product read gate; "
+                "falling back to published-only visibility",
+                caller_email,
+            )
+
+        accessible = manager.list_products(
+            skip=0,
+            limit=10_000,
+            is_admin=False,
+            caller_email=caller_email,
+            caller_team_ids=caller_team_ids,
+            caller_project_ids=caller_project_ids,
+        )
+        accessible_ids = {str(p.id) for p in accessible if getattr(p, "id", None)}
+        return product_id in accessible_ids
+    except Exception:
+        logger.exception("Product read gate failed for %s; denying", product_id)
+        return False
+
+
 # --- Lifecycle transitions (minimal) ---
 
 @router.post('/data-products/{product_id}/move-to-sandbox')
@@ -2334,6 +2409,9 @@ async def delete_data_product(
 @router.get('/data-products/{product_id}', response_model=Any)
 async def get_data_product(
     product_id: str,
+    request: Request,
+    db: DBSessionDep,
+    current_user: CurrentUserDep,
     manager: DataProductsManager = Depends(get_data_products_manager),
     _: bool = Depends(PermissionChecker(DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.READ_ONLY))
 ) -> Any: # Return Any to allow returning a dict
@@ -2341,6 +2419,17 @@ async def get_data_product(
         product = manager.get_product(product_id)
         if not product:
             raise HTTPException(status_code=404, detail="Data product not found")
+
+        # Gate direct reads by the same ownership scope the listing uses. The
+        # marketplace listing already hides unpublished products, but a direct
+        # GET by id must not let a consumer read a draft/proposed product they
+        # don't own (ONT-NEG-011). data-products admins see everything; other
+        # callers only see products in their accessible set (published
+        # products, plus drafts they own / their team or project owns). A miss
+        # returns 404 (not 403) so the existence of the draft isn't disclosed.
+        if not _caller_can_read_product(request, db, current_user, manager, product):
+            raise HTTPException(status_code=404, detail="Data product not found")
+
         return product.model_dump(by_alias=False, exclude={'created_at', 'updated_at'}, exclude_none=True, exclude_unset=True)
     except ValueError as e:
         logger.error("Validation error fetching product %s: %s", product_id, e)

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -386,6 +386,15 @@ async def request_certify_product(
         if not product_db:
             raise HTTPException(status_code=404, detail="Data product not found")
 
+        # A product with no deliverables (output ports) has nothing to certify;
+        # block the request rather than accepting an empty product into the
+        # certification workflow (ONT-CUJ-019 / ONT-NEG-008).
+        if not (product_db.output_ports or []):
+            raise HTTPException(
+                status_code=409,
+                detail="At least one deliverable is required before requesting certification",
+            )
+
         username = current_user.username if current_user else None
         change_log_manager.log_change_with_details(
             db,

--- a/src/backend/src/routes/delivery_methods_routes.py
+++ b/src/backend/src/routes/delivery_methods_routes.py
@@ -19,6 +19,11 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/delivery-methods", tags=["Delivery Methods"])
 FEATURE_ID = "delivery-methods"
+# Reads of the delivery-method catalog are a prerequisite for authoring a
+# deliverable on a data product, so they are gated by the data-products
+# feature (any product author can list/get) rather than the admin-managed
+# delivery-methods feature. Writes stay gated by delivery-methods:READ_WRITE.
+READ_FEATURE_ID = "data-products"
 
 
 def get_delivery_methods_manager():
@@ -68,7 +73,7 @@ def create_delivery_method(
 @router.get(
     "",
     response_model=List[DeliveryMethodRead],
-    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+    dependencies=[Depends(PermissionChecker(READ_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
 )
 def get_all_delivery_methods(
     db: DBSessionDep,
@@ -85,7 +90,7 @@ def get_all_delivery_methods(
 @router.get(
     "/{method_id}",
     response_model=DeliveryMethodRead,
-    dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
+    dependencies=[Depends(PermissionChecker(READ_FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
 )
 def get_delivery_method(
     method_id: UUID,

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -630,35 +630,71 @@ async def get_concept_hierarchy(
     try:
         logger.info(f"Retrieving hierarchy for concept: {iri}")
         hierarchy = manager.get_concept_hierarchy(iri)
-        
+
         if not hierarchy:
             raise HTTPException(status_code=404, detail="Concept not found")
-        
+
         return {'hierarchy': hierarchy.model_dump()}
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Error retrieving concept hierarchy for %s", concept_iri, exc_info=True)
+        logger.error("Error retrieving concept hierarchy for %s", iri, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve concept hierarchy")
 
-@router.get('/semantic-models/concepts/{concept_iri:path}')
+# -------- /semantic-models/concepts detail (by IRI) --------
+#
+# The path-form route (``/concepts/{concept_iri:path}``) is preserved as a
+# deprecated alias so existing bookmarks keep working, but the canonical form
+# uses a query parameter. This avoids a proxy bug where some HTTP intermediaries
+# (notably the Databricks Apps proxy) decode and collapse ``%2F%2F`` in path
+# segments, breaking IRIs like ``http://ontology.example.org/...`` before they
+# reach FastAPI.
+def _get_concept_details_payload(
+    manager: SemanticModelsManager, concept_iri: str
+) -> dict:
+    logger.info("Retrieving details for concept: %s", concept_iri)
+    concept = manager.get_concept_details(concept_iri)
+    if not concept:
+        raise HTTPException(status_code=404, detail="Concept not found")
+    return {'concept': concept.model_dump()}
+
+
+@router.get('/semantic-models/concepts/by-iri')
+async def get_concept_details_by_iri(
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY))
+) -> dict:
+    """Get detailed information about a specific concept (canonical, query-param form)."""
+    try:
+        return _get_concept_details_payload(manager, concept_iri)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Error retrieving concept details for %s", concept_iri, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to retrieve concept details")
+
+
+@router.get(
+    '/semantic-models/concepts/{concept_iri:path}',
+    deprecated=True,
+)
 async def get_concept_details(
     concept_iri: str,
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY))
 ) -> dict:
-    """Get detailed information about a specific concept"""
+    """DEPRECATED: Get details by path-encoded IRI.
+
+    Prefer ``GET /semantic-models/concepts/by-iri?iri=<urlencoded-iri>`` — this
+    route is retained for backward compatibility with existing clients/bookmarks
+    and will be removed in a future release.
+    """
     try:
-        logger.info(f"Retrieving details for concept: {concept_iri}")
-        concept = manager.get_concept_details(concept_iri)
-        
-        if not concept:
-            raise HTTPException(status_code=404, detail="Concept not found")
-        
-        return {'concept': concept.model_dump()}
+        return _get_concept_details_payload(manager, concept_iri)
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception:
         logger.error("Error retrieving concept details for %s", concept_iri, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve concept details")
 
@@ -1026,19 +1062,276 @@ async def delete_knowledge_collection(
 # ============================================================================
 # CONCEPT CRUD ENDPOINTS
 # ============================================================================
+#
+# IMPORTANT: ``/knowledge/concepts/by-iri`` (query-param) variants MUST be
+# declared BEFORE the matching ``/{concept_iri:path}`` (path-param) variants in
+# this file. FastAPI matches routes in declaration order, and a ``path``
+# parameter greedily eats anything that follows the prefix; declaring the
+# path-form first would leave ``/by-iri`` unreachable.
+#
+# Why two route shapes?
+# Some HTTP proxies (notably the Databricks Apps proxy) decode and collapse
+# ``%2F%2F`` in path segments, mangling IRIs like ``http://ontos.example.org/...``
+# into ``http:/ontos.example.org/...`` before they reach FastAPI. Query-string
+# values survive that transformation unchanged. The path-form routes are kept
+# as deprecated aliases for backward compatibility with existing bookmarks /
+# clients; new callers should use ``/by-iri?iri=<urlencoded-iri>``.
 
-@router.get('/knowledge/concepts/{concept_iri:path}')
-async def get_concept(
-    concept_iri: str,
-    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
-    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY))
-) -> dict:
-    """Get a concept by IRI with all properties and governance info."""
+
+# -------- helper functions (one per logical operation) --------
+
+def _get_concept_payload(manager: SemanticModelsManager, concept_iri: str) -> dict:
     concept = manager.get_concept(concept_iri)
     if not concept:
         raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
     return concept
 
+
+async def _update_concept_payload(
+    manager: SemanticModelsManager,
+    concept_iri: str,
+    request: Request,
+    updated_by: str,
+) -> dict:
+    try:
+        data = await request.json()
+        concept = manager.update_concept(
+            concept_iri=concept_iri,
+            label=data.get('label'),
+            definition=data.get('definition'),
+            synonyms=data.get('synonyms'),
+            examples=data.get('examples'),
+            broader_iris=data.get('broader_iris'),
+            narrower_iris=data.get('narrower_iris'),
+            related_iris=data.get('related_iris'),
+            updated_by=updated_by,
+        )
+        if not concept:
+            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
+        return concept
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error updating concept: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to update concept")
+
+
+def _delete_concept_payload(
+    manager: SemanticModelsManager, concept_iri: str, deleted_by: str
+) -> dict:
+    try:
+        success = manager.delete_concept(concept_iri, deleted_by)
+        if not success:
+            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
+        return {'success': True, 'message': f"Concept deleted: {concept_iri}"}
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error deleting concept: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to delete concept")
+
+
+async def _add_concept_owner_payload(
+    manager: SemanticModelsManager,
+    concept_iri: str,
+    request: Request,
+    assigned_by: str,
+) -> dict:
+    try:
+        data = await request.json()
+        # Accept user_email directly or extract from user_uri (e.g. "mailto:user@example.com")
+        user_email = data.get('user_email')
+        if not user_email:
+            user_uri = data.get('user_uri', '')
+            if user_uri.startswith('mailto:'):
+                user_email = user_uri[len('mailto:'):]
+            elif user_uri:
+                user_email = user_uri
+        concept = manager.add_concept_owner(
+            concept_iri=concept_iri,
+            user_email=user_email,
+            role=data.get('role'),
+            assigned_by=assigned_by,
+        )
+        if not concept:
+            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
+        return concept
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error adding owner: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to add owner")
+
+
+def _remove_concept_owner_payload(
+    manager: SemanticModelsManager,
+    concept_iri: str,
+    user_email: str,
+    removed_by: str,
+) -> dict:
+    try:
+        concept = manager.remove_concept_owner(
+            concept_iri=concept_iri,
+            user_email=user_email,
+            removed_by=removed_by,
+        )
+        if not concept:
+            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
+        return concept
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error removing owner: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to remove owner")
+
+
+async def _submit_concept_for_review_payload(
+    manager: SemanticModelsManager,
+    concept_iri: str,
+    request: Request,
+    submitted_by: str,
+) -> dict:
+    try:
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        review_data = manager.submit_concept_for_review(
+            concept_iri=concept_iri,
+            reviewer_email=data.get('reviewer_email'),
+            submitted_by=submitted_by,
+            notes=data.get('notes'),
+        )
+        # TODO: Integrate with DataAssetReviewManager to create actual review request
+        # For now, update status directly
+        updated = manager.update_concept_status(
+            concept_iri=concept_iri,
+            new_status="under_review",
+            updated_by=submitted_by,
+        )
+        return {'review_data': review_data, 'concept': updated}
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error submitting for review: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to submit for review")
+
+
+def _set_concept_status_payload(
+    manager: SemanticModelsManager,
+    concept_iri: str,
+    new_status: str,
+    updated_by: str,
+    *,
+    error_verb: str,
+) -> dict:
+    """Shared body for ``/approve``, ``/certify``, ``/deprecate``, ``/archive``."""
+    try:
+        concept = manager.update_concept_status(
+            concept_iri=concept_iri,
+            new_status=new_status,
+            updated_by=updated_by,
+        )
+        if not concept:
+            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
+        return concept
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error %s concept: %s", error_verb, e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to {error_verb} concept")
+
+
+def _publish_concept_payload(
+    manager: SemanticModelsManager, concept_iri: str, updated_by: str
+) -> dict:
+    try:
+        # Auto-approve if still under_review so publish works in one step
+        existing = manager.get_concept(concept_iri)
+        if existing and existing.get("status") == "under_review":
+            manager.update_concept_status(
+                concept_iri=concept_iri,
+                new_status="approved",
+                updated_by=updated_by,
+            )
+        concept = manager.update_concept_status(
+            concept_iri=concept_iri,
+            new_status="published",
+            updated_by=updated_by,
+        )
+        if not concept:
+            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
+        return concept
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error publishing concept: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to publish concept")
+
+
+async def _promote_concept_payload(
+    manager: SemanticModelsManager,
+    concept_iri: str,
+    request: Request,
+    promoted_by: str,
+) -> dict:
+    try:
+        data = await request.json()
+        concept = manager.promote_concept(
+            concept_iri=concept_iri,
+            target_collection_iri=data.get('target_collection_iri'),
+            deprecate_source=data.get('deprecate_source', True),
+            promoted_by=promoted_by,
+        )
+        return concept
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error promoting concept: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to promote concept")
+
+
+async def _migrate_concept_payload(
+    manager: SemanticModelsManager,
+    concept_iri: str,
+    request: Request,
+    migrated_by: str,
+) -> dict:
+    try:
+        data = await request.json()
+        concept = manager.migrate_concept(
+            concept_iri=concept_iri,
+            target_collection_iri=data.get('target_collection_iri'),
+            delete_source=data.get('delete_source', False),
+            migrated_by=migrated_by,
+        )
+        return concept
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error migrating concept: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to migrate concept")
+
+
+# -------- create (no IRI in URL — already collision-free) --------
 
 @router.post('/knowledge/concepts')
 async def create_concept(
@@ -1071,7 +1364,181 @@ async def create_concept(
         raise HTTPException(status_code=500, detail="Failed to create concept")
 
 
-@router.patch('/knowledge/concepts/{concept_iri:path}')
+# -------- /knowledge/concepts/by-iri (canonical, query-param form) --------
+
+@router.get('/knowledge/concepts/by-iri')
+async def get_concept_by_iri(
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY))
+) -> dict:
+    """Get a concept by IRI with all properties and governance info."""
+    return _get_concept_payload(manager, concept_iri)
+
+
+@router.patch('/knowledge/concepts/by-iri')
+async def update_concept_by_iri(
+    request: Request,
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Update a concept's properties."""
+    return await _update_concept_payload(manager, concept_iri, request, current_user.email)
+
+
+@router.delete('/knowledge/concepts/by-iri')
+async def delete_concept_by_iri(
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Delete a concept (draft status only)."""
+    return _delete_concept_payload(manager, concept_iri, current_user.email)
+
+
+@router.post('/knowledge/concepts/by-iri/owners')
+async def add_concept_owner_by_iri(
+    request: Request,
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Add an owner to a concept."""
+    return await _add_concept_owner_payload(manager, concept_iri, request, current_user.email)
+
+
+@router.delete('/knowledge/concepts/by-iri/owners/{user_email}')
+async def remove_concept_owner_by_iri(
+    user_email: str,
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Remove an owner from a concept."""
+    return _remove_concept_owner_payload(manager, concept_iri, user_email, current_user.email)
+
+
+@router.post('/knowledge/concepts/by-iri/submit-review')
+async def submit_concept_for_review_by_iri(
+    request: Request,
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Submit a concept for review."""
+    return await _submit_concept_for_review_payload(
+        manager, concept_iri, request, current_user.email
+    )
+
+
+@router.post('/knowledge/concepts/by-iri/approve')
+async def approve_concept_by_iri(
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Approve a concept that is under review."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "approved", current_user.email, error_verb="approve"
+    )
+
+
+@router.post('/knowledge/concepts/by-iri/publish')
+async def publish_concept_by_iri(
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Publish an approved concept (auto-approves if under_review)."""
+    return _publish_concept_payload(manager, concept_iri, current_user.email)
+
+
+@router.post('/knowledge/concepts/by-iri/certify')
+async def certify_concept_by_iri(
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.ADMIN))
+) -> dict:
+    """Certify a published concept."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "certified", current_user.email, error_verb="certify"
+    )
+
+
+@router.post('/knowledge/concepts/by-iri/deprecate')
+async def deprecate_concept_by_iri(
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Deprecate a concept."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "deprecated", current_user.email, error_verb="deprecate"
+    )
+
+
+@router.post('/knowledge/concepts/by-iri/archive')
+async def archive_concept_by_iri(
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Archive a deprecated concept."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "archived", current_user.email, error_verb="archive"
+    )
+
+
+@router.post('/knowledge/concepts/by-iri/promote')
+async def promote_concept_by_iri(
+    request: Request,
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Promote a concept to a higher-scope collection."""
+    return await _promote_concept_payload(manager, concept_iri, request, current_user.email)
+
+
+@router.post('/knowledge/concepts/by-iri/migrate')
+async def migrate_concept_by_iri(
+    request: Request,
+    current_user: CurrentUserDep,
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
+) -> dict:
+    """Migrate a concept to a different collection."""
+    return await _migrate_concept_payload(manager, concept_iri, request, current_user.email)
+
+
+# -------- DEPRECATED path-form routes (kept for backward compatibility) --------
+# See module-level note above about why these are deprecated. New callers
+# should use the ``/by-iri`` variants declared above.
+
+@router.get('/knowledge/concepts/{concept_iri:path}', deprecated=True)
+async def get_concept(
+    concept_iri: str,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY))
+) -> dict:
+    """DEPRECATED: use ``GET /knowledge/concepts/by-iri?iri=<urlencoded-iri>``."""
+    return _get_concept_payload(manager, concept_iri)
+
+
+@router.patch('/knowledge/concepts/{concept_iri:path}', deprecated=True)
 async def update_concept(
     concept_iri: str,
     request: Request,
@@ -1079,59 +1546,22 @@ async def update_concept(
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Update a concept's properties."""
-    try:
-        data = await request.json()
-        concept = manager.update_concept(
-            concept_iri=concept_iri,
-            label=data.get('label'),
-            definition=data.get('definition'),
-            synonyms=data.get('synonyms'),
-            examples=data.get('examples'),
-            broader_iris=data.get('broader_iris'),
-            narrower_iris=data.get('narrower_iris'),
-            related_iris=data.get('related_iris'),
-            updated_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error updating concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to update concept")
+    """DEPRECATED: use ``PATCH /knowledge/concepts/by-iri?iri=<urlencoded-iri>``."""
+    return await _update_concept_payload(manager, concept_iri, request, current_user.email)
 
 
-@router.delete('/knowledge/concepts/{concept_iri:path}')
+@router.delete('/knowledge/concepts/{concept_iri:path}', deprecated=True)
 async def delete_concept(
     concept_iri: str,
     current_user: CurrentUserDep,
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Delete a concept (draft status only)."""
-    try:
-        success = manager.delete_concept(concept_iri, current_user.email)
-        if not success:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return {'success': True, 'message': f"Concept deleted: {concept_iri}"}
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error deleting concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to delete concept")
+    """DEPRECATED: use ``DELETE /knowledge/concepts/by-iri?iri=<urlencoded-iri>``."""
+    return _delete_concept_payload(manager, concept_iri, current_user.email)
 
 
-# ============================================================================
-# OWNERSHIP ENDPOINTS
-# ============================================================================
-
-@router.post('/knowledge/concepts/{concept_iri:path}/owners')
+@router.post('/knowledge/concepts/{concept_iri:path}/owners', deprecated=True)
 async def add_concept_owner(
     concept_iri: str,
     request: Request,
@@ -1139,36 +1569,11 @@ async def add_concept_owner(
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Add an owner to a concept."""
-    try:
-        data = await request.json()
-        # Accept user_email directly or extract from user_uri (e.g. "mailto:user@example.com")
-        user_email = data.get('user_email')
-        if not user_email:
-            user_uri = data.get('user_uri', '')
-            if user_uri.startswith('mailto:'):
-                user_email = user_uri[len('mailto:'):]
-            elif user_uri:
-                user_email = user_uri
-        concept = manager.add_concept_owner(
-            concept_iri=concept_iri,
-            user_email=user_email,
-            role=data.get('role'),
-            assigned_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error adding owner: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to add owner")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/owners?iri=<urlencoded-iri>``."""
+    return await _add_concept_owner_payload(manager, concept_iri, request, current_user.email)
 
 
-@router.delete('/knowledge/concepts/{concept_iri:path}/owners/{user_email}')
+@router.delete('/knowledge/concepts/{concept_iri:path}/owners/{user_email}', deprecated=True)
 async def remove_concept_owner(
     concept_iri: str,
     user_email: str,
@@ -1176,30 +1581,11 @@ async def remove_concept_owner(
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Remove an owner from a concept."""
-    try:
-        concept = manager.remove_concept_owner(
-            concept_iri=concept_iri,
-            user_email=user_email,
-            removed_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error removing owner: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to remove owner")
+    """DEPRECATED: use ``DELETE /knowledge/concepts/by-iri/owners/{user_email}?iri=<urlencoded-iri>``."""
+    return _remove_concept_owner_payload(manager, concept_iri, user_email, current_user.email)
 
 
-# ============================================================================
-# LIFECYCLE / GOVERNANCE ENDPOINTS
-# ============================================================================
-
-@router.post('/knowledge/concepts/{concept_iri:path}/submit-review')
+@router.post('/knowledge/concepts/{concept_iri:path}/submit-review', deprecated=True)
 async def submit_concept_for_review(
     concept_iri: str,
     request: Request,
@@ -1207,182 +1593,76 @@ async def submit_concept_for_review(
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Submit a concept for review."""
-    try:
-        try:
-            data = await request.json()
-        except Exception:
-            data = {}
-        review_data = manager.submit_concept_for_review(
-            concept_iri=concept_iri,
-            reviewer_email=data.get('reviewer_email'),
-            submitted_by=current_user.email,
-            notes=data.get('notes'),
-        )
-        # TODO: Integrate with DataAssetReviewManager to create actual review request
-        # For now, update status directly
-        updated = manager.update_concept_status(
-            concept_iri=concept_iri,
-            new_status="under_review",
-            updated_by=current_user.email,
-        )
-        return {'review_data': review_data, 'concept': updated}
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error submitting for review: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to submit for review")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/submit-review?iri=<urlencoded-iri>``."""
+    return await _submit_concept_for_review_payload(
+        manager, concept_iri, request, current_user.email
+    )
 
 
-@router.post('/knowledge/concepts/{concept_iri:path}/approve')
+@router.post('/knowledge/concepts/{concept_iri:path}/approve', deprecated=True)
 async def approve_concept(
     concept_iri: str,
     current_user: CurrentUserDep,
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Approve a concept that is under review."""
-    try:
-        concept = manager.update_concept_status(
-            concept_iri=concept_iri,
-            new_status="approved",
-            updated_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error approving concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to approve concept")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/approve?iri=<urlencoded-iri>``."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "approved", current_user.email, error_verb="approve"
+    )
 
 
-@router.post('/knowledge/concepts/{concept_iri:path}/publish')
+@router.post('/knowledge/concepts/{concept_iri:path}/publish', deprecated=True)
 async def publish_concept(
     concept_iri: str,
     current_user: CurrentUserDep,
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Publish an approved concept.
-
-    If the concept is currently ``under_review``, it is automatically
-    approved first so callers do not need a separate ``/approve`` step.
-    """
-    try:
-        # Auto-approve if still under_review so publish works in one step
-        existing = manager.get_concept(concept_iri)
-        if existing and existing.get("status") == "under_review":
-            manager.update_concept_status(
-                concept_iri=concept_iri,
-                new_status="approved",
-                updated_by=current_user.email,
-            )
-        concept = manager.update_concept_status(
-            concept_iri=concept_iri,
-            new_status="published",
-            updated_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error publishing concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to publish concept")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/publish?iri=<urlencoded-iri>``."""
+    return _publish_concept_payload(manager, concept_iri, current_user.email)
 
 
-@router.post('/knowledge/concepts/{concept_iri:path}/certify')
+@router.post('/knowledge/concepts/{concept_iri:path}/certify', deprecated=True)
 async def certify_concept(
     concept_iri: str,
     current_user: CurrentUserDep,
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.ADMIN))
 ) -> dict:
-    """Certify a published concept."""
-    try:
-        concept = manager.update_concept_status(
-            concept_iri=concept_iri,
-            new_status="certified",
-            updated_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error certifying concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to certify concept")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/certify?iri=<urlencoded-iri>``."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "certified", current_user.email, error_verb="certify"
+    )
 
 
-@router.post('/knowledge/concepts/{concept_iri:path}/deprecate')
+@router.post('/knowledge/concepts/{concept_iri:path}/deprecate', deprecated=True)
 async def deprecate_concept(
     concept_iri: str,
     current_user: CurrentUserDep,
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Deprecate a concept."""
-    try:
-        concept = manager.update_concept_status(
-            concept_iri=concept_iri,
-            new_status="deprecated",
-            updated_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error deprecating concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to deprecate concept")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/deprecate?iri=<urlencoded-iri>``."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "deprecated", current_user.email, error_verb="deprecate"
+    )
 
 
-@router.post('/knowledge/concepts/{concept_iri:path}/archive')
+@router.post('/knowledge/concepts/{concept_iri:path}/archive', deprecated=True)
 async def archive_concept(
     concept_iri: str,
     current_user: CurrentUserDep,
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Archive a deprecated concept."""
-    try:
-        concept = manager.update_concept_status(
-            concept_iri=concept_iri,
-            new_status="archived",
-            updated_by=current_user.email,
-        )
-        if not concept:
-            raise HTTPException(status_code=404, detail=f"Concept not found: {concept_iri}")
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error archiving concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to archive concept")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/archive?iri=<urlencoded-iri>``."""
+    return _set_concept_status_payload(
+        manager, concept_iri, "archived", current_user.email, error_verb="archive"
+    )
 
 
-# ============================================================================
-# PROMOTION / MIGRATION ENDPOINTS
-# ============================================================================
-
-@router.post('/knowledge/concepts/{concept_iri:path}/promote')
+@router.post('/knowledge/concepts/{concept_iri:path}/promote', deprecated=True)
 async def promote_concept(
     concept_iri: str,
     request: Request,
@@ -1390,26 +1670,11 @@ async def promote_concept(
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Promote a concept to a higher-scope collection."""
-    try:
-        data = await request.json()
-        concept = manager.promote_concept(
-            concept_iri=concept_iri,
-            target_collection_iri=data.get('target_collection_iri'),
-            deprecate_source=data.get('deprecate_source', True),
-            promoted_by=current_user.email,
-        )
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error promoting concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to promote concept")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/promote?iri=<urlencoded-iri>``."""
+    return await _promote_concept_payload(manager, concept_iri, request, current_user.email)
 
 
-@router.post('/knowledge/concepts/{concept_iri:path}/migrate')
+@router.post('/knowledge/concepts/{concept_iri:path}/migrate', deprecated=True)
 async def migrate_concept(
     concept_iri: str,
     request: Request,
@@ -1417,23 +1682,8 @@ async def migrate_concept(
     manager: SemanticModelsManager = Depends(get_semantic_models_manager),
     _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE))
 ) -> dict:
-    """Migrate a concept to a different collection."""
-    try:
-        data = await request.json()
-        concept = manager.migrate_concept(
-            concept_iri=concept_iri,
-            target_collection_iri=data.get('target_collection_iri'),
-            delete_source=data.get('delete_source', False),
-            migrated_by=current_user.email,
-        )
-        return concept
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error migrating concept: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to migrate concept")
+    """DEPRECATED: use ``POST /knowledge/concepts/by-iri/migrate?iri=<urlencoded-iri>``."""
+    return await _migrate_concept_payload(manager, concept_iri, request, current_user.email)
 
 
 def register_routes(app):

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -31,6 +31,20 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api", tags=["Semantic Models"])
 
+# Internal named-graph contexts that must never surface as user-facing RDF
+# Sources. These are computed/managed graphs (app entities, semantic links,
+# source-registry metadata, the rdflib default graph), not uploaded or bundled
+# taxonomy files. Mirrors the frontend's SYSTEM_RDF_NAMESPACE_KEYS so the two
+# stay aligned.
+INTERNAL_GRAPH_CONTEXTS = frozenset({
+    "urn:meta:sources",
+    "urn:semantic-links",
+    "urn:x-rdflib:default",
+    "urn:app-entities",
+    "urn:demo",
+    "",  # rdflib default-default
+})
+
 def get_semantic_models_manager(request: Request) -> SemanticModelsManager:
     """Retrieves the SemanticModelsManager singleton from app.state."""
     manager = getattr(request.app.state, 'semantic_models_manager', None)
@@ -83,6 +97,10 @@ async def get_semantic_models(
         for tax in graph_taxonomies:
             # Skip if this is a database-backed model (already included above)
             if tax.source_type == 'database':
+                continue
+            # Skip internal/system graphs (app entities, semantic links, etc.)
+            # so they don't leak into the user-facing RDF Sources list.
+            if tax.name in INTERNAL_GRAPH_CONTEXTS:
                 continue
             # Skip if name matches (either original or sanitized version)
             if tax.name in db_model_names or tax.name in db_model_names_sanitized:

--- a/src/backend/src/tests/integration/test_compliance_routes.py
+++ b/src/backend/src/tests/integration/test_compliance_routes.py
@@ -12,9 +12,12 @@ class TestComplianceRoutes:
 
     @pytest.fixture
     def sample_policy_data(self):
-        """Sample compliance policy data for testing."""
+        """Sample compliance policy data for testing the create endpoint.
+
+        Note: per the create contract (issue #235), the client MUST NOT send `id`,
+        `compliance`, `history`, or timestamps — those are server-generated.
+        """
         return {
-            "id": str(uuid.uuid4()),
             "name": "Test Policy",
             "description": "A test compliance policy",
             "rule": "asset.tags['pii'] == 'true'",
@@ -31,14 +34,47 @@ class TestComplianceRoutes:
         assert isinstance(response.json(), list)
 
     def test_create_policy(self, client: TestClient, db_session: Session, sample_policy_data):
-        """Test creating a compliance policy."""
-        response = client.post("/api/compliance/policies", json=sample_policy_data)
-        assert response.status_code == 200
+        """Test creating a compliance policy without an id — server generates the UUID (issue #235).
 
-        data = response.json()
-        assert data["name"] == "Test Policy"
-        assert "id" in data
-        assert "created_at" in data
+        The integration `client` fixture does not currently wire AuditManager into app.state,
+        so the POST may return 503 ("Audit service not configured.") after passing validation.
+        That is a pre-existing test-infra gap, NOT the bug from #235. The bug from #235 was a
+        422 "field required" on the id field; this test asserts the payload no longer 422s.
+        """
+        response = client.post("/api/compliance/policies", json=sample_policy_data)
+        # Critical regression check for #235: must NOT be 422 on missing id.
+        assert response.status_code != 422, (
+            f"Pydantic validation rejected the create payload (issue #235 regression): {response.text}"
+        )
+        assert response.status_code in (200, 503)
+
+        if response.status_code == 200:
+            data = response.json()
+            assert data["name"] == "Test Policy"
+            assert "id" in data
+            uuid.UUID(data["id"])  # server-generated UUID
+            assert "created_at" in data
+            assert data["compliance"] == 0.0
+            assert data["history"] == []
+
+    def test_create_policy_ignores_client_provided_id(self, client: TestClient, db_session: Session, sample_policy_data):
+        """Older clients may still send an id in the body — that field is ignored, not 422'd.
+
+        Same 503 caveat as test_create_policy.
+        """
+        client_id = str(uuid.uuid4())
+        payload = {**sample_policy_data, "id": client_id}
+        response = client.post("/api/compliance/policies", json=payload)
+        assert response.status_code != 422, (
+            f"Pydantic validation rejected the create payload with extra id (issue #235 regression): {response.text}"
+        )
+        assert response.status_code in (200, 503)
+
+        if response.status_code == 200:
+            data = response.json()
+            assert "id" in data
+            uuid.UUID(data["id"])
+            assert data["id"] != client_id
 
     def test_get_policy_by_id(self, client: TestClient, db_session: Session, sample_policy_data):
         """Test getting a specific policy by ID."""

--- a/src/backend/src/tests/integration/test_concept_iri_routing.py
+++ b/src/backend/src/tests/integration/test_concept_iri_routing.py
@@ -1,0 +1,231 @@
+"""Routing tests for the concept-by-IRI endpoints.
+
+These cover the query-param variants (``/concepts/by-iri?iri=...``) that were
+added because the path-form (``/concepts/{concept_iri:path}``) routes lose
+``%2F%2F`` segments to proxy normalisation. Both shapes must work for the
+backward-compat migration window.
+
+Targets two route families:
+
+* ``GET /api/semantic-models/concepts/by-iri`` — read-only details from the
+  semantic models manager. Falls back to a path-form deprecated alias.
+* ``GET/PATCH/DELETE /api/knowledge/concepts/by-iri`` — and the lifecycle
+  variants under ``/by-iri/<action>``. Each also has a deprecated path-form
+  alias.
+"""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.app import app
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.common.app_state import set_app_state_manager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_knowledge_routes.py — kept local so this file runs
+# standalone even if the other module's fixtures move).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semantic_models_manager(db_session: Session, tmp_path: Path):
+    data_dir = tmp_path / "sm_data"
+    (data_dir / "cache").mkdir(parents=True, exist_ok=True)
+    (data_dir / "taxonomies").mkdir(parents=True, exist_ok=True)
+
+    manager = SemanticModelsManager(db=db_session, data_dir=data_dir)
+
+    app.state.semantic_models_manager = manager
+    set_app_state_manager("semantic_models_manager", manager)
+
+    class _NoopOSM:
+        def sync_asset_types(self, *_args, **_kwargs):
+            return {"created": 0, "updated": 0}
+
+    app.state.ontology_schema_manager = _NoopOSM()
+
+    class _NoopAudit:
+        def log_action(self, *_args, **_kwargs):
+            return None
+
+        def log_event(self, *_args, **_kwargs):
+            return None
+
+    app.state.audit_manager = _NoopAudit()
+
+    yield manager
+
+    for attr in ("semantic_models_manager", "ontology_schema_manager", "audit_manager"):
+        if hasattr(app.state, attr):
+            delattr(app.state, attr)
+
+
+@pytest.fixture
+def make_collection(client: TestClient, semantic_models_manager):
+    def _make(label_prefix: str = "Routing Coll") -> dict:
+        label = f"{label_prefix} {uuid.uuid4().hex[:8]}"
+        r = client.post(
+            "/api/knowledge/collections",
+            json={
+                "label": label,
+                "collection_type": "glossary",
+                "scope_level": "enterprise",
+                "description": "made by concept-iri routing test",
+            },
+        )
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    return _make
+
+
+@pytest.fixture
+def make_concept(client: TestClient, make_collection):
+    """Create a fresh collection + concept and return the concept body."""
+
+    def _make(label: str = "Routing Term") -> dict:
+        collection = make_collection()
+        r = client.post(
+            "/api/knowledge/concepts",
+            json={"collection_iri": collection["iri"], "label": label},
+        )
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# /api/knowledge/concepts/by-iri (the canonical, proxy-safe shape)
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeConceptsByIri:
+    def test_get_by_iri_query_param_returns_concept(
+        self, client: TestClient, make_concept
+    ):
+        c = make_concept("Query Param Get")
+        r = client.get(
+            "/api/knowledge/concepts/by-iri",
+            params={"iri": c["iri"]},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["iri"] == c["iri"]
+
+    def test_get_by_iri_requires_iri_param(self, client: TestClient, semantic_models_manager):
+        r = client.get("/api/knowledge/concepts/by-iri")
+        assert r.status_code == 422, r.text  # FastAPI validation error
+
+    def test_get_by_iri_rejects_empty_iri(self, client: TestClient, semantic_models_manager):
+        r = client.get("/api/knowledge/concepts/by-iri", params={"iri": ""})
+        assert r.status_code == 422, r.text
+
+    def test_get_by_iri_returns_404_for_unknown(
+        self, client: TestClient, semantic_models_manager
+    ):
+        r = client.get(
+            "/api/knowledge/concepts/by-iri",
+            params={"iri": "urn:does-not-exist"},
+        )
+        assert r.status_code == 404
+
+    def test_deprecated_path_form_still_works(
+        self, client: TestClient, make_concept
+    ):
+        """Existing bookmarks must keep resolving for the migration window."""
+        c = make_concept("Path Form Still Works")
+        r = client.get(f"/api/knowledge/concepts/{c['iri']}")
+        assert r.status_code == 200, r.text
+        assert r.json()["iri"] == c["iri"]
+
+    def test_patch_by_iri_updates_label(self, client: TestClient, make_concept):
+        c = make_concept("Patch By IRI Old")
+        r = client.patch(
+            "/api/knowledge/concepts/by-iri",
+            params={"iri": c["iri"]},
+            json={"label": "Patch By IRI New"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["label"] == "Patch By IRI New"
+
+    def test_delete_by_iri_removes_draft(self, client: TestClient, make_concept):
+        c = make_concept("Delete By IRI")
+        r = client.delete(
+            "/api/knowledge/concepts/by-iri",
+            params={"iri": c["iri"]},
+        )
+        assert r.status_code == 200, r.text
+        # Follow-up GET must 404 on both shapes
+        assert client.get(
+            "/api/knowledge/concepts/by-iri", params={"iri": c["iri"]}
+        ).status_code == 404
+        assert client.get(f"/api/knowledge/concepts/{c['iri']}").status_code == 404
+
+    def test_submit_review_by_iri_action(self, client: TestClient, make_concept):
+        """Smoke-test one of the lifecycle ``/by-iri/<action>`` endpoints.
+
+        The point of this test is to prove the lifecycle route is wired through
+        — not to re-test the manager's state machine (covered elsewhere). A
+        fresh draft concept advances to ``under_review`` on submit-review.
+        """
+        c = make_concept("Submit Review By IRI")
+        r = client.post(
+            "/api/knowledge/concepts/by-iri/submit-review",
+            params={"iri": c["iri"]},
+            json={},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        # Endpoint returns ``{review_data, concept}``; concept moves to under_review.
+        assert body["concept"]["status"] == "under_review"
+
+
+# ---------------------------------------------------------------------------
+# /api/semantic-models/concepts/by-iri — read-only details endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticModelsConceptsByIri:
+    def test_query_param_route_404_for_unknown_iri(
+        self, client: TestClient, semantic_models_manager
+    ):
+        """The route must be reachable (and respond 404) even when the iri is
+        not present in the graph. This guards against route-ordering bugs where
+        ``/by-iri`` might be shadowed by ``/{concept_iri:path}``.
+        """
+        r = client.get(
+            "/api/semantic-models/concepts/by-iri",
+            params={"iri": "http://example.org/ontology#NotARealConcept"},
+        )
+        # 404 (concept missing) is the success signal; a 422 / 500 would mean
+        # the route is wired wrong.
+        assert r.status_code == 404, r.text
+
+    def test_query_param_route_preserves_http_iri(
+        self, client: TestClient, semantic_models_manager
+    ):
+        """Reproducer for the original bug: ``http://...`` IRIs survive
+        end-to-end as long as we use the query-string form, even when the path
+        contains the ``%2F%2F`` that proxies otherwise collapse.
+        """
+        iri = "http://ontos.example.org/ontology#Customer"
+        # urlencode includes %2F%2F — the route handler must see them as-is.
+        r = client.get(
+            f"/api/semantic-models/concepts/by-iri?iri={quote(iri, safe='')}"
+        )
+        # We don't expect a payload (concept doesn't exist), but the request
+        # itself must reach the handler intact and 404 instead of 422/500.
+        assert r.status_code == 404, r.text
+
+    def test_deprecated_path_form_still_registered(
+        self, client: TestClient, semantic_models_manager
+    ):
+        r = client.get("/api/semantic-models/concepts/urn:not-a-real-iri")
+        assert r.status_code == 404, r.text

--- a/src/backend/src/tests/integration/test_data_product_routes.py
+++ b/src/backend/src/tests/integration/test_data_product_routes.py
@@ -322,6 +322,44 @@ class TestDataProductRoutes:
         # Verify audit log
         verify_audit_log("data-products", "SUBMIT_CERTIFICATION", success=True)
 
+    def test_request_certify_without_deliverable_fails(
+        self, client, sample_product_data
+    ):
+        """ONT-CUJ-019 / ONT-NEG-008: requesting certification on a product
+        with zero deliverables (output ports) must be blocked (409)."""
+        sample_product_data["status"] = "draft"
+        create_response = client.post("/api/data-products", json=sample_product_data)
+        product_id = create_response.json()["id"]
+
+        response = client.post(
+            f"/api/data-products/{product_id}/request-certify",
+            json={"certification_level": "gold"},
+        )
+
+        assert response.status_code == 409
+        assert "deliverable" in response.json()["detail"].lower()
+
+    def test_request_certify_with_deliverable_succeeds(
+        self, client, sample_product_data
+    ):
+        """A product with at least one deliverable is accepted for
+        certification (202)."""
+        sample_product_data["status"] = "draft"
+        sample_product_data["outputPorts"] = [{
+            "name": "test-output",
+            "version": "1.0.0",
+            "contractId": "test-contract",
+        }]
+        create_response = client.post("/api/data-products", json=sample_product_data)
+        product_id = create_response.json()["id"]
+
+        response = client.post(
+            f"/api/data-products/{product_id}/request-certify",
+            json={"certification_level": "gold"},
+        )
+
+        assert response.status_code == 202
+
     def test_publish_product_success(self, client, sample_product_data):
         """Test POST /api/data-products/{id}/publish."""
         # Arrange

--- a/src/backend/src/tests/unit/test_compliance_manager.py
+++ b/src/backend/src/tests/unit/test_compliance_manager.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
 
 from src.controller.compliance_manager import ComplianceManager
-from src.models.compliance import CompliancePolicy, ComplianceRun, ComplianceResult
+from src.models.compliance import CompliancePolicy, CompliancePolicyCreate, ComplianceRun, ComplianceResult
 from src.db_models.compliance import CompliancePolicyDb, ComplianceRunDb, ComplianceResultDb
 
 
@@ -63,23 +63,25 @@ class TestComplianceManager:
     # =====================================================================
 
     def test_create_policy_success(self, manager, db_session, sample_policy_data):
-        """Test successful policy creation."""
-        # Arrange
-        policy = CompliancePolicy(**{
-            **sample_policy_data,
-            "id": uuid.UUID(sample_policy_data["id"]),
-            "compliance": 0.0,
-            "history": [],
-            "created_at": datetime.now(),
-            "updated_at": datetime.now(),
-        })
+        """Test successful policy creation. The manager should generate the UUID server-side."""
+        # Arrange - CompliancePolicyCreate intentionally omits id, compliance, history, timestamps
+        policy = CompliancePolicyCreate(
+            name=sample_policy_data["name"],
+            description=sample_policy_data["description"],
+            rule=sample_policy_data["rule"],
+            category=sample_policy_data["category"],
+            severity=sample_policy_data["severity"],
+            is_active=sample_policy_data["is_active"],
+        )
 
-        # Act - Manager should handle UUID to string conversion
+        # Act
         result = manager.create_policy(db_session, policy)
 
         # Assert
         assert result is not None
-        assert result.id == sample_policy_data["id"]  # Compare as strings
+        assert result.id is not None
+        # Server-generated id should be a valid UUID string
+        uuid.UUID(result.id)
         assert result.name == policy.name
         assert result.description == policy.description
         assert result.rule == policy.rule
@@ -464,21 +466,24 @@ class TestComplianceManager:
     # Error Handling Tests
     # =====================================================================
 
-    def test_create_policy_duplicate_id(self, manager, db_session, sample_policy_db, sample_policy_data):
-        """Test creating a policy with duplicate ID fails."""
+    def test_create_policy_generates_unique_ids(self, manager, db_session, sample_policy_data):
+        """Two successive creates with the same payload should yield distinct server-generated ids."""
         # Arrange
-        duplicate_policy = CompliancePolicy(**{
-            **sample_policy_data,
-            "id": uuid.UUID(sample_policy_db.id),
-            "name": "Different Name",
-            "compliance": 0.0,
-            "history": [],
-            "created_at": datetime.now(),
-            "updated_at": datetime.now(),
-        })
+        payload = CompliancePolicyCreate(
+            name=sample_policy_data["name"],
+            description=sample_policy_data["description"],
+            rule=sample_policy_data["rule"],
+            category=sample_policy_data["category"],
+            severity=sample_policy_data["severity"],
+            is_active=sample_policy_data["is_active"],
+        )
 
-        # Act & Assert
-        with pytest.raises(Exception):  # SQLAlchemy integrity error
-            manager.create_policy(db_session, duplicate_policy)
-            db_session.commit()
+        # Act
+        first = manager.create_policy(db_session, payload)
+        second = manager.create_policy(db_session, payload)
+
+        # Assert
+        assert first.id != second.id
+        uuid.UUID(first.id)
+        uuid.UUID(second.id)
 

--- a/src/backend/src/tests/unit/test_contract_duplicate_name.py
+++ b/src/backend/src/tests/unit/test_contract_duplicate_name.py
@@ -1,0 +1,68 @@
+"""Unit tests for duplicate data-contract name rejection (ONT-NEG-002).
+
+Creating a contract whose name duplicates an existing contract in the same
+domain previously succeeded silently. It must now raise a ConflictError
+(surfaced as HTTP 409 by the route).
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.common.errors import ConflictError
+from src.controller.data_contracts_manager import DataContractsManager
+from src.db_models.data_contracts import DataContractDb
+
+
+def _manager():
+    mgr = DataContractsManager(data_dir=Path("/tmp"))
+    # The duplicate check runs before any writes; neutralize the post-create
+    # side effects so the happy-path create stays dependency-free.
+    mgr._queue_delivery = lambda *a, **k: None
+    mgr._update_search_index = lambda *a, **k: None
+    return mgr
+
+
+@pytest.fixture
+def existing_contract(db_session: Session):
+    cid = str(uuid.uuid4())
+    db_session.add(
+        DataContractDb(id=cid, name="Customer Data", version="1.0.0", status="active")
+    )
+    db_session.commit()
+    return cid
+
+
+class TestDuplicateContractName:
+    def test_duplicate_name_same_domain_raises_conflict(
+        self, db_session: Session, existing_contract
+    ):
+        manager = _manager()
+        with pytest.raises(ConflictError):
+            manager.create_contract_with_relations(
+                db=db_session,
+                contract_data={"name": "Customer Data", "version": "1.0.0"},
+                current_user="alice@example.com",
+            )
+
+    def test_duplicate_name_is_case_insensitive(
+        self, db_session: Session, existing_contract
+    ):
+        manager = _manager()
+        with pytest.raises(ConflictError):
+            manager.create_contract_with_relations(
+                db=db_session,
+                contract_data={"name": "customer DATA", "version": "1.0.0"},
+                current_user="alice@example.com",
+            )
+
+    def test_distinct_name_is_allowed(self, db_session: Session, existing_contract):
+        manager = _manager()
+        created = manager.create_contract_with_relations(
+            db=db_session,
+            contract_data={"name": "Orders Data", "version": "1.0.0"},
+            current_user="alice@example.com",
+        )
+        assert created.id is not None
+        assert created.name == "Orders Data"

--- a/src/backend/src/tests/unit/test_contract_quality_persistence.py
+++ b/src/backend/src/tests/unit/test_contract_quality_persistence.py
@@ -1,0 +1,114 @@
+"""Unit tests for column-level (property) quality-rule persistence.
+
+Regression coverage for ONT-CUJ-008: quality rules authored on a schema
+column were accepted by the UI but silently dropped on save because
+``_create_schema_objects`` never read ``properties[].quality``. These tests
+exercise the manager's schema-object builder directly against the in-memory
+DB so they stay fast and dependency-free.
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.data_contracts_manager import DataContractsManager
+from src.db_models.data_contracts import (
+    DataContractDb,
+    DataQualityCheckDb,
+    SchemaObjectDb,
+    SchemaPropertyDb,
+)
+
+
+def _manager():
+    return DataContractsManager(data_dir=Path("/tmp"))
+
+
+@pytest.fixture
+def contract(db_session: Session):
+    cid = str(uuid.uuid4())
+    db_session.add(DataContractDb(id=cid, name="C", version="1.0.0", status="draft"))
+    db_session.commit()
+    return cid
+
+
+def _schema_with_column_rule():
+    return [
+        {
+            "name": "orders",
+            "properties": [
+                {
+                    "name": "amount",
+                    "logicalType": "number",
+                    "quality": [
+                        {
+                            "name": "non_negative",
+                            "type": "library",
+                            "rule": "rangeCheck",
+                            "dimension": "accuracy",
+                            "severity": "error",
+                            "description": "amount must be >= 0",
+                            "mustBeGe": "0",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+
+class TestColumnQualityPersistence:
+    def test_property_quality_rule_is_persisted(self, db_session: Session, contract):
+        manager = _manager()
+        manager._create_schema_objects(db_session, contract, _schema_with_column_rule())
+        db_session.commit()
+
+        prop = db_session.query(SchemaPropertyDb).filter_by(name="amount").one()
+        checks = (
+            db_session.query(DataQualityCheckDb)
+            .filter(DataQualityCheckDb.property_id == prop.id)
+            .all()
+        )
+        assert len(checks) == 1
+        check = checks[0]
+        # Bound to the column, not just the table.
+        assert check.property_id == prop.id
+        assert check.object_id is not None
+        assert check.level == "property"
+        # ODCS fields round-trip through the shared builder.
+        assert check.name == "non_negative"
+        assert check.rule == "rangeCheck"
+        assert check.dimension == "accuracy"
+        assert check.severity == "error"
+        assert check.must_be_ge == "0"
+
+    def test_column_without_quality_creates_no_checks(self, db_session: Session, contract):
+        manager = _manager()
+        manager._create_schema_objects(
+            db_session,
+            contract,
+            [{"name": "t", "properties": [{"name": "c", "logicalType": "string"}]}],
+        )
+        db_session.commit()
+        assert db_session.query(DataQualityCheckDb).count() == 0
+
+    def test_object_and_property_checks_coexist(self, db_session: Session, contract):
+        """Object-level (qualityRules) and property-level checks are distinct
+        rows distinguishable by property_id."""
+        manager = _manager()
+        manager._create_schema_objects(db_session, contract, _schema_with_column_rule())
+        db_session.flush()
+        # Object-level rule attaches to the first schema object (property_id NULL).
+        manager._create_quality_checks(
+            db_session, contract, [{"name": "row_count", "type": "sql", "query": "SELECT 1"}]
+        )
+        db_session.commit()
+
+        all_checks = db_session.query(DataQualityCheckDb).all()
+        assert len(all_checks) == 2
+        property_level = [c for c in all_checks if c.property_id is not None]
+        object_level = [c for c in all_checks if c.property_id is None]
+        assert len(property_level) == 1
+        assert len(object_level) == 1
+        assert object_level[0].name == "row_count"

--- a/src/backend/src/tests/unit/test_contract_steward_review.py
+++ b/src/backend/src/tests/unit/test_contract_steward_review.py
@@ -1,0 +1,72 @@
+"""Unit tests for requesting a steward review on a data contract.
+
+Regression coverage for ONT-CUJ-008/ONT-CUJ-012-adjacent behaviour: after a
+producer requests review, the contract must transition to ``proposed`` and be
+discoverable by stewards via the approvals queue. A previous stub in
+``request_steward_review`` constructed an in-memory ReviewedAsset and logged a
+(false) "Created asset review record" without persisting anything; this test
+pins the real surfacing path (the approvals queue) and that the call itself
+does not raise.
+"""
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.approvals_manager import ApprovalsManager
+from src.controller.data_contracts_manager import DataContractsManager
+from src.db_models.data_contracts import DataContractDb
+
+
+def _manager():
+    return DataContractsManager(data_dir=Path("/tmp"))
+
+
+@pytest.fixture
+def draft_contract(db_session: Session):
+    cid = str(uuid.uuid4())
+    db_session.add(DataContractDb(id=cid, name="Reviewable", version="1.0.0", status="draft"))
+    db_session.commit()
+    return cid
+
+
+class TestRequestStewardReview:
+    def test_transitions_to_proposed_and_surfaces_in_approvals_queue(
+        self, db_session: Session, draft_contract
+    ):
+        manager = _manager()
+        result = manager.request_steward_review(
+            db=db_session,
+            notifications_manager=MagicMock(),
+            contract_id=draft_contract,
+            requester_email="producer@example.com",
+            message="please review",
+            current_user="producer@example.com",
+        )
+        db_session.commit()
+
+        assert result["status"] == "proposed"
+
+        contract = db_session.query(DataContractDb).filter_by(id=draft_contract).one()
+        assert contract.status == "proposed"
+
+        # The steward-facing surface: proposed contracts appear in the queue.
+        queue = ApprovalsManager().get_approvals_queue(db_session)
+        queued_ids = {c["id"] for c in queue["contracts"]}
+        assert draft_contract in queued_ids
+
+    def test_rejects_review_from_non_draft_status(self, db_session: Session):
+        manager = _manager()
+        cid = str(uuid.uuid4())
+        db_session.add(DataContractDb(id=cid, name="Active", version="1.0.0", status="active"))
+        db_session.commit()
+
+        with pytest.raises(ValueError):
+            manager.request_steward_review(
+                db=db_session,
+                notifications_manager=MagicMock(),
+                contract_id=cid,
+                requester_email="producer@example.com",
+            )

--- a/src/backend/src/tests/unit/test_data_product_read_gate.py
+++ b/src/backend/src/tests/unit/test_data_product_read_gate.py
@@ -1,0 +1,66 @@
+"""Unit tests for the direct-read gate on data products (ONT-NEG-011).
+
+A consumer could read an unpublished (draft) product by id via
+GET /api/data-products/{id}. The gate must allow published products to
+everyone but restrict unpublished ones to admins and owners.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.routes.data_product_routes import _caller_can_read_product
+
+
+def _request(*, is_admin: bool):
+    auth_manager = MagicMock()
+    auth_manager.get_user_effective_permissions.return_value = {}
+    auth_manager.has_permission.return_value = is_admin
+    request = MagicMock()
+    request.app.state.authorization_manager = auth_manager
+    request.app.state.settings_manager = None
+    return request
+
+
+def _user(email="consumer@example.com"):
+    return SimpleNamespace(email=email, groups=[])
+
+
+class TestProductReadGate:
+    def test_published_product_readable_by_anyone(self):
+        manager = MagicMock()
+        # Even if the accessible set is empty, a published product is readable.
+        manager.list_products.return_value = []
+        product = SimpleNamespace(id="p1", status="active")
+
+        assert _caller_can_read_product(
+            _request(is_admin=False), MagicMock(), _user(), manager, product
+        ) is True
+        # Published short-circuit: we never needed to scope the listing.
+        manager.list_products.assert_not_called()
+
+    def test_draft_denied_for_non_owner_non_admin(self):
+        manager = MagicMock()
+        manager.list_products.return_value = []  # caller owns nothing
+        product = SimpleNamespace(id="p1", status="draft")
+
+        assert _caller_can_read_product(
+            _request(is_admin=False), MagicMock(), _user(), manager, product
+        ) is False
+
+    def test_draft_allowed_for_feature_admin(self):
+        manager = MagicMock()
+        product = SimpleNamespace(id="p1", status="draft")
+
+        assert _caller_can_read_product(
+            _request(is_admin=True), MagicMock(), _user(), manager, product
+        ) is True
+
+    def test_draft_allowed_for_owner_in_accessible_set(self):
+        manager = MagicMock()
+        manager.list_products.return_value = [SimpleNamespace(id="p1")]  # caller owns it
+        product = SimpleNamespace(id="p1", status="draft")
+
+        assert _caller_can_read_product(
+            _request(is_admin=False), MagicMock(), _user(), manager, product
+        ) is True

--- a/src/backend/src/tests/unit/test_data_products_ownership_scope.py
+++ b/src/backend/src/tests/unit/test_data_products_ownership_scope.py
@@ -340,6 +340,55 @@ class TestUpdateProductWithAuthCascade:
         )
         assert result == "UPDATED_OK"
 
+    # ---- feature-admin path (ONT-CUJ-015) ----
+
+    def test_feature_admin_can_edit_orphan(self, manager, db_session):
+        """A data-products feature admin (is_feature_admin=True) edits an
+        owner-less product even when not a workspace admin."""
+        product = _make_product(db_session, name="orphan")
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="role-admin@example.com",
+            user_groups=[],  # not a workspace admin
+            db=db_session,
+            caller_team_ids=[],
+            is_feature_admin=True,
+        )
+        assert result == "UPDATED_OK"
+
+    def test_feature_admin_can_edit_others_product(self, manager, db_session):
+        product = _make_product(
+            db_session, name="theirs", status="draft", draft_owner_id="bob@example.com"
+        )
+
+        result = manager.update_product_with_auth(
+            product_id=product.id,
+            product_data_dict={"name": "renamed"},
+            user_email="role-admin@example.com",
+            user_groups=[],
+            db=db_session,
+            caller_team_ids=[],
+            is_feature_admin=True,
+        )
+        assert result == "UPDATED_OK"
+
+    def test_non_feature_admin_orphan_still_denied(self, manager, db_session):
+        """The default (is_feature_admin=False) preserves fail-closed behavior."""
+        product = _make_product(db_session, name="orphan")
+
+        with pytest.raises(PermissionError):
+            manager.update_product_with_auth(
+                product_id=product.id,
+                product_data_dict={"name": "renamed"},
+                user_email="alice@example.com",
+                user_groups=[],
+                db=db_session,
+                caller_team_ids=[],
+                is_feature_admin=False,
+            )
+
     # ---- project membership branch ----
 
     def test_non_admin_with_project_membership_can_edit(
@@ -501,3 +550,46 @@ class TestUpdateProductWithAuthCascade:
             db=db_session,
         )
         assert result is None
+
+
+class TestCreateProductOwnership:
+    """ONT-CUJ-015: a newly created product must be owned by its creator so
+    the creator can edit it (e.g. add deliverables). Otherwise it is an
+    owner-less orphan that fails the update authorization cascade."""
+
+    @pytest.fixture
+    def manager(self, db_session):
+        mgr = DataProductsManager(
+            db=db_session,
+            ws_client=MagicMock(),
+            notifications_manager=MagicMock(),
+            tags_manager=MagicMock(),
+        )
+        # Focus on ownership stamping — neutralize delivery/search side effects.
+        mgr._queue_delivery = MagicMock()
+        mgr._update_search_index = MagicMock()
+        return mgr
+
+    def _minimal_product(self):
+        return {
+            "info": {"title": "My Product", "owner": "team@example.com"},
+            "name": "My Product",
+            "version": "1.0.0",
+        }
+
+    def test_creator_becomes_draft_owner_when_no_other_owner(
+        self, manager, db_session
+    ):
+        created = manager.create_product(
+            self._minimal_product(), db=db_session, user="alice@example.com"
+        )
+        assert created.draft_owner_id == "alice@example.com"
+
+    def test_explicit_owner_team_is_not_overwritten(self, manager, db_session):
+        data = self._minimal_product()
+        data["owner_team_id"] = "team-A"
+        created = manager.create_product(
+            data, db=db_session, user="alice@example.com"
+        )
+        # Team-owned product stays team-visible; not stamped as a personal draft.
+        assert created.draft_owner_id is None

--- a/src/backend/src/tests/unit/test_semantic_models_internal_contexts.py
+++ b/src/backend/src/tests/unit/test_semantic_models_internal_contexts.py
@@ -1,0 +1,54 @@
+"""Internal/system graphs must not leak into the RDF Sources list.
+
+The `/api/semantic-models` route combines DB-backed models with computed
+graph taxonomies. Internal named graphs (app entities, demo data, semantic
+links, source-registry metadata, the rdflib default graph) are managed/computed
+and have no uploadable file behind them, so surfacing them produces broken rows
+whose Preview action 404s. This guards the route-level filter that strips them.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from src.models.ontology import SemanticModel as SemanticModelOntology
+from src.routes.semantic_models_routes import (
+    INTERNAL_GRAPH_CONTEXTS,
+    get_semantic_models,
+)
+
+
+def _call_endpoint(manager: MagicMock) -> dict:
+    """Invoke the async route handler directly, bypassing FastAPI auth/DI."""
+    return asyncio.run(get_semantic_models(manager=manager, _=True))
+
+
+def test_internal_graphs_are_excluded_from_list() -> None:
+    manager = MagicMock()
+    # No DB-backed models in this scenario.
+    manager.list.return_value = []
+    # Computed taxonomies include internal graphs plus one real file taxonomy.
+    manager.get_taxonomies.return_value = [
+        SemanticModelOntology(name="urn:app-entities", source_type="external"),
+        SemanticModelOntology(name="urn:demo", source_type="external"),
+        SemanticModelOntology(name="urn:semantic-links", source_type="external"),
+        SemanticModelOntology(name="urn:meta:sources", source_type="external"),
+        SemanticModelOntology(name="foo", source_type="file", format="ttl"),
+    ]
+    manager.bundled_taxonomy_file_size_bytes.return_value = 123
+
+    payload = _call_endpoint(manager)
+
+    names = {m["name"] for m in payload["semantic_models"]}
+    assert names == {"foo"}
+    assert not (names & INTERNAL_GRAPH_CONTEXTS)
+
+
+def test_internal_graph_contexts_cover_known_namespaces() -> None:
+    for key in (
+        "urn:meta:sources",
+        "urn:semantic-links",
+        "urn:x-rdflib:default",
+        "urn:app-entities",
+        "urn:demo",
+    ):
+        assert key in INTERNAL_GRAPH_CONTEXTS

--- a/src/backend/src/tests/unit/test_version_family.py
+++ b/src/backend/src/tests/unit/test_version_family.py
@@ -402,6 +402,84 @@ class TestContractsListCollapse:
         # versionCount is intentionally omitted on the expanded view.
         assert all(s.versionCount is None for s in summaries)
 
+    def test_status_filter_narrows_to_single_status(
+        self, db_session: Session, family_with_loose_row
+    ):
+        # ``?status=draft`` must actually filter (previously the route had no
+        # such param so it was silently ignored — CUJ-006). Family A's draft
+        # rep (v3) is the only draft; the active rows must be excluded.
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=True, status="draft"
+        )
+        ids = {s.id for s in summaries}
+        assert ids == {family_with_loose_row["v3"]}
+
+    def test_status_filter_is_case_insensitive(
+        self, db_session: Session, family_with_loose_row
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=True, status="ACTIVE", include_history=True
+        )
+        # Three active rows across the two families; the draft (v3) is excluded.
+        assert {s.id for s in summaries} == {
+            family_with_loose_row["v1"],
+            family_with_loose_row["v2"],
+            family_with_loose_row["loose"],
+        }
+
+
+class TestPersonalDraftVisibility:
+    """A draft stamped with ``draft_owner_id`` is visible to its owner but not
+    to other non-admin callers — the elevation path that lets a contract's
+    creator find the draft they just created (CUJ-006)."""
+
+    @pytest.fixture
+    def two_personal_drafts(self, db_session: Session):
+        from datetime import datetime, timezone
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        alice = str(uuid.uuid4())
+        bob = str(uuid.uuid4())
+        db_session.add(DataContractDb(
+            id=alice, name="Alice Draft", version="1.0.0", status="draft",
+            version_family_id=alice, draft_owner_id="alice@example.com",
+            created_at=base, updated_at=base,
+        ))
+        db_session.add(DataContractDb(
+            id=bob, name="Bob Draft", version="1.0.0", status="draft",
+            version_family_id=bob, draft_owner_id="bob@example.com",
+            created_at=base, updated_at=base,
+        ))
+        db_session.commit()
+        return {"alice": alice, "bob": bob}
+
+    def _manager(self, db_session):
+        from pathlib import Path
+        from src.controller.data_contracts_manager import DataContractsManager
+        return DataContractsManager(data_dir=Path("/tmp"))
+
+    def test_owner_sees_own_draft_others_do_not(
+        self, db_session: Session, two_personal_drafts
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=False, caller_email="alice@example.com"
+        )
+        ids = {s.id for s in summaries}
+        assert two_personal_drafts["alice"] in ids
+        assert two_personal_drafts["bob"] not in ids
+
+    def test_non_owner_consumer_sees_no_drafts(
+        self, db_session: Session, two_personal_drafts
+    ):
+        manager = self._manager(db_session)
+        summaries = manager.list_contracts_from_db(
+            db_session, is_admin=False, caller_email="carol@example.com"
+        )
+        # Carol owns neither personal draft and drafts aren't consumer-visible.
+        assert summaries == []
+
 
 class TestProductsListCollapse:
     """``list_products`` collapses by version_family_id and attaches counts."""

--- a/src/backend/src/tests/unit/test_workflow_triggers_status.py
+++ b/src/backend/src/tests/unit/test_workflow_triggers_status.py
@@ -235,6 +235,69 @@ class TestDataContractsManagerGating:
                 )
 
 
+class TestContractApproveFromProposed:
+    """ONT-CUJ-013: a steward must be able to approve a proposed contract.
+
+    Previously DATA_CONTRACT_TRANSITIONS omitted "approved" from "proposed",
+    so the approve endpoint's transition_status(proposed -> approved) raised
+    ValueError, which the route turned into an opaque 500.
+    """
+
+    def test_lifecycle_map_allows_proposed_to_approved(self):
+        from src.models.lifecycle import DATA_CONTRACT_TRANSITIONS
+        assert 'approved' in DATA_CONTRACT_TRANSITIONS['proposed']
+
+    def test_transition_proposed_to_approved_succeeds(self, db_session):
+        from src.controller.data_contracts_manager import DataContractsManager
+        from src.db_models.data_contracts import DataContractDb
+        import uuid
+        from pathlib import Path
+
+        contract = DataContractDb(
+            id=str(uuid.uuid4()),
+            name="Approvable Contract",
+            version="1.0.0",
+            status="proposed",
+        )
+        db_session.add(contract)
+        db_session.commit()
+
+        mgr = DataContractsManager(data_dir=Path("/tmp"))
+        updated = mgr.transition_status(
+            db=db_session,
+            contract_id=contract.id,
+            new_status='approved',
+            current_user='steward@example.com',
+        )
+        assert updated.status == 'approved'
+
+    def test_invalid_transition_still_raises_valueerror(self, db_session):
+        # A genuinely invalid jump (active -> approved) must still be rejected,
+        # so the route can map it to a 409 rather than silently allowing it.
+        from src.controller.data_contracts_manager import DataContractsManager
+        from src.db_models.data_contracts import DataContractDb
+        import uuid
+        from pathlib import Path
+
+        contract = DataContractDb(
+            id=str(uuid.uuid4()),
+            name="Active Contract",
+            version="1.0.0",
+            status="active",
+        )
+        db_session.add(contract)
+        db_session.commit()
+
+        mgr = DataContractsManager(data_dir=Path("/tmp"))
+        with pytest.raises(ValueError, match="Invalid status transition"):
+            mgr.transition_status(
+                db=db_session,
+                contract_id=contract.id,
+                new_status='approved',
+                current_user='steward@example.com',
+            )
+
+
 # =========================================================================
 # YAML validation — User Story 15
 # =========================================================================

--- a/src/frontend/src/components/knowledge/concept-editor-dialog.tsx
+++ b/src/frontend/src/components/knowledge/concept-editor-dialog.tsx
@@ -110,6 +110,7 @@ export const ConceptEditorDialog: React.FC<ConceptEditorDialogProps> = ({
 
   const isNew = !concept;
   const canEdit = !readOnly && (!concept?.status || concept.status === 'draft');
+  const editableCollections = collections.filter((c) => c.is_editable);
 
   useEffect(() => {
     if (concept) {
@@ -250,7 +251,7 @@ export const ConceptEditorDialog: React.FC<ConceptEditorDialogProps> = ({
           <form onSubmit={handleSubmit}>
             <div className="grid gap-4 py-4 px-1">
               {/* Collection (for new concepts) */}
-              {isNew && collections.length > 0 && (
+              {isNew && editableCollections.length > 0 && (
                 <div className="grid gap-2">
                   <Label htmlFor="collection">{t('Collection')}</Label>
                   <Select
@@ -258,19 +259,17 @@ export const ConceptEditorDialog: React.FC<ConceptEditorDialogProps> = ({
                     onValueChange={(value) =>
                       setFormData((prev) => ({ ...prev, collection_iri: value }))
                     }
-                    disabled={!!collection}
+                    disabled={editableCollections.length <= 1}
                   >
                     <SelectTrigger>
                       <SelectValue placeholder={t('Select collection...')} />
                     </SelectTrigger>
                     <SelectContent>
-                      {collections
-                        .filter((c) => c.is_editable)
-                        .map((c) => (
-                          <SelectItem key={c.iri} value={c.iri}>
-                            {c.label}
-                          </SelectItem>
-                        ))}
+                      {editableCollections.map((c) => (
+                        <SelectItem key={c.iri} value={c.iri}>
+                          {c.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/frontend/src/components/knowledge/node-links-panel.tsx
+++ b/src/frontend/src/components/knowledge/node-links-panel.tsx
@@ -238,7 +238,7 @@ export const NodeLinksPanel: React.FC<NodeLinksPanelProps> = ({
       // TODO: Handle domain/range for properties
       
       const response = await fetch(
-        `/api/knowledge/concepts/${encodeURIComponent(concept.iri)}`,
+        `/api/knowledge/concepts/by-iri?iri=${encodeURIComponent(concept.iri)}`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
@@ -280,7 +280,7 @@ export const NodeLinksPanel: React.FC<NodeLinksPanelProps> = ({
       }
       
       const response = await fetch(
-        `/api/knowledge/concepts/${encodeURIComponent(concept.iri)}`,
+        `/api/knowledge/concepts/by-iri?iri=${encodeURIComponent(concept.iri)}`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },

--- a/src/frontend/src/components/search/concepts-search.tsx
+++ b/src/frontend/src/components/search/concepts-search.tsx
@@ -103,7 +103,7 @@ export default function ConceptsSearch({
       // Load concept from IRI using the exact IRI endpoint
       const loadConceptFromIri = async () => {
         try {
-          const res = await get<{ concept: any }>(`/api/semantic-models/concepts/${encodeURIComponent(urlIri)}`);
+          const res = await get<{ concept: any }>(`/api/semantic-models/concepts/by-iri?iri=${encodeURIComponent(urlIri)}`);
           if (res.data && res.data.concept) {
             const concept = res.data.concept;
             const conceptItem: ConceptItem = {

--- a/src/frontend/src/components/settings/semantic-models-settings.tsx
+++ b/src/frontend/src/components/settings/semantic-models-settings.tsx
@@ -35,10 +35,8 @@ import { useKnowledgeGraphStore } from '@/stores/knowledge-graph-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { systemRdfNamespaceDisplayLabel } from '@/lib/system-rdf-namespace-labels';
+import { systemRdfNamespaceDisplayLabel, SYSTEM_RDF_NAMESPACE_KEY_SET } from '@/lib/system-rdf-namespace-labels';
 import type { TFunction } from 'i18next';
-
-const SYSTEM_CONTEXTS = ['urn:meta:sources', 'urn:semantic-links'];
 
 interface TitleCandidateRow {
   iri: string;
@@ -100,7 +98,7 @@ export default function SemanticModelsSettings() {
   const [titleSaving, setTitleSaving] = useState(false);
 
   const filteredItems = useMemo(() => 
-    items.filter(m => !SYSTEM_CONTEXTS.includes(m.name)),
+    items.filter(m => !SYSTEM_RDF_NAMESPACE_KEY_SET.has(m.name)),
     [items]
   );
 

--- a/src/frontend/src/i18n/locales/es/access-grants.json
+++ b/src/frontend/src/i18n/locales/es/access-grants.json
@@ -20,24 +20,15 @@
       "years_plural": "{{count}} años"
     },
     "submit": "Enviar Solicitud",
-    "cancel": "Cancelar",
-    "success": "Solicitud de acceso enviada exitosamente",
-    "error": "Error al enviar la solicitud de acceso"
+    "success": "Solicitud de acceso enviada exitosamente"
   },
   "panel": {
     "title": "Permisos de Acceso",
     "description": "Usuarios con acceso limitado en tiempo a este recurso",
     "noGrants": "Sin permisos de acceso para este recurso",
     "noGrantsHint": "Los usuarios pueden solicitar acceso limitado en tiempo usando el botón \"Solicitar Acceso\".",
-    "columns": {
-      "user": "Usuario",
-      "permission": "Nivel de Permiso",
-      "granted": "Otorgado",
-      "expires": "Expira",
-      "actions": "Acciones"
-    },
     "revoke": "Revocar",
-    "revokeConfirm": "¿Está seguro de que desea revocar este permiso de acceso?"
+    "revokeConfirm": "¿Está seguro de que desea revocar el acceso de {{user}}?"
   },
   "entityTypes": {
     "data_product": "producto de datos",

--- a/src/frontend/src/i18n/locales/fr/access-grants.json
+++ b/src/frontend/src/i18n/locales/fr/access-grants.json
@@ -20,24 +20,15 @@
       "years_plural": "{{count}} ans"
     },
     "submit": "Envoyer la Demande",
-    "cancel": "Annuler",
-    "success": "Demande d'accès envoyée avec succès",
-    "error": "Échec de l'envoi de la demande d'accès"
+    "success": "Demande d'accès envoyée avec succès"
   },
   "panel": {
     "title": "Autorisations d'Accès",
     "description": "Utilisateurs avec accès limité dans le temps à cette ressource",
     "noGrants": "Aucune autorisation d'accès pour cette ressource",
     "noGrantsHint": "Les utilisateurs peuvent demander un accès limité dans le temps en utilisant le bouton \"Demander l'Accès\".",
-    "columns": {
-      "user": "Utilisateur",
-      "permission": "Niveau de Permission",
-      "granted": "Accordé",
-      "expires": "Expire",
-      "actions": "Actions"
-    },
     "revoke": "Révoquer",
-    "revokeConfirm": "Êtes-vous sûr de vouloir révoquer cette autorisation d'accès ?"
+    "revokeConfirm": "Êtes-vous sûr de vouloir révoquer l'accès de {{user}} ?"
   },
   "entityTypes": {
     "data_product": "produit de données",

--- a/src/frontend/src/i18n/locales/it/access-grants.json
+++ b/src/frontend/src/i18n/locales/it/access-grants.json
@@ -20,24 +20,15 @@
       "years_plural": "{{count}} anni"
     },
     "submit": "Invia Richiesta",
-    "cancel": "Annulla",
-    "success": "Richiesta di accesso inviata con successo",
-    "error": "Impossibile inviare la richiesta di accesso"
+    "success": "Richiesta di accesso inviata con successo"
   },
   "panel": {
     "title": "Autorizzazioni di Accesso",
     "description": "Utenti con accesso limitato nel tempo a questa risorsa",
     "noGrants": "Nessuna autorizzazione di accesso per questa risorsa",
     "noGrantsHint": "Gli utenti possono richiedere accesso limitato nel tempo utilizzando il pulsante \"Richiedi Accesso\".",
-    "columns": {
-      "user": "Utente",
-      "permission": "Livello di Permesso",
-      "granted": "Concesso",
-      "expires": "Scade",
-      "actions": "Azioni"
-    },
     "revoke": "Revoca",
-    "revokeConfirm": "Sei sicuro di voler revocare questa autorizzazione di accesso?"
+    "revokeConfirm": "Sei sicuro di voler revocare l'accesso per {{user}}?"
   },
   "entityTypes": {
     "data_product": "prodotto dati",

--- a/src/frontend/src/i18n/locales/ja/access-grants.json
+++ b/src/frontend/src/i18n/locales/ja/access-grants.json
@@ -20,24 +20,15 @@
       "years_plural": "{{count}}年"
     },
     "submit": "リクエストを送信",
-    "cancel": "キャンセル",
-    "success": "アクセスリクエストが正常に送信されました",
-    "error": "アクセスリクエストの送信に失敗しました"
+    "success": "アクセスリクエストが正常に送信されました"
   },
   "panel": {
     "title": "アクセス権限",
     "description": "このリソースへの期限付きアクセスを持つユーザー",
     "noGrants": "このリソースへのアクセス権限はありません",
     "noGrantsHint": "ユーザーは「アクセスをリクエスト」ボタンを使用して期限付きアクセスをリクエストできます。",
-    "columns": {
-      "user": "ユーザー",
-      "permission": "権限レベル",
-      "granted": "付与日",
-      "expires": "有効期限",
-      "actions": "操作"
-    },
     "revoke": "取り消し",
-    "revokeConfirm": "このアクセス権限を取り消してもよろしいですか？"
+    "revokeConfirm": "{{user}} のアクセス権を取り消してもよろしいですか？"
   },
   "entityTypes": {
     "data_product": "データプロダクト",

--- a/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { systemRdfNamespaceDisplayLabel } from './system-rdf-namespace-labels';
+import {
+  systemRdfNamespaceDisplayLabel,
+  SYSTEM_RDF_NAMESPACE_KEY_SET,
+} from './system-rdf-namespace-labels';
 import { humanizeRdfFilename } from './rdf-filename';
 
 describe('systemRdfNamespaceDisplayLabel', () => {
@@ -27,5 +30,23 @@ describe('systemRdfNamespaceDisplayLabel', () => {
     expect(systemRdfNamespaceDisplayLabel('urn:something-else', t)).toBe(
       humanizeRdfFilename('urn:something-else'),
     );
+  });
+});
+
+describe('SYSTEM_RDF_NAMESPACE_KEY_SET', () => {
+  it('contains all known internal namespaces used to filter RDF Sources', () => {
+    for (const key of [
+      'urn:meta:sources',
+      'urn:semantic-links',
+      'urn:x-rdflib:default',
+      'urn:app-entities',
+      'urn:demo',
+    ]) {
+      expect(SYSTEM_RDF_NAMESPACE_KEY_SET.has(key)).toBe(true);
+    }
+  });
+
+  it('does not include user-facing taxonomy contexts', () => {
+    expect(SYSTEM_RDF_NAMESPACE_KEY_SET.has('urn:taxonomy:foo')).toBe(false);
   });
 });

--- a/src/frontend/src/lib/system-rdf-namespace-labels.ts
+++ b/src/frontend/src/lib/system-rdf-namespace-labels.ts
@@ -6,7 +6,7 @@ import { humanizeRdfFilename } from '@/lib/rdf-filename';
  * Known internal graph names / API pseudo-row `name` values (not user taxonomies).
  * Keys use the semantic-models namespace as default when calling `t`.
  */
-const SYSTEM_RDF_NAMESPACE_KEYS: Record<string, { i18nKey: string; defaultLabel: string }> = {
+export const SYSTEM_RDF_NAMESPACE_KEYS: Record<string, { i18nKey: string; defaultLabel: string }> = {
   'urn:meta:sources': {
     i18nKey: 'rdfSources.systemNamespaces.metaSources',
     defaultLabel: 'Source registry metadata',
@@ -29,6 +29,13 @@ const SYSTEM_RDF_NAMESPACE_KEYS: Record<string, { i18nKey: string; defaultLabel:
     defaultLabel: 'Demo business concepts',
   },
 };
+
+/**
+ * Set of internal graph keys, used to filter system contexts out of user-facing
+ * lists (e.g. the RDF Sources table). Derived from the canonical key map so the
+ * filter automatically covers any new internal namespace added above.
+ */
+export const SYSTEM_RDF_NAMESPACE_KEY_SET = new Set(Object.keys(SYSTEM_RDF_NAMESPACE_KEYS));
 
 /**
  * Human-readable label for internal RDF graph keys, or the original key if unknown.

--- a/src/frontend/src/tests/cuj-4-glossary.spec.ts
+++ b/src/frontend/src/tests/cuj-4-glossary.spec.ts
@@ -83,8 +83,9 @@ test.describe('CUJ-4 — Business Terms Browser', () => {
       const dialog = page.getByRole('dialog')
       await expect(dialog).toBeVisible()
 
-      // The collection select is auto-filled and disabled when a default
-      // collection is provided — no need to interact with it.
+      // The collection select defaults to the first editable collection. It is
+      // interactive when multiple editable collections exist, but this test
+      // relies on the default, so we don't switch it.
       await dialog.getByLabel(/^label$/i).fill(conceptLabel)
 
       await dialog.getByRole('button', { name: /^create$/i }).click()

--- a/src/frontend/src/views/business-terms.tsx
+++ b/src/frontend/src/views/business-terms.tsx
@@ -332,7 +332,9 @@ export default function BusinessTermsView() {
   const editableCollections = collections.filter((c) => c.is_editable);
   const totalConcepts = stats?.total_concepts ?? Object.values(groupedConcepts).flat().length;
   const totalProperties = stats?.total_properties ?? Object.values(groupedProperties).flat().length;
-  const selectedCollection = editableCollections[0] || null;
+  // Seed the editor with a default collection; the dialog lets the user pick
+  // another when more than one editable collection exists.
+  const defaultCollection = editableCollections[0];
 
   return (
     <div className="flex flex-col py-6">
@@ -443,7 +445,7 @@ export default function BusinessTermsView() {
         open={conceptEditorOpen}
         onOpenChange={setConceptEditorOpen}
         concept={null}
-        collection={selectedCollection || editableCollections[0]}
+        collection={defaultCollection}
         collections={editableCollections}
         onSave={handleSaveConcept}
       />

--- a/src/frontend/src/views/concept-detail.tsx
+++ b/src/frontend/src/views/concept-detail.tsx
@@ -108,8 +108,11 @@ export default function ConceptDetailView() {
     setIsLoading(true);
     setError(null);
     try {
+      // Query-param form (``?iri=``) is required because some HTTP proxies
+      // collapse ``%2F%2F`` in path segments, mangling IRIs like
+      // ``http://ontos.example.org/...`` before they reach the backend.
       const res = await get<{ concept?: OntologyConcept }>(
-        `/api/semantic-models/concepts/${encodeURIComponent(conceptIri)}`,
+        `/api/semantic-models/concepts/by-iri?iri=${encodeURIComponent(conceptIri)}`,
       );
       if (res.error || !res.data?.concept) {
         setError(res.error || 'Concept not found');
@@ -207,7 +210,7 @@ export default function ConceptDetailView() {
     try {
       const url = isNew
         ? '/api/knowledge/concepts'
-        : `/api/knowledge/concepts/${encodeURIComponent(concept.iri)}`;
+        : `/api/knowledge/concepts/by-iri?iri=${encodeURIComponent(concept.iri)}`;
       const method = isNew ? 'POST' : 'PATCH';
       const response = await fetch(url, {
         method,
@@ -240,7 +243,7 @@ export default function ConceptDetailView() {
     if (!concept) return;
     try {
       const response = await fetch(
-        `/api/knowledge/concepts/${encodeURIComponent(concept.iri)}`,
+        `/api/knowledge/concepts/by-iri?iri=${encodeURIComponent(concept.iri)}`,
         { method: 'DELETE' },
       );
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Audited every locale namespace under `src/frontend/src/i18n/locales` against the `en` reference (JSON validity, namespace parity, key parity, interpolation-placeholder parity). All files are valid JSON. This PR fixes the genuine **correctness** defects found in `access-grants` for **es/fr/it/ja**:

1. **Placeholder mismatch** — `panel.revokeConfirm` in en is `"...revoke access for {{user}}?"`, but the four translations had dropped the `{{user}}` interpolation ("...revoke this access permission?"), so the revoke-confirmation dialog could not name the affected user in those languages. Restored `{{user}}` in each.
2. **Orphan keys removed** — `panel.columns.*` (user/permission/granted/expires/actions), `request.cancel`, `request.error` existed in es/fr/it/ja but **not** in the `en` source and are **not referenced anywhere in the codebase** (grep = 0 hits). Since i18next resolves by the keys the code requests, these are unreachable and only add drift; removed for consistency with en.

## Scope / non-goals

The audit also shows non-en locales are missing many keys and 6 namespace files vs en. That is **untranslated content**, handled at runtime by `i18next` `fallbackLng: 'en'` (see `src/i18n/config.ts`) — functionally correct, not a defect. This PR deliberately does **not** add machine-generated translations.

If `panel.columns.*` were intended for a planned grants-table feature, the correct fix is to add them to `en` first (and wire them in code) rather than leave them only in non-en locales — happy to do that instead if preferred.

## Testing
- All four edited files validated as JSON.
- Re-ran the parity audit: access-grants es/fr/it/ja now report 0 extra keys and 0 placeholder mismatches vs en.