### PR TITLE
fix(data-products): transition status on request-certify

### DIFF
--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -480,6 +480,15 @@ async def request_certify_product(
             details={"certification_level": certification_level, "message": message},
         )
 
+        # Advance the lifecycle so the product surfaces in the review/approvals
+        # queue. A pre-review product (draft/sandbox) moves to 'proposed' on a
+        # successful certification request; products already in-flight keep their
+        # current status. Without this the documented draft -> proposed
+        # transition never happened (ONT-CUJ-019).
+        current_status = (product_db.status or 'draft').lower()
+        if current_status in ('draft', 'sandbox'):
+            manager.submit_for_review(product_id, username)
+
         get_trigger_registry(db).on_request_certify(
             EntityType.DATA_PRODUCT,
             product_id,

--- a/src/backend/src/tests/unit/test_data_products_manager.py
+++ b/src/backend/src/tests/unit/test_data_products_manager.py
@@ -369,6 +369,30 @@ class TestDataProductsManager:
         assert result is not None
         # Status should transition (actual transition logic verified in integration tests)
 
+    def test_submit_for_review_transitions_draft_to_proposed(
+        self, manager, db_session, sample_product_data
+    ):
+        """A draft product submitted for review/certification must move to 'proposed'.
+
+        Regression guard for ONT-CUJ-019: request-certify returned 202 but the
+        product stayed in 'draft'. The route now calls submit_for_review, so the
+        documented draft -> proposed transition must actually occur and persist.
+        """
+        # Arrange
+        sample_product_data["status"] = "draft"
+        created = manager.create_product(sample_product_data, db=db_session)
+        assert created.status == DataProductStatus.DRAFT.value
+
+        # Act
+        result = manager.submit_for_review(created.id, current_user="requester@example.com")
+
+        # Assert - returned model reflects the transition
+        assert result.status == DataProductStatus.PROPOSED.value
+        # Assert - the change is persisted (a GET would now confirm 'proposed')
+        db_product = db_session.query(DataProductDb).filter_by(id=created.id).first()
+        assert db_product is not None
+        assert db_product.status == DataProductStatus.PROPOSED.value
+
     def test_publish_product_success(
         self, manager, db_session, sample_product_data
     ):


### PR DESCRIPTION
## CUJ
ONT-CUJ-019

## Observed failure
On the live CUJ regression (ontos-dev), `POST /api/data-products/{id}/request-certify` (e.g. requesting a Gold certification level) returned **202** but the product status **stayed `draft`**. A follow-up GET confirmed the documented Draft -> Proposed transition never occurred, so the product never surfaced in the review/approvals queue.

## Root cause
The `request_certify_product` route in `src/backend/src/routes/data_product_routes.py` validated deliverables (the ONT-NEG-008 zero-deliverable guard added in #532), wrote a change-log entry, fired the `on_request_certify` workflow trigger, audited the action, and returned 202 — but it never advanced the product's lifecycle status. PR #532 only added the deliverable guard; it did not implement the state transition. The 202 payload `{"status": "requested"}` describes the workflow request, not the product lifecycle status, which is a separate dimension and was left untouched.

## Fix
After the deliverable guard passes, the route now advances a pre-review product (`draft`/`sandbox`) to `proposed` via the existing `manager.submit_for_review(...)` path (which already validates the transition against `DATA_PRODUCT_TRANSITIONS`, persists it, logs the timeline change, notifies subscribers, fires `on_status_change`, and updates the search index). Products already in-flight keep their current status. The ONT-NEG-008 deliverable guard is unchanged and still runs first, and the 202 response shape is preserved.

## Testing
- Added `test_submit_for_review_transitions_draft_to_proposed` (backend unit test) asserting a draft product moves to `proposed` and the change persists (a GET would now confirm `proposed`).
- `cd src/backend && hatch -e dev run pytest src/tests/unit/test_data_products_manager.py -q`
  - With this change: **28 passed, 7 failed**.
  - On clean main (changes stashed): **27 passed, 7 failed**.
  - The 7 failures are identical and pre-existing on clean main (unrelated to this change); the only delta is the new passing test. Zero new failures introduced. Backend route integration tests are skipped per the known pre-existing audit-service fixture gap.