### PR TITLE
ci: pin actions/checkout to full SHA in back-merge workflow

### DIFF
--- a/.github/workflows/backmerge-main-to-development.yml
+++ b/.github/workflows/backmerge-main-to-development.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

The back-merge workflow added in #548 used `actions/checkout@v4`, which fails the org policy:

> Error: The action actions/checkout@v4 is not allowed in databrickslabs/ontos because all actions must be pinned to a full-length commit SHA.

Pins `actions/checkout` to the exact SHA the rest of this repo's workflows already use: `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6`. No behavior change.

## Testing
- YAML validated; single-line change to the `uses:` pin.