### PR TITLE
chore: hide alpha surfaces and mockup connectors from V1 UI

### DIFF
--- a/src/backend/src/controller/connections_manager.py
+++ b/src/backend/src/controller/connections_manager.py
@@ -199,8 +199,15 @@ class ConnectionsManager:
     # ------------------------------------------------------------------
 
     def list_connector_types(self) -> List[Dict[str, Any]]:
-        """Return metadata about all registered connector types."""
+        """Return metadata about registered connector types available for use.
+
+        Connectors that are not available (``is_available`` is False) are
+        filtered out so mockup/stub connectors (e.g. Snowflake, PowerBI, Kafka)
+        do not appear in the Add Connection dropdown. The default connector type
+        is always retained so the primary connection path is never hidden.
+        """
         registry = get_registry()
+        default_type = getattr(registry, "_default_connector_type", None)
         result = []
         for ctype in registry.list_registered():
             info: Dict[str, Any] = {
@@ -212,6 +219,10 @@ class ConnectionsManager:
             }
             try:
                 connector = registry.get_connector(ctype)
+                # Hide unavailable connectors (stubs hard-code is_available=False),
+                # but always keep the default connector type.
+                if not connector.is_available and ctype != default_type:
+                    continue
                 info["display_name"] = connector.display_name
                 info["description"] = connector.description
                 info["capabilities"] = {

--- a/src/backend/src/tests/unit/test_connector_types_availability.py
+++ b/src/backend/src/tests/unit/test_connector_types_availability.py
@@ -1,0 +1,89 @@
+"""Unit tests for ConnectionsManager.list_connector_types() availability filtering.
+
+Verifies that connector types whose connector reports ``is_available is False``
+(e.g. the Snowflake/PowerBI/Kafka mockup stubs) are excluded from the list
+surfaced to the Add Connection dropdown, while available connectors and the
+default connector type are retained.
+"""
+
+from types import SimpleNamespace
+
+import src.controller.connections_manager as cm
+from src.controller.connections_manager import ConnectionsManager
+
+
+class _FakeCapabilities:
+    can_list_assets = True
+    can_get_metadata = True
+    can_get_sample_data = False
+
+
+class _FakeConnector:
+    def __init__(self, ctype: str, is_available: bool):
+        self.connector_type = ctype
+        self.display_name = ctype.title()
+        self.description = f"{ctype} connector"
+        self._is_available = is_available
+        self.capabilities = _FakeCapabilities()
+
+    @property
+    def is_available(self) -> bool:
+        return self._is_available
+
+
+class _FakeRegistry:
+    def __init__(self, connectors, default_type=None):
+        self._connectors = connectors
+        self._default_connector_type = default_type
+
+    def list_registered(self):
+        return sorted(self._connectors.keys())
+
+    def get_connector(self, ctype):
+        return self._connectors[ctype]
+
+
+def _make_manager(monkeypatch, registry):
+    monkeypatch.setattr(cm, "get_registry", lambda: registry)
+    # Avoid pulling in connector config classes / pydantic models in this test.
+    monkeypatch.setattr(cm, "_get_config_classes", lambda: {})
+    return ConnectionsManager(db=None)
+
+
+def test_unavailable_stub_connectors_are_excluded(monkeypatch):
+    registry = _FakeRegistry(
+        connectors={
+            "databricks": _FakeConnector("databricks", is_available=True),
+            "bigquery": _FakeConnector("bigquery", is_available=True),
+            "snowflake": _FakeConnector("snowflake", is_available=False),
+            "powerbi": _FakeConnector("powerbi", is_available=False),
+            "kafka": _FakeConnector("kafka", is_available=False),
+        },
+        default_type="databricks",
+    )
+    manager = _make_manager(monkeypatch, registry)
+
+    types = {info["connector_type"] for info in manager.list_connector_types()}
+
+    assert "databricks" in types
+    assert "bigquery" in types
+    assert "snowflake" not in types
+    assert "powerbi" not in types
+    assert "kafka" not in types
+
+
+def test_default_connector_is_kept_even_when_unavailable(monkeypatch):
+    # The default connector path must never be hidden, even if is_available is
+    # momentarily False (e.g. workspace client not yet attached).
+    registry = _FakeRegistry(
+        connectors={
+            "databricks": _FakeConnector("databricks", is_available=False),
+            "snowflake": _FakeConnector("snowflake", is_available=False),
+        },
+        default_type="databricks",
+    )
+    manager = _make_manager(monkeypatch, registry)
+
+    types = {info["connector_type"] for info in manager.list_connector_types()}
+
+    assert types == {"databricks"}

--- a/src/frontend/src/components/home/quick-actions.tsx
+++ b/src/frontend/src/components/home/quick-actions.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
 import { usePermissions } from '@/stores/permissions-store';
+import { useFeatureVisibilityStore } from '@/stores/feature-visibility-store';
 import { FeatureAccessLevel } from '@/types/settings';
 import { features, type FeatureGroup } from '@/config/features';
 import { SkeletonLine } from '@/components/common/list-view-skeleton';
@@ -17,6 +18,7 @@ interface QuickAction {
 export default function QuickActions() {
   const { t } = useTranslation(['home', 'features']);
   const { isLoading: permissionsLoading, hasPermission } = usePermissions();
+  const allowedMaturities = useFeatureVisibilityStore((state) => state.allowedMaturities);
 
   const actions: QuickAction[] = useMemo(() => {
     if (permissionsLoading) return [];
@@ -52,7 +54,13 @@ export default function QuickActions() {
 
     actionMapping.forEach(({ featureId, requiredLevel, action }) => {
       const feature = features.find(f => f.id === featureId || f.permissionId === featureId);
-      if (feature && hasPermission(feature.permissionId || feature.id, requiredLevel)) {
+      // Respect feature maturity gating the same way the sidebar navigation does,
+      // so hidden-maturity features (e.g. alpha) never leak in as quick actions.
+      if (
+        feature &&
+        allowedMaturities.includes(feature.maturity) &&
+        hasPermission(feature.permissionId || feature.id, requiredLevel)
+      ) {
         // Skip if we already added an action for this feature (prefer write actions)
         if (addedFeatures.has(featureId)) return;
 
@@ -68,7 +76,7 @@ export default function QuickActions() {
     });
 
     return list;
-  }, [permissionsLoading, hasPermission]);
+  }, [permissionsLoading, hasPermission, allowedMaturities]);
 
   // Group actions by feature group
   const groupedActions = useMemo(() => {

--- a/src/frontend/src/config/features.ts
+++ b/src/frontend/src/config/features.ts
@@ -208,7 +208,7 @@ import {
       description: 'Side-by-side catalog explorer for asset management.',
       icon: FolderKanban,
       group: 'Deploy',
-      maturity: 'beta',
+      maturity: 'alpha',
       showInLanding: true,
     },
   ];


### PR DESCRIPTION
## Summary

Hides several not-ready surfaces from the default V1 UI so users only see GA/beta features and real connectors.

## Surfaces hidden

| Surface | Mechanism |
| --- | --- |
| Catalog Commander | maturity flipped `beta` -> `alpha` in `features.ts` (now hidden by default like the others) |
| Estate Manager | already `alpha`; now also removed from home Quick Actions |
| Entitlements | already `alpha`; now also removed from home Quick Actions |
| Security Features | already `alpha`; now also removed from home Quick Actions |
| Mockup connectors (Snowflake, PowerBI, Kafka) | filtered out of the Add Connection dropdown via `is_available` |

## Mechanism

**Maturity gating (4 navigation surfaces).** The sidebar already hides non-allowed maturities via `feature-visibility-store.ts` (default `showAlpha: false`), so `alpha` features are hidden from navigation. Two gaps closed:

1. `src/frontend/src/config/features.ts` — Catalog Commander changed from `beta` to `alpha` so it is hidden by default alongside Estate Manager / Entitlements / Security Features.
2. `src/frontend/src/components/home/quick-actions.tsx` — Quick Actions previously filtered **only** by permission, not maturity, so they still linked to alpha surfaces (Catalog Commander, Estate Manager, Entitlements) even when those were hidden from the sidebar. Quick Actions now also gate on `allowedMaturities` from `useFeatureVisibilityStore`, mirroring `navigation.tsx`, while keeping the existing permission filtering (both conditions combined).

**`is_available` filtering (connectors).** `src/backend/src/controller/connections_manager.py` `list_connector_types()` now skips connector types whose connector reports `is_available is False`. The Snowflake/PowerBI/Kafka stub connectors hard-code `is_available = False`, so they stop appearing in the Add Connection dropdown. The default connector type (Databricks) is always retained so the primary connection path is never hidden; real connectors like BigQuery still appear when available.

## Testing

- Frontend: `yarn type-check` (`tsc --noEmit`) — clean.
- Backend: added `src/backend/src/tests/unit/test_connector_types_availability.py` covering (a) stub connectors with `is_available=False` are excluded while available connectors are kept, and (b) the default connector is retained even when its `is_available` is `False`. Result: `2 passed`. (Run with a prebuilt dev env / coverage disabled; route integration tests `test_data_*_routes.py` fail on clean main due to a known audit-service fixture gap and are unrelated to this change.)