### PR TITLE
fix(data-products): actually gate consumer reads of unpublished products

### DIFF
--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -104,36 +104,66 @@ def _caller_can_read_product(request, db, current_user, manager, product) -> boo
             if auth_manager.has_permission(eff, DATA_PRODUCTS_FEATURE_ID, FeatureAccessLevel.ADMIN):
                 return True
 
-        # Non-admin: resolve ownership scope and check the accessible set.
+        # Non-admin: grant only if the caller genuinely OWNS *this* product.
+        #
+        # ONT-NEG-011 follow-up (PR #535 was ineffective): the prior fix
+        # resolved the caller's scope via ``projects_manager.get_user_projects``
+        # and then checked membership of ``manager.list_products(...)``. But
+        # ``get_user_projects`` treats *any* group whose name merely contains
+        # the substring "admin" (e.g. the ubiquitous workspace ``admins``
+        # group) as a global admin and returns EVERY project. A Data Consumer
+        # in such a group therefore got ``caller_project_ids`` = all projects,
+        # which matched the draft's ``project_id`` in ``list_products`` and
+        # leaked the draft. We must NOT trust that broad, substring-admin
+        # scope. Instead resolve the three ownership facts against THIS product
+        # only, using membership-based checks (no substring-admin shortcut):
+        #   * draft_owner_id == caller (creator ownership)
+        #   * owner_team_id in caller's real team memberships
+        #   * project_id where the caller is a genuine project member
         from src.controller.teams_manager import teams_manager
         from src.controller.projects_manager import projects_manager
 
-        caller_team_ids: list = []
-        caller_project_ids: list = []
-        try:
-            user_teams = teams_manager.get_teams_for_user(db, caller_email, user_groups)
-            caller_team_ids = [t.id for t in user_teams if getattr(t, "id", None)]
-            user_projects = projects_manager.get_user_projects(db, caller_email, user_groups)
-            caller_project_ids = [
-                p.id for p in user_projects.projects if getattr(p, "id", None)
-            ]
-        except Exception:
-            logger.exception(
-                "Failed to resolve ownership scope for %s in product read gate; "
-                "falling back to published-only visibility",
-                caller_email,
-            )
+        if not caller_email:
+            return False
 
-        accessible = manager.list_products(
-            skip=0,
-            limit=10_000,
-            is_admin=False,
-            caller_email=caller_email,
-            caller_team_ids=caller_team_ids,
-            caller_project_ids=caller_project_ids,
-        )
-        accessible_ids = {str(p.id) for p in accessible if getattr(p, "id", None)}
-        return product_id in accessible_ids
+        owner_email = getattr(product, "draft_owner_id", None)
+        if owner_email and str(owner_email).lower() == str(caller_email).lower():
+            return True
+
+        product_team_id = getattr(product, "owner_team_id", None)
+        if product_team_id:
+            try:
+                user_teams = teams_manager.get_teams_for_user(db, caller_email, user_groups)
+                if any(str(getattr(t, "id", None)) == str(product_team_id) for t in user_teams):
+                    return True
+            except Exception:
+                logger.exception(
+                    "Team-membership resolution failed for %s in product read gate",
+                    caller_email,
+                )
+
+        product_project_id = getattr(product, "project_id", None)
+        if product_project_id:
+            try:
+                from src.common.config import get_settings
+                # ``is_user_project_member`` uses configured admin groups
+                # (is_user_admin), not a substring match, and verifies real
+                # team membership of the project — so it does not over-grant.
+                if projects_manager.is_user_project_member(
+                    db=db,
+                    user_identifier=caller_email,
+                    user_groups=user_groups or [],
+                    project_id=str(product_project_id),
+                    settings=get_settings(),
+                ):
+                    return True
+            except Exception:
+                logger.exception(
+                    "Project-membership resolution failed for %s in product read gate",
+                    caller_email,
+                )
+
+        return False
     except Exception:
         logger.exception("Product read gate failed for %s; denying", product_id)
         return False

--- a/src/backend/src/tests/unit/test_data_product_read_gate.py
+++ b/src/backend/src/tests/unit/test_data_product_read_gate.py
@@ -41,8 +41,10 @@ class TestProductReadGate:
 
     def test_draft_denied_for_non_owner_non_admin(self):
         manager = MagicMock()
-        manager.list_products.return_value = []  # caller owns nothing
-        product = SimpleNamespace(id="p1", status="draft")
+        product = SimpleNamespace(
+            id="p1", status="draft", draft_owner_id="someone-else@example.com",
+            owner_team_id=None, project_id=None,
+        )
 
         assert _caller_can_read_product(
             _request(is_admin=False), MagicMock(), _user(), manager, product
@@ -50,17 +52,115 @@ class TestProductReadGate:
 
     def test_draft_allowed_for_feature_admin(self):
         manager = MagicMock()
-        product = SimpleNamespace(id="p1", status="draft")
+        product = SimpleNamespace(
+            id="p1", status="draft", draft_owner_id="someone-else@example.com",
+            owner_team_id=None, project_id=None,
+        )
 
         assert _caller_can_read_product(
             _request(is_admin=True), MagicMock(), _user(), manager, product
         ) is True
 
-    def test_draft_allowed_for_owner_in_accessible_set(self):
+    def test_draft_allowed_for_draft_owner(self):
+        # Creator ownership: draft_owner_id matches the caller (case-insensitive).
         manager = MagicMock()
-        manager.list_products.return_value = [SimpleNamespace(id="p1")]  # caller owns it
-        product = SimpleNamespace(id="p1", status="draft")
+        product = SimpleNamespace(
+            id="p1", status="draft", draft_owner_id="Consumer@Example.com",
+            owner_team_id=None, project_id=None,
+        )
 
         assert _caller_can_read_product(
             _request(is_admin=False), MagicMock(), _user(), manager, product
+        ) is True
+        # The gate must decide from the product's own ownership facts, never
+        # by trusting the broad listing scope (ONT-NEG-011 follow-up).
+        manager.list_products.assert_not_called()
+
+
+class TestProductReadGateSubstringAdminLeak:
+    """Regression for the gap that made PR #535 ineffective (ONT-NEG-011).
+
+    The prior gate resolved the caller's project scope via
+    ``projects_manager.get_user_projects``, whose admin check treats *any*
+    group whose name merely CONTAINS the substring "admin" as a global admin
+    and returns EVERY project. A Data Consumer in a group like
+    ``account-admins`` (which is NOT a configured app-admin group) therefore
+    got every project in scope, matched the draft's ``project_id`` in
+    ``list_products``, and read the draft — exactly the leak NEG-011 reports.
+
+    These tests exercise the REAL gate against a real DB + real managers.
+    """
+
+    def _make_product(self, db, *, status, draft_owner_id=None, owner_team_id=None, project_id=None):
+        import uuid
+        from src.db_models.data_products import DataProductDb
+
+        p = DataProductDb(
+            id=str(uuid.uuid4()), api_version="v1.0.0", kind="DataProduct",
+            status=status, name="p", version="1.0.0",
+            draft_owner_id=draft_owner_id, owner_team_id=owner_team_id, project_id=project_id,
+        )
+        db.add(p); db.commit(); db.refresh(p)
+        return p
+
+    def _gate(self, db, product_id, *, email, groups, is_admin=False):
+        from src.controller.data_products_manager import DataProductsManager
+
+        manager = DataProductsManager(db=db)
+        product = manager.get_product(product_id)
+        auth_manager = MagicMock()
+        auth_manager.get_user_effective_permissions.return_value = {}
+        auth_manager.has_permission.return_value = is_admin
+        request = MagicMock()
+        request.app.state.authorization_manager = auth_manager
+        request.app.state.settings_manager = None
+        user = SimpleNamespace(email=email, groups=groups)
+        return _caller_can_read_product(request, db, user, manager, product)
+
+    def test_consumer_in_admin_substring_group_denied_draft_in_unowned_project(self, db_session):
+        """The exact NEG-011 leak: consumer in an 'admin'-named (but not
+        app-admin) group must NOT read a draft living in a project they are
+        not a member of."""
+        from src.db_models.projects import ProjectDb
+
+        db_session.add(ProjectDb(
+            id="proj-secret", name="secret-proj", project_type="TEAM",
+            created_by="owner@example.com", updated_by="owner@example.com",
+        ))
+        db_session.commit()
+        draft = self._make_product(
+            db_session, status="draft",
+            draft_owner_id="owner@example.com", project_id="proj-secret",
+        )
+
+        assert self._gate(
+            db_session, draft.id,
+            email="consumer@example.com", groups=["account-admins"],
+        ) is False
+
+    def test_published_in_unowned_project_still_readable(self, db_session):
+        """Published products remain readable by anyone (catalog contract)."""
+        from src.db_models.projects import ProjectDb
+
+        db_session.add(ProjectDb(
+            id="proj-pub", name="pub-proj", project_type="TEAM",
+            created_by="owner@example.com", updated_by="owner@example.com",
+        ))
+        db_session.commit()
+        active = self._make_product(
+            db_session, status="active",
+            draft_owner_id="owner@example.com", project_id="proj-pub",
+        )
+
+        assert self._gate(
+            db_session, active.id,
+            email="consumer@example.com", groups=["account-admins"],
+        ) is True
+
+    def test_draft_owner_can_read_own_draft(self, db_session):
+        draft = self._make_product(
+            db_session, status="draft", draft_owner_id="creator@example.com",
+        )
+        assert self._gate(
+            db_session, draft.id, email="creator@example.com", groups=[],
         ) is True


### PR DESCRIPTION
## Summary

Follow-up to #535 ("gate direct reads of unpublished products (NEG-011)"), which was **merged and deployed but ineffective**: re-run on deployed main, a Data Consumer (`data-products=Read-only`, confirmed via `/api/user/permissions`) could still `GET /api/data-products/{draftId}` and receive `200` with the full draft (status `draft`). Expected `404`. Fixes **ONT-NEG-011**.

## Root cause: why #535 didn't take

The #535 gate (`_caller_can_read_product`) resolved the caller's project scope via `projects_manager.get_user_projects(...)`, then granted the read if the product appeared in `manager.list_products(...)` for that scope.

But `get_user_projects` has its own naive admin check:

```python
is_admin = any("admin" in group.lower() for group in user_groups) if user_groups else False
```

This treats **any** group whose name merely *contains* the substring `"admin"` — e.g. the ubiquitous workspace `account-admins` group, which is **not** the configured app-admin group (`APP_ADMIN_DEFAULT_GROUPS` defaults to `["admins"]`) — as a global admin and returns **every project**. A Data Consumer in such a group got `caller_project_ids = all projects`, which matched the draft's `project_id` inside `list_products`, so the gate returned `True` and leaked the draft.

Verified with a real-DB repro: with the old gate, a consumer in `account-admins` reads a draft in a project they do not belong to (`can_read_draft=True`); with the new gate they are denied (`False`).

## The fix

Stop trusting the broad listing scope. The gate now decides from **this product's own ownership facts**, using membership-based checks only:

- Published (`active`/`deprecated`) stays readable by everyone (catalog/marketplace contract).
- data-products feature admins (incl. in-app role override) see everything.
- Otherwise grant only **genuine ownership of this product**:
  - `draft_owner_id == caller` (case-insensitive, creator ownership),
  - `owner_team_id` in the caller's real team memberships (`teams_manager.get_teams_for_user`, membership-based, no substring-admin shortcut),
  - project membership via `projects_manager.is_user_project_member(...)`, which uses configured admin groups (`is_user_admin`) and real project-team membership rather than a substring match.

A denied read returns `404` (not `403`) so the draft's existence isn't disclosed.

## Testing

- Real-DB regression in `test_data_product_read_gate.py` proving a consumer in an `"admin"`-substring group (`account-admins`) is **denied** a draft in an unowned project; published-in-unowned-project stays readable; the draft owner is allowed.
- Updated the existing mock-based gate tests to the new ownership-fact logic.
- `test_data_product_read_gate.py`, `test_data_products_ownership_scope.py`, `test_data_products_repository.py`: **57 passed**.
- The `test_data_*_routes.py` integration suites and 7 `test_data_products_manager.py` cases fail identically on clean `main` (pre-existing audit-service fixture gap), unrelated to this change. Zero new failures introduced.