### PR TITLE
fix(data-products): surface proposed products in the steward review queue

### DIFF
--- a/src/backend/src/controller/approvals_manager.py
+++ b/src/backend/src/controller/approvals_manager.py
@@ -41,11 +41,19 @@ class ApprovalsManager:
         except Exception as e:
             logger.debug(f"Approvals queue: contracts query failed: {e}", exc_info=True)
         
-        # Products pending certification
+        # Products awaiting steward review (proposed or under_review)
         try:
             from src.db_models.data_products import DataProductDb
-            # ODPS v1.0.0: Query products in 'draft' status (awaiting approval to become 'active')
-            q = db.query(DataProductDb).filter(DataProductDb.status == 'draft')
+            # A product enters the steward review queue once it is submitted for
+            # review: request-certify transitions a pre-review product
+            # (draft/sandbox) to 'proposed' (see DataProductsManager.submit_for_review,
+            # ONT-CUJ-019). Mirror the contracts filter so proposed/under_review
+            # products surface to stewards. Filtering on 'draft' instead listed
+            # not-yet-submitted products and hid the ones actually awaiting
+            # review (ONT-CUJ-020).
+            q = db.query(DataProductDb).filter(
+                DataProductDb.status.in_(['proposed', 'under_review'])
+            )
             for p in q.all():
                 items['products'].append({
                     'id': p.id,

--- a/src/backend/src/tests/unit/test_approvals_manager.py
+++ b/src/backend/src/tests/unit/test_approvals_manager.py
@@ -75,21 +75,66 @@ class TestApprovalsManager:
         assert contract3.id not in contract_ids
 
     def test_get_approvals_queue_with_products(self, manager, db_session):
-        """Test getting approvals queue with draft products."""
-        # Arrange - Create products with different statuses
-        product1 = DataProductDb(
+        """Proposed/under_review products surface; draft and active do not.
+
+        A product only enters the steward review queue once it has been
+        submitted for review (request-certify transitions draft -> proposed).
+        A still-draft product is not yet awaiting review and must not appear;
+        an active product is already published. See ONT-CUJ-020.
+        """
+        # Arrange - Create products across the lifecycle
+        proposed = DataProductDb(
+            id=str(uuid.uuid4()),
+            name="Proposed Product",
+            version="1.0.0",
+            status="proposed",
+        )
+        under_review = DataProductDb(
+            id=str(uuid.uuid4()),
+            name="Under Review Product",
+            version="1.0.0",
+            status="under_review",
+        )
+        draft = DataProductDb(
             id=str(uuid.uuid4()),
             name="Draft Product",
             version="1.0.0",
             status="draft",
         )
-        product2 = DataProductDb(
+        active = DataProductDb(
             id=str(uuid.uuid4()),
             name="Active Product",
             version="1.0.0",
             status="active",
         )
-        db_session.add_all([product1, product2])
+        db_session.add_all([proposed, under_review, draft, active])
+        db_session.commit()
+
+        # Act
+        result = manager.get_approvals_queue(db=db_session)
+
+        # Assert - only the two awaiting-review products surface
+        product_ids = {p['id'] for p in result['products']}
+        assert product_ids == {proposed.id, under_review.id}
+        assert draft.id not in product_ids
+        assert active.id not in product_ids
+
+    def test_proposed_product_surfaces_after_request_certify(self, manager, db_session):
+        """Regression for ONT-CUJ-020: a product submitted for review (proposed)
+        appears in the steward approvals queue.
+
+        Before the fix the products query filtered on status == 'draft', so a
+        product that had been moved to 'proposed' by request-certify (ONT-CUJ-019)
+        never surfaced to stewards ('No results').
+        """
+        # Arrange - a product that has been submitted for review
+        proposed = DataProductDb(
+            id=str(uuid.uuid4()),
+            name="Awaiting Steward Review",
+            version="1.0.0",
+            status="proposed",
+        )
+        db_session.add(proposed)
         db_session.commit()
 
         # Act
@@ -97,8 +142,9 @@ class TestApprovalsManager:
 
         # Assert
         assert len(result['products']) == 1
-        assert result['products'][0]['id'] == product1.id
-        assert result['products'][0]['title'] == "Draft Product"
+        assert result['products'][0]['id'] == proposed.id
+        assert result['products'][0]['title'] == "Awaiting Steward Review"
+        assert result['products'][0]['status'] == "proposed"
 
     def test_get_approvals_queue_mixed(self, manager, db_session):
         """Test getting approvals queue with both contracts and products."""
@@ -112,9 +158,9 @@ class TestApprovalsManager:
         )
         product = DataProductDb(
             id=str(uuid.uuid4()),
-            name="Draft Product",
+            name="Proposed Product",
             version="1.0.0",
-            status="draft",
+            status="proposed",
         )
         db_session.add_all([contract, product])
         db_session.commit()
@@ -126,5 +172,5 @@ class TestApprovalsManager:
         assert len(result['contracts']) == 1
         assert len(result['products']) == 1
         assert result['contracts'][0]['name'] == "Proposed Contract"
-        assert result['products'][0]['title'] == "Draft Product"
+        assert result['products'][0]['title'] == "Proposed Product"
 


### PR DESCRIPTION
## ONT-CUJ-020 (Golden Path)

On a freshly-deployed ontos-dev, with #549 effective a data product can reach `proposed`/`under_review` (Request Certification works), but the submitted product never appears in the steward review/approvals queue (the queue shows "No results"). This PR fixes that surfacing bug (part a). Part (b) — a full product-review screen — is a missing feature and is noted as needs-design below.

## Root cause (part a)

`ApprovalsManager.get_approvals_queue()` (`src/backend/src/controller/approvals_manager.py`) built the products list with:

```python
q = db.query(DataProductDb).filter(DataProductDb.status == 'draft')
```

Since #549 (ONT-CUJ-019), `request-certify` advances a pre-review product (draft/sandbox) to `proposed` via `DataProductsManager.submit_for_review`. A product that has actually been submitted for review is therefore no longer `draft`, so it never appeared in the queue, while not-yet-submitted drafts were shown instead. The sibling contracts query already correctly filters `status.in_(['proposed', 'under_review'])`.

This is the real steward surface for proposed products/contracts: #529 ("surface proposed contracts to stewards") documented that proposed assets reach stewards through `GET /api/approvals/queue` (and the `ON_REQUEST_REVIEW` workflow trigger), not via `/data-asset-reviews`, which targets Unity Catalog assets and requires an explicit reviewer-assignment policy that does not exist yet.

## Fix

Mirror the contracts filter so products in `proposed`/`under_review` surface in the steward review queue.

## Tests

`src/backend/src/tests/unit/test_approvals_manager.py`:
- Updated `test_get_approvals_queue_with_products` and `test_get_approvals_queue_mixed` to assert the corrected lifecycle semantics (proposed/under_review surface; draft and active do not).
- Added `test_proposed_product_surfaces_after_request_certify` as a focused ONT-CUJ-020 regression.

Run: `pytest src/tests/unit/test_approvals_manager.py -q` -> 6 passed (against the worktree source via a provisioned dev env). Route integration tests (`test_data_*_routes.py`) are skipped here due to a known pre-existing audit-service fixture gap on clean main.

## Part (b) — needs-design (not in this PR)

There is no product-review screen: even in `under_review` the product detail shows deliverables only, with no per-policy compliance pass/fail and no quality-metric review panel. CUJ-020 expects the steward to open the product review and see mappings/metrics/compliance results. That is a genuinely large feature spanning a new backend review-aggregation surface (per-policy compliance results + quality metrics for a product) and new frontend, and it needs design (including a steward-assignment policy if reviews are ever to be routed to `/data-asset-reviews`). Filing/triaging that is left as a follow-up; this PR delivers only the localizable part (a).