### PR TITLE
fix(settings): redact secret-shaped keys in update_settings log line

### DIFF
--- a/src/backend/src/common/logging.py
+++ b/src/backend/src/common/logging.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 
 def setup_logging(
@@ -42,11 +42,59 @@ def setup_logging(
 
 def get_logger(name: str) -> logging.Logger:
     """Get a logger instance with the specified name.
-    
+
     Args:
         name: Logger name, typically __name__ from the calling module
-        
+
     Returns:
         Configured logger instance
     """
     return logging.getLogger(name)
+
+
+# Substrings (case-insensitive) that mark a config key as secret-bearing.
+# Curated to be specific enough to avoid clobbering benign keys like
+# WORKSPACE_DEPLOYMENT_PATH (`path` is intentionally NOT in this set).
+_SENSITIVE_KEY_SUBSTRINGS = (
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "credential",
+    "api_key",
+    "apikey",
+    "private_key",
+    "client_secret",
+    "bearer",
+    "github_pat",
+    "mcp_token",
+)
+
+_REDACTED = "***REDACTED***"
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    k = key.lower()
+    return any(s in k for s in _SENSITIVE_KEY_SUBSTRINGS)
+
+
+def redact_sensitive_keys(payload: Any) -> Any:
+    """Return a copy of ``payload`` with values for secret-shaped keys masked.
+
+    Safe to log. Recurses into nested dicts and lists. Non-container values
+    pass through unchanged. The original payload is never mutated, so callers
+    can still hand the real values to downstream handlers.
+
+    The match is a case-insensitive substring check on the key name, so
+    ``github_pat``, ``MCP_GITHUB_TOKEN``, and ``my_api_key`` all redact.
+    """
+    if isinstance(payload, dict):
+        return {
+            k: (_REDACTED if _is_sensitive_key(k) else redact_sensitive_keys(v))
+            for k, v in payload.items()
+        }
+    if isinstance(payload, list):
+        return [redact_sensitive_keys(item) for item in payload]
+    return payload

--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -35,7 +35,7 @@ from ..common.authorization import PermissionChecker
 from ..common.features import FeatureAccessLevel
 
 # Configure logging
-from src.common.logging import get_logger
+from src.common.logging import get_logger, redact_sensitive_keys
 logger = get_logger(__name__)
 
 
@@ -72,10 +72,16 @@ async def update_settings(
     success = False
     details = {}
     try:
-        logger.info(f"Received settings update request: {settings_payload}")
+        # Redact secret-shaped keys before logging — `settings_payload` may
+        # contain GitHub PATs, MCP tokens, etc. The unredacted payload is
+        # still passed to `manager.update_settings` below.
+        logger.info(f"Received settings update request: {redact_sensitive_keys(settings_payload)}")
         logger.info(f"job_cluster_id in payload: {settings_payload.get('job_cluster_id')}")
 
-        # Track what settings changed
+        # Track what settings changed. This is an explicit allowlist of
+        # safe keys that land in the audit-log `details` column — do NOT
+        # mirror the full payload here, or secret-shaped fields will leak
+        # into the audit table.
         if 'job_cluster_id' in settings_payload:
             details['job_cluster_id'] = settings_payload.get('job_cluster_id')
         if 'sync_enabled' in settings_payload:

--- a/src/backend/src/tests/unit/test_log_redaction.py
+++ b/src/backend/src/tests/unit/test_log_redaction.py
@@ -1,0 +1,145 @@
+"""Unit tests for ``common.logging.redact_sensitive_keys``.
+
+These pin the redaction contract used by ``settings_routes.update_settings``
+(and any future log lines that need to render request bodies safely). The
+redactor must:
+
+- Replace values whose key matches a known secret pattern with
+  ``***REDACTED***``.
+- Match case-insensitive substrings (so ``GITHUB_TOKEN`` and ``my_api_key``
+  both redact).
+- Recurse into nested dicts and lists.
+- Leave benign keys alone — notably keys containing ``path`` such as
+  ``WORKSPACE_DEPLOYMENT_PATH``, which are real settings, not secrets.
+- Never mutate the original payload (the route still passes the real
+  payload to the manager).
+"""
+from src.common.logging import redact_sensitive_keys
+
+
+REDACTED = "***REDACTED***"
+
+
+def test_empty_dict_passes_through():
+    assert redact_sensitive_keys({}) == {}
+
+
+def test_non_sensitive_keys_unchanged():
+    payload = {
+        "job_cluster_id": "abc123",
+        "sync_enabled": True,
+        "sync_repository": "git@example.com:org/repo.git",
+        "enabled_jobs": ["job-a", "job-b"],
+        "WORKSPACE_DEPLOYMENT_PATH": "/Workspace/ontos/dev",
+    }
+    assert redact_sensitive_keys(payload) == payload
+
+
+def test_redacts_known_secret_keys():
+    payload = {
+        "github_token": "ghp_xxx",
+        "github_pat": "ghp_yyy",
+        "mcp_token": "tok_zzz",
+        "password": "hunter2",
+        "api_key": "ak_abc",
+        "private_key": "-----BEGIN-----",
+        "client_secret": "csec",
+        "bearer_token": "btok",
+        "user_credential": "ucred",
+        "passwd": "pwd",
+    }
+    result = redact_sensitive_keys(payload)
+    for k in payload:
+        assert result[k] == REDACTED, f"{k} should be redacted"
+
+
+def test_match_is_case_insensitive():
+    assert redact_sensitive_keys({"GITHUB_TOKEN": "x"}) == {"GITHUB_TOKEN": REDACTED}
+    assert redact_sensitive_keys({"My_Api_Key": "x"}) == {"My_Api_Key": REDACTED}
+    assert redact_sensitive_keys({"PASSWORD": "x"}) == {"PASSWORD": REDACTED}
+
+
+def test_substring_match_catches_nested_secret_words():
+    payload = {
+        "github_repo_token": "ghp_xxx",          # 'token' substring
+        "user_api_key_field": "ak_abc",          # 'api_key' substring
+        "external_bearer_value": "bv",           # 'bearer' substring
+    }
+    result = redact_sensitive_keys(payload)
+    assert result == {
+        "github_repo_token": REDACTED,
+        "user_api_key_field": REDACTED,
+        "external_bearer_value": REDACTED,
+    }
+
+
+def test_path_keys_not_redacted():
+    # Regression guard: 'path' must not become a sensitive substring,
+    # else WORKSPACE_DEPLOYMENT_PATH and similar settings get clobbered.
+    payload = {
+        "WORKSPACE_DEPLOYMENT_PATH": "/Workspace/ontos/dev",
+        "volume_path": "/Volumes/main/default/x",
+        "file_path": "/tmp/y",
+        "deployment_path": "/foo",
+    }
+    assert redact_sensitive_keys(payload) == payload
+
+
+def test_nested_dicts_recurse():
+    payload = {
+        "git": {
+            "token": "ghp_xxx",
+            "repository": "git@host:org/repo.git",
+        },
+        "llm": {
+            "api_key": "ak_abc",
+            "model": "claude-opus",
+        },
+    }
+    result = redact_sensitive_keys(payload)
+    assert result == {
+        "git": {"token": REDACTED, "repository": "git@host:org/repo.git"},
+        "llm": {"api_key": REDACTED, "model": "claude-opus"},
+    }
+
+
+def test_lists_of_dicts_recurse():
+    payload = {
+        "connections": [
+            {"name": "snowflake", "client_secret": "csec1"},
+            {"name": "bigquery", "credential": "csec2"},
+            {"name": "databricks", "host": "h"},
+        ],
+    }
+    result = redact_sensitive_keys(payload)
+    assert result == {
+        "connections": [
+            {"name": "snowflake", "client_secret": REDACTED},
+            {"name": "bigquery", "credential": REDACTED},
+            {"name": "databricks", "host": "h"},
+        ],
+    }
+
+
+def test_non_dict_input_passes_through():
+    assert redact_sensitive_keys("a string") == "a string"
+    assert redact_sensitive_keys(42) == 42
+    assert redact_sensitive_keys(None) is None
+    assert redact_sensitive_keys([1, 2, 3]) == [1, 2, 3]
+
+
+def test_original_payload_not_mutated():
+    original = {
+        "github_token": "ghp_xxx",
+        "nested": {"api_key": "ak_abc", "model": "claude-opus"},
+    }
+    snapshot = {"github_token": "ghp_xxx", "nested": {"api_key": "ak_abc", "model": "claude-opus"}}
+    redact_sensitive_keys(original)
+    assert original == snapshot, "redact_sensitive_keys must not mutate input"
+
+
+def test_non_string_keys_do_not_crash():
+    # Defensive: a dict with a non-string key (e.g. int) should pass through
+    # without raising. The non-string key can't match a substring pattern.
+    payload = {1: "a", "token": "x"}
+    assert redact_sensitive_keys(payload) == {1: "a", "token": REDACTED}


### PR DESCRIPTION
## Summary

`PUT /api/settings` logged the inbound payload at INFO level (`settings_routes.py:75`), so any GitHub PAT, MCP token, or future secret field in the request body would land in plaintext logs.

Today's schema doesn't include a secret-shaped field, so the leak is **forward-looking, not currently exposing a live secret**. But the log line is type-agnostic — the moment a `github_token` / `git_token` / OAuth-secret sibling is added to the settings payload, it leaks silently. This PR puts a redactor in place before that happens.

## Changes

- **New helper `redact_sensitive_keys()` in `common/logging.py`.** Case-insensitive substring match on a curated set (`secret`, `token`, `password`, `credential`, `api_key`, `private_key`, `client_secret`, `bearer`, `github_pat`, `mcp_token`, …). Recurses into nested dicts and lists. Never mutates the input — the route still hands the real payload to `manager.update_settings`.
- **The `path` substring is intentionally excluded** so settings like `WORKSPACE_DEPLOYMENT_PATH`, `volume_path`, `file_path` are not clobbered. The "don't redact paths" contract is pinned by a dedicated regression test.
- **`routes/settings_routes.py`:** wraps the leaky log line and adds an allowlist-discipline comment on the audit-log `details` dict so future contributors don't mirror the full payload there either (the audit `details` is currently a 4-key allowlist — `job_cluster_id`, `sync_enabled`, `sync_repository`, `enabled_jobs` — and should stay that way).
- **11 unit tests in `tests/unit/test_log_redaction.py`** covering: pass-through, known-secret keys, case-insensitivity, substring match, nested dicts, lists of dicts, the `path`-not-redacted regression, non-string keys, and the no-mutation contract.

## Why a redactor (vs. typing the payload)

The route accepts `settings_payload: dict` because the underlying schema is fluid (per-feature toggles, branding, sync config, etc.). A Pydantic model with `SecretStr` fields would be the long-term fix but would require migrating the manager and frontend in lockstep. A redactor at the log boundary is the smallest defensive shim that survives until that refactor lands.

## What this PR does NOT do

- Does not change the audit-log `details` dict (already an allowlist by design).
- Does not change `update_settings` behavior — the unredacted `settings_payload` is still what the manager receives.
- Does not apply redaction to other routes. The MCP-token flow is already clean end-to-end (`mcp_tokens_routes.py` / `mcp_tokens_manager.py` log only `id`, `name`, `scopes` — never the plaintext token; `mcp_routes.py:580` logs `token_info.name`, not the API key). Other routes that log request bodies (none found at audit time) can adopt the helper as needed.

## Test plan

- [x] `cd src && hatch -e dev run pytest backend/src/tests/unit/test_log_redaction.py -v --no-cov` → **11 passed**
- [x] Confirmed via `git stash` round-trip that the two pre-existing failures in `test_settings_manager::test_get_settings_returns_dict` and `test_settings_routes::test_get_settings` reproduce on clean `upstream/main` HEAD and are unrelated to this change (stale mock missing `WORKSPACE_DEPLOYMENT_PATH`; stale response-shape assertion expecting `job_clusters` at top level).
- [x] Verified the redactor keeps `WORKSPACE_DEPLOYMENT_PATH` and other `*_path` keys intact (regression test).
- [x] Verified the original payload is not mutated (regression test).

This pull request and its description were written by Isaac.