### PR TITLE
fix(workflows): surface on_behalf_of and consumer_principals in webhook payloads

### DIFF
--- a/src/backend/src/common/workflow_executor.py
+++ b/src/backend/src/common/workflow_executor.py
@@ -281,6 +281,10 @@ def _resolve_role_to_users(
                     return [(r.name, r.id)]
         return [(role_name, role.id if role else None)]
 
+    # Strip "user:" prefix emitted by the PrincipalPicker (e.g. "user:foo@bar.com").
+    if role_spec.startswith('user:'):
+        role_spec = role_spec[len('user:'):]
+
     if '@' in role_spec:
         # Pre-comma-split single email -- treat as a direct recipient.
         return [(role_spec, None)]

--- a/src/backend/src/controller/access_grants_manager.py
+++ b/src/backend/src/controller/access_grants_manager.py
@@ -241,6 +241,10 @@ class AccessGrantsManager:
                     # via the wizard.
                     if "consumer_principals" not in entity_data:
                         entity_data["consumer_principals"] = cp_list
+                    if "consumer_principals_value" not in entity_data and cp_list:
+                        first = cp_list[0]
+                        if isinstance(first, dict):
+                            entity_data["consumer_principals_value"] = first.get("value", "")
                     # Catalog + output_ports enrichment for webhook
                     # body_templates that need ${entity.catalogs} and
                     # ${entity.output_ports}. Helper preserves caller

--- a/src/frontend/src/components/workflows/approval-wizard-dialog.tsx
+++ b/src/frontend/src/components/workflows/approval-wizard-dialog.tsx
@@ -651,6 +651,11 @@ export default function ApprovalWizardDialog({
       if (currentStep.step_type === 'user_action' && submissionPayload && typeof submissionPayload === 'object') {
         collectedFieldsRef.current = { ...collectedFieldsRef.current, ...submissionPayload };
       }
+      // Thread on_behalf_of step result through so wizard_data carries it into
+      // entity_data for ${context.on_behalf_of.*} template resolution.
+      if (currentStep.step_type === 'on_behalf_of' && submissionPayload && typeof submissionPayload === 'object') {
+        collectedFieldsRef.current = { ...collectedFieldsRef.current, on_behalf_of: submissionPayload };
+      }
       const res = await post<{ complete?: boolean; agreement_id?: string; pdf_storage_path?: string; pdf_url?: string; current_step?: WizardStep; step_results?: unknown[] }>(
         `/api/approvals/sessions/${sessionId}/steps`,
         { step_id: currentStep.step_id, payload: submissionPayload },


### PR DESCRIPTION
## Summary

- **`workflow_executor.py`** — strip the `user:` prefix that PrincipalPicker serialises approver specs with (e.g. `user:foo@bar.com`). Without this, `_resolve_role_to_users` stored the prefixed string as the notification recipient so approval tasks were invisible in the admin UI.
- **`access_grants_manager.py`** — add `consumer_principals_value` scalar to `entity_data` (first CP group's `value` field). Allows webhook templates to use `${entity.consumer_principals_value}` to embed the UC access-group name directly instead of quoting a full JSON array.
- **`approval-wizard-dialog.tsx`** — thread the `on_behalf_of` step payload into `collectedFieldsRef` / `wizard_data` so the process workflow receives it in `entity_data` and `${context.on_behalf_of.value}` resolves correctly in webhook body templates.

Fixes #579.

## Test plan

End-to-end tested on `fevm-valcon-demo` workspace against a live httpbun.com echo endpoint:

- [x] Approval task appears in admin UI after submitting an access request (confirms `user:` prefix fix)
- [x] `on_behalf_of` renders as group name (not `null` / unresolved) — tested with both **"my group" dropdown** (`users`) and **free-text other** (`admins`) modes
- [x] `data_product_group` field in webhook body contains the UC group string `099_TREASURE-DSHA-WEU-OAI-MAYAI22-DEV_GDMP_10` (confirms `consumer_principals_value` fix)
- [x] All 6 workflow steps pass: notification → approval → approval response → webhook (HTTP 200) → notification → pass

This pull request was authored with Claude Code assistance.