### PR TITLE
fix: consumer asset scoping (#583) + copy-from-team pre-fill (#570)

### DIFF
--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -14,6 +14,7 @@ from src.models.assets import (
 )
 from src.db_models.assets import AssetTypeDb, AssetDb, AssetRelationshipDb
 from src.common.errors import ConflictError, NotFoundError, ValidationError
+from src.common.version_visibility import is_visible_consumer
 from src.common.logging import get_logger
 from src.common.search_interfaces import SearchableAsset, SearchIndexItem
 from src.common.database import get_session_factory
@@ -267,8 +268,9 @@ class AssetsManager(SearchableAsset):
             return None
         try:
             products = data_products_manager.list_products(
-                skip=0, limit=10_000, is_admin=False,
+                skip=0, limit=10_000, is_admin=True,
             )
+            products = [p for p in products if is_visible_consumer(p)]
         except Exception:
             logger.exception("Failed to list accessible data products for scoping")
             return []

--- a/src/backend/tests/test_assets_manager.py
+++ b/src/backend/tests/test_assets_manager.py
@@ -1,0 +1,104 @@
+"""Unit tests for AssetsManager.resolve_accessible_asset_ids (#583)."""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.controller.assets_manager import AssetsManager
+
+
+class TestResolveAccessibleAssetIds:
+
+    @pytest.fixture
+    def manager(self):
+        return AssetsManager(ontology_schema_manager=None)
+
+    def _make_product(self, product_id: str, status: str):
+        p = MagicMock()
+        p.id = product_id
+        p.status = status
+        return p
+
+    def test_filters_to_consumer_visible_statuses(self, manager):
+        """Only asset IDs for active/deprecated DPs are returned; draft excluded."""
+        db = MagicMock()
+
+        active_id = str(uuid.uuid4())
+        deprecated_id = str(uuid.uuid4())
+        draft_id = str(uuid.uuid4())
+
+        active_assets = [uuid.uuid4(), uuid.uuid4()]
+        deprecated_assets = [uuid.uuid4()]
+        draft_assets = [uuid.uuid4()]
+
+        products = [
+            self._make_product(active_id, "active"),
+            self._make_product(deprecated_id, "deprecated"),
+            self._make_product(draft_id, "draft"),
+        ]
+
+        def fake_list_linked(db, *, product_ids, port_ids=None):
+            result = set()
+            for pid in product_ids:
+                if pid == active_id:
+                    result.update(active_assets)
+                elif pid == deprecated_id:
+                    result.update(deprecated_assets)
+                elif pid == draft_id:
+                    result.update(draft_assets)
+            return result
+
+        mock_dpm = MagicMock()
+        mock_dpm.list_products.return_value = products
+        mock_dpm.list_linked_asset_ids_for_products.side_effect = fake_list_linked
+
+        result = manager.resolve_accessible_asset_ids(
+            db, data_products_manager=mock_dpm, is_admin=False,
+        )
+
+        expected = set(active_assets) | set(deprecated_assets)
+        assert set(result) == expected
+        for aid in draft_assets:
+            assert aid not in result
+        mock_dpm.list_products.assert_called_once_with(skip=0, limit=10_000, is_admin=True)
+
+    def test_admin_returns_none(self, manager):
+        """Admin callers get None (no filter); list_products is never called."""
+        db = MagicMock()
+        mock_dpm = MagicMock()
+
+        result = manager.resolve_accessible_asset_ids(
+            db, data_products_manager=mock_dpm, is_admin=True,
+        )
+
+        assert result is None
+        mock_dpm.list_products.assert_not_called()
+
+    def test_no_visible_products_returns_empty(self, manager):
+        """Returns empty when all DPs are in non-consumer-visible statuses."""
+        db = MagicMock()
+        mock_dpm = MagicMock()
+        mock_dpm.list_products.return_value = [
+            self._make_product(str(uuid.uuid4()), "draft"),
+            self._make_product(str(uuid.uuid4()), "proposed"),
+        ]
+
+        result = manager.resolve_accessible_asset_ids(
+            db, data_products_manager=mock_dpm, is_admin=False,
+        )
+
+        assert list(result) == []
+        mock_dpm.list_linked_asset_ids_for_products.assert_not_called()
+
+    def test_list_products_exception_returns_empty(self, manager):
+        """Returns empty (no exception) when list_products raises."""
+        db = MagicMock()
+        mock_dpm = MagicMock()
+        mock_dpm.list_products.side_effect = RuntimeError("DB down")
+
+        result = manager.resolve_accessible_asset_ids(
+            db, data_products_manager=mock_dpm, is_admin=False,
+        )
+
+        assert list(result) == []

--- a/src/frontend/src/components/common/assign-owner-dialog.tsx
+++ b/src/frontend/src/components/common/assign-owner-dialog.tsx
@@ -22,9 +22,11 @@ interface AssignOwnerDialogProps {
   objectType: OwnerObjectType;
   objectId: string;
   onSuccess: () => void;
+  initialEmail?: string;
+  initialName?: string;
 }
 
-export function AssignOwnerDialog({ open, onOpenChange, objectType, objectId, onSuccess }: AssignOwnerDialogProps) {
+export function AssignOwnerDialog({ open, onOpenChange, objectType, objectId, onSuccess, initialEmail, initialName }: AssignOwnerDialogProps) {
   const { t } = useTranslation(['business-owners', 'common']);
   const { get: apiGet, post: apiPost } = useApi();
   const { toast } = useToast();
@@ -58,6 +60,13 @@ export function AssignOwnerDialog({ open, onOpenChange, objectType, objectId, on
       setRoleId('');
     }
   }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      if (initialEmail) setUserEmail(initialEmail);
+      if (initialName) setUserName(initialName);
+    }
+  }, [open, initialEmail, initialName]);
 
   const handleSubmit = async () => {
     if (!userEmail.trim() || !roleId) return;

--- a/src/frontend/src/components/common/ownership-panel.tsx
+++ b/src/frontend/src/components/common/ownership-panel.tsx
@@ -77,6 +77,7 @@ export function OwnershipPanel({
 
   // Assign dialog state
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
+  const [pendingMember, setPendingMember] = useState<{ member_identifier: string; member_name?: string } | null>(null);
 
   // Copy from Team dialog state
   const [copyFromTeamOpen, setCopyFromTeamOpen] = useState(false);
@@ -312,7 +313,12 @@ export function OwnershipPanel({
       {/* Assign Owner Dialog */}
       <AssignOwnerDialog
         open={assignDialogOpen}
-        onOpenChange={setAssignDialogOpen}
+        onOpenChange={(open) => {
+          setAssignDialogOpen(open);
+          if (!open) setPendingMember(null);
+        }}
+        initialEmail={pendingMember?.member_identifier}
+        initialName={pendingMember?.member_name}
         objectType={objectType}
         objectId={objectId}
         onSuccess={fetchOwners}
@@ -383,6 +389,7 @@ export function OwnershipPanel({
                           variant="outline"
                           className="h-7 text-xs"
                           onClick={() => {
+                            setPendingMember(member);
                             setCopyFromTeamOpen(false);
                             setAssignDialogOpen(true);
                           }}


### PR DESCRIPTION
## Summary

- **#583 — Data Consumer 403 on `GET /assets/{id}`**: `resolve_accessible_asset_ids` was calling `list_products(is_admin=False)` with no caller context, triggering the repository's fail-closed guard and returning an empty asset set for every consumer. Fixed by calling `list_products(is_admin=True)` then filtering to `is_visible_consumer` — assets of active/deprecated DPs are visible to any consumer, matching the marketplace contract.
- **#570 — Copy from Team → Assign opens empty dialog**: `AssignOwnerDialog` had no props for pre-filling fields, and the Assign button in the Copy-from-Team flow did not pass the clicked member. Added `initialEmail`/`initialName` props with a seeding `useEffect`, added `pendingMember` state in `OwnershipPanel`, and wired the member into the dialog on open.

## Changes

| File | Change |
|---|---|
| `src/backend/src/controller/assets_manager.py` | `is_admin=True` + `is_visible_consumer` filter in `resolve_accessible_asset_ids` |
| `src/backend/tests/test_assets_manager.py` | 4 unit tests — admin path, visible-only filter, empty result, exception handling |
| `src/frontend/src/components/common/assign-owner-dialog.tsx` | `initialEmail`/`initialName` props + seeding effect |
| `src/frontend/src/components/common/ownership-panel.tsx` | `pendingMember` state + wired to Assign button and dialog |

## Test plan

- [ ] Unit tests: `pytest backend/tests/test_assets_manager.py` — 4/4 passing
- [ ] FEVM smoke: Data Consumer role → navigate to asset linked to an active DP → 200 (was 403)
- [ ] FEVM smoke: Data Product with Owner Team → Owners panel → Copy from Team → Assign → dialog opens pre-filled with member email/name

This pull request and its description were written by Isaac.