### PR TITLE
feat(#570): pre-fill Assign Owner dialog from Copy from Team selection

### DIFF
--- a/src/frontend/src/components/common/assign-owner-dialog.tsx
+++ b/src/frontend/src/components/common/assign-owner-dialog.tsx
@@ -22,9 +22,11 @@ interface AssignOwnerDialogProps {
   objectType: OwnerObjectType;
   objectId: string;
   onSuccess: () => void;
+  initialEmail?: string;
+  initialName?: string;
 }
 
-export function AssignOwnerDialog({ open, onOpenChange, objectType, objectId, onSuccess }: AssignOwnerDialogProps) {
+export function AssignOwnerDialog({ open, onOpenChange, objectType, objectId, onSuccess, initialEmail, initialName }: AssignOwnerDialogProps) {
   const { t } = useTranslation(['business-owners', 'common']);
   const { get: apiGet, post: apiPost } = useApi();
   const { toast } = useToast();
@@ -52,12 +54,15 @@ export function AssignOwnerDialog({ open, onOpenChange, objectType, objectId, on
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (!open) {
+    if (open) {
+      if (initialEmail) setUserEmail(initialEmail);
+      if (initialName) setUserName(initialName);
+    } else {
       setUserEmail('');
       setUserName('');
       setRoleId('');
     }
-  }, [open]);
+  }, [open, initialEmail, initialName]);
 
   const handleSubmit = async () => {
     if (!userEmail.trim() || !roleId) return;

--- a/src/frontend/src/components/common/ownership-panel.tsx
+++ b/src/frontend/src/components/common/ownership-panel.tsx
@@ -77,6 +77,7 @@ export function OwnershipPanel({
 
   // Assign dialog state
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
+  const [pendingMember, setPendingMember] = useState<{ member_identifier: string; member_name?: string } | null>(null);
 
   // Copy from Team dialog state
   const [copyFromTeamOpen, setCopyFromTeamOpen] = useState(false);
@@ -312,10 +313,12 @@ export function OwnershipPanel({
       {/* Assign Owner Dialog */}
       <AssignOwnerDialog
         open={assignDialogOpen}
-        onOpenChange={setAssignDialogOpen}
+        onOpenChange={(open) => { setAssignDialogOpen(open); if (!open) setPendingMember(null); }}
         objectType={objectType}
         objectId={objectId}
         onSuccess={fetchOwners}
+        initialEmail={pendingMember?.member_identifier}
+        initialName={pendingMember?.member_name ?? ''}
       />
 
       {/* Remove Owner Confirmation Dialog */}
@@ -383,6 +386,7 @@ export function OwnershipPanel({
                           variant="outline"
                           className="h-7 text-xs"
                           onClick={() => {
+                            setPendingMember(member);
                             setCopyFromTeamOpen(false);
                             setAssignDialogOpen(true);
                           }}


### PR DESCRIPTION
## Summary
- When a user clicks **Assign** next to a team member in the "Copy from Team" dialog, the Assign Owner dialog now opens with that member's email and display name pre-populated
- Eliminates the need to manually re-type the email after selecting from the team list

## Changes
- `assign-owner-dialog.tsx`: Added `initialEmail?` / `initialName?` props; seeds state when dialog opens
- `ownership-panel.tsx`: Added `pendingMember` state; passes it to `AssignOwnerDialog`; clears on close

## Test plan
- [ ] Open a Data Product → Business Owners panel → Copy from Team → click Assign next to a member
- [ ] Verify the Assign Owner dialog opens with User field pre-filled and Display Name pre-filled
- [ ] Verify submitting the form assigns the owner correctly
- [ ] Verify opening Assign Owner directly (not from Copy from Team) still shows empty form

This pull request and its description were written by Isaac.