### PR TITLE
feat(#571): rich references + markdown links in approval wizard steps

### DIFF
--- a/src/backend/src/models/process_workflows.py
+++ b/src/backend/src/models/process_workflows.py
@@ -192,6 +192,12 @@ class WorkflowScope(BaseModel):
 
 # --- Step Configurations ---
 
+class ReferenceDocumentConfig(BaseModel):
+    """A labelled hyperlink shown at the bottom of an approval wizard step."""
+    label: str
+    url: str
+
+
 class ValidationStepConfig(BaseModel):
     """Configuration for validation steps."""
     rule: str = Field(..., description="Compliance DSL rule to evaluate")
@@ -234,7 +240,11 @@ class UserActionStepConfig(BaseModel):
         default_factory=list,
         description="List of { id, label, type: 'text'|'text_list', required?: bool }",
     )
-    
+    references: Optional[List[ReferenceDocumentConfig]] = Field(
+        None,
+        description="Optional labelled links shown at the bottom of the step",
+    )
+
     class Config:
         json_schema_extra = {
             "example": {
@@ -252,6 +262,10 @@ class LegalDocumentStepConfig(BaseModel):
     require_scroll_to_end: bool = Field(False, description="Require user to scroll to bottom")
     require_acknowledgement_checkbox: bool = Field(False, description="Require acknowledgement checkbox")
     acknowledgement_label: Optional[str] = Field("I have read and understood the above", description="Label for acknowledgement checkbox")
+    references: Optional[List[ReferenceDocumentConfig]] = Field(
+        None,
+        description="Optional labelled links shown at the bottom of the step",
+    )
 
 
 class AcknowledgementChecklistStepConfig(BaseModel):
@@ -261,6 +275,11 @@ class AcknowledgementChecklistStepConfig(BaseModel):
     items: List[Dict[str, Any]] = Field(
         default_factory=list,
         description="List of { id, label, required } checkbox items (max 10)",
+    )
+
+    references: Optional[List[ReferenceDocumentConfig]] = Field(
+        None,
+        description="Optional labelled links shown at the bottom of the step",
     )
 
     @field_validator('items')

--- a/src/frontend/src/components/workflows/approval-wizard-dialog.tsx
+++ b/src/frontend/src/components/workflows/approval-wizard-dialog.tsx
@@ -25,16 +25,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, Check, XCircle, ChevronRight, FileText, Eye } from 'lucide-react';
+import { Loader2, Check, XCircle, ChevronRight, FileText, Eye, ExternalLink } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
 import { useUserStore } from '@/stores/user-store';
 
-/** Lightweight markdown to HTML — handles headers, bold, lists, paragraphs. */
+/** Lightweight markdown to HTML — handles headers, bold, lists, paragraphs, and inline links. */
 function simpleMarkdown(text: string): string {
   return text
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')  // escape HTML
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
     .replace(/^### (.+)$/gm, '<h3>$1</h3>')
     .replace(/^## (.+)$/gm, '<h2>$1</h2>')
     .replace(/^# (.+)$/gm, '<h1>$1</h1>')
@@ -46,6 +47,32 @@ function simpleMarkdown(text: string): string {
     .replace(/\n\n/g, '</p><p>')
     .replace(/\n/g, '<br/>')
     .replace(/^/, '<p>').replace(/$/, '</p>');
+}
+
+interface ReferenceDoc { label: string; url: string; }
+
+function ReferenceDocuments({ refs }: { refs?: ReferenceDoc[] }) {
+  if (!refs || refs.length === 0) return null;
+  return (
+    <div className="mt-4 border-t pt-3">
+      <p className="text-xs font-medium text-muted-foreground mb-2">Reference documents</p>
+      <ul className="space-y-1">
+        {refs.map((ref, i) => (
+          <li key={i}>
+            <a
+              href={ref.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-primary hover:underline flex items-center gap-1"
+            >
+              <ExternalLink className="h-3 w-3 flex-shrink-0" />
+              {ref.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 interface ApprovalWorkflowRef {
@@ -770,6 +797,8 @@ export default function ApprovalWizardDialog({
     ? completionAction.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
     : 'proceed';
 
+  const refs = currentStep?.config?.references as ReferenceDoc[] | undefined;
+
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="sm:max-w-lg">
@@ -906,7 +935,10 @@ export default function ApprovalWizardDialog({
               <div className="space-y-1">
                 <Label className="text-base">{(currentStep.config.title as string)}</Label>
                 {(currentStep.config?.description as string) && (
-                  <p className="text-sm text-muted-foreground">{(currentStep.config.description as string)}</p>
+                  <p
+                    className="text-sm text-muted-foreground"
+                    dangerouslySetInnerHTML={{ __html: simpleMarkdown((currentStep.config.description as string)) }}
+                  />
                 )}
               </div>
             )}
@@ -952,6 +984,7 @@ export default function ApprovalWizardDialog({
                     )}
                   </div>
                 ))}
+                <ReferenceDocuments refs={refs} />
               </div>
             )}
 
@@ -995,6 +1028,7 @@ export default function ApprovalWizardDialog({
                     </Label>
                   </div>
                 )}
+                <ReferenceDocuments refs={refs} />
               </div>
             )}
 
@@ -1012,11 +1046,12 @@ export default function ApprovalWizardDialog({
                       disabled={loading}
                     />
                     <Label htmlFor={`checklist-${item.id}`} className="text-sm cursor-pointer leading-tight">
-                      {item.label}
+                      <span dangerouslySetInnerHTML={{ __html: simpleMarkdown(item.label || '') }} />
                       {item.required !== false && <span className="text-destructive ml-1">*</span>}
                     </Label>
                   </div>
                 ))}
+                <ReferenceDocuments refs={refs} />
               </div>
             )}
 

--- a/src/frontend/src/types/process-workflow.ts
+++ b/src/frontend/src/types/process-workflow.ts
@@ -214,6 +214,11 @@ export interface EntityActionStepConfig {
   fixed_scope?: EntityActionFixedScope;
 }
 
+export interface ReferenceDocumentConfig {
+  label: string;
+  url: string;
+}
+
 export interface LegalDocumentStepConfig {
   title?: string;
   description?: string;
@@ -221,12 +226,14 @@ export interface LegalDocumentStepConfig {
   require_scroll_to_end?: boolean;
   require_acknowledgement_checkbox?: boolean;
   acknowledgement_label?: string;
+  references?: ReferenceDocumentConfig[];
 }
 
 export interface AcknowledgementChecklistStepConfig {
   title?: string;
   description?: string;
   items?: Array<{ id: string; label: string; required?: boolean }>;
+  references?: ReferenceDocumentConfig[];
 }
 
 export interface CoSignersStepConfig {


### PR DESCRIPTION
## Summary
- Approval wizard `user_action` steps now render markdown in the description field (links, bold, etc.)
- A new "References" section renders at the bottom of wizard steps when `references` are configured on the step
- Both features are data-driven — no UI changes needed per-workflow; driven by step config

## Changes
- Frontend: render markdown description in `user_action` steps; render `references` list as clickable links
- Backend: `references` field exposed in step config schema

## Test plan
- [ ] Subscribe to a Data Product that has a `for_subscribe` approval workflow with markdown links in description — verify links are clickable
- [ ] Verify "References" section appears when step has `references` configured
- [ ] Verify steps without `references` show no references section
- [ ] Verify plain-text descriptions still render correctly

This pull request and its description were written by Isaac.