### PR TITLE
feat(#572): unified approval UX — full payload, adjust terms, My Actions inline

### DIFF
--- a/src/backend/src/common/workflow_executor.py
+++ b/src/backend/src/common/workflow_executor.py
@@ -439,6 +439,23 @@ def _extract_approval_facets(context: "StepContext") -> Dict[str, Any]:
         if request_id:
             facets["request_id"] = str(request_id)
 
+    # --- Universal extras (all trigger types) ---
+
+    on_behalf_of = entity.get("on_behalf_of")
+    if isinstance(on_behalf_of, dict) and on_behalf_of.get("type") and on_behalf_of.get("value"):
+        facets["on_behalf_of"] = {
+            "type": str(on_behalf_of["type"]),
+            "value": str(on_behalf_of["value"]),
+        }
+
+    step_results = entity.get("step_results") or entity.get("required_fields_answers")
+    if isinstance(step_results, dict) and step_results:
+        facets["step_results"] = step_results
+
+    # Full entity_data for the frontend's generic key→value detail section.
+    if entity:
+        facets["full_payload"] = dict(entity)
+
     return facets
 
 

--- a/src/frontend/src/components/home/required-actions-section.tsx
+++ b/src/frontend/src/components/home/required-actions-section.tsx
@@ -6,6 +6,7 @@ import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { useNotificationsStore } from '@/stores/notifications-store';
 import { Link } from 'react-router-dom';
 import ConfirmRoleRequestDialog from '@/components/settings/confirm-role-request-dialog';
+import WorkflowApprovalResponseDialog, { type WorkflowApprovalResponseDialogPayload } from '@/components/workflows/workflow-approval-response-dialog';
 
 interface ApprovalsQueue {
   contracts: { id: string; name?: string; status?: string }[];
@@ -21,6 +22,8 @@ export default function RequiredActionsSection() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogPayload, setDialogPayload] = useState<Record<string, any> | null>(null);
   const [roleRequestPage, setRoleRequestPage] = useState(0);
+  const [wfApprovalOpen, setWfApprovalOpen] = useState(false);
+  const [wfApprovalPayload, setWfApprovalPayload] = useState<WorkflowApprovalResponseDialogPayload | null>(null);
 
   useEffect(() => {
     fetchNotifications();
@@ -53,15 +56,22 @@ export default function RequiredActionsSection() {
     n => n.type === 'action_required' && n.action_type === 'handle_role_request'
   );
 
-  // Filter other action items (excluding role requests)
+  // Filter workflow approval items separately so they get inline approve/deny
+  const workflowApprovalNotifications = notifications.filter(
+    n => n.type === 'action_required' && n.action_type === 'workflow_approval'
+  );
+
+  // Filter other action items (excluding role requests and workflow approvals)
   const actionItems = notifications.filter(
-    n => n.type === 'action_required' && n.action_type !== 'handle_role_request'
+    n => n.type === 'action_required'
+      && n.action_type !== 'handle_role_request'
+      && n.action_type !== 'workflow_approval'
   );
 
   // Create unified approvals list
   type UnifiedApproval = {
     id: string;
-    type: 'role_request' | 'contract' | 'product';
+    type: 'role_request' | 'contract' | 'product' | 'workflow_approval';
     title: string;
     subtitle?: string;
     date: string;
@@ -97,6 +107,15 @@ export default function RequiredActionsSection() {
       date: new Date().toISOString(), // Products don't have date from API
       link: `/data-products/${p.id}`,
     })),
+    // Workflow approvals
+    ...workflowApprovalNotifications.map(n => ({
+      id: n.id,
+      type: 'workflow_approval' as const,
+      title: n.action_payload?.entity_name || n.title || 'Approval request',
+      subtitle: n.action_payload?.requester_email || n.subtitle,
+      date: n.created_at,
+      payload: n.action_payload ?? undefined,
+    })),
   ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const handleOpenConfirmDialog = (payload: Record<string, any> | null) => {
@@ -108,6 +127,34 @@ export default function RequiredActionsSection() {
     setDialogOpen(false);
     setDialogPayload(null);
     fetchNotifications(); // Refresh notifications after approval/denial
+  };
+
+  const handleOpenWfApproval = (payload: Record<string, any>) => {
+    setWfApprovalPayload({
+      execution_id: payload.execution_id ?? '',
+      entity_name: payload.entity_name,
+      requester_email: payload.requester_email,
+      entity_type: payload.entity_type,
+      entity_id: payload.entity_id,
+      underlying_entity_type: payload.underlying_entity_type,
+      underlying_entity_id: payload.underlying_entity_id,
+      underlying_entity_name: payload.underlying_entity_name,
+      permission_level: payload.permission_level,
+      requested_duration_days: payload.requested_duration_days,
+      reason: payload.reason,
+      request_id: payload.request_id,
+      workflow_name: payload.workflow_name,
+      workflow_message: payload.workflow_message,
+      on_behalf_of: payload.on_behalf_of,
+      full_payload: payload,
+    });
+    setWfApprovalOpen(true);
+  };
+
+  const handleCloseWfApproval = () => {
+    setWfApprovalOpen(false);
+    setWfApprovalPayload(null);
+    fetchNotifications();
   };
 
   // Type badge helper
@@ -124,6 +171,10 @@ export default function RequiredActionsSection() {
       product: {
         label: 'Product',
         className: 'bg-green-500/15 text-green-700 dark:bg-green-500/20 dark:text-green-300'
+      },
+      workflow_approval: {
+        label: 'Approval',
+        className: 'bg-amber-500/15 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300'
       },
     };
     const badge = badges[type];
@@ -202,6 +253,16 @@ export default function RequiredActionsSection() {
                                   <CheckSquare className="h-3.5 w-3.5" />
                                 </Button>
                               </>
+                            ) : item.type === 'workflow_approval' ? (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-7 px-2"
+                                onClick={() => handleOpenWfApproval(item.payload!)}
+                                title="Approve/Deny workflow request"
+                              >
+                                <CheckSquare className="h-3.5 w-3.5" />
+                              </Button>
                             ) : (
                               <Button asChild size="sm" variant="ghost" className="h-7 px-2">
                                 <Link to={item.link!}>Open</Link>
@@ -290,6 +351,13 @@ export default function RequiredActionsSection() {
           onDecisionMade={handleCloseDialog}
         />
       )}
+      {/* Workflow Approval Dialog */}
+      <WorkflowApprovalResponseDialog
+        isOpen={wfApprovalOpen}
+        onOpenChange={(open) => { if (!open) handleCloseWfApproval(); }}
+        payload={wfApprovalPayload}
+        onDecisionMade={handleCloseWfApproval}
+      />
     </>
   );
 }

--- a/src/frontend/src/components/workflows/workflow-approval-response-dialog.tsx
+++ b/src/frontend/src/components/workflows/workflow-approval-response-dialog.tsx
@@ -10,7 +10,15 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Loader2, Check, XCircle, ExternalLink } from 'lucide-react';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
@@ -49,6 +57,8 @@ export interface WorkflowApprovalResponseDialogPayload {
   request_id?: string;
   workflow_name?: string;
   workflow_message?: string;
+  on_behalf_of?: { type: string; value: string };
+  full_payload?: Record<string, unknown>;
 }
 
 interface WorkflowApprovalResponseDialogProps {
@@ -80,6 +90,21 @@ function humanizeEntityType(entityType: string | undefined | null): string {
     .join(' ');
 }
 
+const SKIP_KEYS = new Set([
+  'entity_id', 'entity_type', 'underlying_entity_id', 'underlying_entity_type',
+  'request_id', 'workspace_id', 'execution_id', 'workflow_id',
+]);
+
+function renderPayloadValue(val: unknown): string {
+  if (Array.isArray(val)) return val.join(', ');
+  if (typeof val === 'object' && val !== null) return JSON.stringify(val);
+  return String(val);
+}
+
+function humanizeKey(key: string): string {
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 interface DetailRow {
   label: string;
   value: React.ReactNode;
@@ -93,6 +118,13 @@ function buildDetailRows(
 
   if (payload.requester_email) {
     rows.push({ label: 'Requester', value: payload.requester_email });
+  }
+
+  if (payload.on_behalf_of) {
+    rows.push({
+      label: 'On behalf of',
+      value: `${payload.on_behalf_of.type} ${payload.on_behalf_of.value}`,
+    });
   }
 
   const resourceType = payload.underlying_entity_type ?? payload.entity_type;
@@ -147,6 +179,23 @@ function buildDetailRows(
     rows.push({ label: 'Workflow', value: payload.workflow_name });
   }
 
+  if (payload.full_payload) {
+    const alreadySurfaced = new Set([
+      'requester_email', 'on_behalf_of', 'entity_type', 'entity_id', 'entity_name',
+      'underlying_entity_type', 'underlying_entity_id', 'underlying_entity_name',
+      'permission_level', 'requested_duration_days', 'reason',
+      'message', 'workflow_name', 'workflow_id', 'execution_id', 'request_id',
+      'workspace_id', 'step_results', 'required_fields_answers', 'data_product_name',
+    ]);
+    for (const [key, val] of Object.entries(payload.full_payload)) {
+      if (key.startsWith('_')) continue;
+      if (SKIP_KEYS.has(key)) continue;
+      if (alreadySurfaced.has(key)) continue;
+      if (val === null || val === undefined || val === '') continue;
+      rows.push({ label: humanizeKey(key), value: renderPayloadValue(val) });
+    }
+  }
+
   return rows;
 }
 
@@ -163,6 +212,15 @@ export default function WorkflowApprovalResponseDialog({
   const [loadingConfig, setLoadingConfig] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [reason, setReason] = useState('');
+  const [grantedDays, setGrantedDays] = useState<number | ''>(payload?.requested_duration_days ?? '');
+  const [grantedPermission, setGrantedPermission] = useState<string>(payload?.permission_level ?? '');
+
+  useEffect(() => {
+    if (isOpen) {
+      setGrantedDays(payload?.requested_duration_days ?? '');
+      setGrantedPermission(payload?.permission_level ?? '');
+    }
+  }, [isOpen, payload]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -218,11 +276,14 @@ export default function WorkflowApprovalResponseDialog({
     }
     setSubmitting(true);
     try {
-      const response = await post('/api/workflows/handle-approval', {
+      const body: Record<string, unknown> = {
         execution_id: payload.execution_id,
         approved,
         message: reason.trim() || (approved ? 'Approved' : 'Rejected'),
-      });
+      };
+      if (grantedDays !== '') body.granted_duration_days = Number(grantedDays);
+      if (grantedPermission) body.permission_level = grantedPermission;
+      const response = await post('/api/workflows/handle-approval', body);
       if (response.error) {
         toast({
           title: 'Error',
@@ -282,6 +343,43 @@ export default function WorkflowApprovalResponseDialog({
                     </div>
                   ))}
                 </dl>
+              </div>
+            )}
+            {(payload?.requested_duration_days != null || payload?.permission_level) && (
+              <div className="rounded-md border p-3 space-y-3">
+                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Adjust approval terms
+                </div>
+                {payload.requested_duration_days != null && (
+                  <div className="space-y-1">
+                    <Label htmlFor="granted-days" className="text-sm">Duration (days)</Label>
+                    <Input
+                      id="granted-days"
+                      type="number"
+                      min={1}
+                      value={grantedDays}
+                      onChange={(e) => setGrantedDays(e.target.value === '' ? '' : Number(e.target.value))}
+                      disabled={submitting}
+                      className="w-32"
+                    />
+                  </div>
+                )}
+                {payload.permission_level && (
+                  <div className="space-y-1">
+                    <Label className="text-sm">Permission level</Label>
+                    <Select value={grantedPermission} onValueChange={setGrantedPermission} disabled={submitting}>
+                      <SelectTrigger className="w-48">
+                        <SelectValue placeholder="Select permission" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="CAN_READ">CAN_READ</SelectItem>
+                        <SelectItem value="CAN_USE">CAN_USE</SelectItem>
+                        <SelectItem value="CAN_EDIT">CAN_EDIT</SelectItem>
+                        <SelectItem value="CAN_MANAGE">CAN_MANAGE</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
               </div>
             )}
             <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Approval response dialog now shows `on_behalf_of` and full payload details from the workflow execution context
- Approvers can adjust grant duration and permission level before approving
- My Actions / Required Actions section shows workflow approval notifications inline with a one-click approve/deny button

## Changes
- `workflow_executor.py`: extract `on_behalf_of`, `step_results`, `full_payload` in approval facets for all trigger types
- `workflow-approval-response-dialog.tsx`: extended payload type; `buildDetailRows` for on_behalf_of + full_payload; adjust terms panel with duration/permission inputs
- `required-actions-section.tsx`: separate `workflow_approval` notifications; inline CheckSquare button; amber badge type

## Test plan
- [ ] Trigger a workflow with an approval step — verify notification appears in My Actions with inline approve/deny
- [ ] Open the approval dialog — verify on_behalf_of row appears when present
- [ ] Verify "Adjust approval terms" panel shows duration and permission level inputs
- [ ] Approve with custom terms — verify `granted_duration_days` / `permission_level` are passed in the response body
- [ ] Deny — verify dialog closes and notification disappears

This pull request and its description were written by Isaac.