### PR TITLE
fix(#583): scope Data Consumer asset visibility to DP-linked assets

### DIFF
--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
 from src.repositories.assets_repository import asset_type_repo, asset_repo, asset_relationship_repo
+from src.common.version_visibility import is_visible_consumer
 from src.models.assets import (
     AssetTypeCreate, AssetTypeUpdate, AssetTypeRead, AssetTypeSummary,
     AssetCreate, AssetUpdate, AssetRead, AssetSummary,
@@ -267,8 +268,9 @@ class AssetsManager(SearchableAsset):
             return None
         try:
             products = data_products_manager.list_products(
-                skip=0, limit=10_000, is_admin=False,
+                skip=0, limit=10_000, is_admin=True,
             )
+            products = [p for p in products if is_visible_consumer(p)]
         except Exception:
             logger.exception("Failed to list accessible data products for scoping")
             return []

--- a/src/backend/src/tests/unit/test_data_product_asset_scoping.py
+++ b/src/backend/src/tests/unit/test_data_product_asset_scoping.py
@@ -128,7 +128,7 @@ def _mock_dpm(accessible_dps: List[DataProductDb]):
     """
     dpm = MagicMock()
     dpm.list_products.return_value = [
-        SimpleNamespace(id=dp.id, name=dp.name) for dp in accessible_dps
+        SimpleNamespace(id=dp.id, name=dp.name, status=dp.status) for dp in accessible_dps
     ]
 
     def _linked(db, *, product_ids, port_ids=None):
@@ -232,6 +232,18 @@ def test_assets_manager_resolve_non_admin_no_dps_empty(db_session):
         db_session, data_products_manager=dpm, is_admin=False,
     )
     assert result == []  # empty list, not None
+
+
+def test_assets_manager_resolve_non_admin_filters_non_consumer_statuses(db_session, asset_graph):
+    """list_products(is_admin=True) may return draft/proposed DPs — only active/deprecated
+    should contribute assets to a consumer's visible set."""
+    draft_dp = DataProductDb(id=str(uuid.uuid4()), name="DP_draft", version="0.1.0", status="draft")
+    # Only dp1 (active) is accessible; draft_dp assets must be excluded.
+    dpm = _mock_dpm([asset_graph.dp1, draft_dp])
+    result = assets_manager.resolve_accessible_asset_ids(
+        db_session, data_products_manager=dpm, is_admin=False,
+    )
+    assert set(result) == {asset_graph.a.id, asset_graph.b.id, asset_graph.d.id}
 
 
 def test_assets_manager_resolve_dpm_failure_fails_closed(db_session):


### PR DESCRIPTION
## Summary
- Fixes "Asset is not linked to a Data Product accessible to this user" error for consumers browsing assets (#583)
- Root cause: `list_products(is_admin=False)` with no caller scope context returns empty (fail-closed design), causing all consumers to get an empty asset list
- Fix: list all products with `is_admin=True` then filter to consumer-visible statuses (`active`, `deprecated`) — consistent with what consumers can already see in the Data Products catalog

## Changes
- `assets_manager.py` (`resolve_accessible_asset_ids`): use `is_admin=True` + `is_visible_consumer` filter instead of `is_admin=False` which returns empty without caller scope

## Test plan
- [ ] As a Data Consumer, grant "Read only" access to an asset linked to a published Data Product
- [ ] Browse to the Assets page — verify the asset is visible and accessible (no 403)
- [ ] Verify assets NOT linked to any Data Product are still not visible to consumers
- [ ] Verify admin users still see all assets regardless

This pull request and its description were written by Isaac.