### PR TITLE
ci: fix development branch filters and back-merge runner IP failure

### DIFF
--- a/.github/workflows/backmerge-main-to-development.yml
+++ b/.github/workflows/backmerge-main-to-development.yml
@@ -21,7 +21,13 @@ concurrency:
 
 jobs:
   backmerge:
-    runs-on: ubuntu-latest
+    # Must run on the protected runner group: the databrickslabs org has an IP
+    # allow list, and stock GitHub-hosted runner IPs are not on it, so any
+    # GitHub API call from ubuntu-latest fails with "your IP address is not
+    # permitted to access this resource".
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -31,6 +37,8 @@ jobs:
       - name: Open or reuse back-merge PR (main -> development)
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
 
@@ -42,15 +50,17 @@ jobs:
 
           # Reuse an existing open back-merge PR if one is already there
           # (a branch-to-branch PR auto-tracks new commits on main).
-          existing="$(gh pr list --base development --head main --state open \
-            --json number --jq '.[0].number // empty')"
+          # Plain REST via `gh api`; the gh pr subcommands use GraphQL.
+          existing="$(gh api "repos/${REPO}/pulls?base=development&head=${OWNER}:main&state=open" \
+            --jq '.[0].number // empty')"
           if [ -n "$existing" ]; then
             echo "Back-merge PR already open: #$existing (it will include the new commits)."
             exit 0
           fi
 
-          gh pr create \
-            --base development \
-            --head main \
-            --title "chore: back-merge main into development" \
-            --body "Automated back-merge to keep \`development\` in sync with \`main\`, triggered by a push to \`main\`. If GitHub reports conflicts, resolve them on this PR before merging. (Workflow: \`.github/workflows/backmerge-main-to-development.yml\`.)"
+          gh api "repos/${REPO}/pulls" \
+            -f base=development \
+            -f head=main \
+            -f title="chore: back-merge main into development" \
+            -f body="Automated back-merge to keep \`development\` in sync with \`main\`, triggered by a push to \`main\`. If GitHub reports conflicts, resolve them on this PR before merging. (Workflow: \`.github/workflows/backmerge-main-to-development.yml\`.)" \
+            --jq '"Opened back-merge PR #" + (.number | tostring)'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,9 +2,9 @@ name: Test Coverage
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
   # Required by the merge queue: GitHub builds each batch on a temporary
   # gh-readonly-queue/<base>/... branch and fires a merge_group event. The
   # required status checks must run on that event or queued PRs hang forever
@@ -62,7 +62,7 @@ jobs:
           files: ./src/coverage.xml
           flags: backend
           name: backend-coverage
-          # Required for uploads to protected branches (main/develop). Without
+          # Required for uploads to protected branches (main/development). Without
           # it Codecov rejects the upload ("Token required because branch is
           # protected") while the step stays green due to fail_ci_if_error:false,
           # which silently froze the coverage badges. Forks have no access to the

--- a/docs/TESTING_PLAN.md
+++ b/docs/TESTING_PLAN.md
@@ -1082,7 +1082,7 @@ name: Test Coverage
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Why

PRs targeting `development` are stuck: they never receive the five required status checks, so they stay BLOCKED forever and can never enter the merge queue. Two root causes:

1. **Stale branch filters in `test-coverage.yml`**: the `push` and `pull_request` triggers listened on `develop`, a branch that does not exist. The working branch is `development`, so PRs based on it (e.g. #598) got zero CI runs while the ruleset kept waiting on checks that would never report.
2. **Back-merge workflow fails on every push to `main`**: the job ran on stock `ubuntu-latest` runners, whose IPs are not on the org IP allow list. Every GitHub API call died with `your IP address is not permitted to access this resource`, so fixes on `main` (including the `merge_group` trigger this repo already added there) never flowed back into `development`.

## What

- `test-coverage.yml`: branch filters `[main, develop]` -> `[main, development]` on both `push` and `pull_request`; updated the Codecov comment to match.
- `backmerge-main-to-development.yml`: moved the job to the `databrickslabs-protected-runner-group` (same as every other job in this repo, and its egress IPs are on the org allow list), and rewrote the PR step to use plain REST via `gh api` instead of the GraphQL-backed `gh pr` subcommands.

## Follow-ups (not in this PR)

- `development`'s copy of `test-coverage.yml` also lacks the `merge_group` trigger; once this merges, the fixed back-merge workflow should carry it over. If the back-merge PR cannot pass checks for the same chicken-and-egg reason, an admin bypass merge onto `development` is needed once.
- #577 proposed deleting the back-merge workflow as non-functional; with this fix it works, so #577 can likely be closed.

This pull request and its description were written by Isaac.