### PR TITLE
fix(products): publish_product reads nonexistent port.data_contract_id

### DIFF
--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -931,7 +931,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             if product_db.output_ports:
                 ports_without_contracts = [
                     port.name for port in product_db.output_ports
-                    if not port.data_contract_id
+                    if not port.contract_id
                 ]
                 if ports_without_contracts:
                     raise ValueError(
@@ -946,8 +946,8 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 contracts_not_approved = []
                 
                 for port in product_db.output_ports:
-                    if port.data_contract_id:
-                        contract = data_contract_repo.get(db=self._db, id=port.data_contract_id)
+                    if port.contract_id:
+                        contract = data_contract_repo.get(db=self._db, id=port.contract_id)
                         if contract:
                             contract_status = (contract.status or '').lower()
                             if contract_status not in valid_contract_statuses:


### PR DESCRIPTION
## Problem

`publish_product` accesses `port.data_contract_id` in three places, but the `OutputPortDb` column is `contract_id`; `data_contract_id` exists nowhere on the model (no column, property, or alias). Publishing any product that has at least one output port therefore raises `AttributeError`, which the route's generic exception handler surfaces as HTTP 500 ("Failed to publish product"), hiding the cause.

## Impact

The canonical publish action (approved -> active + publication scope, WITH validation that every output port has an approved contract) is unusable for real products. The alternate paths that still reach the marketplace (change-status to active, then set-publication-scope or handle-publish) skip that contract validation entirely, so the only governance-checked route to publication is the broken one.

Introduced in 0b3920d7 (route-to-manager refactor), where the manager was written against a field name the model never had.

## Fix

Read `port.contract_id` (the real column) in all three sites.

## Testing

- Backend unit suite on this branch, rebased on latest `main`: 1449 passed, 1 skipped (identical to the `main` baseline; no regressions).
- ORM confirmation: `OutputPortDb.__table__.columns` contains `contract_id` and not `data_contract_id`, and `data_contract_id` is absent from the model entirely, so the stock access path raises `AttributeError`.
- Live deployment: with the fix, POST `/data-products/{id}/publish` on a product with three contracted output ports executes through the full contract-validation loop (reaching the status-transition step) instead of returning 500; the product publishes with `publication_scope` set and appears in the marketplace.

This pull request and its description were written by Isaac.
