### PR TITLE
fix(readiness): count output-port contracts via contractId

### DIFF
--- a/src/backend/src/routes/readiness_routes.py
+++ b/src/backend/src/routes/readiness_routes.py
@@ -70,7 +70,10 @@ def get_readiness_report(
     # 2. At least one output port / contract
     output_ports = product.outputPorts or []
     has_output = len(output_ports) > 0
-    contract_count = sum(1 for op in output_ports if op.customProperties and op.customProperties.get("contract_id"))
+    contract_count = sum(
+        1 for op in output_ports
+        if getattr(op, "contractId", None)
+    )
     checks.append(ReadinessCheck(
         name="At least one output contract",
         status="pass" if contract_count > 0 else ("warn" if has_output else "fail"),


### PR DESCRIPTION
## Problem

Readiness check #2 read `op.customProperties.get("contract_id")`, but `customProperties` on the `OutputPort` API model is a `List[CustomProperty]`: `.get()` on a non-empty list raises `AttributeError`, and no code path ever writes `contract_id` into `customProperties` anyway. The linked contract lives on `OutputPort.contractId` (ORM column `contract_id`), which is what the rest of the codebase reads (e.g. `data_products_manager`).

## Impact

The check could never count a single contract, so products never passed this readiness item even with contracts linked on every output port; a fully governed product was stuck below 6/6.

## Fix

Count output-port contracts via `op.contractId`.

## Testing

- Backend unit suite on this branch, rebased on latest `main`: 1449 passed, 1 skipped (identical to the `main` baseline; no regressions).
- Live deployment: two products with contracts linked on every output port now report "3 contract(s) linked via 3 output port(s)" for check #2 and reach 6/6 readiness (they were stuck below before).

This pull request and its description were written by Isaac.
