### PR TITLE
fix(mcp): scoped tokens cannot list or call read-scoped tools

### DIFF
--- a/src/backend/src/routes/mcp_routes.py
+++ b/src/backend/src/routes/mcp_routes.py
@@ -324,6 +324,11 @@ class MCPHandler:
     
     def _has_scope(self, required_scope: str) -> bool:
         """Check if token has required scope."""
+        # Tools may declare required_scope=None meaning "no scope required"
+        # (e.g. get_app_state, search_ontos_handbook). Without this guard,
+        # tools/list crashes on `":" in None` for any non-wildcard token.
+        if not required_scope:
+            return True
         scopes = self._token_info.scopes
         
         # Admin wildcard

--- a/src/backend/src/tools/data_contracts.py
+++ b/src/backend/src/tools/data_contracts.py
@@ -476,6 +476,7 @@ class SearchDataContractsTool(BaseTool):
         }
     }
     required_params = ["query"]
+    required_scope = "contracts:read"
     
     async def execute(
         self,
@@ -552,6 +553,7 @@ class GetDataContractTool(BaseTool):
         }
     }
     required_params = ["contract_id"]
+    required_scope = "contracts:read"
     
     async def execute(self, ctx: ToolContext, contract_id: str) -> ToolResult:
         """Get a data contract by ID."""
@@ -677,6 +679,7 @@ class DeleteDataContractTool(BaseTool):
         }
     }
     required_params = ["contract_id"]
+    required_scope = "contracts:write"
     
     async def execute(self, ctx: ToolContext, contract_id: str) -> ToolResult:
         """Delete a data contract."""

--- a/src/backend/src/tools/data_products.py
+++ b/src/backend/src/tools/data_products.py
@@ -507,6 +507,7 @@ class GetDataProductTool(BaseTool):
         }
     }
     required_params = ["product_id"]
+    required_scope = "data-products:read"
     
     async def execute(self, ctx: ToolContext, product_id: str) -> ToolResult:
         """Get a data product by ID."""
@@ -656,6 +657,7 @@ class DeleteDataProductTool(BaseTool):
         }
     }
     required_params = ["product_id"]
+    required_scope = "data-products:write"
     
     async def execute(self, ctx: ToolContext, product_id: str) -> ToolResult:
         """Delete a data product."""


### PR DESCRIPTION
## Problem

Least-privilege (scoped) MCP tokens could not use the server:

1. **`tools/list` crashed for scoped tokens.** `get_app_state` and `search_ontos_handbook` declare `required_scope=None` (no scope needed), and `_has_scope` evaluated `":" in None` -> `TypeError` for any token without the `"*"` wildcard. Scoped tokens could never list tools.
2. **Duplicate tool class definitions dropped their scope.** `data_products.py` and `data_contracts.py` each define get/delete (and `search_data_contracts`) twice; the later definition wins at import time and lacked `required_scope`, silently inheriting the admin-only `"*"` default. Any read-only token was denied `get_data_product` / `get_data_contract` even with the right read scope.

## Fix

- Guard `_has_scope` against `required_scope=None` (treat as "no scope required").
- Add the missing `required_scope` on the surviving (duplicate) tool class definitions.

## Testing

- Backend unit suite: 1449 passed, 1 skipped (matches `main` baseline, no regressions).
- Verified on a live deployment: a scoped read-only token can `tools/list` and call `get_data_product`/`get_data_contract`.

This pull request and its description were written by Isaac.
