### PR TITLE
fix(mcp): comply with JSON-RPC and release DB session for streaming clients

### DIFF
--- a/src/backend/src/routes/mcp_routes.py
+++ b/src/backend/src/routes/mcp_routes.py
@@ -495,6 +495,15 @@ async def mcp_sse_stream(
         }
         logger.info(f"Created new MCP session: {session_id}")
     
+    # Release the DB connection BEFORE streaming: FastAPI keeps dependencies
+    # alive until the response completes, which for a long-lived SSE stream
+    # means each open stream pins one pooled connection indefinitely.
+    # Reconnecting clients (Kasal retries on any hiccup) exhaust the pool
+    # within seconds — after which token validation can't query and every
+    # request 401s or hangs on pool timeout. The stream loop only touches
+    # the in-memory session dict, so the session is safe to close here.
+    db.close()
+
     # Return SSE stream
     return EventSourceResponse(
         sse_stream_generator(token_info, session_id, request),

--- a/src/backend/src/routes/mcp_routes.py
+++ b/src/backend/src/routes/mcp_routes.py
@@ -78,6 +78,20 @@ def make_success_response(
     return JSONRPCResponse(result=result, id=request_id)
 
 
+def dump_jsonrpc_response(resp: JSONRPCResponse) -> Dict[str, Any]:
+    """Serialize per JSON-RPC 2.0: exactly ONE of result/error.
+
+    JSONRPCResponse.model_dump() emits both keys (one null), which strict
+    clients (e.g. the MCP Python SDK used by Kasal/CrewAI) reject.
+    """
+    out: Dict[str, Any] = {"jsonrpc": "2.0", "id": resp.id}
+    if resp.error is not None:
+        out["error"] = resp.error.model_dump()
+    else:
+        out["result"] = resp.result
+    return out
+
+
 def generate_session_id() -> str:
     """Generate a cryptographically secure session ID."""
     return secrets.token_urlsafe(32)
@@ -517,10 +531,10 @@ async def mcp_handler(
     
     # Helper to create error response in the appropriate format
     async def error_response(code: int, message: str, request_id: Any = None):
-        response_data = JSONRPCResponse(
+        response_data = dump_jsonrpc_response(JSONRPCResponse(
             error=JSONRPCError(code=code, message=message),
             id=request_id
-        ).model_dump()
+        ))
         
         if use_sse:
             return EventSourceResponse(
@@ -528,6 +542,29 @@ async def mcp_handler(
                 headers={"MCP-Session-Id": session_id} if session_id else {}
             )
         return JSONResponse(content=response_data)
+    
+    # Parse request body first so every error response can carry the id
+    try:
+        body = await request.json()
+    except Exception as e:
+        return await error_response(JSONRPC_PARSE_ERROR, f"Failed to parse JSON: {str(e)}")
+    
+    # Validate JSON-RPC format
+    try:
+        rpc_request = JSONRPCRequest(**body)
+    except Exception as e:
+        return await error_response(JSONRPC_INVALID_REQUEST, f"Invalid request: {str(e)}",
+                                    body.get("id") if isinstance(body, dict) else None)
+    
+    # JSON-RPC notifications (no id) MUST NOT receive a response body — the
+    # MCP spec says unknown notifications are ignored and streamable HTTP
+    # expects 202 Accepted. Replying with an error (id=null) crashes strict
+    # clients (MCP Python SDK / Kasal). notifications/cancelled et al. land here.
+    if rpc_request.id is None and rpc_request.method.startswith("notifications/"):
+        if rpc_request.method == "notifications/initialized" and session_id in _sessions:
+            _sessions[session_id]["initialized"] = True
+        return Response(status_code=202,
+                        headers={"MCP-Session-Id": session_id} if session_id else {})
     
     # Validate API key
     token_info = validate_api_key(db, x_api_key)
@@ -541,19 +578,9 @@ async def mcp_handler(
             success=False,
             details={"reason": "Invalid or missing API key"},
         )
-        return await error_response(MCP_AUTH_FAILED, "Invalid or missing API key")
+        return await error_response(MCP_AUTH_FAILED, "Invalid or missing API key",
+                                    rpc_request.id)
     
-    # Parse request body
-    try:
-        body = await request.json()
-    except Exception as e:
-        return await error_response(JSONRPC_PARSE_ERROR, f"Failed to parse JSON: {str(e)}")
-    
-    # Validate JSON-RPC format
-    try:
-        rpc_request = JSONRPCRequest(**body)
-    except Exception as e:
-        return await error_response(JSONRPC_INVALID_REQUEST, f"Invalid request: {str(e)}")
     
     # Handle session management
     is_initialize = rpc_request.method == "initialize"
@@ -590,7 +617,7 @@ async def mcp_handler(
         logger.error(f"Error committing MCP changes: {e}")
         db.rollback()
     
-    response_data = response.model_dump()
+    response_data = dump_jsonrpc_response(response)
     
     # Build response headers
     response_headers = {}


### PR DESCRIPTION
## Problem

Two transport-layer defects broke MCP clients that reconnect or validate strictly (Kasal / MCP Python SDK / CrewAI):

1. **DB session pinned for the life of an SSE stream.** FastAPI holds route dependencies until the response finishes; for the GET SSE stream that pinned one pooled DB connection per open stream for the stream's whole lifetime. Auto-reconnecting clients exhausted the pool within seconds, after which token lookups failed (`401 'Invalid or missing API key'`) and other requests hung on the pool timeout. The stream loop only uses the in-memory session store, so the DB session can be returned up front.
2. **JSON-RPC spec violations.** Unknown notifications (e.g. `notifications/cancelled` from CrewAI) got a `METHOD_NOT_FOUND` error with `id=null`, which the MCP Python SDK cannot parse (SSE stream crashed, reconnect loop). `model_dump()` emitted both `result` and `error` keys (one null), rejected by strict `JSONRPCMessage` validation. The body was parsed after auth, so auth/validation errors echoed `id=null`.

## Fix

- Release the DB session before entering the long-lived SSE loop.
- Never reply to notifications (return `202 Accepted`, no body, per the streamable HTTP spec); serialize exactly one of `result`/`error`; parse the body before auth so errors echo the request id.

## Testing

- Backend unit suite: 1449 passed, 1 skipped (matches `main` baseline, no regressions).
- Verified on a live deployment: MCP Python SDK / Kasal client connects, lists tools, and calls tools without the reconnect loop or pool exhaustion.

This pull request and its description were written by Isaac.
