### PR TITLE
fix(mcp): agent data-access tools never worked (workspace client, ports, contracts)

### DIFF
--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -179,6 +179,11 @@ async def startup_event():
         from src.controller.grant_manager import init_grant_manager
         from src.common.workspace_client import get_workspace_client
         ws_client = get_workspace_client(settings=settings)
+        # Expose the app-identity workspace client for MCP analytics tools
+        # (get_table_schema / execute_analytics_query read
+        # app.state.workspace_client via ToolContext; it was never set,
+        # so those tools always failed with "Workspace client not available").
+        app.state.workspace_client = ws_client
         grant_manager = init_grant_manager(ws_client=ws_client, settings=settings)
         app.state.grant_manager = grant_manager
         logger.info("Grant Manager initialized")

--- a/src/backend/src/tools/data_contracts.py
+++ b/src/backend/src/tools/data_contracts.py
@@ -487,12 +487,12 @@ class SearchDataContractsTool(BaseTool):
         """Search for data contracts."""
         logger.info(f"[search_data_contracts] Starting - query='{query}', domain={domain}, status={status}")
         
-        if not ctx.data_contracts_manager:
-            logger.error(f"[search_data_contracts] FAILED: Data contracts manager not available")
-            return ToolResult(success=False, error="Data contracts manager not available")
-        
         try:
-            contracts = ctx.data_contracts_manager.list_contracts()
+            # Query the DB directly: DataContractsManager.list_contracts()
+            # reads a legacy in-memory dict that is never populated, so the
+            # tool always returned zero contracts.
+            from src.db_models.data_contracts import DataContractDb
+            contracts = ctx.db.query(DataContractDb).limit(500).all()
             
             query_lower = query.lower() if query and query != '*' else ''
             filtered = []
@@ -502,7 +502,8 @@ class SearchDataContractsTool(BaseTool):
                 if query_lower:
                     name_match = query_lower in (c.name or "").lower()
                     domain_match = query_lower in (getattr(c, 'domain', '') or "").lower()
-                    desc_match = query_lower in (c.description or "").lower() if c.description else False
+                    desc_text = str(getattr(c, 'description_purpose', None) or getattr(c, 'description', '') or '')
+                    desc_match = query_lower in desc_text.lower()
                     include = name_match or domain_match or desc_match
                 else:
                     include = True
@@ -517,12 +518,12 @@ class SearchDataContractsTool(BaseTool):
                     continue
                 
                 filtered.append({
-                    "id": c.id,
+                    "id": str(c.id),
                     "name": c.name,
-                    "domain": getattr(c, 'domain', None),
+                    "domain": getattr(c, 'domain', None) or getattr(c, 'domain_id', None),
                     "status": c.status,
-                    "version": c.version,
-                    "format": c.format
+                    "version": getattr(c, 'version', None),
+                    "format": getattr(c, 'format', None)
                 })
             
             logger.info(f"[search_data_contracts] SUCCESS: Found {len(filtered)} matching contracts")

--- a/src/backend/src/tools/data_products.py
+++ b/src/backend/src/tools/data_products.py
@@ -525,10 +525,12 @@ class GetDataProductTool(BaseTool):
                     error=f"Data product '{product_id}' not found"
                 )
             
-            # Extract description purpose
+            # Extract description purpose (handles Description model, dict, or str)
             desc_purpose = None
             if product.description:
-                if isinstance(product.description, dict):
+                if hasattr(product.description, 'purpose'):
+                    desc_purpose = product.description.purpose
+                elif isinstance(product.description, dict):
                     desc_purpose = product.description.get('purpose')
                 elif isinstance(product.description, str):
                     try:
@@ -537,6 +539,23 @@ class GetDataProductTool(BaseTool):
                             desc_purpose = desc_dict.get('purpose')
                     except Exception:
                         desc_purpose = product.description
+            
+            # Surface output ports so agents can find the physical tables
+            output_ports = []
+            for port in (product.outputPorts or []):
+                server = getattr(port, 'server', None)
+                location = getattr(port, 'assetIdentifier', None)
+                if not location and server is not None:
+                    host = getattr(server, 'host', '') or ''
+                    schema = getattr(server, 'schema_name', '') or ''
+                    location = f"{host}.{schema}" if host and schema else (host or None)
+                output_ports.append({
+                    "name": port.name,
+                    "description": getattr(port, 'description', None),
+                    "contract_id": getattr(port, 'contractId', None),
+                    "contract_name": getattr(port, 'contractName', None),
+                    "location": location,
+                })
             
             logger.info(f"[get_data_product] SUCCESS: Found product {product.name}")
             return ToolResult(
@@ -549,6 +568,8 @@ class GetDataProductTool(BaseTool):
                     "status": product.status,
                     "version": product.version,
                     "owner_team_id": getattr(product, 'owner_team_id', None),
+                    "owner_team_name": getattr(product, 'owner_team_name', None),
+                    "output_ports": output_ports,
                     "tenant": getattr(product, 'tenant', None),
                     "url": f"/data-products/{product.id}"
                 }


### PR DESCRIPTION
## Problem

Agent data access through Ontos MCP tools did not work:

- `app.state.workspace_client` was never set, so the analytics tools (`get_table_schema`, `execute_analytics_query`, `explore_catalog_schema`) always failed with "Workspace client not available" — agents could not query any data through Ontos.
- `get_data_product` ignored `Description` model objects (description came back null) and returned no output ports, so agents saw a bare product with no pointers to the physical tables.
- `search_data_contracts` read `DataContractsManager._contracts`, a legacy in-memory dict that is never populated — always zero results.

## Fix

- Set `app.state.workspace_client` at startup so the analytics tools have a client.
- Return the product description and output ports from `get_data_product`.
- Query the contracts table directly in `search_data_contracts` instead of the empty in-memory dict.

## Testing

- Backend unit suite: 1449 passed, 1 skipped (matches `main` baseline, no regressions), including the data-products/contracts tool tests.
- Verified on a live deployment: an agent lists a product with its description and output ports, then runs an analytics query against the referenced tables.

This pull request and its description were written by Isaac.
